### PR TITLE
STM32U3 RTC: enable APB clock (boot-hang fix) + drop bogus U3/U5 RTC EXTI

### DIFF
--- a/os/hal/ports/STM32/STM32U3xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U3xx/hal_lld.c
@@ -760,8 +760,8 @@ void stm32_clock_init(void) {
   rccResetAPB3(~0);
 
   /* RTC APB clock enable.*/
-#if (HAL_USE_RTC == TRUE) && defined(RCC_APB3ENR_RTCAPBEN)
-  rccEnableAPB3(RCC_APB3ENR_RTCAPBEN, true);
+#if (HAL_USE_RTC == TRUE) && defined(RCC_APB1ENR1_RTCAPBEN)
+  rccEnableAPB1R1(RCC_APB1ENR1_RTCAPBEN, true);
 #endif
 
   /* Static PWR configurations.*/

--- a/os/hal/ports/STM32/STM32U3xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U3xx/stm32_registry.h
@@ -191,8 +191,6 @@
 #define STM32_RTC_TAMP_HANDLER              Vector50
 #define STM32_RTC_GLOBAL_NUMBER             2
 #define STM32_RTC_TAMP_NUMBER               4
-#define STM32_RTC_GLOBAL_EXTI               17
-#define STM32_RTC_TAMP_EXTI                 19
 #if !defined(STM32_RTC_GLOBAL_IRQ_PRIORITY) || defined(__DOXYGEN__)
 #define STM32_RTC_GLOBAL_IRQ_PRIORITY       STM32_IRQ_EXTI15_PRIORITY
 #endif
@@ -204,17 +202,14 @@
   nvicEnableVector(STM32_RTC_TAMP_NUMBER, STM32_RTC_TAMP_IRQ_PRIORITY);     \
 } while (false)
 
- /* Enabling RTC-related EXTI lines.*/
+ /* This device has no RTC-dedicated EXTI lines: the RTC interrupts are
+   connected directly to the NVIC (RM0487 Table 131 - EXTI lines 17/19 are
+   COMP1/VDDUSB, not RTC). The RTC EXTI enable/clear are no-ops.*/
 #define STM32_RTC_ENABLE_ALL_EXTI() do {                                    \
-  extiEnableGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                      \
-                   EXTI_MASK1(STM32_RTC_TAMP_EXTI),                         \
-                   EXTI_MODE_RISING_EDGE | EXTI_MODE_ACTION_INTERRUPT);     \
 } while (false)
 
-/* Clearing EXTI interrupts. */
+/* Clearing EXTI interrupts (no RTC EXTI lines, no-op). */
 #define STM32_RTC_CLEAR_ALL_EXTI() do {                                     \
-  extiClearGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                       \
-                  EXTI_MASK1(STM32_RTC_TAMP_EXTI));                         \
 } while (false)
 
 /* Masks used to preserve state of RTC and TAMP register reserved bits. */

--- a/os/hal/ports/STM32/STM32U3xx_TEST/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U3xx_TEST/hal_lld.c
@@ -722,8 +722,8 @@ void stm32_clock_init(void) {
   rccResetAPB3(~0);
 
   /* RTC APB clock enable.*/
-#if (HAL_USE_RTC == TRUE) && defined(RCC_APB3ENR_RTCAPBEN)
-  rccEnableAPB3(RCC_APB3ENR_RTCAPBEN, true);
+#if (HAL_USE_RTC == TRUE) && defined(RCC_APB1ENR1_RTCAPBEN)
+  rccEnableAPB1R1(RCC_APB1ENR1_RTCAPBEN, true);
 #endif
 
   /* Static PWR configurations.*/

--- a/os/hal/ports/STM32/STM32U3xx_TEST/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U3xx_TEST/stm32_registry.h
@@ -191,8 +191,6 @@
 #define STM32_RTC_TAMP_HANDLER              Vector50
 #define STM32_RTC_GLOBAL_NUMBER             2
 #define STM32_RTC_TAMP_NUMBER               4
-#define STM32_RTC_GLOBAL_EXTI               17
-#define STM32_RTC_TAMP_EXTI                 19
 #if !defined(STM32_RTC_GLOBAL_IRQ_PRIORITY) || defined(__DOXYGEN__)
 #define STM32_RTC_GLOBAL_IRQ_PRIORITY       STM32_IRQ_EXTI15_PRIORITY
 #endif
@@ -204,17 +202,14 @@
   nvicEnableVector(STM32_RTC_TAMP_NUMBER, STM32_RTC_TAMP_IRQ_PRIORITY);     \
 } while (false)
 
- /* Enabling RTC-related EXTI lines.*/
+ /* This device has no RTC-dedicated EXTI lines: the RTC interrupts are
+   connected directly to the NVIC (RM0487 Table 131 - EXTI lines 17/19 are
+   COMP1/VDDUSB, not RTC). The RTC EXTI enable/clear are no-ops.*/
 #define STM32_RTC_ENABLE_ALL_EXTI() do {                                    \
-  extiEnableGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                      \
-                   EXTI_MASK1(STM32_RTC_TAMP_EXTI),                         \
-                   EXTI_MODE_RISING_EDGE | EXTI_MODE_ACTION_INTERRUPT);     \
 } while (false)
 
-/* Clearing EXTI interrupts. */
+/* Clearing EXTI interrupts (no RTC EXTI lines, no-op). */
 #define STM32_RTC_CLEAR_ALL_EXTI() do {                                     \
-  extiClearGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                       \
-                  EXTI_MASK1(STM32_RTC_TAMP_EXTI));                         \
 } while (false)
 
 /* Masks used to preserve state of RTC and TAMP register reserved bits. */

--- a/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
@@ -205,8 +205,6 @@
 #define STM32_RTC_TAMP_HANDLER              Vector50
 #define STM32_RTC_GLOBAL_NUMBER             2
 #define STM32_RTC_TAMP_NUMBER               4
-#define STM32_RTC_GLOBAL_EXTI               17
-#define STM32_RTC_TAMP_EXTI                 19
 #if !defined(STM32_RTC_GLOBAL_IRQ_PRIORITY) || defined(__DOXYGEN__)
 #define STM32_RTC_GLOBAL_IRQ_PRIORITY       STM32_IRQ_EXTI15_PRIORITY
 #endif
@@ -218,17 +216,14 @@
   nvicEnableVector(STM32_RTC_TAMP_NUMBER, STM32_RTC_TAMP_IRQ_PRIORITY);     \
 } while (false)
 
-/* Enabling RTC-related EXTI lines.*/
+/* This device has no RTC-dedicated EXTI lines: the RTC interrupts are
+   connected directly to the NVIC (RM0456 Table 187 - EXTI lines 17/19 are
+   COMP1/VDDUSB, not RTC). The RTC EXTI enable/clear are no-ops.*/
 #define STM32_RTC_ENABLE_ALL_EXTI() do {                                    \
-  extiEnableGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                      \
-                   EXTI_MASK1(STM32_RTC_TAMP_EXTI),                         \
-                   EXTI_MODE_RISING_EDGE | EXTI_MODE_ACTION_INTERRUPT);     \
 } while (false)
 
-/* Clearing EXTI interrupts. */
+/* Clearing EXTI interrupts (no RTC EXTI lines, no-op). */
 #define STM32_RTC_CLEAR_ALL_EXTI() do {                                     \
-  extiClearGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                       \
-                  EXTI_MASK1(STM32_RTC_TAMP_EXTI));                         \
 } while (false)
 
 /* Masks used to preserve state of RTC and TAMP register reserved bits. */

--- a/os/xhal/ports/STM32/STM32U3xx/hal_lld.c
+++ b/os/xhal/ports/STM32/STM32U3xx/hal_lld.c
@@ -760,8 +760,8 @@ void stm32_clock_init(void) {
   rccResetAPB3(~0);
 
   /* RTC APB clock enable.*/
-#if (HAL_USE_RTC == TRUE) && defined(RCC_APB3ENR_RTCAPBEN)
-  rccEnableAPB3(RCC_APB3ENR_RTCAPBEN, true);
+#if (HAL_USE_RTC == TRUE) && defined(RCC_APB1ENR1_RTCAPBEN)
+  rccEnableAPB1R1(RCC_APB1ENR1_RTCAPBEN, true);
 #endif
 
   /* Static PWR configurations.*/

--- a/os/xhal/ports/STM32/STM32U3xx/stm32_registry.h
+++ b/os/xhal/ports/STM32/STM32U3xx/stm32_registry.h
@@ -191,8 +191,6 @@
 #define STM32_RTC_TAMP_HANDLER              Vector50
 #define STM32_RTC_GLOBAL_NUMBER             2
 #define STM32_RTC_TAMP_NUMBER               4
-#define STM32_RTC_GLOBAL_EXTI               17
-#define STM32_RTC_TAMP_EXTI                 19
 #if !defined(STM32_RTC_GLOBAL_IRQ_PRIORITY) || defined(__DOXYGEN__)
 #define STM32_RTC_GLOBAL_IRQ_PRIORITY       STM32_IRQ_EXTI15_PRIORITY
 #endif
@@ -204,17 +202,14 @@
   nvicEnableVector(STM32_RTC_TAMP_NUMBER, STM32_RTC_TAMP_IRQ_PRIORITY);     \
 } while (false)
 
- /* Enabling RTC-related EXTI lines.*/
+ /* This device has no RTC-dedicated EXTI lines: the RTC interrupts are
+   connected directly to the NVIC (RM0487 Table 131 - EXTI lines 17/19 are
+   COMP1/VDDUSB, not RTC). The RTC EXTI enable/clear are no-ops.*/
 #define STM32_RTC_ENABLE_ALL_EXTI() do {                                    \
-  extiEnableGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                      \
-                   EXTI_MASK1(STM32_RTC_TAMP_EXTI),                         \
-                   EXTI_MODE_RISING_EDGE | EXTI_MODE_ACTION_INTERRUPT);     \
 } while (false)
 
-/* Clearing EXTI interrupts. */
+/* Clearing EXTI interrupts (no RTC EXTI lines, no-op). */
 #define STM32_RTC_CLEAR_ALL_EXTI() do {                                     \
-  extiClearGroup1(EXTI_MASK1(STM32_RTC_GLOBAL_EXTI) |                       \
-                  EXTI_MASK1(STM32_RTC_TAMP_EXTI));                         \
 } while (false)
 
 /* Masks used to preserve state of RTC and TAMP register reserved bits. */

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,13 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: STM32U3 and STM32U5 RTC drivers operated on the wrong EXTI lines. The
+       ports defined STM32_RTC_GLOBAL_EXTI=17 / STM32_RTC_TAMP_EXTI=19 (copied
+       from STM32H5) and enabled/cleared them, but on U3/U5 those lines are
+       COMP1 and VDDUSB (RM0487 Table 131 / RM0456 Table 187) and the RTC has
+       no EXTI line at all (RTC interrupts go directly to the NVIC). The RTC
+       EXTI enable/clear are now no-ops on both families (HAL and XHAL ports)
+       (github PR #NN).
 - NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
        the os/hal/lib sources (streams, mfs, serial_nor), no functional
        change (github PR #30).

--- a/readme.txt
+++ b/readme.txt
@@ -81,13 +81,20 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: STM32U3 RTC was completely non-functional - the driver hung at boot in
+       rtc_enter_init() waiting for INITF. The RTC APB clock was never enabled:
+       hal_lld guarded it on defined(RCC_APB3ENR_RTCAPBEN) (the STM32H5/U5
+       register), but on STM32U3 the bit is RCC_APB1ENR1_RTCAPBEN (APB1ENR1
+       bit 30), so the guard was always false and the RTC register interface
+       was unclocked. Enable it via rccEnableAPB1R1(RCC_APB1ENR1_RTCAPBEN) on
+       STM32U3xx (HAL + XHAL). HW-verified on NUCLEO-U385RG (github PR #31).
 - FIX: STM32U3 and STM32U5 RTC drivers operated on the wrong EXTI lines. The
        ports defined STM32_RTC_GLOBAL_EXTI=17 / STM32_RTC_TAMP_EXTI=19 (copied
        from STM32H5) and enabled/cleared them, but on U3/U5 those lines are
        COMP1 and VDDUSB (RM0487 Table 131 / RM0456 Table 187) and the RTC has
        no EXTI line at all (RTC interrupts go directly to the NVIC). The RTC
        EXTI enable/clear are now no-ops on both families (HAL and XHAL ports)
-       (github PR #NN).
+       (github PR #31).
 - NEW: Coding-style cleanup (whitespace, spacing and comment formatting) of
        the os/hal/lib sources (streams, mfs, serial_nor), no functional
        change (github PR #30).


### PR DESCRIPTION
Two RTC fixes for the new STM32U3 (and a related U5 cleanup), **HW-verified on NUCLEO-U385RG**.

### 1. STM32U3 RTC was completely non-functional (boot hang) — `a266184a`
Any RTC-using build hung at boot in `rtc_enter_init()` spinning on `INITF`. The RTC **APB register-interface clock was never enabled**: `hal_lld_init()` guards it on `defined(RCC_APB3ENR_RTCAPBEN)` (the STM32H5/U5 bit), but on STM32U3 the bit is **`RCC_APB1ENR1_RTCAPBEN` (APB1ENR1 bit 30)** — so the guard was always false and the RTC stayed unclocked (all registers read 0, writes dropped, `INITF` never set).

Proven on the debug probe: `RCC_APB1ENR1 = 0` and `RTC_PRER = 0`; setting APB1ENR1 bit 30 made `RTC_PRER` read its `0x007F00FF` reset value. Fix: `rccEnableAPB1R1(RCC_APB1ENR1_RTCAPBEN)` on STM32U3xx / U3xx_TEST (HAL) + U3xx (XHAL). **U5 keeps its correct APB3 enable.**

### 2. STM32U3/U5 RTC operated on the wrong EXTI lines — `1316ab7c`
The ports defined `STM32_RTC_GLOBAL_EXTI=17` / `STM32_RTC_TAMP_EXTI=19` (copied from H5) and enabled/cleared them, but on U3/U5 lines 17/19 are **COMP1 and VDDUSB** (RM0487 Table 131 / RM0456 Table 187) and the RTC has **no EXTI line** (NVIC-direct). The RTC EXTI enable/clear are now no-ops (HAL + XHAL).

### HW verification (NUCLEO-U385RG)
With both fixes the RTC initializes and the RTC **alarm callback fires** (Alarm A, event=1) — confirming the RTC IRQ is NVIC-direct and no EXTI line is involved. Builds clean on U3 (RTCv3 + XHAL RTCv4) and U5 (RTCv3).

Sheriff-authored; for human review/merge.