### PR TITLE
ADCv6, ADCv7: add missing STM32_ADC_ADC2_IRQ_HOOK invocations

### DIFF
--- a/os/hal/ports/STM32/LLD/ADCv6/hal_adc_lld.c
+++ b/os/hal/ports/STM32/LLD/ADCv6/hal_adc_lld.c
@@ -349,7 +349,9 @@ OSAL_IRQ_HANDLER(STM32_ADC2_HANDLER) {
 
   isr  = ADC2->ISR;
   ADC2->ISR = isr;
-
+#if defined(STM32_ADC_ADC2_IRQ_HOOK)
+  STM32_ADC_ADC2_IRQ_HOOK
+#endif
   adc_lld_serve_interrupt(&ADCD1, isr);
 
   OSAL_IRQ_EPILOGUE();
@@ -370,12 +372,14 @@ OSAL_IRQ_HANDLER(STM32_ADC2_HANDLER) {
 
   isr  = ADC2->ISR;
   ADC2->ISR = isr;
-
+#if defined(STM32_ADC_ADC2_IRQ_HOOK)
+  STM32_ADC_ADC2_IRQ_HOOK
+#endif
   adc_lld_serve_interrupt(&ADCD2, isr);
 
   OSAL_IRQ_EPILOGUE();
 }
-#endif /* STM32_ADC_USE_ADC4 */
+#endif /* STM32_ADC_USE_ADC2 */
 
 #if STM32_ADC_USE_ADC3 || defined(__DOXYGEN__)
 /**

--- a/os/hal/ports/STM32/LLD/ADCv7/hal_adc_lld.c
+++ b/os/hal/ports/STM32/LLD/ADCv7/hal_adc_lld.c
@@ -293,7 +293,9 @@ OSAL_IRQ_HANDLER(STM32_ADC2_HANDLER) {
 
   isr  = ADC2->ISR;
   ADC2->ISR = isr;
-
+#if defined(STM32_ADC_ADC2_IRQ_HOOK)
+  STM32_ADC_ADC2_IRQ_HOOK
+#endif
   adc_lld_serve_interrupt(&ADCD1, isr);
 
   OSAL_IRQ_EPILOGUE();

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: Missing STM32_ADC_ADC2_IRQ_HOOK invocations in the STM32 ADCv6 and
+       ADCv7 drivers (forum bug report).
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3)
        (backported to 21.11.6).

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ See .devcontainer/README.md for included tools and usage.
 
 *** Next ***
 - FIX: Missing STM32_ADC_ADC2_IRQ_HOOK invocations in the STM32 ADCv6 and
-       ADCv7 drivers (forum bug report).
+       ADCv7 drivers (forum bug report, github PR #11).
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3)
        (backported to 21.11.6).


### PR DESCRIPTION
🤖 chibios-sheriff — PR authored from a forum bug report (advisory; review and merge decisions stay with human maintainers)

## Summary

Adds the missing `STM32_ADC_ADC2_IRQ_HOOK` invocations in the STM32 ADCv6 and ADCv7 drivers: the ADC2 interrupt handlers (dual-mode slave and standalone) did not invoke the hook, unlike all other ADC instances in the same drivers. Also fixes a wrong `#endif` comment in ADCv6 (`USE_ADC4` closing the `USE_ADC2` conditional).

Origin: forum bug report by **drizzi** (https://forum.chibios.org/viewtopic.php?t=6685). The report named ADCv3/ADC4/ADC5 — those are actually covered in the current tree; the audit it prompted found the ADC2 gaps above instead (full ADCv1–v7 hook sweep done).

## Related

- Issue(s): forum bug report https://forum.chibios.org/viewtopic.php?t=6685
- Notes for reviewers: out of scope but recorded — ADCv6 allows `STM32_ADC_USE_ADC2` together with `STM32_ADC_DUAL_MODE`, which would define `STM32_ADC2_HANDLER` twice; ADCv7 guards the standalone handler with `&& !STM32_ADC_DUAL_MODE`, ADCv6 does not. Left for a separate change.

## Target Branch Check

- [x] This PR targets `main` — all changes land on `main` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `main`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant (full hook inventory of ADCv1–v7; ADCv6 = STM32H5, ADCv7 = STM32U3/U5)

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files (changed lines clean; 4 pre-existing findings in ADCv6 untouched)
- [x] Build check passed (ARM target compiles, see Testing)

## Testing

- [x] Test run successfully locally: `testhal/STM32/multi/ADC` for STM32H563 (ADCv6) and STM32U385 (ADCv7), stock plus three configurations with the hook defined (H5 standalone ADC2, H5 dual mode, U3 dual mode)
- Any other tests run on a device? No — compile-level change (hook is preprocessed out unless user-defined)

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
