### PR TITLE
STM32G4xx: add FMC clock and IRQ definitions

### DIFF
--- a/os/hal/ports/STM32/STM32G4xx/stm32_isr.h
+++ b/os/hal/ports/STM32/STM32G4xx/stm32_isr.h
@@ -171,6 +171,17 @@
 #define STM32_FDCAN3_IT1_NUMBER             89
 
 /*
+ * FSMC unit.
+ */
+#if defined(STM32G473xx) || defined(STM32G483xx) ||                         \
+    defined(STM32G474xx) || defined(STM32G484xx) ||                         \
+    defined(__DOXYGEN__)
+#define STM32_FSMC_HANDLER                  Vector100
+
+#define STM32_FSMC_NUMBER                   48
+#endif
+
+/*
  * I2C units.
  */
 #define STM32_I2C1_EV_HANDLER               VectorBC

--- a/os/hal/ports/STM32/STM32G4xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32G4xx/stm32_rcc.h
@@ -310,6 +310,34 @@
 /** @} */
 
 /**
+ * @name    FSMC peripherals specific RCC operations
+ * @{
+ */
+/**
+ * @brief   Enables the FSMC peripheral clock.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableFSMC(lp) rccEnableAHB3(RCC_AHB3ENR_FMCEN, lp)
+
+/**
+ * @brief   Disables the FSMC peripheral clock.
+ *
+ * @api
+ */
+#define rccDisableFSMC() rccDisableAHB3(RCC_AHB3ENR_FMCEN)
+
+/**
+ * @brief   Resets the FSMC peripheral.
+ *
+ * @api
+ */
+#define rccResetFSMC() rccResetAHB3(RCC_AHB3RSTR_FMCRST)
+/** @} */
+
+/**
  * @name    ADC peripherals specific RCC operations
  * @{
  */

--- a/os/hal/ports/STM32/STM32G4xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32G4xx/stm32_registry.h
@@ -328,7 +328,7 @@
 #define STM32_HAS_DMA2D                     FALSE
 
 /* FSMC attributes.*/
-#define STM32_HAS_FSMC                      FALSE
+#define STM32_HAS_FSMC                      TRUE
 
 /* CRC attributes.*/
 #define STM32_HAS_CRC                       TRUE

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,8 @@
 *****************************************************************************
 
 *** 21.11.6 ***
+- NEW: STM32G4xx: added FSMC RCC macros, IRQ vector definitions and
+       registry switch for the FMC-capable devices (github PR #7).
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3).
 - FIX: Fixed RT trace halt event can dereference uninitialized trace buffer


### PR DESCRIPTION
## Summary

- Enable STM32_HAS_FSMC for STM32G473/G483/G474/G484 devices.
- Add STM32_FSMC_HANDLER and STM32_FSMC_NUMBER aliases.
- Add rccEnableFSMC(), rccDisableFSMC(), and rccResetFSMC() helpers.

## Validation

- git diff --check stable-21.11.x..HEAD
- patch-id compared with /tmp/stm32g4-fmc.patch.zip