### PR TITLE
STM32C0xx: add SPI2 RCC macros and DMAMUX identifiers

### DIFF
--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32c071rb_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32c071rb_nucleo64/mcuconf.h
@@ -183,10 +183,15 @@
  * SPI driver system settings.
  */
 #define STM32_SPI_USE_SPI1                  FALSE
+#define STM32_SPI_USE_SPI2                  FALSE
 #define STM32_SPI_SPI1_RX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
 #define STM32_SPI_SPI1_TX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
+#define STM32_SPI_SPI2_RX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
+#define STM32_SPI_SPI2_TX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
 #define STM32_SPI_SPI1_DMA_PRIORITY         1
+#define STM32_SPI_SPI2_DMA_PRIORITY         1
 #define STM32_SPI_SPI1_IRQ_PRIORITY         2
+#define STM32_SPI_SPI2_IRQ_PRIORITY         2
 #define STM32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
 
 /*

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32c071rb_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32c071rb_nucleo64/mcuconf.h
@@ -183,10 +183,15 @@
  * SPI driver system settings.
  */
 #define STM32_SPI_USE_SPI1                  FALSE
+#define STM32_SPI_USE_SPI2                  FALSE
 #define STM32_SPI_SPI1_RX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
 #define STM32_SPI_SPI1_TX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
+#define STM32_SPI_SPI2_RX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
+#define STM32_SPI_SPI2_TX_DMA_STREAM        STM32_DMA_STREAM_ID_ANY
 #define STM32_SPI_SPI1_DMA_PRIORITY         1
+#define STM32_SPI_SPI2_DMA_PRIORITY         1
 #define STM32_SPI_SPI1_IRQ_PRIORITY         2
+#define STM32_SPI_SPI2_IRQ_PRIORITY         2
 #define STM32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
 
 /*

--- a/os/hal/ports/STM32/STM32C0xx/stm32_dmamux.h
+++ b/os/hal/ports/STM32/STM32C0xx/stm32_dmamux.h
@@ -42,6 +42,8 @@
 #define STM32_DMAMUX1_I2C1_TX       11
 #define STM32_DMAMUX1_SPI1_RX       16
 #define STM32_DMAMUX1_SPI1_TX       17
+#define STM32_DMAMUX1_SPI2_RX       18
+#define STM32_DMAMUX1_SPI2_TX       19
 #define STM32_DMAMUX1_TIM1_CH1      20
 #define STM32_DMAMUX1_TIM1_CH2      21
 #define STM32_DMAMUX1_TIM1_CH3      22

--- a/os/hal/ports/STM32/STM32C0xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32C0xx/stm32_rcc.h
@@ -412,6 +412,29 @@
  * @api
  */
 #define rccResetSPI1() rccResetAPBR2(RCC_APBRSTR2_SPI1RST)
+
+/**
+ * @brief   Enables the SPI2 peripheral clock.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableSPI2(lp) rccEnableAPBR1(RCC_APBENR1_SPI2EN, lp)
+
+/**
+ * @brief   Disables the SPI2 peripheral clock.
+ *
+ * @api
+ */
+#define rccDisableSPI2() rccDisableAPBR1(RCC_APBENR1_SPI2EN)
+
+/**
+ * @brief   Resets the SPI2 peripheral.
+ *
+ * @api
+ */
+#define rccResetSPI2() rccResetAPBR1(RCC_APBRSTR1_SPI2RST)
 /** @} */
 
 /**

--- a/os/xhal/ports/STM32/STM32C0xx/stm32_dmamux.h
+++ b/os/xhal/ports/STM32/STM32C0xx/stm32_dmamux.h
@@ -42,6 +42,8 @@
 #define STM32_DMAMUX1_I2C1_TX       11
 #define STM32_DMAMUX1_SPI1_RX       16
 #define STM32_DMAMUX1_SPI1_TX       17
+#define STM32_DMAMUX1_SPI2_RX       18
+#define STM32_DMAMUX1_SPI2_TX       19
 #define STM32_DMAMUX1_TIM1_CH1      20
 #define STM32_DMAMUX1_TIM1_CH2      21
 #define STM32_DMAMUX1_TIM1_CH3      22

--- a/os/xhal/ports/STM32/STM32C0xx/stm32_rcc.h
+++ b/os/xhal/ports/STM32/STM32C0xx/stm32_rcc.h
@@ -412,6 +412,29 @@
  * @api
  */
 #define rccResetSPI1() rccResetAPBR2(RCC_APBRSTR2_SPI1RST)
+
+/**
+ * @brief   Enables the SPI2 peripheral clock.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableSPI2(lp) rccEnableAPBR1(RCC_APBENR1_SPI2EN, lp)
+
+/**
+ * @brief   Disables the SPI2 peripheral clock.
+ *
+ * @api
+ */
+#define rccDisableSPI2() rccDisableAPBR1(RCC_APBENR1_SPI2EN)
+
+/**
+ * @brief   Resets the SPI2 peripheral.
+ *
+ * @api
+ */
+#define rccResetSPI2() rccResetAPBR1(RCC_APBRSTR1_SPI2RST)
 /** @} */
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -83,7 +83,7 @@ See .devcontainer/README.md for included tools and usage.
 *** Next ***
 - FIX: Missing SPI2 RCC macros and DMAMUX identifiers in the STM32C0xx
        port, SPI2 was unusable on the devices that have it (forum bug
-       report).
+       report, github PR #12).
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3)
        (backported to 21.11.6).

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ See .devcontainer/README.md for included tools and usage.
 
 *** Next ***
 - FIX: Missing SPI2 RCC macros and DMAMUX identifiers in the STM32C0xx
-       port, SPI2 was unusable on the devices that have it (forum bug
+       HAL and XHAL ports, SPI2 was unusable on the devices that have it (forum bug
        report, github PR #12).
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3)

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: Missing SPI2 RCC macros and DMAMUX identifiers in the STM32C0xx
+       port, SPI2 was unusable on the devices that have it (forum bug
+       report).
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3)
        (backported to 21.11.6).


### PR DESCRIPTION
🤖 chibios-sheriff — PR authored from a forum bug report (advisory; review and merge decisions stay with human maintainers)

## Summary

Adds the missing SPI2 support pieces in the STM32C0xx port: `rccEnableSPI2()`/`rccDisableSPI2()`/`rccResetSPI2()` in `stm32_rcc.h` and the SPI2 DMAMUX request identifiers (18/19) in `stm32_dmamux.h`. The registry already enables SPI2 on C051/C071/C091/C092, but `STM32_SPI_USE_SPI2` failed to compile with exactly these identifiers missing.

Origin: forum bug report by **geoffrey.brown** (https://forum.chibios.org/viewtopic.php?t=6679), who also supplied the RCC macros.

Verification: RCC bits checked against the CMSIS header (`RCC_APBENR1_SPI2EN`, `RCC_APBRSTR1_SPI2RST`); DMAMUX inputs 18/19 checked against RM0490 Table 49 and the STM32G0xx port. A C071 application with `STM32_SPI_USE_SPI2=TRUE` builds clean on this branch and fails on unpatched `main` with the three missing identifiers.

## Related

- Issue(s): forum bug report https://forum.chibios.org/viewtopic.php?t=6679
- Notes for reviewers:
  - The other half of the report is in the FTL templates: `mcuconf_stm32c071xx/mcuconf.h.ftl` lists only SPI1 — follow-up PR planned in the chibios-ftl repository.
  - Recorded, out of scope: `stm32_dmamux.h` is also missing I2C2 (12/13) and USART3/4 (54–57) identifiers used by newer C0 family members (C071 registry already claims `STM32_HAS_I2C2 TRUE`) — candidate for a separate audit/fix.

## Target Branch Check

- [x] This PR targets `main` — all changes land on `main` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `main`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant (STM32C0xx only; additive macros)

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files
- [x] Build check passed (ARM target compile, see Testing)

## Testing

- [x] Test run successfully locally: C071 build with SPI driver + SPI2 enabled (positive), unpatched-tree negative proof
- Any other tests run on a device? No hardware at hand — compile-level enablement; the macros mirror the verified register map

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
