### PR TITLE
readme: add missing change log entries for resolved PRs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -136,7 +136,7 @@ See .devcontainer/README.md for included tools and usage.
 - FIX: RT: Fixed chThdCreateFromMemoryPool() rejects valid fixed memory pools
        due to overly strict alignment assertion (bug github #3)
        (backported to 21.11.6).
-- FIX: RT: Fixed lign aheap-created thread working area size (bug #1307)
+- FIX: RT: Fixed align heap-created thread working area size (bug #1307)
        (backported to 21.11.6).
 - FIX; NIL: Fixed wrong alignment check in chThdCreateI() (bug #1306)
        (backported to 21.11.6).

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,21 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- NEW: Coding-style cleanup of the XHAL OOP driver code generator: a glued
+       comparison operator was corrected in the hal_base_driver codegen model
+       (os/xhal/codegen) and the generated source regenerated; no functional
+       change (github PR #24).
+- NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
+       the VFS sources, no functional change (github PR #23).
+- NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
+       the XHAL hand-written sources, no functional change (github PR #22).
+- NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
+       the HAL sources, no functional change (github PR #20).
+- FIX: The STM32F303 mcuconf template was missing its I2S driver settings
+       section, so regenerating an F303 configuration silently dropped the
+       I2S settings; the section was restored and all templated mcuconf/
+       xmcuconf configurations were regenerated against their templates
+       (github PR #19).
 - FIX: STM32L4+/L4Rxx clock point name table (CLK_POINT_NAMES) had a comma
        misplaced inside the "PLLSAI2R" string literal, so adjacent string
        literals were concatenated and the table held one entry fewer than
@@ -93,7 +108,8 @@ See .devcontainer/README.md for included tools and usage.
        nearest integer and the achieved tick is checked against the
        tolerance, letting devices whose clock tree cannot produce an
        exact multiple (e.g. STM32U0/U3 with MSI feeding the PLL) run
-       without a clock-rounding system halt (github PR #17).
+       without a clock-rounding system halt (github PR #17). The STM32U0 and
+       STM32U3 device configurations set the tolerance to 0.5% (github PR #18).
 - FIX: STM32U0xx RTC alarm/tamper interrupt could halt the system on the
        first event (assertions enabled): rtc_lld_serve_interrupt() cleared
        the RTC/TAMP EXTI lines, which are direct event inputs on STM32U0


### PR DESCRIPTION
Back-fills the `*** Next ***` change log so every resolved PR is recorded (some were missing). No code change — documentation only.

Added:
- **FIX** — STM32F303 mcuconf template I2S gap + tree-wide config regen (#19)
- **#18** folded into the #17 entry (U0/U3 device configs set tolerance to 0.5%)
- coding-style cleanups, one entry per PR (your call): **HAL #20**, **XHAL #22**, **VFS #23**, **XHAL-codegen #24**

After this, the change log references #10–#22 (merged) plus #23/#24 (in review). #13 is intentionally absent (still held). Sheriff-authored; for human review/merge.