### PR TITLE
NVIC: fix nvicSetSystemHandlerPriority() wrong SHPR write on Cortex-M0/M0+/M23

### DIFF
--- a/os/hal/ports/common/ARMCMx/nvic.c
+++ b/os/hal/ports/common/ARMCMx/nvic.c
@@ -150,8 +150,15 @@ void nvicSetSystemHandlerPriority(uint32_t handler, uint32_t prio) {
 
 #if defined(__CORE_CM0_H_GENERIC) || defined(__CORE_CM0PLUS_H_GENERIC) ||   \
     defined(__CORE_CM23_H_GENERIC)
-  SCB->__SHPR[_SHP_IDX(handler)] = (SCB->__SHPR[_SHP_IDX(handler)] & ~(0xFFU << _BIT_SHIFT(handler))) |
-                                   (NVIC_PRIORITY_MASK(prio) << _BIT_SHIFT(handler));
+  /* On these cores SCB->SHPR is a word array accessed through the CMSIS
+     _SHP_IDX()/_BIT_SHIFT() macros, which expect the (negative) system
+     exception number, not the positive ChibiOS handler index, so the
+     handler index is converted to the matching exception number here.*/
+  {
+    int32_t irqn = (int32_t)handler - 12;
+    SCB->__SHPR[_SHP_IDX(irqn)] = (SCB->__SHPR[_SHP_IDX(irqn)] & ~(0xFFU << _BIT_SHIFT(irqn))) |
+                                  (NVIC_PRIORITY_MASK(prio) << _BIT_SHIFT(irqn));
+  }
 #else
   SCB->__SHPR[handler] = NVIC_PRIORITY_MASK(prio);
 #endif

--- a/os/xhal/ports/common/ARMCMx/nvic.c
+++ b/os/xhal/ports/common/ARMCMx/nvic.c
@@ -150,8 +150,15 @@ void nvicSetSystemHandlerPriority(uint32_t handler, uint32_t prio) {
 
 #if defined(__CORE_CM0_H_GENERIC) || defined(__CORE_CM0PLUS_H_GENERIC) ||   \
     defined(__CORE_CM23_H_GENERIC)
-  SCB->__SHPR[_SHP_IDX(handler)] = (SCB->__SHPR[_SHP_IDX(handler)] & ~(0xFFU << _BIT_SHIFT(handler))) |
-                                   (NVIC_PRIORITY_MASK(prio) << _BIT_SHIFT(handler));
+  /* On these cores SCB->SHPR is a word array accessed through the CMSIS
+     _SHP_IDX()/_BIT_SHIFT() macros, which expect the (negative) system
+     exception number, not the positive ChibiOS handler index, so the
+     handler index is converted to the matching exception number here.*/
+  {
+    int32_t irqn = (int32_t)handler - 12;
+    SCB->__SHPR[_SHP_IDX(irqn)] = (SCB->__SHPR[_SHP_IDX(irqn)] & ~(0xFFU << _BIT_SHIFT(irqn))) |
+                                  (NVIC_PRIORITY_MASK(prio) << _BIT_SHIFT(irqn));
+  }
 #else
   SCB->__SHPR[handler] = NVIC_PRIORITY_MASK(prio);
 #endif

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,14 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: nvicSetSystemHandlerPriority() programmed the wrong SCB->SHPR field on
+       Cortex-M0, M0+ and M23: the positive ChibiOS handler index was passed
+       to the CMSIS _SHP_IDX()/_BIT_SHIFT() macros, which expect the negative
+       system exception number, so the priority write (e.g. SysTick from the
+       ST driver) landed on the wrong register slot - SysTick was left at its
+       reset priority and another handler's priority was corrupted. The handler
+       index is now converted to the matching exception number (HAL and XHAL
+       ports) (forum bug report, github PR #34).
 - FIX: RP2040 early (pre-XOSC) tick generator was configured with a divisor of
        1 instead of clk/1MHz, so the boot-time microsecond tick ran about six
        times too fast until clk_ref switched to the XOSC (the post-switch


### PR DESCRIPTION
🤖 This PR was prepared by the ChibiOS sheriff (assistant-operated account) on the maintainer's direction, from a forum bug report. It is for **human review and merge** — the sheriff does not review or merge its own PRs.

**Forum:** [nvicSetSystemHandlerPriority writes to wrong SHP register on Cortex-M0+/M0/M23](https://forum.chibios.org/viewtopic.php?t=6702) (reported by *Daniil Emb*; relates to SourceForge bug #1308)

### Bug
On Cortex-M0/M0+/M23, `SCB->SHPR` is a **word** array and CMSIS accesses it through the `_SHP_IDX()`/`_BIT_SHIFT()` macros, which are defined for the **negative system exception number** (`SysTick_IRQn = -1`, …). `nvicSetSystemHandlerPriority()` was passing the **positive ChibiOS handler index** (`HANDLER_SYSTICK = 11`, …) straight into those macros, so the priority write landed on the wrong slot.

Worked example (`HANDLER_SYSTICK = 11`): `_SHP_IDX(11)=0`, `_BIT_SHIFT(11)=24` → writes `SHPR[0]` byte 3 (the **SVCall** slot) instead of `SHPR[1]` byte 3 (SysTick). The ST drivers call this function with `HANDLER_SYSTICK` on every tick setup, so on **every baseline-core port (RP2040, STM32C0/G0/L0, STM32WL, …)** SysTick was left at its **reset priority (0 = highest)** and the SVCall priority was corrupted.

The `#else` branch (M3/M4/M7/M33, byte-array `SCB->SHP[]` indexed directly by the handler) is correct and is unchanged.

### Fix
Convert the handler index to the matching CMSIS exception number (`(int32_t)handler - 12` → 11→−1, 10→−2, 7→−5) before the macros. Applied to the **HAL and XHAL** copies (`os/{hal,xhal}/ports/common/ARMCMx/nvic.c`).

### Verification
- Builds clean (GCC 14.3.1): HAL M0+ `RT-STM32L053R8-NUCLEO64`, XHAL M0+ `RT-XHAL-STM32-MULTI` (stm32c031c6).
- `stylecheck.py` clean on changed lines.
- ⚠️ Not yet validated on hardware — recommend confirming the SysTick priority lands correctly on a baseline-core target (e.g. read back `SCB->SHPR`) before merge.

Based on the fix proposed by the reporter.
