### PR TITLE
various: fix deterministic style anomalies (conservative)

### DIFF
--- a/os/various/lwip_bindings/arch/sys_arch.c
+++ b/os/various/lwip_bindings/arch/sys_arch.c
@@ -63,11 +63,11 @@
 #include "arch/sys_arch.h"
 #include "lwipopts.h"
 
-#ifndef CH_LWIP_USE_MEM_POOLS 
+#ifndef CH_LWIP_USE_MEM_POOLS
 #define CH_LWIP_USE_MEM_POOLS FALSE
 #endif
 
-#if CH_LWIP_USE_MEM_POOLS 
+#if CH_LWIP_USE_MEM_POOLS
 static MEMORYPOOL_DECL(lwip_sys_arch_sem_pool, sizeof(semaphore_t), 4, chCoreAllocAlignedI);
 static MEMORYPOOL_DECL(lwip_sys_arch_mbox_pool, sizeof(mailbox_t) + sizeof(msg_t) * TCPIP_MBOX_SIZE, 4, chCoreAllocAlignedI);
 static MEMORYPOOL_DECL(lwip_sys_arch_thread_pool, THD_WORKING_AREA_SIZE(TCPIP_THREAD_STACKSIZE), PORT_WORKING_AREA_ALIGN, chCoreAllocAlignedI);

--- a/os/various/lwip_bindings/lwipthread.c
+++ b/os/various/lwip_bindings/lwipthread.c
@@ -160,7 +160,7 @@ static err_t low_level_output(struct netif *netif, struct pbuf *p) {
   if (((u8_t*)p->payload)[0] & 1) {
     /* broadcast or multicast packet*/
     MIB2_STATS_NETIF_INC(netif, ifoutnucastpkts);
-  } 
+  }
   else {
     /* unicast packet */
     MIB2_STATS_NETIF_INC(netif, ifoutucastpkts);
@@ -235,7 +235,7 @@ static bool low_level_input(struct netif *netif, struct pbuf **pbuf) {
     if (*(uint8_t *)((*pbuf)->payload) & 1) {
       /* broadcast or multicast packet*/
       MIB2_STATS_NETIF_INC(netif, ifinnucastpkts);
-    } 
+    }
     else {
       /* unicast packet*/
       MIB2_STATS_NETIF_INC(netif, ifinucastpkts);
@@ -253,7 +253,7 @@ static bool low_level_input(struct netif *netif, struct pbuf **pbuf) {
     LINK_STATS_INC(link.drop);
     MIB2_STATS_NETIF_INC(netif, ifindiscards);
   }
-  
+
   return true;
 }
 

--- a/os/various/lwip_bindings/lwipthread.h
+++ b/os/various/lwip_bindings/lwipthread.h
@@ -185,13 +185,13 @@
  */
 typedef enum {
 #if LWIP_DHCP || defined(__DOXYGEN__)
-    /** 
+    /**
      * @brief   Assign a DHCP given address.
      */
     NET_ADDRESS_DHCP = 1,
 #endif
     /**
-     * @brief   Assign a statically IPv4 address. 
+     * @brief   Assign a statically IPv4 address.
      */
     NET_ADDRESS_STATIC = 2,
 #if LWIP_AUTOIP  || defined(__DOXYGEN__)

--- a/os/various/shell/shell.c
+++ b/os/various/shell/shell.c
@@ -175,7 +175,7 @@ static void save_history(ShellHistory *shp, char *line, int length) {
 }
 
 static int get_history(ShellHistory *shp, char *line, int dir) {
-  int count=0;
+  int count = 0;
 
   if (shp == NULL)
     return -1;

--- a/os/various/shell/shell_cmd.c
+++ b/os/various/shell/shell_cmd.c
@@ -318,7 +318,7 @@ static void cmd_cat(BaseSequentialStream *chp, int argc, char *argv[]) {
     }
 
     fd = open(argv[0], O_RDONLY);
-    if(fd == -1) {
+    if (fd == -1) {
       chprintf(chp, "Cannot open file" SHELL_NEWLINE_STR);
       break;
     }

--- a/os/various/wolfssl_bindings/wolfssl_chibios.c
+++ b/os/various/wolfssl_bindings/wolfssl_chibios.c
@@ -113,7 +113,6 @@ void sslconn_close(sslconn *sk)
     chHeapFree(sk);
 }
 
-
 /* IO Callbacks */
 int wolfssl_send_cb(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 {
@@ -134,7 +133,6 @@ int wolfssl_send_cb(WOLFSSL* ssl, char *buf, int sz, void *ctx)
   else
     return WOLFSSL_CBIO_ERR_WANT_WRITE;
 }
-
 
 #define MAX_SSL_BUF 1460
 static uint8_t ssl_recv_buffer[MAX_SSL_BUF];
@@ -161,7 +159,6 @@ int wolfssl_recv_cb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         }
         return sz;
     }
-
 
     err = netconn_recv(sk->conn, &inbuf);
     if (err == ERR_OK) {
@@ -203,7 +200,6 @@ int wolfssl_recv_cb(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 #define ST2MS(n) (((n) * 1000UL + CH_CFG_ST_FREQUENCY - 1UL) / CH_CFG_ST_FREQUENCY)
 #endif
 
-
 word32 LowResTimer(void)
 {
     systime_t t = chVTGetSystemTimeX();
@@ -223,7 +219,7 @@ void *chHeapRealloc (void *addr, uint32_t size)
 
     void *ptr;
 
-    if(addr == NULL) {
+    if (addr == NULL) {
         return chHeapAlloc(NULL, size);
     }
 
@@ -231,20 +227,20 @@ void *chHeapRealloc (void *addr, uint32_t size)
     hp = addr - sizeof(union heap_header);
     prev_size = hp->used.size; /* size is always multiple of 8 */
 
-    /* check new size memory alignment */
-    if(size % 8 == 0) {
+    /* Check new size memory alignment */
+    if (size % 8 == 0) {
         new_size = size;
     }
     else {
         new_size = ((int) (size / 8)) * 8 + 8;
     }
 
-    if(prev_size >= new_size) {
+    if (prev_size >= new_size) {
         return addr;
     }
 
     ptr = chHeapAlloc(NULL, size);
-    if(ptr == NULL) {
+    if (ptr == NULL) {
         return NULL;
     }
 

--- a/os/various/xshell/xshell_cmd.c
+++ b/os/various/xshell/xshell_cmd.c
@@ -203,7 +203,7 @@ static void cmd_exit(xshell_t *xshp, int argc, char *argv[], char *envp[]) {
     xshellUsage(xshp, "");
     return;
   }
-  
+
   chThdTerminate(chThdGetSelfX());
 }
 #endif

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
+       the os/various sources (shell, xshell, bindings glue), no functional
+       change (github PR #29).
 - NEW: tools/style/stylecheck.py no longer reports two false positives:
        "#endif /* defined(X) */" guard comments (the lower-case "defined"
        operator) and operators/commas inside string literals (only the first


### PR DESCRIPTION
Conservative style pass over `os/various` (Giovanni Di Sirio copyright). The subsystem is mostly **external-library binding shims**, so this is limited to universally-safe and clearly-ChibiOS findings:

- trailing spaces + multiple blank-line runs (lwip/wolfssl/xshell glue);
- glued `if(` → `if (` and one `count=0` → `count = 0` in the core shell/xshell code and the ChibiOS-side `wolfssl_chibios.c` glue (plus capitalizing one adjacent lower-case comment so the changed line is clean).

**Deliberately not touched** (mirrors upstream conventions): littlefs `lfs_config.h` intrinsics, FatFs ChaN sample layer, newlib syscalls doxygen, wolfssl `hwrng.c` sample, and upstream-API macro signatures (`XMALLOC(s,h,t)`, `IP4_ADDR_VALUE(a,b,c,d)`). Whitespace/comment-only; CI changed-line stylecheck clean. Sheriff-authored; for human review/merge.