### PR TITLE
SB notes: drop stale open_points cleanup entry

### DIFF
--- a/os/sb/open_points.md
+++ b/os/sb/open_points.md
@@ -77,5 +77,4 @@ Full assessment in [note_sb_isolation_security.md](note_sb_isolation_security.md
 
 ## Cleanup
 
-- Remove or archive the stale backup files `vio/sbvio_eth (copy).c` and `vio/sbvio_eth (copy).h` if they are no longer needed.
 - Periodically sync this file with resolved items so it stays a useful working backlog rather than a historical dump.


### PR DESCRIPTION
The open_points 'Cleanup' section asked to remove backup files `vio/sbvio_eth (copy).c` and `vio/sbvio_eth (copy).h`. Those files are no longer present on disk and were never tracked in git (untracked working-copy backups, since removed), so the item is obsolete. This drops the stale bullet and keeps the still-valid periodic-sync reminder. Docs-only.