### PR TITLE
Adding dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc-arm-none-eabi \
+    libnewlib-arm-none-eabi \
+    gdb-multiarch \
+    openocd \
+    build-essential \
+    make \
+    gawk \
+    git \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -sf /usr/bin/gdb-multiarch /usr/local/bin/arm-none-eabi-gdb

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gawk \
     git \
     python3 \
+    python-is-python3 \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+# this will always pull the latest version of the base image, which is updated regularly by Microsoft
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,10 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
 
+ENV LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    LANGUAGE=C.UTF-8 \
+    PYTHONUTF8=1
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc-arm-none-eabi \
     libnewlib-arm-none-eabi \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,30 @@
+# Dev Container for ChibiOS
+
+This folder contains the Visual Studio Code Dev Containers configuration for this repository.
+
+## Files
+
+- `devcontainer.json`: VS Code container definition (image build, extensions, post-create hook).
+- `Dockerfile`: Ubuntu-based image with ARM embedded build/debug tools.
+- `post-create.sh`: Post-create setup script executed by VS Code after container creation.
+
+## What the container provides
+
+- ARM GCC cross compiler (`arm-none-eabi-gcc`).
+- Multi-arch GDB exposed as `arm-none-eabi-gdb`.
+- OpenOCD.
+- Python 3 and pip, plus workflow Python dependencies from `tools/workflows/requirements.txt`.
+- Common build tools (`make`, `build-essential`, `gawk`, `git`).
+
+## Usage
+
+1. Open the repository in VS Code.
+2. Run "Dev Containers: Reopen in Container".
+3. Wait for image build and post-create script completion.
+
+After that, project builds can be executed from the integrated terminal, for example:
+
+```sh
+cd testhal/RP/RP2040/XIP-VALIDATION
+make -j$(nproc)
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "ChibiOS ARM Dev",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-vscode.makefile-tools",
+        "ms-python.python"
+      ]
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,18 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
+  "containerEnv": {
+    "LANG": "C.UTF-8",
+    "LC_ALL": "C.UTF-8",
+    "LANGUAGE": "C.UTF-8",
+    "PYTHONUTF8": "1"
+  },
   "customizations": {
     "vscode": {
+      "settings": {
+        "files.encoding": "utf8",
+        "files.autoGuessEncoding": false
+      },
       "extensions": [
         "ms-vscode.cpptools",
         "ms-vscode.makefile-tools",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from repository root even if VS Code starts from a different cwd.
+cd "$(dirname "$0")/.."
+
+# Install Python packages used by CI/workflow helper scripts.
+python3 -m pip install --no-cache-dir -r tools/workflows/requirements.txt
+
+# Quick toolchain sanity checks so container setup fails early if something is missing.
+arm-none-eabi-gcc --version
+arm-none-eabi-gdb --version
+openocd --version

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,10 +4,18 @@ set -euo pipefail
 # Run from repository root even if VS Code starts from a different cwd.
 cd "$(dirname "$0")/.."
 
+# Initialise submodules (ext → chibios-ext, tools/ftl → chibios-ftl).
+# A fresh container clone won't have them populated, which breaks any build
+# that pulls in FatFS, lwIP, wolfSSL, littlefs, or the FTL code-gen templates.
+git submodule update --init --recursive
+
 # Install Python packages used by CI/workflow helper scripts.
 python3 -m pip install --no-cache-dir -r tools/workflows/requirements.txt
 
 # Quick toolchain sanity checks so container setup fails early if something is missing.
+# NOTE: Ubuntu 22.04 ships gcc-arm-none-eabi ~10.x, while the canonical ChibiStudio
+# toolchain is 14.3.1. Builds will generally succeed, but there may be minor
+# version-specific differences (warning flags, optimisation behaviour, etc.).
 arm-none-eabi-gcc --version
 arm-none-eabi-gdb --version
 openocd --version

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,18 +4,18 @@ set -euo pipefail
 # Run from repository root even if VS Code starts from a different cwd.
 cd "$(dirname "$0")/.."
 
-# Initialise submodules (ext → chibios-ext, tools/ftl → chibios-ftl).
-# A fresh container clone won't have them populated, which breaks any build
+# Initialize submodules (ext -> chibios-ext, tools/ftl -> chibios-ftl).
+# A fresh container clone will not have them populated, which breaks any build
 # that pulls in FatFS, lwIP, wolfSSL, littlefs, or the FTL code-gen templates.
 git submodule update --init --recursive
 
 # Install Python packages used by CI/workflow helper scripts.
-python3 -m pip install --no-cache-dir -r tools/workflows/requirements.txt
+python3 -m pip install --break-system-packages --no-cache-dir -r tools/workflows/requirements.txt
 
 # Quick toolchain sanity checks so container setup fails early if something is missing.
 # NOTE: Ubuntu 22.04 ships gcc-arm-none-eabi ~10.x, while the canonical ChibiStudio
 # toolchain is 14.3.1. Builds will generally succeed, but there may be minor
-# version-specific differences (warning flags, optimisation behaviour, etc.).
+# version-specific differences (warning flags, optimization behavior, etc.).
 arm-none-eabi-gcc --version
 arm-none-eabi-gdb --version
 openocd --version

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 *****************************************************************************
 
 --{root}                        - ChibiOS directory.
+  +--.devcontainer/             - VS Code dev container configuration.
   +--readme.txt                 - This file.
   +--documentation.html         - Shortcut to the web documentation page.
   +--license.txt                - GPL license text.
@@ -71,6 +72,9 @@
   |  |  +--coverage/            - RT code coverage project.
   +--testex/                    - EX integration test demos.
   +--testhal/                   - HAL integration test demos.
+
+NOTE: The optional VS Code dev container setup is in .devcontainer/.
+See .devcontainer/README.md for included tools and usage.
 
 *****************************************************************************
 *** Releases and Change Log                                               ***

--- a/tools/workflows/requirements.txt
+++ b/tools/workflows/requirements.txt
@@ -2,7 +2,7 @@ certifi==2021.5.30
 charset-normalizer==2.0.4
 idna==3.2
 junit-xml==1.9
-PyYAML==5.4.1
+PyYAML==6.0.2
 requests==2.26.0
 six==1.16.0
 urllib3==1.26.6


### PR DESCRIPTION
This PR adds a dev container. Making it easier to build any target withing a container without having to add anything on the machine.
This has been tested building few targets.
In case something is seen missing over time, this can be adjusted.