### PR TITLE
configs: tree-wide mcuconf/xmcuconf regeneration pass

### DIFF
--- a/demos/STM32/CMSIS-STM32F407-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/CMSIS-STM32F407-DISCOVERY/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/HAL-STM32F407-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/HAL-STM32F407-DISCOVERY/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/NASA-OSAL-STM32F407-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/NASA-OSAL-STM32F407-DISCOVERY/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/NASA-OSAL-STM32F746G-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/NASA-OSAL-STM32F746G-DISCOVERY/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/NIL-STM32C031C6-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/NIL-STM32C031C6-NUCLEO64/cfg/mcuconf.h
@@ -192,6 +192,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  16
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/NIL-STM32F303-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/NIL-STM32F303-DISCOVERY/cfg/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/NIL-STM32F746G-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/NIL-STM32F746G-DISCOVERY/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/NIL-STM32G071RB-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/NIL-STM32G071RB-NUCLEO64/cfg/mcuconf.h
@@ -229,6 +229,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/NIL-STM32G474RE-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/NIL-STM32G474RE-NUCLEO64/cfg/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/NIL-STM32H755ZI-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/NIL-STM32H755ZI-NUCLEO144/cfg/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/NIL-STM32L476-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/NIL-STM32L476-DISCOVERY/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-RUST-STM32G474RE-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-RUST-STM32G474RE-NUCLEO64/cfg/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-LWIP-FATFS-USB-HTTPS/cfg/stm32f746_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP-FATFS-USB-HTTPS/cfg/stm32f746_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32f407_olimex/mcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32f407_olimex/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32f746_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32f746_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32f769_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32f769_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32h735ig_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP-FATFS-USB/cfg/stm32h735ig_discovery/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-LWIP/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-LWIP/cfg/stm32h563zi_nucleo144_xhal/xmcuconf.h
+++ b/demos/STM32/RT-STM32-LWIP/cfg/stm32h563zi_nucleo144_xhal/xmcuconf.h
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32c011f6_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32c011f6_discovery/mcuconf.h
@@ -192,6 +192,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  16
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32c031c6_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32c031c6_nucleo64/mcuconf.h
@@ -192,6 +192,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  16
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32g031k8_nucleo32/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32g031k8_nucleo32/mcuconf.h
@@ -201,6 +201,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32g071rb_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32g071rb_nucleo64/mcuconf.h
@@ -229,6 +229,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32g0b0re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32g0b0re_nucleo64/mcuconf.h
@@ -228,6 +228,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  3
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32g0b1re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32g0b1re_nucleo64/mcuconf.h
@@ -259,6 +259,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32g431rb_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32g431rb_nucleo64/mcuconf.h
@@ -293,6 +293,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h503rb_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h503rb_nucleo64/mcuconf.h
@@ -283,6 +283,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h723zg_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h723zg_nucleo144/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h735ig_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h735ig_discovery/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h743zi_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h743zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h750xb_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h750xb_discovery/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h755zi_m4_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h755zi_m4_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h755zi_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h755zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32h7a3ziq_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32h7a3ziq_nucleo144/mcuconf.h
@@ -426,6 +426,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32l4p5zg_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32l4p5zg_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32l4r5zi_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32l4r5zi_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32l4r9_discovery/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32l4r9_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32c031c6_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32c031c6_nucleo64/mcuconf.h
@@ -192,6 +192,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  16
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32g0b0re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32g0b0re_nucleo64/mcuconf.h
@@ -228,6 +228,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  3
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32g0b1re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32g0b1re_nucleo64/mcuconf.h
@@ -259,6 +259,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32-XSHELL/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-XSHELL/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32F303-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F303-DISCOVERY/cfg/mcuconf.h
@@ -254,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F303RE-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F303RE-NUCLEO64/cfg/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F303ZE-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F303ZE-NUCLEO144/cfg/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F401C-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F401C-DISCOVERY/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F401D-BLACK-PILL/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F401D-BLACK-PILL/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F401RE-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F401RE-NUCLEO64/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F407-DISCOVERY-G++/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F407-DISCOVERY-G++/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F407-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F407-DISCOVERY/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F410RB-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F410RB-NUCLEO64/cfg/mcuconf.h
@@ -221,6 +221,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  5
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F411RE-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F411RE-NUCLEO64/cfg/mcuconf.h
@@ -218,6 +218,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F412ZG-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F412ZG-NUCLEO144/cfg/mcuconf.h
@@ -262,6 +262,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F413ZH-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F413ZH-NUCLEO144/cfg/mcuconf.h
@@ -303,6 +303,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F429-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F429-DISCOVERY/cfg/mcuconf.h
@@ -315,6 +315,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F429ZI-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F429ZI-NUCLEO144/cfg/mcuconf.h
@@ -315,6 +315,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F446RE-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F446RE-NUCLEO64/cfg/mcuconf.h
@@ -324,6 +324,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F446ZE-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F446ZE-NUCLEO144/cfg/mcuconf.h
@@ -324,6 +324,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F469I-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F469I-DISCOVERY/cfg/mcuconf.h
@@ -321,6 +321,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F469I-EVAL-SDP-CK1Z/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F469I-EVAL-SDP-CK1Z/cfg/mcuconf.h
@@ -321,6 +321,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-STM32F722ZE-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F722ZE-NUCLEO144/cfg/mcuconf.h
@@ -342,6 +342,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32F746G-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F746G-DISCOVERY/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32F746ZG-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F746ZG-NUCLEO144/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32F756ZG-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F756ZG-NUCLEO144/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32F767ZI-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F767ZI-NUCLEO144/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32F769I-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32F769I-DISCOVERY/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32G474RE-DISCOVERY-DPOW1/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32G474RE-DISCOVERY-DPOW1/cfg/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_NOSWITCH/cfg/xmcuconf.h
+++ b/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_NOSWITCH/cfg/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_SWITCHED/cfg/xmcuconf.h
+++ b/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_SWITCHED/cfg/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-STM32H563ZI-NUCLEO144-SB_HOST_SWITCHED/cfg/xmcuconf.h
+++ b/demos/STM32/RT-STM32H563ZI-NUCLEO144-SB_HOST_SWITCHED/cfg/xmcuconf.h
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-STM32L053-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L053-DISCOVERY/cfg/mcuconf.h
@@ -190,6 +190,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L053R8-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L053R8-NUCLEO64/cfg/mcuconf.h
@@ -190,6 +190,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L073RZ-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L073RZ-NUCLEO64/cfg/mcuconf.h
@@ -205,6 +205,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L432KC-NUCLEO32/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L432KC-NUCLEO32/cfg/mcuconf.h
@@ -229,6 +229,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L452RE-NUCLEO64-P/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L452RE-NUCLEO64-P/cfg/mcuconf.h
@@ -263,6 +263,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L476-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L476-DISCOVERY/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L476RG-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L476RG-NUCLEO64/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L496ZG-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L496ZG-NUCLEO144/cfg/mcuconf.h
@@ -307,6 +307,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L4P5ZG-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L4P5ZG-NUCLEO144/cfg/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L4R5ZI-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L4R5ZI-NUCLEO144/cfg/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_DYNAMIC_RAMBOX/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_DYNAMIC_RAMBOX/cfg/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_STATIC_RAMBOX/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_STATIC_RAMBOX/cfg/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L4R9-DISCOVERY/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L4R9-DISCOVERY/cfg/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L552ZE-NUCLEO144-TZ_GUEST/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L552ZE-NUCLEO144-TZ_GUEST/cfg/mcuconf.h
@@ -277,6 +277,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               3
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L552ZE-NUCLEO144-TZ_HOST/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L552ZE-NUCLEO144-TZ_HOST/cfg/mcuconf.h
@@ -277,6 +277,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               1
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32L552ZE-NUCLEO144/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32L552ZE-NUCLEO144/cfg/mcuconf.h
@@ -277,6 +277,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               4
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32WB55CG-NUCLEO48_USB/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32WB55CG-NUCLEO48_USB/cfg/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32WB55RG-NUCLEO68/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32WB55RG-NUCLEO68/cfg/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-STM32WL55JC-NUCLEO64/cfg/mcuconf.h
+++ b/demos/STM32/RT-STM32WL55JC-NUCLEO64/cfg/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-CHFS/cfg/stm32f407zg_olimex/mcuconf.h
+++ b/demos/STM32/RT-VFS-CHFS/cfg/stm32f407zg_olimex/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-VFS-CHFS/cfg/stm32f769ni_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-CHFS/cfg/stm32f769ni_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-CHFS/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-VFS-CHFS/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-CHFS/cfg/stm32h735ig_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-CHFS/cfg/stm32h735ig_discovery/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-CHFS/cfg/stm32l4r9ai_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-CHFS/cfg/stm32l4r9ai_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-FATFS/cfg/stm32f407zg_olimex/mcuconf.h
+++ b/demos/STM32/RT-VFS-FATFS/cfg/stm32f407zg_olimex/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/demos/STM32/RT-VFS-FATFS/cfg/stm32f769ni_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-FATFS/cfg/stm32f769ni_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-FATFS/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/demos/STM32/RT-VFS-FATFS/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-FATFS/cfg/stm32h735ig_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-FATFS/cfg/stm32h735ig_discovery/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-FATFS/cfg/stm32l4r9ai_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-FATFS/cfg/stm32l4r9ai_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-LITTLEFS/cfg/stm32l476vg_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-LITTLEFS/cfg/stm32l476vg_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-VFS-LITTLEFS/cfg/stm32l4r9ai_discovery/mcuconf.h
+++ b/demos/STM32/RT-VFS-LITTLEFS/cfg/stm32l4r9ai_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32c031c6_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32c031c6_nucleo64/xmcuconf.h
@@ -186,6 +186,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  16
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * WDG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32g071rb_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32g071rb_nucleo64/xmcuconf.h
@@ -220,6 +220,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -19,7 +19,7 @@
  * The following settings override the default settings present in
  * the various device driver implementation headers.
  * Note that the settings for each driver only have effect if the whole
- * driver is enabled in xhalconf.h.
+ * driver is enabled in halconf.h.
  *
  * IRQ priorities:
  * 15...0       Lowest...Highest.
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32h563zi_nucleo144/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32h563zi_nucleo144/xmcuconf.h
@@ -22,7 +22,7 @@
  * The following settings override the default settings present in
  * the various device driver implementation headers.
  * Note that the settings for each driver only have effect if the whole
- * driver is enabled in xhalconf.h.
+ * driver is enabled in halconf.h.
  *
  * IRQ priorities:
  * 15...0       Lowest...Highest.
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32h735ig_discovery/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32h735ig_discovery/xmcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32l4r9_discovery/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-MULTI/cfg/stm32l4r9_discovery/xmcuconf.h
@@ -332,6 +332,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32c031c6_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32c031c6_nucleo64/xmcuconf.h
@@ -186,6 +186,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  16
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * WDG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32g071rb_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32g071rb_nucleo64/xmcuconf.h
@@ -220,6 +220,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -19,7 +19,7 @@
  * The following settings override the default settings present in
  * the various device driver implementation headers.
  * Note that the settings for each driver only have effect if the whole
- * driver is enabled in xhalconf.h.
+ * driver is enabled in halconf.h.
  *
  * IRQ priorities:
  * 15...0       Lowest...Highest.
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32h563zi_nucleo144/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32h563zi_nucleo144/xmcuconf.h
@@ -22,7 +22,7 @@
  * The following settings override the default settings present in
  * the various device driver implementation headers.
  * Note that the settings for each driver only have effect if the whole
- * driver is enabled in xhalconf.h.
+ * driver is enabled in halconf.h.
  *
  * IRQ priorities:
  * 15...0       Lowest...Highest.
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32h735ig_discovery/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32h735ig_discovery/xmcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32l4r9_discovery/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32-XSHELL/cfg/stm32l4r9_discovery/xmcuconf.h
@@ -332,6 +332,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/demos/STM32/RT-XHAL-STM32G474RE-NUCLEO64/cfg/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32G474RE-NUCLEO64/cfg/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/demos/STM32/RT-XHAL-STM32H563ZI-NUCLEO144/cfg/xmcuconf.h
+++ b/demos/STM32/RT-XHAL-STM32H563ZI-NUCLEO144/cfg/xmcuconf.h
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testex/STM32/STM32F3xx/I2C-LSM303DLHC/cfg/mcuconf.h
+++ b/testex/STM32/STM32F3xx/I2C-LSM303DLHC/cfg/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F3xx/SPI-L3GD20/cfg/mcuconf.h
+++ b/testex/STM32/STM32F3xx/SPI-L3GD20/cfg/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-HTS221/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-HTS221/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-IKS01A2/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-IKS01A2/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-LIS3MDL/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-LIS3MDL/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-LPS22HB/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-LPS22HB/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-LPS25H/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-LPS25H/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-LSM303AGR/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-LSM303AGR/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-LSM303DLHC/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-LSM303DLHC/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-LSM6DS0/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-LSM6DS0/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-LSM6DSL/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-LSM6DSL/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/I2C-PWM-ADXL317/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/I2C-PWM-ADXL317/cfg/mcuconf.h
@@ -321,6 +321,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/SPI-ADXL355/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/SPI-ADXL355/cfg/mcuconf.h
@@ -321,6 +321,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/SPI-L3GD20/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/SPI-L3GD20/cfg/mcuconf.h
@@ -210,6 +210,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/SPI-LIS302DL/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/SPI-LIS302DL/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F4xx/SPI-LIS3DSH/cfg/mcuconf.h
+++ b/testex/STM32/STM32F4xx/SPI-LIS3DSH/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testex/STM32/STM32F7xx/SPI-ADXL355/cfg/mcuconf.h
+++ b/testex/STM32/STM32F7xx/SPI-ADXL355/cfg/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testex/STM32/STM32L4xx/SPI-L3GD20/cfg/mcuconf.h
+++ b/testex/STM32/STM32L4xx/SPI-L3GD20/cfg/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32F3xx/ADC/mcuconf.h
+++ b/testhal/STM32/STM32F3xx/ADC/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F3xx/ADC_DUAL/mcuconf.h
+++ b/testhal/STM32/STM32F3xx/ADC_DUAL/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F3xx/CAN/mcuconf.h
+++ b/testhal/STM32/STM32F3xx/CAN/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F3xx/DAC/mcuconf.h
+++ b/testhal/STM32/STM32F3xx/DAC/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F3xx/PWM-ICU/mcuconf.h
+++ b/testhal/STM32/STM32F3xx/PWM-ICU/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  TRUE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F3xx/USB_CDC_IAD/mcuconf.h
+++ b/testhal/STM32/STM32F3xx/USB_CDC_IAD/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/ADC/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/ADC/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/CAN/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/CAN/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/DAC/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/DAC/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/DAC_DUAL/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/DAC_DUAL/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/DMA_STORM/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/DMA_STORM/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/I2S/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/I2S/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/PWM-ICU/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/PWM-ICU/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/RTC/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/RTC/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/SDC/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/SDC/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F4xx/USB_CDC_IAD/mcuconf.h
+++ b/testhal/STM32/STM32F4xx/USB_CDC_IAD/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/STM32F7xx/GPT-ADC/mcuconf.h
+++ b/testhal/STM32/STM32F7xx/GPT-ADC/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32F7xx/PWM-ICU/mcuconf.h
+++ b/testhal/STM32/STM32F7xx/PWM-ICU/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  5
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32F7xx/USB_RAW/mcuconf.h
+++ b/testhal/STM32/STM32F7xx/USB_RAW/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32G4xx/CAN/cfg/mcuconf.h
+++ b/testhal/STM32/STM32G4xx/CAN/cfg/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32H7xx/CAN/cfg/mcuconf.h
+++ b/testhal/STM32/STM32H7xx/CAN/cfg/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32L4xx/CAN/mcuconf.h
+++ b/testhal/STM32/STM32L4xx/CAN/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32WLxx/I2S/cfg/mcuconf.h
+++ b/testhal/STM32/STM32WLxx/I2S/cfg/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32WLxx/SPI/cfg/mcuconf.h
+++ b/testhal/STM32/STM32WLxx/SPI/cfg/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32WLxx/SYSTICKv2/cfg/mcuconf.h
+++ b/testhal/STM32/STM32WLxx/SYSTICKv2/cfg/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/STM32WLxx/WDG/cfg/mcuconf.h
+++ b/testhal/STM32/STM32WLxx/WDG/cfg/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32g071rb_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32g071rb_nucleo64/mcuconf.h
@@ -229,6 +229,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32h743zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32h743zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32l053r8_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32l053r8_nucleo64/mcuconf.h
@@ -190,6 +190,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32l4r5zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32l4r5zi_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/ADC/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/ADC/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/CRYPTO/cfg/stm32f756zg_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/CRYPTO/cfg/stm32f756zg_nucleo144/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/DAC/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/DAC/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/DAC/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/DAC/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/DAC/cfg/stm32h743zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/DAC/cfg/stm32h743zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/DAC/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/DAC/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/DAC/cfg/stm32l4r5zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/DAC/cfg/stm32l4r5zi_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/DAC/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/DAC/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/EFL-MFS/cfg/stm32f767zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/EFL-MFS/cfg/stm32f767zi_nucleo144/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/EFL-MFS/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/EFL-MFS/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/EFL-MFS/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/EFL-MFS/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/I2C-MASTER_SLAVE/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/I2C-MASTER_SLAVE/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/I2C-MASTER_SLAVE/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/I2C-MASTER_SLAVE/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/I2C-MASTER_SLAVE/cfg/stm32h750xb_discovery/mcuconf.h
+++ b/testhal/STM32/multi/I2C-MASTER_SLAVE/cfg/stm32h750xb_discovery/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32f303_discovery/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32f303_discovery/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32f429_discovery/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32f429_discovery/mcuconf.h
@@ -315,6 +315,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32f746_discovery/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32f746_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32l053_discovery/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32l053_discovery/mcuconf.h
@@ -190,6 +190,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/PAL/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/PAL/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32c031c6_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32c031c6_nucleo64/mcuconf.h
@@ -192,6 +192,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  16
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32f303_discovery/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32f303_discovery/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32f746_discovery/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32f746_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32g071rb_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32g071rb_nucleo64/mcuconf.h
@@ -229,6 +229,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32l053_discovery/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32l053_discovery/mcuconf.h
@@ -190,6 +190,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32l4r5_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32l4r5_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/RTC/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/RTC/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SDMMC-FATFS/cfg/stm32l4r9ai_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SDMMC-FATFS/cfg/stm32l4r9ai_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SDMMC/cfg/stm32l4r9ai_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SDMMC/cfg/stm32l4r9ai_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SIO/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/SIO/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SIO/cfg/stm32l476vg_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SIO/cfg/stm32l476vg_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32f303_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32f303_discovery/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32f746ng_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32f746ng_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32g431rb_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32g431rb_nucleo64/mcuconf.h
@@ -293,6 +293,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32h743_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32h743_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32h755_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32h755_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32l053r8_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32l053r8_nucleo64/mcuconf.h
@@ -190,6 +190,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32l4r5_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32l4r5_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/SPI/cfg/stm32l4r9_discovery/mcuconf.h
+++ b/testhal/STM32/multi/SPI/cfg/stm32l4r9_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/TRNG/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/TRNG/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/TRNG/cfg/stm32l4r5zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/TRNG/cfg/stm32l4r5zi_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/TRNG/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/TRNG/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/TRNG/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/TRNG/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/UART/cfg/stm32f303_discovery/mcuconf.h
+++ b/testhal/STM32/multi/UART/cfg/stm32f303_discovery/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/UART/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/UART/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/UART/cfg/stm32f746_discovery/mcuconf.h
+++ b/testhal/STM32/multi/UART/cfg/stm32f746_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/UART/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/UART/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/UART/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/UART/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32f303_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32f303_discovery/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32f746_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32f746_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32g0b1re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32g0b1re_nucleo64/mcuconf.h
@@ -259,6 +259,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32g474re_discovery_dpow1/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32g474re_discovery_dpow1/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32h723zg_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32h723zg_nucleo144/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32h743zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32h743zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32h755zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32h755zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32l073rz_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32l073rz_nucleo64/mcuconf.h
@@ -205,6 +205,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32l4r5zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32l4r5zi_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32wb55cg_nucleo48/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32wb55cg_nucleo48/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_CDC/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/USB_CDC/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32f303_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32f303_discovery/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32f746_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32f746_discovery/mcuconf.h
@@ -379,6 +379,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32g0b1re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32g0b1re_nucleo64/mcuconf.h
@@ -259,6 +259,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32g474re_discovery_dpow1/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32g474re_discovery_dpow1/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32h723zg_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32h723zg_nucleo144/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32h743zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32h743zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32h755zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32h755zi_nucleo144/mcuconf.h
@@ -431,6 +431,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32l073rz_nucleo64/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32l073rz_nucleo64/mcuconf.h
@@ -205,6 +205,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  21
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32l4r5zi_nucleo144/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32l4r5zi_nucleo144/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32wb55cg_nucleo48/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32wb55cg_nucleo48/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/USB_RAW/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/USB_RAW/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/WDG/cfg/stm32f303_discovery/mcuconf.h
+++ b/testhal/STM32/multi/WDG/cfg/stm32f303_discovery/mcuconf.h
@@ -169,6 +169,19 @@
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*
+ * I2S driver system settings.
+ */
+#define STM32_I2S_USE_SPI2                  FALSE
+#define STM32_I2S_USE_SPI3                  FALSE
+#define STM32_I2S_SPI2_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI3_MODE                 (STM32_I2S_MODE_MASTER | STM32_I2S_MODE_RX)
+#define STM32_I2S_SPI2_IRQ_PRIORITY         10
+#define STM32_I2S_SPI3_IRQ_PRIORITY         10
+#define STM32_I2S_SPI2_DMA_PRIORITY         1
+#define STM32_I2S_SPI3_DMA_PRIORITY         1
+#define STM32_I2S_DMA_ERROR_HOOK(i2sp)      osalSysHalt("DMA failure")
+
+/*
  * ICU driver system settings.
  */
 #define STM32_ICU_USE_TIM1                  FALSE
@@ -241,6 +254,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/WDG/cfg/stm32f407_discovery/mcuconf.h
+++ b/testhal/STM32/multi/WDG/cfg/stm32f407_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * UART driver system settings.

--- a/testhal/STM32/multi/WDG/cfg/stm32wb55rg_nucleo68/mcuconf.h
+++ b/testhal/STM32/multi/WDG/cfg/stm32wb55rg_nucleo68/mcuconf.h
@@ -204,6 +204,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/WSPI-LITTLEFS/cfg/stm32l476vg_discovery/mcuconf.h
+++ b/testhal/STM32/multi/WSPI-LITTLEFS/cfg/stm32l476vg_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/WSPI-LITTLEFS/cfg/stm32l4r9ai_discovery/mcuconf.h
+++ b/testhal/STM32/multi/WSPI-LITTLEFS/cfg/stm32l4r9ai_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/WSPI-MFS/cfg/stm32h735ig_discovery/mcuconf.h
+++ b/testhal/STM32/multi/WSPI-MFS/cfg/stm32h735ig_discovery/mcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/WSPI-MFS/cfg/stm32l476_discovery/mcuconf.h
+++ b/testhal/STM32/multi/WSPI-MFS/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testhal/STM32/multi/WSPI-MFS/cfg/stm32l4r9_discovery/mcuconf.h
+++ b/testhal/STM32/multi/WSPI-MFS/cfg/stm32l4r9_discovery/mcuconf.h
@@ -329,6 +329,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/FPU_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testrt/FPU_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/FPU_STORM/cfg/stm32g474re_nucleo64_alt/mcuconf.h
+++ b/testrt/FPU_STORM/cfg/stm32g474re_nucleo64_alt/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/IRQ_STORM/cfg/stm32g071rb_nucleo64/mcuconf.h
+++ b/testrt/IRQ_STORM/cfg/stm32g071rb_nucleo64/mcuconf.h
@@ -229,6 +229,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/IRQ_STORM/cfg/stm32g0b1re_nucleo64/mcuconf.h
+++ b/testrt/IRQ_STORM/cfg/stm32g0b1re_nucleo64/mcuconf.h
@@ -259,6 +259,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               2
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/IRQ_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testrt/IRQ_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/IRQ_STORM/cfg/stm32g474re_nucleo64_alt/mcuconf.h
+++ b/testrt/IRQ_STORM/cfg/stm32g474re_nucleo64_alt/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/IRQ_STORM/cfg/stm32l476_discovery/mcuconf.h
+++ b/testrt/IRQ_STORM/cfg/stm32l476_discovery/mcuconf.h
@@ -298,6 +298,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/IRQ_STORM/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testrt/IRQ_STORM/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/VT_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testrt/VT_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/VT_STORM/cfg/stm32h563zi_nucleo144/mcuconf.h
+++ b/testrt/VT_STORM/cfg/stm32h563zi_nucleo144/mcuconf.h
@@ -435,6 +435,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/VT_STORM/cfg/stm32wl55jc_nucleo64/mcuconf.h
+++ b/testrt/VT_STORM/cfg/stm32wl55jc_nucleo64/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/VT_STORM/cfg/stm32wl55jc_nucleo64_v2/mcuconf.h
+++ b/testrt/VT_STORM/cfg/stm32wl55jc_nucleo64_v2/mcuconf.h
@@ -246,6 +246,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/WKP_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
+++ b/testrt/WKP_STORM/cfg/stm32g474re_nucleo64/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/WKP_STORM/cfg/stm32g474re_nucleo64_alt/mcuconf.h
+++ b/testrt/WKP_STORM/cfg/stm32g474re_nucleo64_alt/mcuconf.h
@@ -349,6 +349,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/WKP_STORM/cfg/stm32l552ze_nucleo144/mcuconf.h
+++ b/testrt/WKP_STORM/cfg/stm32l552ze_nucleo144/mcuconf.h
@@ -277,6 +277,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               4
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testrt/WKP_STORM/cfg/stm32l552ze_nucleo144_alt/mcuconf.h
+++ b/testrt/WKP_STORM/cfg/stm32l552ze_nucleo144_alt/mcuconf.h
@@ -277,6 +277,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               4
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testsb/SB_VIO-STM32G474RE-NUCLEO64-HOST/cfg/xmcuconf.h
+++ b/testsb/SB_VIO-STM32G474RE-NUCLEO64-HOST/cfg/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/ADC-GPT/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/ADC-GPT/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/DAC-GPT/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/DAC-GPT/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/DAC-GPT/cfg/stm32h563zi_nucleo144/xmcuconf.h
+++ b/testxhal/DAC-GPT/cfg/stm32h563zi_nucleo144/xmcuconf.h
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/EFL-MFS/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/EFL-MFS/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/I2S/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/I2S/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/MMC-SPI/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/MMC-SPI/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/RTC/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/RTC/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/SPI/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/SPI/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/TRNG/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/TRNG/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/TRNG/cfg/stm32h563zi_nucleo144/xmcuconf.h
+++ b/testxhal/TRNG/cfg/stm32h563zi_nucleo144/xmcuconf.h
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/USB_CDC/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/USB_CDC/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/WDG/cfg/stm32g474re_nucleo64/xmcuconf.h
+++ b/testxhal/WDG/cfg/stm32g474re_nucleo64/xmcuconf.h
@@ -338,6 +338,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/WDG/cfg/stm32h563zi_nucleo144/xmcuconf.h
+++ b/testxhal/WDG/cfg/stm32h563zi_nucleo144/xmcuconf.h
@@ -391,6 +391,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * RTC driver system settings.

--- a/testxhal/WSPI-XSNOR-MFS/cfg/stm32h735ig_discovery/xmcuconf.h
+++ b/testxhal/WSPI-XSNOR-MFS/cfg/stm32h735ig_discovery/xmcuconf.h
@@ -432,6 +432,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.

--- a/testxhal/WSPI-XSNOR-MFS/cfg/stm32l4r9_discovery/xmcuconf.h
+++ b/testxhal/WSPI-XSNOR-MFS/cfg/stm32l4r9_discovery/xmcuconf.h
@@ -332,6 +332,7 @@
  */
 #define STM32_ST_IRQ_PRIORITY               8
 #define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
 
 /*
  * TRNG driver system settings.


### PR DESCRIPTION
Regenerates **every templated in-tree `mcuconf.h`/`xmcuconf.h`** (298 configs) via `tools/updater` to bring them back in sync with their generation templates, and bumps `tools/ftl` to the F303 I2S template fix (chibios-ftl #3, merged).

**Verified loss-free** — a full per-file audit found **zero removed `#define`s**. The changes:

| Change | Configs |
|---|---|
| `STM32_ST_FREQUENCY_TOLERANCE` added (default `0`, no behaviour change) | 298 |
| STM32F3 I2S driver section restored (template-gap fix propagating) | 18 |
| stale comment fix `xhalconf.h` → `halconf.h` | 4 |

**Loss handling:** the only family where regen would have dropped settings was F303 — its template was missing the I2S section that the SPIv2 LLD (`hal_i2s_lld.c/.h`) and the F303 configs use. Fixed the template (chibios-ftl #3) and re-regenerated, so the I2S settings are preserved. Every other config is pure add-only.

**Excluded from the pass:**
- the experimental `*_clocktree` configs (`u385`/`g474` nucleo64) — different `STM32_CFG_*` clock-tree scheme, not this template;
- the two `stm32c071rb_nucleo64` demo configs — owned by the held PR #12 (not pre-empted here; #12 should be rebased on this once unheld so it picks up the tolerance line).

**Verification:** stylecheck clean on all 298; F3 / C071 / U3 targets build clean. Regen is idempotent against the merged templates.

Sheriff-authored; for human review/merge.