### PR TITLE
SB: guard the VRQ-state atomicity invariant (re-review of margin 6)

### DIFF
--- a/os/sb/host/sbvrq.c
+++ b/os/sb/host/sbvrq.c
@@ -32,6 +32,28 @@
 /* Module local definitions.                                                 */
 /*===========================================================================*/
 
+/* The read-modify-write sequences on the shared VRQ state (vrq.isr,
+   vrq.wtmask, vrq.flags[]) in the fastcall handlers below are NOT explicitly
+   locked: their atomicity against the asynchronous producers (sbVRQTriggerI()
+   and sbVRQSetFlagsI(), both I-class) rests entirely on a priority invariant.
+   The handlers run at the SVCall priority, while any IRQ allowed to call an
+   I-class function sits at CORTEX_MAX_KERNEL_PRIORITY or below (numerically
+   higher, i.e. less urgent). SVCall therefore out-prioritizes every VRQ
+   producer and a producer cannot preempt a handler mid-sequence; the
+   sequences are atomic by construction (see note_sb_isolation_security.md,
+   margin 6). The fast-priority band above SVCall cannot produce VRQs because
+   it cannot call OS primitives.
+
+   This guard fails the build if a port or priority reconfiguration ever
+   breaks that ordering, rather than silently reopening the lost-update race.
+   The ALT ports define CORTEX_MAX_KERNEL_PRIORITY == CORTEX_PRIORITY_SVCALL + 1
+   so the invariant holds. (Lower numeric value == higher priority.) */
+#if defined(CORTEX_PRIORITY_SVCALL) && defined(CORTEX_MAX_KERNEL_PRIORITY)
+#if CORTEX_PRIORITY_SVCALL >= CORTEX_MAX_KERNEL_PRIORITY
+#error "VRQ state atomicity requires SVCall to out-prioritize every kernel-preempting IRQ (CORTEX_PRIORITY_SVCALL < CORTEX_MAX_KERNEL_PRIORITY)"
+#endif
+#endif
+
 /*===========================================================================*/
 /* Module exported variables.                                                */
 /*===========================================================================*/

--- a/os/sb/note_sb_improvement_priorities.md
+++ b/os/sb/note_sb_improvement_priorities.md
@@ -26,9 +26,14 @@ done items are marked inline.
    / `vio/sbvio_uart.c`, plus the EFAULT-vs-fault policy decision. The
    only *escape-relevant* gap active today; everything else
    security-wise is crash-resistance. (isolation note, margin 2)
-2. **VRQ masking atomicity re-review** — `vrq.isr` /
-   `SB_VRQ_ISR_DISABLED` discipline across the entry -> dispatch ->
-   return sequence. Live today, supervisor integrity. (margin 6)
+2. **VRQ masking atomicity re-review** — ✅ **DONE (2026-06-17)**:
+   the `vrq.isr` / `SB_VRQ_ISR_DISABLED` (and `wtmask`/`flags[]`) RMW
+   sequences are atomic by priority design — SVCall out-prioritizes every
+   kernel-preempting IRQ in the ALT ports, so no VRQ producer can preempt a
+   handler mid-sequence. No locking needed. Documented in the isolation
+   note (margin 6) and guarded by a `#if … #error`
+   (`CORTEX_PRIORITY_SVCALL < CORTEX_MAX_KERNEL_PRIORITY`) in
+   `host/sbvrq.c`. (margin 6)
 3. **v7-M guard-region coverage verification** — confirm the guard MPU
    region backs the privileged stack base
    (`SB_CFG_PRIVILEGED_STACK_SIZE`) for every sandbox config (no PSPLIM

--- a/os/sb/note_sb_isolation_security.md
+++ b/os/sb/note_sb_isolation_security.md
@@ -130,8 +130,37 @@ misses the guard is direct supervisor-memory corruption.
 The `vrq.isr` / `SB_VRQ_ISR_DISABLED` masking discipline prevents a VRQ
 being injected during the return transition. `sbVRQTriggerI` fires
 asynchronously from ISRs, so the masking atomicity across the entry ->
-dispatch -> return sequence needs explicit re-review (see open_points
-"Host").
+dispatch -> return sequence needed explicit re-review.
+
+**Re-reviewed 2026-06-17 — safe by priority design, now guarded.** The
+fastcall handlers in `host/sbvrq.c` perform unlocked read-modify-write on
+the shared VRQ state (`vrq.isr`, `vrq.wtmask`, `vrq.flags[]`); their
+atomicity against the asynchronous producers `sbVRQTriggerI()` /
+`sbVRQSetFlagsI()` (both I-class) rests on a priority invariant rather than
+a lock. The handlers run at SVCall priority; any IRQ permitted to call an
+I-class function is at `CORTEX_MAX_KERNEL_PRIORITY` or below (numerically
+higher = less urgent), which the ALT ports pin one level under SVCall
+(`CORTEX_MAX_KERNEL_PRIORITY == CORTEX_PRIORITY_SVCALL + 1`,
+`ARMv7-M-ALT`/`ARMv8-M-ML-ALT` `chcore.h`). A VRQ producer therefore cannot
+preempt a handler mid-sequence, so the would-be lost-update windows are
+closed by construction:
+
+- `wtmask` RMW vs. a producer's `|= (1 << nvrq)` — no interleave, no dropped
+  VRQ.
+- `flags[n]` read-and-clear in `gcsts` vs. `sbVRQSetFlagsI`'s `|=` — no
+  interleave, no lost completion flags (this is the VIO completion path).
+- the `isr = 0` -> mask-check window in `vrq_enable` / `vrq_return` — no
+  producer runs between the store and the check; the `asm("":::"memory")`
+  barrier is only compiler-ordering belt-and-suspenders.
+
+The fast-priority band *above* SVCall cannot produce VRQs (it cannot call OS
+primitives). The S-class producer `sbVRQTriggerS()` runs under `chSysLock`,
+same-core only (`owner == currcore` assert), so it cannot overlap a handler
+either. Converting these handlers to the IRQ-fastcall lock contract would be
+redundant overhead. Because the safety depends entirely on
+`CORTEX_PRIORITY_SVCALL < CORTEX_MAX_KERNEL_PRIORITY`, a `#if … #error`
+guard in `host/sbvrq.c` now fails the build if a future port or priority
+reconfiguration breaks that ordering.
 
 ## Design-decision impacts (2026-06-11)
 

--- a/os/sb/open_points.md
+++ b/os/sb/open_points.md
@@ -16,7 +16,7 @@ maintained in
 
 ## Host
 
-- Re-review syscall return and VRQ paths in `host/sbsyscall.c` and `host/sbvrq.c`, especially around restart/teardown windows, late producers, and the `vrq.isr`/`SB_VRQ_ISR_DISABLED` masking atomicity across the entry -> dispatch -> return sequence.
+- Re-review syscall return and VRQ paths in `host/sbsyscall.c` and `host/sbvrq.c`, especially around restart/teardown windows and late producers. **Masking-atomicity part resolved 2026-06-17:** the `vrq.isr`/`SB_VRQ_ISR_DISABLED` masking RMW sequences are atomic by priority design — SVCall out-prioritizes every kernel-preempting (I-class-capable) IRQ in the ALT ports (`CORTEX_PRIORITY_SVCALL < CORTEX_MAX_KERNEL_PRIORITY`), so no VRQ producer can preempt a handler mid-sequence. Documented in `note_sb_isolation_security.md` margin 6 and guarded by a `#if … #error` in `host/sbvrq.c`. Restart/teardown/late-producer review (the `chThdTerminatedX` guards) still open.
 - Decide whether sandbox memory-range violations in host services should keep returning `CH_RET_EFAULT` or escalate to a sandbox fault/termination policy.
 - Add more host-side validation tests for multi-image bring-up, because incorrect flashing order can produce misleading startup failures during debug.
 - Evaluate whether a host-side integration demo/test should be added for the working host + SB1 + SB2 configuration used during VETH/lwIP bring-up.


### PR DESCRIPTION
## Summary

Re-review and close Tier‑1 item 2 (VRQ masking atomicity) from the SB improvement priorities.

The fastcall handlers in `host/sbvrq.c` perform unlocked read‑modify‑write on the shared VRQ state (`vrq.isr`, `vrq.wtmask`, `vrq.flags[]`). This confirms those sequences are atomic **by priority design, not by luck**, and adds a build‑time guard so the invariant can't silently regress.

## Why it's safe

- Handlers run at **SVCall** priority.
- The only VRQ producers (`sbVRQTriggerI`, `sbVRQSetFlagsI`) are I‑class, so they can only run from an IRQ at `CORTEX_MAX_KERNEL_PRIORITY` or below — which the ALT ports pin **one level under SVCall** (`CORTEX_MAX_KERNEL_PRIORITY == CORTEX_PRIORITY_SVCALL + 1`).
- A producer therefore cannot preempt a handler mid‑sequence, closing:
  - the `wtmask` lost‑update (dropped VRQ),
  - the `flags[]` read‑and‑clear race in `gcsts` vs `sbVRQSetFlagsI` (the VIO completion path),
  - the `isr = 0` → mask‑check window in `vrq_enable`/`vrq_return`.
- The fast‑priority band above SVCall can't produce VRQs (no OS primitives); `sbVRQTriggerS` runs under `chSysLock`, same‑core only.

No locking is needed.

## Change

- `host/sbvrq.c`: a `#if … #error` guard asserting `CORTEX_PRIORITY_SVCALL < CORTEX_MAX_KERNEL_PRIORITY` (C99‑safe preprocessor; inert on ports lacking the symbols), with the rationale in a comment.
- Documentation: isolation note margin 6 updated to "safe by design + guarded", priorities item 2 and the open‑points host bullet marked resolved.

Verified: builds clean on the ARMv8‑M‑ML‑ALT host demo; guard proven active (inverting the condition fires the `#error`).
