### PR TITLE
STM32L4+/L4R: fix malformed CLK_POINT_NAMES (misplaced comma)

### DIFF
--- a/os/hal/ports/STM32/STM32L4xx+/hal_lld.h
+++ b/os/hal/ports/STM32/STM32L4xx+/hal_lld.h
@@ -100,7 +100,7 @@
 #define CLK_POINT_NAMES                                                     \
   {                                                                         \
     "SYSCLK", "MSI", "MSIS", "PLLP", "PLLQ", "PLLR",                        \
-    "PLLSAI1P", "PLLSAI1Q", "PLLSAI1R", "PLLSAI2P", "PLLSAI2Q", "PLLSAI2R," \
+    "PLLSAI1P", "PLLSAI1Q", "PLLSAI1R", "PLLSAI2P", "PLLSAI2Q", "PLLSAI2R", \
     "HCLK", "PCLK1", "PCLK1TIM", "PCLK2", "PCLK2TIM", "MCO"                 \
   }
 /** @} */

--- a/os/xhal/ports/STM32/STM32L4xx+/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32L4xx+/hal_lld.h
@@ -100,7 +100,7 @@
 #define CLK_POINT_NAMES                                                     \
   {                                                                         \
     "SYSCLK", "MSI", "MSIS", "PLLP", "PLLQ", "PLLR",                        \
-    "PLLSAI1P", "PLLSAI1Q", "PLLSAI1R", "PLLSAI2P", "PLLSAI2Q", "PLLSAI2R," \
+    "PLLSAI1P", "PLLSAI1Q", "PLLSAI1R", "PLLSAI2P", "PLLSAI2Q", "PLLSAI2R", \
     "HCLK", "PCLK1", "PCLK1TIM", "PCLK2", "PCLK2TIM", "MCO"                 \
   }
 /** @} */

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,12 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: STM32L4+/L4Rxx clock point name table (CLK_POINT_NAMES) had a comma
+       misplaced inside the "PLLSAI2R" string literal, so adjacent string
+       literals were concatenated and the table held one entry fewer than
+       CLK_ARRAY_SIZE; clock point names from PLLSAI2R onward were shifted
+       and the last was NULL. The comma is moved outside the string (HAL and
+       XHAL ports) (github PR #21).
 - NEW: SYSTICKv1 free running mode gained STM32_ST_FREQUENCY_TOLERANCE, the
        allowed ST tick deviation in per-mille (default 0 = exact divisor
        required, unchanged behavior). The prescaler is rounded to the


### PR DESCRIPTION
In `STM32L4xx+/hal_lld.h` the `CLK_POINT_NAMES` initializer has the comma **inside** the `"PLLSAI2R"` string literal (`"PLLSAI2R,"`) instead of after it. C concatenates adjacent string literals, so `"PLLSAI2R,"` and the following `"HCLK"` merge into one `"PLLSAI2R,HCLK"` entry — the table then holds **17 entries against `CLK_ARRAY_SIZE` (18U)**, shifting every clock-point name from `PLLSAI2R` onward and leaving the final entry `NULL`.

Impact: wrong clock-point names (introspection/debug paths) and a potential out-of-bounds read at index 17.

Fix: move the comma outside the string literal. Applied to **both** the HAL and XHAL STM32L4xx+ ports. Surfaced by the deterministic style sweep (#20) but kept separate as it's a behavioural fix; changelog entry added.

Sheriff-authored; for human review/merge.