### PR TITLE
xhal: fix glued operator in generated hal_base_driver (at codegen source)

### DIFF
--- a/os/xhal/codegen/hal_base_driver.xml
+++ b/os/xhal/codegen/hal_base_driver.xml
@@ -522,7 +522,7 @@ osalSysLock();
 
 drvp = drvRegGetFirstX();
 while (drvp != NULL) {
-  if (strcmp(drvGetNameX(drvp), name) ==0) {
+  if (strcmp(drvGetNameX(drvp), name) == 0) {
     
     msg = drvStart(drvp, NULL);
     if (msg != HAL_RET_SUCCESS) {

--- a/os/xhal/src/hal_base_driver.c
+++ b/os/xhal/src/hal_base_driver.c
@@ -170,7 +170,7 @@ hal_base_driver_c *drvStartByName(const char *name, msg_t *msgp) {
 
   drvp = drvRegGetFirstX();
   while (drvp != NULL) {
-    if (strcmp(drvGetNameX(drvp), name) ==0) {
+    if (strcmp(drvGetNameX(drvp), name) == 0) {
 
       msg = drvStart(drvp, NULL);
       if (msg != HAL_RET_SUCCESS) {


### PR DESCRIPTION
Completes the XHAL style sweep (#22): the one real deterministic finding that lived in a **generated** file — a glued comparison operator in `hal_base_driver.c` (`name) ==0`).

Generated files are not hand-edited; per the codegen workflow the fix is made in the **source model** `os/xhal/codegen/hal_base_driver.xml` and the output regenerated via fmpp (`config.fmpp`). A baseline dry-regen confirmed zero drift, so the only regenerated output that changes is `hal_base_driver.c` (`==0` → `== 0`). Whitespace-only; H5 RT-XHAL-MULTI builds clean.

Sheriff-authored; for human review/merge.