### PR TITLE
common: fix deterministic style anomalies (safe subset)

### DIFF
--- a/os/common/abstractions/cmsis_os/cmsis_os.c
+++ b/os/common/abstractions/cmsis_os/cmsis_os.c
@@ -902,7 +902,7 @@ osEvent osMailGet(osMailQId queue_id, uint32_t millisec) {
       .mail_id = NULL
     }
   };
-  
+
   if (queue_id == NULL) {
     event.status = osErrorParameter;
     return event;
@@ -959,7 +959,7 @@ osStatus osMailFree(osMailQId queue_id, void *mail)
     return osErrorValue;
   }
 
-  chDbgCheck((queue_id != NULL) && (mail != NULL));    
+  chDbgCheck((queue_id != NULL) && (mail != NULL));
 
   syssts_t sts = chSysGetStatusAndLockX();
   chFifoReturnObjectI(queue_id, mail);

--- a/os/common/abstractions/cmsis_os/cmsis_os.h
+++ b/os/common/abstractions/cmsis_os/cmsis_os.h
@@ -57,7 +57,7 @@
  * @name    CMSIS Capabilities
  * @{
  */
-#define osFeature_MainThread        1       
+#define osFeature_MainThread        1
 #define osFeature_Pool              1
 #define osFeature_MailQ             1
 #define osFeature_MessageQ          1
@@ -437,7 +437,7 @@ const osMessageQDef_t os_messageQ_def_##name = {                            \
  */
 #if defined(osObjectsExternal)
 #define osMailQDef(name, queue_sz, type)                \
-  extern const osMailQDef_t os_mailQ_def_##name         
+  extern const osMailQDef_t os_mailQ_def_##name
 #else
 #define osMailQDef(name, queue_sz, type)                \
   static msg_t os_mailQ_mb_buf_##name[queue_sz];        \

--- a/os/common/abstractions/nasa_cfe/osal/src/osapi.c
+++ b/os/common/abstractions/nasa_cfe/osal/src/osapi.c
@@ -2206,7 +2206,7 @@ int32 OS_IntAck(int32 InterruptNumber) {
 /* In ChibiOS exceptions are statically linked, the vectors table is in
    flash.*/
 int32 OS_ExcAttachHandler(uint32 ExceptionNumber,
-                          void (*ExceptionHandler)(uint32, uint32 *,uint32),
+                          void (*ExceptionHandler)(uint32, uint32 *, uint32),
                           int32 parameter) {
 
   (void)ExceptionNumber;

--- a/os/common/oop/src/oop_chprintf.c
+++ b/os/common/oop/src/oop_chprintf.c
@@ -138,13 +138,13 @@ int chvprintf(sequential_stream_i *stmp, const char *fmt, va_list ap) {
     if (c == 0) {
       return n;
     }
-    
+
     if (c != '%') {
       stmPut(stmp, (uint8_t)c);
       n++;
       continue;
     }
-    
+
     p = tmpbuf;
     s = tmpbuf;
 
@@ -168,9 +168,9 @@ int chvprintf(sequential_stream_i *stmp, const char *fmt, va_list ap) {
       fmt++;
       filler = '0';
     }
-    
+
     /* Width modifier.*/
-    if ( *fmt == '*') {
+    if (*fmt == '*') {
       width = va_arg(ap, int);
       ++fmt;
       c = *fmt++;
@@ -191,7 +191,7 @@ int chvprintf(sequential_stream_i *stmp, const char *fmt, va_list ap) {
         }
       }
     }
-    
+
     /* Precision modifier.*/
     precision = 0;
     if (c == '.') {
@@ -214,7 +214,7 @@ int chvprintf(sequential_stream_i *stmp, const char *fmt, va_list ap) {
         }
       }
     }
-    
+
     /* Long modifier.*/
     if (c == 'l' || c == 'L') {
       is_long = true;

--- a/os/common/ports/ARMv6-M/chcore.h
+++ b/os/common/ports/ARMv6-M/chcore.h
@@ -187,11 +187,11 @@
 
 /* Handling a GCC problem impacting ARMv6-M.*/
 #if defined(__GNUC__) && !defined(PORT_IGNORE_GCC_VERSION_CHECK)
-  #if ( __GNUC__ > 5 ) && ( __GNUC__ < 10 )
-    #define GCC_VERSION ( __GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__ )
-    #if ( __GNUC__ == 7 ) && ( GCC_VERSION >= 70500 )
-    #elif ( __GNUC__ == 8 ) && ( GCC_VERSION >= 80400 )
-    #elif ( __GNUC__ == 9 ) && ( GCC_VERSION >= 90300 )
+  #if (__GNUC__ > 5) && (__GNUC__ < 10)
+    #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+    #if (__GNUC__ == 7) && (GCC_VERSION >= 70500)
+    #elif (__GNUC__ == 8) && (GCC_VERSION >= 80400)
+    #elif (__GNUC__ == 9) && (GCC_VERSION >= 90300)
     #else
       #warning "This compiler has a know problem with Cortex-M0, see GCC bugs: 88167, 88656."
     #endif

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -136,7 +136,7 @@ void __port_smp_init(os_instance_t *oip) {
   port_timer_enable(oip);
 #endif
 
-#if CH_CFG_SMP_MODE== TRUE
+#if CH_CFG_SMP_MODE == TRUE
   /* FIFO handlers for each core.*/
   SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
   if (oip->core_id == 0U) {

--- a/os/common/ports/ARMv7-M/chcore.c
+++ b/os/common/ports/ARMv7-M/chcore.c
@@ -236,7 +236,6 @@ void __port_irq_epilogue(void) {
     (void) __get_FPSCR();
 #endif
 
-
     /* Adding an artificial exception return context, there is no need to
        populate it fully.*/
     psp = __get_PSP();

--- a/os/common/ports/ARMv8-M-ML-TZ/chcore.h
+++ b/os/common/ports/ARMv8-M-ML-TZ/chcore.h
@@ -108,7 +108,6 @@
 /* Inclusion of the Cortex-Mx implementation specific parameters.*/
 #include "cmparams.h"
 
-
 /**
  * @name    Kernel modes
  * @{

--- a/os/common/ports/ARMv8-M-ML/chcore.h
+++ b/os/common/ports/ARMv8-M-ML/chcore.h
@@ -271,7 +271,6 @@
    */
   #define PORT_CORE_VARIANT_NAME        "Cortex-M33"
 
-
 #else
   #error "unknown ARMv8-M variant"
 #endif

--- a/os/common/ports/ARMvx-M-SB/chcore.c
+++ b/os/common/ports/ARMvx-M-SB/chcore.c
@@ -50,7 +50,6 @@
 /* Module interrupt handlers.                                                */
 /*===========================================================================*/
 
-
 #if PORT_USE_LOCAL_SYSTICK == TRUE
 CH_IRQ_HANDLER(__sb_vector0) {
 

--- a/os/common/ports/SIMIA32/chcore.c
+++ b/os/common/ports/SIMIA32/chcore.c
@@ -116,9 +116,8 @@ void _port_thread_start(msg_t (*pf)(void *), void *p) {
   chSysUnlock();
   pf(p);
   chThdExit(0);
-  while(1);
+  while (1);
 }
-
 
 /**
  * @brief   Returns the current value of the realtime counter.

--- a/os/common/ports/SIMX86_64/chcore.c
+++ b/os/common/ports/SIMX86_64/chcore.c
@@ -110,9 +110,8 @@ void _port_thread_start(msg_t (*pf)(void *), void *p) {
   chSysUnlock();
   pf(p);
   chThdExit(0);
-  while(1);
+  while (1);
 }
-
 
 /**
  * @brief   Returns the current value of the realtime counter.

--- a/os/common/startup/ARMCMx/devices/STM32WLxx-M0PLUS/cmparams.h
+++ b/os/common/startup/ARMCMx/devices/STM32WLxx-M0PLUS/cmparams.h
@@ -64,7 +64,6 @@
  */
 #define CORTEX_NUM_VECTORS      32
 
-
 /* The following code is not processed when the file is included from an
    asm module.*/
 #if !defined(_FROM_ASM_)

--- a/os/common/utils/src/paths.c
+++ b/os/common/utils/src/paths.c
@@ -372,7 +372,7 @@ size_t path_normalize(char *dst, const char *src, size_t size) {
         do {
           dst--;
           n--;
-        } while(*(dst - 1) != '/');
+        } while (*(dst - 1) != '/');
       }
       continue;
     }

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,9 @@ See .devcontainer/README.md for included tools and usage.
 
 *** Next ***
 - NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
+       the os/common sources (ports, oop, abstractions), no functional change
+       (github PR #27).
+- NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
        the SB (sandbox) sources, no functional change (github PR #26).
 - NEW: Coding-style cleanup of the XHAL OOP driver code generator: a glued
        comparison operator was corrected in the hal_base_driver codegen model


### PR DESCRIPTION
Conservative style pass over `os/common` (Giovanni Di Sirio copyright only — 151 of 602 files; the rest are vendor/CMSIS/NASA). Whitespace/comment-only; U083RC (ARMv6-M) and H563 (ARMv8-M) build clean; CI changed-line stylecheck clean.

**Fixed:** trailing spaces (oop_chprintf, cmsis_os); collapsed blank-line runs (several ports, cmparams); glued do/while in utils/paths.c + SIM ports; loose parens in the ARMv6-M GCC version-check block + oop_chprintf; glued `==` in ARMv6-M rp2 chcoresmp.c; one comma-no-space in the nasa_cfe OSAL typedef.

**Deliberately not touched:**
- `ext/` vendor headers (RP register files);
- inline-asm / `_Pragma` constraint strings flagged as glued operators (`"=r"`, IAR `data_alignment=n`) — in-string FPs;
- tab-aligned `PORT_SETUP_CONTEXT` macro continuations (deliberate alignment);
- comment-capitalization and `//` categories.

Sheriff-authored; for human review/merge.