### PR TITLE
REVIEW.md: reviewer owns the changelog entry (drafts it if missing)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -116,14 +116,21 @@ Stage C dimensions (deep):
   (issue, knowledge base, separate fix) and leave the author out of it. The same
   principle the CI applies to style (changed lines only) applies to judgment
   findings.
-- **Changelog tagging is fixed project-side:** every change's `readme.txt` entry
-  references its pull request — `(github PR #N)` — and backports add
-  `(backported to <release>)`. Contributors are not expected to get this tagging
-  right: the reviewer checks that the entry itself exists and describes the change
-  (that part IS the author's, Stage B); tagging/format errors (missing PR number,
-  `FIX:`/`NEW:` prefix, wrapping, annotations) are fixed by the reviewer with a
-  small commit pushed directly to the PR branch and a one-line comment — never
-  raised as findings, never a fix round on their own.
+- **Changelog is reviewer-owned:** every change's `readme.txt` entry references
+  its pull request — `(github PR #N)` — and backports add
+  `(backported to <release>)`. The reviewer OWNS this entry, for two reasons:
+  the reviewer just analysed the change so is best placed to describe it
+  accurately, and `readme.txt`'s top-of-section is a frequent merge-conflict
+  point, so it is kept out of the author's hands. So:
+  - if the entry is **missing**, the reviewer DRAFTS it (from the review just
+    done) and pushes it to the PR branch — it is NOT raised as a finding;
+  - if present but **mis-tagged** (missing PR number, `FIX:`/`NEW:` prefix,
+    wrapping, annotations), the reviewer fixes it the same way.
+  Either way it is a small, clearly-attributed commit to the PR branch plus a
+  one-line comment — never a finding, never a fix round on its own. Add it late
+  (near merge) to minimise rebasing against other PRs' entries. The author is
+  only expected to make the change itself correct; the changelog line is on the
+  reviewer.
 - **Make findings reproducible:** when reporting style findings, include the local
   reproduction hint so the author can self-check before pushing:
   `python3 tools/style/stylecheck.py <file>` (findings are printed as `style:`/


### PR DESCRIPTION
🤖 Sheriff-prepared, docs-only. Procedure refinement you requested: the missing-changelog case is no longer a Stage B author finding — the reviewer drafts and pushes the `readme.txt` entry itself (it's more accurate from the review just done, and `readme.txt`'s top-of-section is a frequent merge-conflict point). Added late/near-merge. (Direct push to `main` is blocked by the ruleset — PR required — so this is a PR for you to merge.)