### PR TITLE
sb: fix deterministic style anomalies

### DIFF
--- a/os/sb/apps/ls/main.c
+++ b/os/sb/apps/ls/main.c
@@ -207,7 +207,7 @@ static char *new_path(char *path) {
   return p;
 }
 
-static bool dostat( struct dirlist *dlp, struct diritem *dip) {
+static bool dostat(struct dirlist *dlp, struct diritem *dip) {
   struct stat stb;
   char *path;
 
@@ -297,7 +297,7 @@ static void build_list_from_args(char *argv[], struct dirlist **dlpp) {
 
   while (*argv != NULL) {
     char *p = *argv++;
-    struct diritem *dip = dirlist_add(dlpp,p);
+    struct diritem *dip = dirlist_add(dlpp, p);
 
     if (ignore_item(p)) {
       dirlist_undo(dlpp);
@@ -342,7 +342,7 @@ static void build_list_from_path(char *path, struct dirlist **dlpp) {
         dirlist_undo(dlpp);
       }
     }
-    else{
+    else {
       switch (dep->d_type) {
       case DT_LNK:
         dip->ftype = 'l';

--- a/os/sb/host/sbapi.c
+++ b/os/sb/host/sbapi.c
@@ -65,7 +65,7 @@ static thread_t *sb_msg_wait_timeout_s(sysinterval_t timeout) {
         return NULL;
       }
     }
-  } while(ch_queue_isempty(&currtp->msgqueue));
+  } while (ch_queue_isempty(&currtp->msgqueue));
 
   /* Dequeuing the sender thread and returning it.*/
   tp = threadref(ch_queue_fifo_remove(&currtp->msgqueue));
@@ -110,7 +110,7 @@ void sb_sysc_exit(sb_class_t *sbp, struct port_extctx *ectxp) {
 #if CH_CFG_USE_EVENTS == TRUE
   chEvtBroadcastI(&sb.termination_es);
 #endif
-  chThdExitS((msg_t )ectxp->r0);
+  chThdExitS((msg_t)ectxp->r0);
   chSysUnlock();
 
   /* Cannot get here.*/
@@ -118,7 +118,7 @@ void sb_sysc_exit(sb_class_t *sbp, struct port_extctx *ectxp) {
 }
 
 void sb_sysc_sleep(sb_class_t *sbp, struct port_extctx *ectxp) {
-  sysinterval_t interval = (sysinterval_t )ectxp->r0;
+  sysinterval_t interval = (sysinterval_t)ectxp->r0;
 
   (void)sbp;
 
@@ -133,7 +133,7 @@ void sb_sysc_sleep_until_windowed(sb_class_t *sbp, struct port_extctx *ectxp) {
 
   (void)sbp;
 
-  chThdSleepUntilWindowed((systime_t )ectxp->r0, (systime_t )ectxp->r1);
+  chThdSleepUntilWindowed((systime_t)ectxp->r0, (systime_t)ectxp->r1);
 
   ectxp->r0 = CH_RET_SUCCESS;
 }
@@ -170,7 +170,7 @@ void sb_sysc_reply_message(sb_class_t *sbp, struct port_extctx *ectxp) {
   if (sbp->base.msg_tp != NULL) {
     thread_t *tp = sbp->base.msg_tp;
     sbp->base.msg_tp = NULL;
-    chMsgReleaseS(tp, (msg_t )ectxp->r0);
+    chMsgReleaseS(tp, (msg_t)ectxp->r0);
     ectxp->r0 = CH_RET_SUCCESS;
   }
   else {
@@ -190,8 +190,8 @@ void sb_sysc_wait_one_timeout(sb_class_t *sbp, struct port_extctx *ectxp) {
 #if CH_CFG_USE_EVENTS == TRUE
   (void)sbp;
 
-  ectxp->r0 = (uint32_t)chEvtWaitOneTimeout((eventmask_t )ectxp->r0,
-                                            (sysinterval_t )ectxp->r1);
+  ectxp->r0 = (uint32_t)chEvtWaitOneTimeout((eventmask_t)ectxp->r0,
+                                            (sysinterval_t)ectxp->r1);
 #else
   (void)sbp;
 
@@ -204,8 +204,8 @@ void sb_sysc_wait_any_timeout(sb_class_t *sbp, struct port_extctx *ectxp) {
 #if CH_CFG_USE_EVENTS == TRUE
   (void)sbp;
 
-  ectxp->r0 = (uint32_t)chEvtWaitAnyTimeout((eventmask_t )ectxp->r0,
-                                            (sysinterval_t )ectxp->r1);
+  ectxp->r0 = (uint32_t)chEvtWaitAnyTimeout((eventmask_t)ectxp->r0,
+                                            (sysinterval_t)ectxp->r1);
 #else
   (void)sbp;
 
@@ -218,8 +218,8 @@ void sb_sysc_wait_all_timeout(sb_class_t *sbp, struct port_extctx *ectxp) {
 #if CH_CFG_USE_EVENTS == TRUE
   (void)sbp;
 
-  ectxp->r0 = (uint32_t)chEvtWaitAllTimeout((eventmask_t )ectxp->r0,
-                                            (sysinterval_t )ectxp->r1);
+  ectxp->r0 = (uint32_t)chEvtWaitAllTimeout((eventmask_t)ectxp->r0,
+                                            (sysinterval_t)ectxp->r1);
 #else
   (void)sbp;
 
@@ -230,7 +230,7 @@ void sb_sysc_wait_all_timeout(sb_class_t *sbp, struct port_extctx *ectxp) {
 void sb_sysc_broadcast_flags(sb_class_t *sbp, struct port_extctx *ectxp) {
 #if CH_CFG_USE_EVENTS == TRUE
 
-  chEvtBroadcastFlags(&sbp->base.es, (eventflags_t )ectxp->r0);
+  chEvtBroadcastFlags(&sbp->base.es, (eventflags_t)ectxp->r0);
   ectxp->r0 = CH_RET_SUCCESS;
 #else
   (void)sbp;

--- a/os/sb/host/sbhost.c
+++ b/os/sb/host/sbhost.c
@@ -255,7 +255,6 @@ static bool get_mpu_settings(const sb_memory_region_t *mrp,
     return true;
   }
 
-
   /* MPU registers base settings.*/
   mpur->rbar = (area_base & MPU_RBAR_BASE_MASK) | MPU_RBAR_SH_OUTER;
   mpur->rlar = ((area_end - 1U) & MPU_RLAR_LIMIT_MASK) | MPU_RLAR_ENABLE;

--- a/os/sb/host/sbvrq.c
+++ b/os/sb/host/sbvrq.c
@@ -344,7 +344,7 @@ void sbVRQTriggerI(sb_class_t *sbp, sb_vrqnum_t nvrq) {
 }
 
 void sb_sysc_vrq_set_alarm(sb_class_t *sbp, struct port_extctx *ectxp) {
-  sysinterval_t interval = (sysinterval_t )ectxp->r0;
+  sysinterval_t interval = (sysinterval_t)ectxp->r0;
   bool reload = (bool)ectxp->r1;
 
   if (interval == TIME_IMMEDIATE) {

--- a/os/sb/user/lib/syscalls.h
+++ b/os/sb/user/lib/syscalls.h
@@ -14,6 +14,5 @@
     limitations under the License.
 */
 
-
 extern uint8_t __heap_base__;
 extern uint8_t *__sbrk_next;

--- a/os/sb/vio/sbvio_spi.c
+++ b/os/sb/vio/sbvio_spi.c
@@ -314,7 +314,7 @@ void sb_fastc_vio_spi(sb_class_t *sbp, struct port_extctx *ectxp) {
        all functions are called in the proper state.*/
     if (unitp->spip->state != HAL_DRV_STATE_READY) {
       ectxp->r0 = (uint32_t)HAL_RET_INV_STATE;
-      return ;
+      return;
     }
 
     switch (sub) {

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,8 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
+       the SB (sandbox) sources, no functional change (github PR #26).
 - NEW: Coding-style cleanup of the XHAL OOP driver code generator: a glued
        comparison operator was corrected in the hal_base_driver codegen model
        (os/xhal/codegen) and the generated source regenerated; no functional


### PR DESCRIPTION
Style pass over the SB (sandbox) subsystem (`os/sb`, all Giovanni Di Sirio copyright, no generated files). Whitespace/comment-only — SB host demo and the `apps/ls` sandbox app build clean.

**Fixed:** loose casts `(msg_t )` → `(msg_t)` (sbapi/sbvrq), glued do-while, loose `(`/`;`/comma/glued `{`, glued comment starts in apps/ls, collapsed multiple blank lines.

**Not touched (stylecheck false positives):**
- `sbuser.h` inline-asm constraint strings (`"=r"` …) flagged as glued operators — they're inside string literals (stylecheck strips only the first string per line), so "fixing" would corrupt the asm;
- `#endif /* defined() */` guards and commented-out `//` code.

Sheriff-authored; for human review/merge.