### PR TITLE
STM32G4xx: add FSMC clock and IRQ definitions

### DIFF
--- a/os/hal/ports/STM32/STM32G4xx/stm32_isr.h
+++ b/os/hal/ports/STM32/STM32G4xx/stm32_isr.h
@@ -171,6 +171,13 @@
 #define STM32_FDCAN3_IT1_NUMBER             89
 
 /*
+ * FSMC unit.
+ */
+#define STM32_FSMC_HANDLER                  Vector100
+
+#define STM32_FSMC_NUMBER                   48
+
+/*
  * I2C units.
  */
 #define STM32_I2C1_EV_HANDLER               VectorBC

--- a/os/hal/ports/STM32/STM32G4xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32G4xx/stm32_rcc.h
@@ -565,6 +565,34 @@
 /** @} */
 
 /**
+ * @name    FSMC peripherals specific RCC operations
+ * @{
+ */
+/**
+ * @brief   Enables the FSMC peripheral clock.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableFSMC(lp) rccEnableAHB3(RCC_AHB3ENR_FMCEN, lp)
+
+/**
+ * @brief   Disables the FSMC peripheral clock.
+ *
+ * @api
+ */
+#define rccDisableFSMC() rccDisableAHB3(RCC_AHB3ENR_FMCEN)
+
+/**
+ * @brief   Resets the FSMC peripheral.
+ *
+ * @api
+ */
+#define rccResetFSMC() rccResetAHB3(RCC_AHB3RSTR_FMCRST)
+/** @} */
+
+/**
  * @name    PWR interface specific RCC operations
  * @{
  */

--- a/os/hal/ports/STM32/STM32G4xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32G4xx/stm32_registry.h
@@ -328,7 +328,7 @@
 #define STM32_HAS_DMA2D                     FALSE
 
 /* FSMC attributes.*/
-#define STM32_HAS_FSMC                      FALSE
+#define STM32_HAS_FSMC                      TRUE
 
 /* CRC attributes.*/
 #define STM32_HAS_CRC                       TRUE

--- a/os/hal/ports/STM32/STM32G4xx_OLD/stm32_isr.h
+++ b/os/hal/ports/STM32/STM32G4xx_OLD/stm32_isr.h
@@ -171,6 +171,13 @@
 #define STM32_FDCAN3_IT1_NUMBER             89
 
 /*
+ * FSMC unit.
+ */
+#define STM32_FSMC_HANDLER                  Vector100
+
+#define STM32_FSMC_NUMBER                   48
+
+/*
  * I2C units.
  */
 #define STM32_I2C1_EV_HANDLER               VectorBC

--- a/os/hal/ports/STM32/STM32G4xx_OLD/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32G4xx_OLD/stm32_rcc.h
@@ -565,6 +565,34 @@
 /** @} */
 
 /**
+ * @name    FSMC peripherals specific RCC operations
+ * @{
+ */
+/**
+ * @brief   Enables the FSMC peripheral clock.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableFSMC(lp) rccEnableAHB3(RCC_AHB3ENR_FMCEN, lp)
+
+/**
+ * @brief   Disables the FSMC peripheral clock.
+ *
+ * @api
+ */
+#define rccDisableFSMC() rccDisableAHB3(RCC_AHB3ENR_FMCEN)
+
+/**
+ * @brief   Resets the FSMC peripheral.
+ *
+ * @api
+ */
+#define rccResetFSMC() rccResetAHB3(RCC_AHB3RSTR_FMCRST)
+/** @} */
+
+/**
  * @name    PWR interface specific RCC operations
  * @{
  */

--- a/os/hal/ports/STM32/STM32G4xx_OLD/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32G4xx_OLD/stm32_registry.h
@@ -328,7 +328,7 @@
 #define STM32_HAS_DMA2D                     FALSE
 
 /* FSMC attributes.*/
-#define STM32_HAS_FSMC                      FALSE
+#define STM32_HAS_FSMC                      TRUE
 
 /* CRC attributes.*/
 #define STM32_HAS_CRC                       TRUE

--- a/os/hal/ports/STM32/STM32G4xx_TEST/stm32_isr.h
+++ b/os/hal/ports/STM32/STM32G4xx_TEST/stm32_isr.h
@@ -171,6 +171,13 @@
 #define STM32_FDCAN3_IT1_NUMBER             89
 
 /*
+ * FSMC unit.
+ */
+#define STM32_FSMC_HANDLER                  Vector100
+
+#define STM32_FSMC_NUMBER                   48
+
+/*
  * I2C units.
  */
 #define STM32_I2C1_EV_HANDLER               VectorBC

--- a/os/hal/ports/STM32/STM32G4xx_TEST/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32G4xx_TEST/stm32_rcc.h
@@ -565,6 +565,34 @@
 /** @} */
 
 /**
+ * @name    FSMC peripherals specific RCC operations
+ * @{
+ */
+/**
+ * @brief   Enables the FSMC peripheral clock.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableFSMC(lp) rccEnableAHB3(RCC_AHB3ENR_FMCEN, lp)
+
+/**
+ * @brief   Disables the FSMC peripheral clock.
+ *
+ * @api
+ */
+#define rccDisableFSMC() rccDisableAHB3(RCC_AHB3ENR_FMCEN)
+
+/**
+ * @brief   Resets the FSMC peripheral.
+ *
+ * @api
+ */
+#define rccResetFSMC() rccResetAHB3(RCC_AHB3RSTR_FMCRST)
+/** @} */
+
+/**
  * @name    PWR interface specific RCC operations
  * @{
  */

--- a/os/hal/ports/STM32/STM32G4xx_TEST/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32G4xx_TEST/stm32_registry.h
@@ -328,7 +328,7 @@
 #define STM32_HAS_DMA2D                     FALSE
 
 /* FSMC attributes.*/
-#define STM32_HAS_FSMC                      FALSE
+#define STM32_HAS_FSMC                      TRUE
 
 /* CRC attributes.*/
 #define STM32_HAS_CRC                       TRUE

--- a/os/xhal/ports/STM32/STM32G4xx/stm32_isr.h
+++ b/os/xhal/ports/STM32/STM32G4xx/stm32_isr.h
@@ -182,6 +182,13 @@
 #define STM32_FDCAN3_IT1_NUMBER             89
 
 /*
+ * FSMC unit.
+ */
+#define STM32_FSMC_HANDLER                  Vector100
+
+#define STM32_FSMC_NUMBER                   48
+
+/*
  * I2C units.
  */
 #define STM32_I2C1_EV_HANDLER               VectorBC

--- a/os/xhal/ports/STM32/STM32G4xx/stm32_rcc.h
+++ b/os/xhal/ports/STM32/STM32G4xx/stm32_rcc.h
@@ -565,6 +565,34 @@
 /** @} */
 
 /**
+ * @name    FSMC peripherals specific RCC operations
+ * @{
+ */
+/**
+ * @brief   Enables the FSMC peripheral clock.
+ *
+ * @param[in] lp        low power enable flag
+ *
+ * @api
+ */
+#define rccEnableFSMC(lp) rccEnableAHB3(RCC_AHB3ENR_FMCEN, lp)
+
+/**
+ * @brief   Disables the FSMC peripheral clock.
+ *
+ * @api
+ */
+#define rccDisableFSMC() rccDisableAHB3(RCC_AHB3ENR_FMCEN)
+
+/**
+ * @brief   Resets the FSMC peripheral.
+ *
+ * @api
+ */
+#define rccResetFSMC() rccResetAHB3(RCC_AHB3RSTR_FMCRST)
+/** @} */
+
+/**
  * @name    PWR interface specific RCC operations
  * @{
  */

--- a/os/xhal/ports/STM32/STM32G4xx/stm32_registry.h
+++ b/os/xhal/ports/STM32/STM32G4xx/stm32_registry.h
@@ -317,7 +317,7 @@
 #define STM32_HAS_DMA2D                     FALSE
 
 /* FSMC attributes.*/
-#define STM32_HAS_FSMC                      FALSE
+#define STM32_HAS_FSMC                      TRUE
 
 /* CRC attributes.*/
 #define STM32_HAS_CRC                       TRUE

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- NEW: STM32G4xx: added FSMC RCC macros, IRQ vector definitions and
+       registry switch for the FMC-capable devices (G473/G483/G474/G484),
+       in all four G4 port copies (github PR #14).
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3)
        (backported to 21.11.6).


### PR DESCRIPTION
🤖 This PR was prepared by the ChibiOS sheriff (assistant-operated account) on the maintainer's direction.

Retarget of #7 to `main`, as offered there and accepted by @alex31 ([comment](https://github.com/chibios-upstream/chibios/pull/7#issuecomment-4639664341)). Authorship of the change is preserved (commit author: Alexandre Bustico).

Adaptations vs the original stable-21.11.x patch:
- Applied to **all four** G4 port copies on main: `os/hal/ports/STM32/{STM32G4xx, STM32G4xx_OLD, STM32G4xx_TEST}` and `os/xhal/ports/STM32/STM32G4xx`.
- The vector defines (`STM32_FSMC_HANDLER` = Vector100, `STM32_FSMC_NUMBER` = 48) are **unconditional** per maintainer guidance; device scoping is provided by the registry instead.
- `STM32_HAS_FSMC` is set to `TRUE` only in the G473/G483/G474/G484 registry block (main's registry is per-device); all other G4 devices keep `FALSE`.
- Changelog entry added to `readme.txt`.

Verification:
- `demos/STM32/NIL-STM32G474RE-NUCLEO64` (classic HAL) and `demos/STM32/RT-XHAL-STM32G474RE-NUCLEO64` (XHAL) build clean.
- Positive/negative compile proof: a TU exercising all five new identifiers (including a real `OSAL_IRQ_HANDLER(STM32_FSMC_HANDLER)`) compiles on the patched tree for both HALs and fails on unpatched `main` with exactly those identifiers undefined.
- IRQ number 48 / Vector100 verified against the in-tree G4 CMSIS headers.
- stylecheck: changed lines clean (the pre-existing registry findings are untouched).

After this lands, #7 remains the basis for the stable-21.11.x backport.