### PR TITLE
tools/style: suppress two stylecheck.py false positives

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,11 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- NEW: tools/style/stylecheck.py no longer reports two false positives:
+       "#endif /* defined(X) */" guard comments (the lower-case "defined"
+       operator) and operators/commas inside string literals (only the first
+       string per line was previously blanked). Strictly more permissive
+       (github PR #28).
 - NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
        the os/common sources (ports, oop, abstractions), no functional change
        (github PR #27).

--- a/tools/style/stylecheck.py
+++ b/tools/style/stylecheck.py
@@ -50,7 +50,11 @@ def main():
     if re.match(r"\s*/\*[^\s\*=]", comment):
       style("detected glued comment start")
 
-    if re.match(r"\s*/\*\s*[a-z]", comment):
+    # A leading lower-case word is reported, EXCEPT for preprocessor guard
+    # comments such as "#endif /* defined(X) */" / "/* !defined(X) */", where
+    # "defined" is the C operator and must stay lower case.
+    if re.match(r"\s*/\*\s*[a-z]", comment) and \
+       not re.match(r"\s*/\*\s*!?defined\b", comment):
       style("detected lower case comment start")
 
   for raw_line in c_source:
@@ -85,8 +89,11 @@ def main():
     else:
       emptycnt = 0
 
-    line = line.replace('\\"', "", 1)
-    line = re.sub(r"\"[^\"]*\"", "_string_", line, count=1)
+    # Blank out ALL string literals on the line (not just the first) so that
+    # operators, commas, etc. inside string literals are not style-checked
+    # (e.g. inline-asm constraints "=r", or a comma inside a quoted token).
+    line = line.replace('\\"', "")
+    line = re.sub(r"\"[^\"]*\"", "_string_", line)
 
     # Minimal state machine to track comment parsing for follow-up checks.
     if state == "start":

--- a/tools/style/test_negatives.txt
+++ b/tools/style/test_negatives.txt
@@ -52,3 +52,7 @@ foo(); /* Multiple lines
 
 /*===========================================================================*/
 
+#endif /* defined(STM32F4XX) */
+/* !defined(STM32F4XX) */
+__asm volatile ("mrs %[p0], CPSR" : [p0] "=r" (sr));
+name = "PLLSAI2R,";

--- a/tools/style/test_positives.txt
+++ b/tools/style/test_positives.txt
@@ -63,3 +63,4 @@ a ^^b
 /*Comment*/
 /* comment*/
 /* Comment. */
+x =y; foo("z");


### PR DESCRIPTION
**This touches the CI gate (stylecheck.py) — please review carefully.**

Two systematic false positives in the mechanical style checker were forcing reviewers to leave real findings unaddressed:

1. **`#endif /* defined(X) */` guard comments** were flagged as *lower case comment start* (the C `defined` operator is lower case). The lower-case check now exempts `/* defined(...) */` and `/* !defined(...) */`.
2. **operators/commas inside string literals** were flagged because only the *first* string per line was blanked (e.g. inline-asm constraints `"=r"`, or a comma inside a quoted token). Now **all** string literals on a line are blanked before the token checks.

Both changes are **strictly more permissive** — they can only remove findings, never add — so no currently-green PR or merged file is affected.

**Tests:** `test_negatives.txt` gains the newly-tolerated cases (still **0** findings); `test_positives.txt` gains a case proving a real glued operator on a line that *also* has a string is still flagged (positives 61 → 62).

**Effect on the HAL tree:** lower-case-comment 226 → 34 (the 192 endif-guard FPs cleared), in-string operator FPs → 0, total 349 → 96. No crashes across all `py_style_*` suites.

Note: the legacy `stylecheck.pl` (not used by CI — only the manual `style_*.sh` dev scripts) is left unchanged; it could get the same two changes for parity as a follow-up.

After this lands, a genuine lower-case-comment / `//` cleanup pass becomes feasible (the FP noise is gone). Sheriff-authored; for human review/merge.