### PR TITLE
STM32U0xx: fix RTC EXTI-clear system halt on first alarm/tamper event

### DIFF
--- a/os/hal/ports/STM32/STM32U0xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U0xx/stm32_registry.h
@@ -62,10 +62,14 @@
                    EXTI_MODE_RISING_EDGE | EXTI_MODE_ACTION_INTERRUPT);     \
 } while (false)
 
-/* Clearing EXTI interrupts. */
+/* Clearing EXTI interrupts. The RTC and TAMP EXTI lines are direct event
+   inputs on STM32U0 (marked fixed in STM32_EXTI_IMR1_MASK): no EXTI pending
+   bit, the source flags are cleared in the RTC peripheral. Masking out the
+   fixed lines makes this a no-op here and keeps the extiClearGroup1() guard.*/
 #define STM32_RTC_CLEAR_ALL_EXTI() do {                                     \
-  extiClearGroup1(EXTI_MASK1(STM32_RTC_EVENT_RTC_EXTI) |                    \
-                  EXTI_MASK1(STM32_RTC_EVENT_TAMP_EXTI));                   \
+  extiClearGroup1((EXTI_MASK1(STM32_RTC_EVENT_RTC_EXTI) |                   \
+                   EXTI_MASK1(STM32_RTC_EVENT_TAMP_EXTI)) &                 \
+                  ~STM32_EXTI_IMR1_MASK);                                   \
 } while (false)
 
 /* Masks used to preserve state of RTC and TAMP register reserved bits. */

--- a/os/xhal/ports/STM32/STM32U0xx/stm32_registry.h
+++ b/os/xhal/ports/STM32/STM32U0xx/stm32_registry.h
@@ -62,10 +62,14 @@
                    EXTI_MODE_RISING_EDGE | EXTI_MODE_ACTION_INTERRUPT);     \
 } while (false)
 
-/* Clearing EXTI interrupts. */
+/* Clearing EXTI interrupts. The RTC and TAMP EXTI lines are direct event
+   inputs on STM32U0 (marked fixed in STM32_EXTI_IMR1_MASK): no EXTI pending
+   bit, the source flags are cleared in the RTC peripheral. Masking out the
+   fixed lines makes this a no-op here and keeps the extiClearGroup1() guard.*/
 #define STM32_RTC_CLEAR_ALL_EXTI() do {                                     \
-  extiClearGroup1(EXTI_MASK1(STM32_RTC_EVENT_RTC_EXTI) |                    \
-                  EXTI_MASK1(STM32_RTC_EVENT_TAMP_EXTI));                   \
+  extiClearGroup1((EXTI_MASK1(STM32_RTC_EVENT_RTC_EXTI) |                   \
+                   EXTI_MASK1(STM32_RTC_EVENT_TAMP_EXTI)) &                 \
+                  ~STM32_EXTI_IMR1_MASK);                                   \
 } while (false)
 
 /* Masks used to preserve state of RTC and TAMP register reserved bits. */

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,12 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: STM32U0xx RTC alarm/tamper interrupt could halt the system on the
+       first event (assertions enabled): rtc_lld_serve_interrupt() cleared
+       the RTC/TAMP EXTI lines, which are direct event inputs on STM32U0
+       (no EXTI pending bit) and tripped the extiClearGroup1() fixed-lines
+       assertion. The clear now masks out the direct lines (HAL and XHAL
+       ports). Same defect as the STM32H5 fix in #15 (github PR #16).
 - FIX: STM32H5xx RTC alarm/tamper interrupt caused a system halt on the
        first event: rtc_lld_serve_interrupt() cleared the RTC/TAMP EXTI
        lines, which are direct event inputs on STM32H5 (no EXTI pending


### PR DESCRIPTION
🤖 Prepared by the ChibiOS sheriff (assistant-operated account) on the maintainer's direction.

The STM32U0 counterpart of #15, found by the cross-port sweep done while fixing that one.

### Root cause
On STM32U0 the RTC and TAMP EXTI lines (20, 21) are **direct event inputs** — marked fixed in `STM32_EXTI_IMR1_MASK` (`0xFFF80000`), no EXTI pending bit, source flags cleared in the RTC peripheral (`RTC->SCR`). `rtc_lld_serve_interrupt()` (RTCv3) calls `STM32_RTC_CLEAR_ALL_EXTI()`, which passes those lines to `extiClearGroup1()`; the fixed-lines assertion then halts the system on the first RTC event **when assertions are enabled** (`CH_DBG_ENABLE_ASSERTS`). Identical mechanism to the STM32H5 case in #15.

### Fix
`STM32_RTC_CLEAR_ALL_EXTI()` masks out the fixed lines (`& ~STM32_EXTI_IMR1_MASK`), mirroring `extiEnableGroup1()` — a no-op for direct lines, with the `extiClearGroup1()` guard preserved. HAL and XHAL U0 ports.

### Verification (on hardware, NUCLEO-U083RC)
Using the existing `stm32u083rc_nucleo64` target in `testhal/STM32/multi/RTC`:
- Patched build dispatches the RTC **Alarm A** and **Alarm B** callbacks repeatedly (~30 s apart), with **no halt and no interrupt storm** — confirming the masked-out lines are direct event inputs that need no EXTI clearing.
- Classic HAL target HW-verified; XHAL U0 (`RT-XHAL-STM32-MULTI` u083rc) builds; stylecheck clean on changed lines.