### PR TITLE
hal/lib: fix deterministic style anomalies

### DIFF
--- a/os/hal/lib/complex/mfs/hal_mfs.c
+++ b/os/hal/lib/complex/mfs/hal_mfs.c
@@ -917,7 +917,7 @@ mfs_error_t mfsStart(MFSDriver *mfsp, const MFSConfig *config) {
   mfsp->config = config;
 
   return mfs_mount(mfsp);
-} 
+}
 
 /**
  * @brief   Deactivates a MFS driver.

--- a/os/hal/lib/complex/serial_nor/devices/macronix_mx25/hal_flash_device.c
+++ b/os/hal/lib/complex/serial_nor/devices/macronix_mx25/hal_flash_device.c
@@ -435,7 +435,6 @@ flash_error_t snor_device_read(SNORDriver *devp, flash_offset_t offset,
   return FLASH_NO_ERROR;
 }
 
-
 /**
  * @brief   Device program.
  *
@@ -512,7 +511,6 @@ flash_error_t snor_device_start_erase_all(SNORDriver *devp) {
 
   return FLASH_NO_ERROR;
 }
-
 
 /**
  * @brief   Device sector erase start.

--- a/os/hal/lib/complex/serial_nor/hal_serial_nor.c
+++ b/os/hal/lib/complex/serial_nor/hal_serial_nor.c
@@ -746,7 +746,7 @@ void snorStart(SNORDriver *devp, const SNORConfig *config) {
     /* Bus release.*/
     bus_release(devp->config->busp);
   }
-} 
+}
 
 /**
  * @brief   Deactivates the SNOR driver.

--- a/os/hal/lib/streams/chprintf.c
+++ b/os/hal/lib/streams/chprintf.c
@@ -139,13 +139,13 @@ int chvprintf(BaseSequentialStream *chp, const char *fmt, va_list ap) {
     if (c == 0) {
       return n;
     }
-    
+
     if (c != '%') {
       streamPut(chp, (uint8_t)c);
       n++;
       continue;
     }
-    
+
     p = tmpbuf;
     s = tmpbuf;
 
@@ -169,9 +169,9 @@ int chvprintf(BaseSequentialStream *chp, const char *fmt, va_list ap) {
       fmt++;
       filler = '0';
     }
-    
+
     /* Width modifier.*/
-    if ( *fmt == '*') {
+    if (*fmt == '*') {
       width = va_arg(ap, int);
       ++fmt;
       c = *fmt++;
@@ -192,7 +192,7 @@ int chvprintf(BaseSequentialStream *chp, const char *fmt, va_list ap) {
         }
       }
     }
-    
+
     /* Precision modifier.*/
     precision = 0;
     if (c == '.') {
@@ -215,7 +215,7 @@ int chvprintf(BaseSequentialStream *chp, const char *fmt, va_list ap) {
         }
       }
     }
-    
+
     /* Long modifier.*/
     if (c == 'l' || c == 'L') {
       is_long = true;

--- a/os/hal/lib/streams/memstreams.h
+++ b/os/hal/lib/streams/memstreams.h
@@ -17,7 +17,7 @@
 /**
  * @file    memstreams.h
  * @brief   Memory streams structures and macros.
-
+ *
  * @addtogroup HAL_MEMORY_STREAMS
  * @{
  */

--- a/os/hal/lib/streams/memstreams.h
+++ b/os/hal/lib/streams/memstreams.h
@@ -17,7 +17,7 @@
 /**
  * @file    memstreams.h
  * @brief   Memory streams structures and macros.
- 
+
  * @addtogroup HAL_MEMORY_STREAMS
  * @{
  */

--- a/os/hal/lib/streams/nullstreams.h
+++ b/os/hal/lib/streams/nullstreams.h
@@ -17,7 +17,7 @@
 /**
  * @file    nullstreams.h
  * @brief   Null streams structures and macros.
- 
+
  * @addtogroup HAL_NULL_STREAMS
  * @{
  */

--- a/os/hal/lib/streams/nullstreams.h
+++ b/os/hal/lib/streams/nullstreams.h
@@ -17,7 +17,7 @@
 /**
  * @file    nullstreams.h
  * @brief   Null streams structures and macros.
-
+ *
  * @addtogroup HAL_NULL_STREAMS
  * @{
  */

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,9 @@ See .devcontainer/README.md for included tools and usage.
 
 *** Next ***
 - NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
+       the os/hal/lib sources (streams, mfs, serial_nor), no functional
+       change (github PR #30).
+- NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
        the os/various sources (shell, xshell, bindings glue), no functional
        change (github PR #29).
 - NEW: tools/style/stylecheck.py no longer reports two false positives:


### PR DESCRIPTION
Style pass over `os/hal/lib` (Giovanni Di Sirio copyright) — **not** covered by the earlier HAL pass #20 (whose scope was include/src/templates/osal/ports only). Whitespace-only + one loose paren; `chprintf` builds clean.

- trailing spaces (`streams/chprintf.c`, `memstreams.h`, `nullstreams.h`, `serial_nor`, `mfs`)
- collapsed multiple blank lines (macronix_mx25 flash device)
- loose `(` in chprintf (`if ( *fmt` → `if (*fmt`)

The generated xsnor device sources (`complex/xsnor/codegen`) had no findings. `os/xhal/lib` was already swept by #22 and is clean. Sheriff-authored; for human review/merge.