### PR TITLE
vfs: fix glued do-while in vfspaths.c

### DIFF
--- a/os/vfs/src/vfspaths.c
+++ b/os/vfs/src/vfspaths.c
@@ -369,7 +369,7 @@ size_t vfs_path_normalize(char *dst, const char *src, size_t size) {
         do {
           dst--;
           n--;
-        } while(*(dst - 1) != '/');
+        } while (*(dst - 1) != '/');
       }
       continue;
     }


### PR DESCRIPTION
Style pass over the VFS subsystem (`os/vfs`, all Giovanni Di Sirio copyright).

VFS is nearly clean — the only deterministic finding in a **hand-written** file is a glued do-while condition in `vfspaths.c`: `} while(` → `} while (`. Whitespace-only; the G4 SB-host demo builds clean.

Not touched: the **generated** VFS files (`chibios_config_wizard`); their only non-false-positive finding is a deliberately column-aligned bit-smearing macro block in `drvchfs.c` (`(   (x) | ...`), which is intentional and lives in generated code.

Sheriff-authored; for human review/merge.