### PR TITLE
xhal codegen: schema-conform the module XMLs (no output change)

### DIFF
--- a/os/xhal/codegen/hal_base_driver.xml
+++ b/os/xhal/codegen/hal_base_driver.xml
@@ -156,13 +156,13 @@ drv_reg_remove(self);
                 ignored, calls with a non-@p NULL configuration perform a live
                 reconfiguration equivalent to @p drvSetCfgX().]]>
               </details>
-              <param ctype="const void *" name="config" dir="in">Driver
-                configuration or @p NULL.</param>
               <note><![CDATA[The function can fail with error
                 @p HAL_RET_INV_STATE if called while the driver is already
                 being started or stopped. In case you need multiple threads
                 to perform start and stop operation on the driver then it is
                 suggested to lock/unlock the driver during such operations.]]></note>
+              <param ctype="const void *" name="config" dir="in">Driver
+                configuration or @p NULL.</param>
               <return>The operation status.</return>
               <retval value="HAL_RET_SUCCESS">Operation successful.</retval>
               <retval value="HAL_RET_INV_STATE"><![CDATA[If the driver was

--- a/os/xhal/codegen/hal_i2s.xml
+++ b/os/xhal/codegen/hal_i2s.xml
@@ -11,12 +11,6 @@
     <includes_always>
       <include style="regular">hal_cb_driver.h</include>
     </includes_always>
-    <configs>
-      <config name="I2S_USE_SYNCHRONIZATION" default="TRUE">
-        <brief>Support for thread synchronization API.</brief>
-        <assert invalid="($N != FALSE) &amp;&amp; ($N != TRUE)" />
-      </config>
-    </configs>
     <definitions_early>
       <group description="I2S event flags">
         <define name="I2S_EVENT_HALF" value="(1U &lt;&lt; 0)">
@@ -27,6 +21,12 @@
         </define>
       </group>
     </definitions_early>
+    <configs>
+      <config name="I2S_USE_SYNCHRONIZATION" default="TRUE">
+        <brief>Support for thread synchronization API.</brief>
+        <assert invalid="($N != FALSE) &amp;&amp; ($N != TRUE)" />
+      </config>
+    </configs>
     <macros>
       <group description="Macro functions">
         <macro name="i2sIsBufferComplete">
@@ -406,7 +406,7 @@ return errors;]]></implementation>
             </method>
           </inline>
           <override>
-            <method name="start" shortname="start" ctype="msg_t">
+            <method shortname="start">
               <implementation><![CDATA[
 if (config != NULL) {
   self->config = __i2s_setcfg_impl(self, config);
@@ -424,20 +424,18 @@ self->errors = I2S_NO_ERROR;
 
 return i2s_lld_start(self);]]></implementation>
             </method>
-            <method name="stop" shortname="stop" ctype="void">
+            <method shortname="stop">
               <implementation><![CDATA[
 i2s_lld_stop(self);
 self->events = 0U;
 self->errors = I2S_NO_ERROR;]]></implementation>
             </method>
-            <method name="setcfg" shortname="setcfg" ctype="const void *">
-              <param name="config" ctype="const void *" dir="in">New driver configuration.</param>
+            <method shortname="setcfg">
               <implementation><![CDATA[
 return (const void *)i2s_lld_setcfg(self,
                                     (const hal_i2s_config_t *)config);]]></implementation>
             </method>
-            <method name="selcfg" shortname="selcfg" ctype="const void *">
-              <param name="cfgnum" ctype="unsigned" dir="in">Driver configuration number.</param>
+            <method shortname="selcfg">
               <implementation><![CDATA[
 return (const void *)i2s_lld_selcfg(self, cfgnum);]]></implementation>
             </method>

--- a/os/xhal/codegen/hal_sdc.xml
+++ b/os/xhal/codegen/hal_sdc.xml
@@ -328,10 +328,10 @@ return sdcGetInfo(self, bdip);]]></implementation>
           <field name="capacity" ctype="uint32_t">
             <brief>Card capacity expressed in logical blocks.</brief>
           </field>
-          <field name="cid[4]" ctype="uint32_t">
+          <field name="cid" ctype="uint32_t$I$N[4]">
             <brief>Card CID register image.</brief>
           </field>
-          <field name="csd[4]" ctype="uint32_t">
+          <field name="csd" ctype="uint32_t$I$N[4]">
             <brief>Card CSD register image.</brief>
           </field>
           <condition check="SDC_USE_SYNCHRONIZATION == TRUE">

--- a/os/xhal/codegen/hal_sio.xml
+++ b/os/xhal/codegen/hal_sio.xml
@@ -1105,36 +1105,6 @@ self->siop = siop;]]></implementation>
             <implementation><![CDATA[
 __drv_dispose_impl(self);]]></implementation>
           </dispose>
-          <override>
-            <method shortname="start">
-              <implementation><![CDATA[
-msg_t msg;
-
-/* Starting the undelying SIO driver.*/
-msg = drvStart(self->siop, config);
-if (msg == HAL_RET_SUCCESS) {
-  self->config = self->siop->config;
-  drvSetArgumentX(self->siop, self);
-  drvSetCallbackX(self->siop, &__bsio_default_cb);
-  sioWriteEnableFlagsX(self->siop,
-                       SIO_EV_ALL_ERRORS | SIO_EV_RX_NOTEMPTY |
-                       SIO_EV_RX_IDLE);
-}
-
-return msg;]]></implementation>
-            </method>
-            <method shortname="stop">
-              <implementation><![CDATA[
-
-drvStop(self->siop);]]></implementation>
-            </method>
-            <method shortname="setcfg">
-              <implementation><![CDATA[
-
-/* Configuring the underlying SIO driver.*/
-return __sio_setcfg_impl(self->siop, config);]]></implementation>
-            </method>
-          </override>
           <regular>
             <method name="bsIncomingDataI" ctype="void">
               <brief>Handles incoming data.</brief>
@@ -1197,6 +1167,36 @@ return b;]]></implementation>
 osalEventBroadcastFlagsI(&self->event, flags);]]></implementation>
             </method>
           </inline>
+          <override>
+            <method shortname="start">
+              <implementation><![CDATA[
+msg_t msg;
+
+/* Starting the undelying SIO driver.*/
+msg = drvStart(self->siop, config);
+if (msg == HAL_RET_SUCCESS) {
+  self->config = self->siop->config;
+  drvSetArgumentX(self->siop, self);
+  drvSetCallbackX(self->siop, &__bsio_default_cb);
+  sioWriteEnableFlagsX(self->siop,
+                       SIO_EV_ALL_ERRORS | SIO_EV_RX_NOTEMPTY |
+                       SIO_EV_RX_IDLE);
+}
+
+return msg;]]></implementation>
+            </method>
+            <method shortname="stop">
+              <implementation><![CDATA[
+
+drvStop(self->siop);]]></implementation>
+            </method>
+            <method shortname="setcfg">
+              <implementation><![CDATA[
+
+/* Configuring the underlying SIO driver.*/
+return __sio_setcfg_impl(self->siop, config);]]></implementation>
+            </method>
+          </override>
         </methods>
       </class>
       


### PR DESCRIPTION
## What

Bring the XHAL module XMLs into line with the ccode schema. **All changes are
codegen-source hygiene — regenerating produces byte-identical output** (verified
after every edit).

- **`hal_sio.xml`** — reorder the `hal_buffered_sio` method groups to schema order
  (objinit, dispose, virtual, regular, inline, override); `override` had been
  placed before `regular`/`inline`.
- **`hal_i2s.xml`** — move `<definitions_early>` before `<configs>` (schema section
  order); drop redundant `name`/`ctype`/`<param>` from the override methods
  (overrides take their signature from the ancestor — only `shortname` +
  `implementation` are used, as in `hal_sio`).
- **`hal_base_driver.xml`** — move the `drvStart` `<note>` before `<param>` (notes
  belong to the documented-item part, ahead of the parameterized part).
- **`hal_sdc.xml`** — express the `cid`/`csd` arrays via the ctype `$I$N[4]` idiom
  (already used elsewhere, e.g. `cfgs` fields) instead of embedding `[4]` in the
  field `name`, which the name pattern disallows.

## Why

While turning a forum-reported WL build break into a fix, validating the XHAL
module XMLs against `modules.xsd` surfaced these conformance gaps. None affect
output; this just lets the XMLs validate.

## Depends on

chibios-upstream/chibios-ftl#5 (the `<special/>` + brief-length schema changes).
The `tools/ftl` submodule pointer in this PR references that branch — **merge #5
first**, then re-point the submodule to the merged `main` SHA before merging this.

## Validation

After these XML changes plus #5, **all ccode-style codegen trees validate clean**
(XHAL, VFS, VNS, OOP, serial-usb, xsnor ×2, sensors), and regen is byte-identical
to current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)