### PR TITLE
xhal SIO: make the buffered SIO class optional (SIO_USE_BUFFERING)

### DIFF
--- a/os/xhal/codegen/hal_sio.xml
+++ b/os/xhal/codegen/hal_sio.xml
@@ -980,7 +980,8 @@ return (const void *)sio_lld_selcfg(self, cfgnum);]]></implementation>
         </methods>
       </class>
       <class name="hal_buffered_sio" type="regular" namespace="bsio"
-        descr="buffered SIO wrapper" ancestorname="hal_base_driver">
+        descr="buffered SIO wrapper" ancestorname="hal_base_driver"
+        check="SIO_USE_BUFFERING == TRUE">
         <brief>This class implements a buffered channel interface on top of SIO.</brief>
         <implements>
           <if name="asynchronous_channel">

--- a/os/xhal/include/hal_sio.h
+++ b/os/xhal/include/hal_sio.h
@@ -659,6 +659,8 @@ struct hal_sio_driver {
 };
 /** @} */
 
+#if (SIO_USE_BUFFERING == TRUE) || defined (__DOXYGEN__)
+
 /**
  * @class       hal_buffered_sio_c
  * @extends     hal_base_driver_c
@@ -753,6 +755,8 @@ struct hal_buffered_sio {
 };
 /** @} */
 
+#endif /* SIO_USE_BUFFERING == TRUE */
+
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/
@@ -779,6 +783,7 @@ extern "C" {
   msg_t sioSynchronizeTX(void *ip, sysinterval_t timeout);
   msg_t sioSynchronizeTXEnd(void *ip, sysinterval_t timeout);
 #endif /* SIO_USE_SYNCHRONIZATION == TRUE */
+#if (SIO_USE_BUFFERING == TRUE) || defined (__DOXYGEN__)
   /* Methods of hal_buffered_sio_c.*/
   void *__bsio_objinit_impl(void *ip, const void *vmt, hal_sio_driver_c *siop,
                             uint8_t *ib, size_t ibsize, uint8_t *ob,
@@ -789,6 +794,7 @@ extern "C" {
   const void *__bsio_setcfg_impl(void *ip, const void *config);
   void bsIncomingDataI(void *ip, uint8_t b);
   msg_t bsRequestDataI(void *ip);
+#endif /* SIO_USE_BUFFERING == TRUE */
   /* Regular functions.*/
   void sioInit(void);
 #ifdef __cplusplus
@@ -820,6 +826,7 @@ static inline hal_sio_driver_c *sioObjectInit(hal_sio_driver_c *self) {
 }
 /** @} */
 
+#if (SIO_USE_BUFFERING == TRUE) || defined (__DOXYGEN__)
 /**
  * @name        Default constructor of hal_buffered_sio_c
  * @{
@@ -849,7 +856,9 @@ static inline hal_buffered_sio_c *bsioObjectInit(hal_buffered_sio_c *self,
                              ob, obsize);
 }
 /** @} */
+#endif /* SIO_USE_BUFFERING == TRUE */
 
+#if (SIO_USE_BUFFERING == TRUE) || defined (__DOXYGEN__)
 /**
  * @name        Inline methods of hal_buffered_sio_c
  * @{
@@ -870,6 +879,7 @@ static inline void bsAddFlagsI(void *ip, eventflags_t flags) {
   osalEventBroadcastFlagsI(&self->event, flags);
 }
 /** @} */
+#endif /* SIO_USE_BUFFERING == TRUE */
 
 #endif /* HAL_USE_SIO == TRUE */
 

--- a/os/xhal/src/hal_sio.c
+++ b/os/xhal/src/hal_sio.c
@@ -908,6 +908,8 @@ msg_t sioSynchronizeTXEnd(void *ip, sysinterval_t timeout) {
 /* Module class "hal_buffered_sio_c" methods.                                */
 /*===========================================================================*/
 
+#if (SIO_USE_BUFFERING == TRUE) || defined (__DOXYGEN__)
+
 /**
  * @name        Interfaces implementation of hal_buffered_sio_c
  * @{
@@ -1320,6 +1322,8 @@ msg_t bsRequestDataI(void *ip) {
   return b;
 }
 /** @} */
+
+#endif /* SIO_USE_BUFFERING == TRUE */
 
 #endif /* HAL_USE_SIO == TRUE */
 


### PR DESCRIPTION
## Problem

Reported on the forum for STM32WL XHAL: with `SIO_USE_BUFFERING = FALSE` the SIO
driver fails to compile:

```
hal_sio.c: error: '__bsio_onotify' undeclared (first use in this function)
hal_sio.c: error: '__bsio_default_cb' undeclared (first use in this function)
```

The private buffered-SIO helpers were guarded by `SIO_USE_BUFFERING`, but the
`hal_buffered_sio` class — its VMT and `__bsio_objinit_impl` / `__bsio_start_impl`,
which call those helpers — was generated **unconditionally**, so it referenced
symbols compiled out when buffering is disabled. (Default is `TRUE`, which is why
it went unnoticed.)

## Fix

Gate the whole class on the option: `check="SIO_USE_BUFFERING == TRUE"` on the
`hal_buffered_sio` class definition in `os/xhal/codegen/hal_sio.xml`, then
regenerate. The buffered class now drops out completely when buffering is off and
is unchanged when on.

This relies on new class-level `@check` support in the ccode generator:
**depends on chibios-upstream/chibios-ftl#4** (the `tools/ftl` submodule bump in
this PR points at that branch).

## Verification

Reproduced and verified on `RT-XHAL-STM32G474RE-NUCLEO64` (USARTv3, same USART IP
family as STM32WL):

- pre-fix + `SIO_USE_BUFFERING FALSE` → reproduces the exact two errors
- post-fix + `FALSE` → builds clean
- post-fix + `TRUE` → builds clean (no regression)
- `stylecheck.py` passes on both regenerated files

## Merge ordering

Merge chibios-ftl#4 first, then **re-point the `tools/ftl` submodule to the merged
`main` SHA** before merging this PR (the current pointer is the PR branch head). If
chibios-ftl#4 fast-forwards, the SHA is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)