### PR TITLE
STM32U0/U3 configs: regenerate with STM32_ST_FREQUENCY_TOLERANCE=5

### DIFF
--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u083rc_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u083rc_nucleo64/mcuconf.h
@@ -216,6 +216,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SERIAL driver system settings.
@@ -264,6 +267,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32u083rc_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32u083rc_nucleo64/mcuconf.h
@@ -216,6 +216,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SERIAL driver system settings.
@@ -264,6 +267,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32u083rc_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32u083rc_nucleo64/xmcuconf.h
@@ -256,6 +256,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32u385rg_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32u385rg_nucleo64/xmcuconf.h
@@ -332,6 +332,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32u083rc_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32u083rc_nucleo64/xmcuconf.h
@@ -256,6 +256,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32u385rg_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32u385rg_nucleo64/xmcuconf.h
@@ -332,6 +332,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32u083rc_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32u083rc_nucleo64/mcuconf.h
@@ -267,6 +267,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -341,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testrt/FPU_STORM/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/testrt/FPU_STORM/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testrt/FPU_STORM/cfg/stm32u385rg_nucleo64_alt/mcuconf.h
+++ b/testrt/FPU_STORM/cfg/stm32u385rg_nucleo64_alt/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testrt/VT_STORM/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/testrt/VT_STORM/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testrt/WKP_STORM/cfg/stm32u385rg_nucleo64/mcuconf.h
+++ b/testrt/WKP_STORM/cfg/stm32u385rg_nucleo64/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.

--- a/testrt/WKP_STORM/cfg/stm32u385rg_nucleo64_alt/mcuconf.h
+++ b/testrt/WKP_STORM/cfg/stm32u385rg_nucleo64_alt/mcuconf.h
@@ -284,6 +284,9 @@
 /*
  * RTC driver system settings.
  */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
 
 /*
  * SDC driver system settings.
@@ -338,6 +341,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        5
 
 /*
  * TRNG driver system settings.


### PR DESCRIPTION
Stage 2/3 of the SYSTICKv1 ST-tolerance fix (Stage 1 = #17, merged `275aae19`; templates = chibios-ftl #2, merged).

Regenerates the in-tree **STM32U0** and **STM32U3** `mcuconf.h`/`xmcuconf.h` configs to carry `STM32_ST_FREQUENCY_TOLERANCE = 5` (0.5%), and bumps the `tools/ftl` submodule to the merged template change.

**Why U0/U3 only:** both clock the system from the MSI PLL using accurate (non-round) MSI frequencies, so SYSCLK is not an exact multiple of the kernel tick and the free running ST timer can't divide it exactly. With asserts enabled `st_lld_init()` halts on "clock rounding error". The 0.5% tolerance accepts the <0.02% rounding; the driver default stays strict (`0`) for every other family.

**Scope notes**
- 17 configs regenerated (`u073xx` + `u375xx`, classic + XHAL) via `tools/updater`. Configs that lacked the RTC default block pick up `STM32_RTC_PRESA/PRESS/CR_INIT` as a faithful re-render.
- The experimental `u385rg_nucleo64_clocktree` config is intentionally **not** regenerated (different `STM32_CFG_*` clock-tree scheme).
- The `tools/ftl` bump (`6357e6e9 → e697bf98`) spans chibios-ftl #2 (tolerance, consumed here) **and** #1 (C071 SPI2 templates) — both already merged on ftl main; the C071 templates are inert until chibios #12 lands.

**Verification:** stylecheck clean on all 17 configs; STM32U3 RTC testhal target builds clean against the merged driver; U3 confirmed on the MSI-PLL path (`MSIRC0_PLL_LSE`). Regen is idempotent against the merged templates. Stage-1 behaviour HW-verified on NUCLEO-U083RC in #17.

Sheriff-authored; for human review/merge.