### PR TITLE
Add ADDITIONAL_OUTFILES to the ARMCMx GCC build rules

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/mk/rules.mk
+++ b/os/common/startup/ARMCMx/compilers/GCC/mk/rules.mk
@@ -89,6 +89,11 @@ ifdef SREC
   OUTFILES += $(BUILDDIR)/$(PROJECT).srec
 endif
 
+# Additional output files, the ADDITIONAL_OUTFILES variable can be populated
+# by makefiles included before this one, the listed files are built as part
+# of the "all" target using user-provided rules.
+ADDITIONAL_OUTFILES ?=
+
 # Source files groups and paths
 SRC      := $(CSRC) $(CPPSRC)
 SRCPATHS += $(sort $(dir $(ASMXSRC)) $(dir $(ASMSRC)) $(dir $(SRC)))
@@ -143,7 +148,8 @@ VPATH     = $(SRCPATHS)
 # Makefile rules
 #
 
-all: PRE_MAKE_ALL_RULE_HOOK $(OBJS) $(OUTFILES) POST_MAKE_ALL_RULE_HOOK
+all: PRE_MAKE_ALL_RULE_HOOK $(OBJS) $(OUTFILES) \
+     $(ADDITIONAL_OUTFILES) POST_MAKE_ALL_RULE_HOOK
 
 PRE_MAKE_ALL_RULE_HOOK:
 

--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,9 @@ See .devcontainer/README.md for included tools and usage.
 - FIX; NIL: Fixed wrong alignment check in chThdCreateI() (bug #1306)
        (backported to 21.11.6).
 - FIX: DACv1 trigger mask sized for 3 or 4 bit trigger source identifier
+- NEW: Added ADDITIONAL_OUTFILES variable to the ARMCMx GCC build rules,
+       included makefiles can now add extra generated files to the "all"
+       target.
 - NEW: Sensors subsystem in XHAL equivalent to EX for old HAL.
 - NEW: Thread mode for EP0 handling in USB HAL driver.
 - NEW: ADC driver in XHAL.

--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ See .devcontainer/README.md for included tools and usage.
 - FIX: DACv1 trigger mask sized for 3 or 4 bit trigger source identifier
 - NEW: Added ADDITIONAL_OUTFILES variable to the ARMCMx GCC build rules,
        included makefiles can now add extra generated files to the "all"
-       target.
+       target (github PR #10).
 - NEW: Sensors subsystem in XHAL equivalent to EX for old HAL.
 - NEW: Thread mode for EP0 handling in USB HAL driver.
 - NEW: ADC driver in XHAL.


### PR DESCRIPTION
🤖 chibios-sheriff — PR authored from a forum bug report (advisory; review and merge decisions stay with human maintainers)

## Summary

Implements the `ADDITIONAL_OUTFILES` extension to the ARMCMx GCC `rules.mk`, as proposed by **electronic_eel** on the forum and endorsed by the maintainer there. Makefiles included before `rules.mk` can list extra generated output files (and provide the rules building them); they are built as part of the `all` target. The pre-existing `OUTFILES` variable stays internal.

Use case: optional `.uf2` image generation for the RP2 family.

## Related

- Issue(s): forum bug report https://forum.chibios.org/viewtopic.php?t=6691
- Notes for reviewers: scoped to ARMCMx per the report; the other `rules.mk` variants (ARM/ARMCRx, AVR, e200, SIM) share the limitation and could receive the same construct in a follow-up if wanted.

## Target Branch Check

- [x] This PR targets `main` — all changes land on `main` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `main`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files (none touched — makefile + readme only)
- [x] Build check passed (RP2040 ARM target compile; `rules.mk` not used by the POSIX simulator)

## Testing

- [x] Test run successfully locally: unmodified build unaffected (variable empty → no-op); with a test makefile adding a `.uf2` rule, `make all` builds `build/ch.uf2`
- Any other tests run on a device? n/a (build-system change)

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
