### PR TITLE
NVIC: fix nvicSetSystemHandlerPriority() wrong SHPR write on M0/M0+/M23 (backport to 21.11.6)

### DIFF
--- a/os/hal/ports/common/ARMCMx/nvic.c
+++ b/os/hal/ports/common/ARMCMx/nvic.c
@@ -150,8 +150,15 @@ void nvicSetSystemHandlerPriority(uint32_t handler, uint32_t prio) {
 
 #if defined(__CORE_CM0_H_GENERIC) || defined(__CORE_CM0PLUS_H_GENERIC) ||   \
     defined(__CORE_CM23_H_GENERIC)
-  SCB->__SHPR[_SHP_IDX(handler)] = (SCB->__SHPR[_SHP_IDX(handler)] & ~(0xFFU << _BIT_SHIFT(handler))) |
-                                   (NVIC_PRIORITY_MASK(prio) << _BIT_SHIFT(handler));
+  /* On these cores SCB->SHPR is a word array accessed through the CMSIS
+     _SHP_IDX()/_BIT_SHIFT() macros, which expect the (negative) system
+     exception number, not the positive ChibiOS handler index, so the
+     handler index is converted to the matching exception number here.*/
+  {
+    int32_t irqn = (int32_t)handler - 12;
+    SCB->__SHPR[_SHP_IDX(irqn)] = (SCB->__SHPR[_SHP_IDX(irqn)] & ~(0xFFU << _BIT_SHIFT(irqn))) |
+                                  (NVIC_PRIORITY_MASK(prio) << _BIT_SHIFT(irqn));
+  }
 #else
   SCB->__SHPR[handler] = NVIC_PRIORITY_MASK(prio);
 #endif

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,13 @@
 *****************************************************************************
 
 *** 21.11.6 ***
+- FIX: nvicSetSystemHandlerPriority() programmed the wrong SCB->SHPR field on
+       Cortex-M0, M0+ and M23: the positive ChibiOS handler index was passed
+       to the CMSIS _SHP_IDX()/_BIT_SHIFT() macros, which expect the negative
+       system exception number, so the priority write (e.g. SysTick from the
+       ST driver) landed on the wrong register slot - SysTick was left at its
+       reset priority and another handler's priority was corrupted. The handler
+       index is now converted to the matching exception number (github PR #34).
 - NEW: STM32G4xx: added FSMC RCC macros, IRQ vector definitions and
        registry switch for the FMC-capable devices (github PR #7).
 - FIX: STM32U3 RTC was completely non-functional, the driver hung at boot in


### PR DESCRIPTION
🤖 Sheriff-prepared backport, for human review/merge.

Backport to **stable-21.11.x** (21.11.6) of github PR #34, merged on `main` as `31e09a9b`. **HAL-only** — 21.11.x has no XHAL port.

On Cortex-M0/M0+/M23 `SCB->SHPR` is a word array driven through the CMSIS `_SHP_IDX()`/`_BIT_SHIFT()` macros, which expect the *negative* system exception number. `nvicSetSystemHandlerPriority()` passed the positive ChibiOS handler index (`HANDLER_SYSTICK = 11`, …), so the priority write hit the wrong SHPR slot — SysTick kept its reset priority (0, highest) and SVCall's was corrupted. Converted to the matching exception number (`handler - 12`). Affects every baseline-core port (RP2040, STM32C0/G0/L0, STM32WL, …).

**Gates (local):** `RT-STM32L053…` (Cortex-M0+) builds clean; `stylecheck.py` clean on changed lines. Same fix as the HW-validated main change; HW re-confirmation on a baseline target is welcome but the code is identical to `main`.