### PR TITLE
Fix comment typos across core subsystems

### DIFF
--- a/os/nil/include/ch.h
+++ b/os/nil/include/ch.h
@@ -565,7 +565,7 @@ struct nil_os_instance {
   /**
    * @brief   Pointer to the next thread to be executed.
    * @note    This pointer must point at the same thread pointed by @p current
-   *          or to an higher priority thread if a switch is required.
+   *          or to a higher priority thread if a switch is required.
    */
   thread_t              *next;
 #if (CH_CFG_ST_TIMEDELTA == 0) || defined(__DOXYGEN__)
@@ -1085,7 +1085,7 @@ struct nil_os_instance {
 /**
  * @brief   Enters the kernel lock state from within an interrupt handler.
  * @note    This API may do nothing on some architectures, it is required
- *          because on ports that support preemptable interrupt handlers
+ *          because on ports that support preemptible interrupt handlers
  *          it is required to raise the interrupt mask to the same level of
  *          the system mutual exclusion zone.<br>
  *          It is good practice to invoke this API before invoking any I-class
@@ -1103,7 +1103,7 @@ struct nil_os_instance {
  * @brief   Leaves the kernel lock state from within an interrupt handler.
  *
  * @note    This API may do nothing on some architectures, it is required
- *          because on ports that support preemptable interrupt handlers
+ *          because on ports that support preemptible interrupt handlers
  *          it is required to raise the interrupt mask to the same level of
  *          the system mutual exclusion zone.<br>
  *          It is good practice to invoke this API after invoking any I-class

--- a/os/nil/include/chevt.h
+++ b/os/nil/include/chevt.h
@@ -231,7 +231,7 @@ typedef void (*evhandler_t)(eventid_t id);
  *          lowest event id. The function is meant to be invoked into a loop
  *          in order to serve all the pending events.<br>
  *          This means that Event Listeners with a lower event identifier have
- *          an higher priority.
+ *          a higher priority.
  *
  * @param[in] events    events that the function should wait
  *                      for, @p ALL_EVENTS enables all the events

--- a/os/nil/src/ch.c
+++ b/os/nil/src/ch.c
@@ -658,7 +658,7 @@ void chSchRescheduleS(void) {
  *          awakened with a @p MSG_TIMEOUT low level message.
  *
  * @param[in] newstate  the new thread state or a semaphore pointer
- * @param[in] timeout   the number of ticks before the operation timeouts.
+ * @param[in] timeout   the number of ticks before the operation times out.
  *                      the following special values are allowed:
  *                      - @a TIME_INFINITE no timeout.
  * @return              The wakeup message.
@@ -895,11 +895,11 @@ msg_t chThdWait(thread_t *tp) {
  *          context.
  *
  * @param[in] trp       a pointer to a thread reference object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
- * @return              The wake up message.
+ * @return              The wakeup message.
  *
  * @sclass
  */
@@ -1006,11 +1006,11 @@ void chThdSleepUntil(systime_t abstime) {
 /**
  * @brief   Enqueues the caller thread on a threads queue object.
  * @details The caller thread is enqueued and put to sleep until it is
- *          dequeued or the specified timeouts expires.
+ *          dequeued or the specified timeout expires.
  *
  * @param[in] tqp       pointer to a @p threads_queue_t structure
  * @param[in] timeout   the timeout in system ticks, the special values are
- *                      handled as follow:
+ *                      handled as follows:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
  * @return              The message from @p osalQueueWakeupOneI() or

--- a/os/nil/src/chevt.c
+++ b/os/nil/src/chevt.c
@@ -348,11 +348,11 @@ void chEvtDispatch(const evhandler_t *handlers, eventmask_t events) {
  *          lowest event id. The function is meant to be invoked into a loop
  *          in order to serve all the pending events.<br>
  *          This means that Event Listeners with a lower event identifier have
- *          an higher priority.
+ *          a higher priority.
  *
  * @param[in] events    events that the function should wait
  *                      for, @p ALL_EVENTS enables all the events
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -396,7 +396,7 @@ eventmask_t chEvtWaitOneTimeout(eventmask_t events, sysinterval_t timeout) {
  *
  * @param[in] mask      mask of the event flags that the function should wait
  *                      for, @p ALL_EVENTS enables all the events
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -437,7 +437,7 @@ eventmask_t chEvtWaitAnyTimeout(eventmask_t mask, sysinterval_t timeout) {
  *
  * @param[in] mask      mask of the event flags that the function should wait
  *                      for, @p ALL_EVENTS enables all the events
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/nil/src/chmsg.c
+++ b/os/nil/src/chmsg.c
@@ -119,7 +119,7 @@ thread_t *chMsgWait(void) {
  * @note    The reference counter of the sender thread is not increased, the
  *          returned pointer is a temporary reference.
  *
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -151,7 +151,7 @@ thread_t *chMsgWaitTimeout(sysinterval_t timeout) {
  * @note    The reference counter of the sender thread is not increased, the
  *          returned pointer is a temporary reference.
  *
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_INFINITE no timeout.
  * @return              A pointer to the thread carrying the message.

--- a/os/nil/src/chsem.c
+++ b/os/nil/src/chsem.c
@@ -56,7 +56,7 @@
  * @brief   Performs a wait operation on a semaphore with timeout specification.
  *
  * @param[in] sp        pointer to a @p semaphore_t structure
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -84,7 +84,7 @@ msg_t chSemWaitTimeout(semaphore_t *sp, sysinterval_t timeout) {
  * @brief   Performs a wait operation on a semaphore with timeout specification.
  *
  * @param[in] sp        pointer to a @p semaphore_t structure
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/nil/templates/chconf.h
+++ b/os/nil/templates/chconf.h
@@ -18,10 +18,10 @@
  * @file    nil/templates/chconf.h
  * @brief   Configuration file template.
  * @details A copy of this file must be placed in each project directory, it
- *          contains the application specific kernel settings.
+ *          contains the application-specific kernel settings.
  *
  * @addtogroup NIL_CONFIG
- * @details Kernel related settings and hooks.
+ * @details Kernel-related settings and hooks.
  * @{
  */
 
@@ -44,7 +44,7 @@
  *          implicitly handled.
  * @note    Set this value to be exactly equal to the number of threads you
  *          will use or you would be wasting RAM and cycles.
- * @note    This values also defines the number of available priorities
+ * @note    This value also defines the number of available priorities
  *          (0..CH_CFG_MAX_THREADS-1).
  */
 #if !defined(CH_CFG_MAX_THREADS)

--- a/os/oslib/include/chbsem.h
+++ b/os/oslib/include/chbsem.h
@@ -164,7 +164,7 @@ static inline msg_t chBSemWaitS(binary_semaphore_t *bsp) {
  * @brief   Wait operation on the binary semaphore.
  *
  * @param[in] bsp       pointer to a @p binary_semaphore_t object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -190,7 +190,7 @@ static inline msg_t chBSemWaitTimeoutS(binary_semaphore_t *bsp,
  * @brief   Wait operation on the binary semaphore.
  *
  * @param[in] bsp       pointer to a @p binary_semaphore_t object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/oslib/include/chjobs.h
+++ b/os/oslib/include/chjobs.h
@@ -201,7 +201,7 @@ static inline job_descriptor_t *chJobGetI(jobs_queue_t *jqp) {
  * @brief   Allocates a free job object.
  *
  * @param[in] jqp       pointer to a @p jobs_queue_t object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -221,7 +221,7 @@ static inline job_descriptor_t *chJobGetTimeoutS(jobs_queue_t *jqp,
  * @brief   Allocates a free job object.
  *
  * @param[in] jqp       pointer to a @p jobs_queue_t object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -384,7 +384,7 @@ static inline msg_t chJobDispatch(jobs_queue_t *jqp) {
  * @brief   Waits for a job then executes it.
  *
  * @param[in] jqp       pointer to a @p jobs_queue_t object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/oslib/include/chobjfifos.h
+++ b/os/oslib/include/chobjfifos.h
@@ -177,7 +177,7 @@ static inline void *chFifoTakeObjectI(objects_fifo_t *ofp) {
  * @brief   Allocates a free object.
  *
  * @param[in] ofp       pointer to a @p objects_fifo_t object
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -197,7 +197,7 @@ static inline void *chFifoTakeObjectTimeoutS(objects_fifo_t *ofp,
  * @brief   Allocates a free object.
  *
  * @param[in] ofp       pointer to a @p objects_fifo_t object
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -379,7 +379,7 @@ static inline msg_t chFifoReceiveObjectI(objects_fifo_t *ofp,
  *
  * @param[in] ofp       pointer to a @p objects_fifo_t object
  * @param[in] objpp     pointer to the fetched object reference
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -401,7 +401,7 @@ static inline msg_t chFifoReceiveObjectTimeoutS(objects_fifo_t *ofp,
  *
  * @param[in] ofp       pointer to a @p objects_fifo_t object
  * @param[in] objpp     pointer to the fetched object reference
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/oslib/src/chdelegates.c
+++ b/os/oslib/src/chdelegates.c
@@ -180,7 +180,7 @@ msg_t chDelegateCallVeneer(thread_t *tp, delegate_veneer_t veneer, ...) {
 
 /**
  * @brief   Call messages dispatching.
- * @details The function awaits for an incoming call messages and calls the
+ * @details The function waits for incoming call messages and calls the
  *          specified functions, then it returns. In case multiple threads
  *          are sending messages then the requests are served in priority
  *          order.
@@ -201,12 +201,12 @@ void chDelegateDispatch(void) {
 
 /**
  * @brief   Call messages dispatching with timeout.
- * @details The function awaits for an incoming call messages and calls the
+ * @details The function waits for incoming call messages and calls the
  *          specified functions, then it returns. In case multiple threads
  *          are sending messages then the requests are served in priority
  *          order.
  *
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/oslib/src/chfactory.c
+++ b/os/oslib/src/chfactory.c
@@ -21,7 +21,7 @@
  * @brief   ChibiOS objects factory and registry code.
  *
  * @addtogroup oslib_objects_factory
- * @details The object factory is a subsystem that allows to:
+ * @details The object factory is a subsystem that allows:
  *          - Register static objects by name.
  *          - Dynamically create objects and assign them a name.
  *          - Retrieve existing objects by name.

--- a/os/oslib/src/chmboxes.c
+++ b/os/oslib/src/chmboxes.c
@@ -179,7 +179,7 @@ void chMBResetI(mailbox_t *mbp) {
  *
  * @param[in] mbp       pointer to a @p mailbox_t object
  * @param[in] msg       message to be posted on the mailbox
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -207,7 +207,7 @@ msg_t chMBPostTimeout(mailbox_t *mbp, msg_t msg, sysinterval_t timeout) {
  *
  * @param[in] mbp       pointer to a @p mailbox_t object
  * @param[in] msg       message to be posted on the mailbox
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -302,7 +302,7 @@ msg_t chMBPostI(mailbox_t *mbp, msg_t msg) {
  *
  * @param[in] mbp       pointer to a @p mailbox_t object
  * @param[in] msg       message to be posted on the mailbox
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -330,7 +330,7 @@ msg_t chMBPostAheadTimeout(mailbox_t *mbp, msg_t msg, sysinterval_t timeout) {
  *
  * @param[in] mbp       pointer to a @p mailbox_t object
  * @param[in] msg       message to be posted on the mailbox
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -425,7 +425,7 @@ msg_t chMBPostAheadI(mailbox_t *mbp, msg_t msg) {
  *
  * @param[in] mbp       pointer to a @p mailbox_t object
  * @param[out] msgp     pointer to a message variable for the received message
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -453,7 +453,7 @@ msg_t chMBFetchTimeout(mailbox_t *mbp, msg_t *msgp, sysinterval_t timeout) {
  *
  * @param[in] mbp       pointer to a @p mailbox_t object
  * @param[out] msgp     pointer to a message variable for the received message
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/oslib/src/chmemcore.c
+++ b/os/oslib/src/chmemcore.c
@@ -24,8 +24,8 @@
  * @details Core Memory Manager related APIs and services.
  *          <h2>Operation mode</h2>
  *          The core memory manager is a simplified allocator that only
- *          allows to allocate memory blocks without the possibility to
- *          free them.<br>
+ *          allows allocating memory blocks without the possibility of
+ *          freeing them.<br>
  *          This allocator is meant as a memory blocks provider for the
  *          other allocators such as:
  *          - C-Runtime allocator (through a compiler specific adapter module).

--- a/os/oslib/src/chmempools.c
+++ b/os/oslib/src/chmempools.c
@@ -310,7 +310,7 @@ void chGuardedPoolLoadArray(guarded_memory_pool_t *gmp, void *p, size_t n) {
  * @pre     The guarded memory pool must already be initialized.
  *
  * @param[in] gmp       pointer to a @p guarded_memory_pool_t object
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -336,7 +336,7 @@ void *chGuardedPoolAllocTimeoutS(guarded_memory_pool_t *gmp,
  * @pre     The guarded memory pool must already be initialized.
  *
  * @param[in] gmp       pointer to a @p guarded_memory_pool_t object
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/oslib/src/chobjcaches.c
+++ b/os/oslib/src/chobjcaches.c
@@ -21,7 +21,7 @@
  * @brief   Objects Caches code.
  * @details Objects caches.
  *          <h2>Operation mode</h2>
- *          An object cache allows to retrieve and release objects from a
+ *          An object cache allows retrieving and releasing objects from a
  *          slow media, for example a disk or flash.<br>
  *          The most recently used objects are kept in a series of RAM
  *          buffers making access faster. Objects are identified by a

--- a/os/oslib/src/chpipes.c
+++ b/os/oslib/src/chpipes.c
@@ -263,7 +263,7 @@ void chPipeReset(pipe_t *pp) {
  * @param[in] bp        pointer to the data buffer
  * @param[in] n         number of bytes to be written, the value 0 is
  *                      reserved
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -327,7 +327,7 @@ size_t chPipeWriteTimeout(pipe_t *pp, const uint8_t *bp,
  * @param[out] bp       pointer to the data buffer
  * @param[in] n         number of bytes to be read, the value 0 is
  *                      reserved
- * @param[in] timeout   number of ticks before the operation timeouts,
+ * @param[in] timeout   number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/rt/include/ch.h
+++ b/os/rt/include/ch.h
@@ -23,7 +23,7 @@
  * @addtogroup kernel_info
  * @details This header includes all the required kernel headers so it is the
  *          only kernel header you usually want to include in your application.
- * @details Kernel related info.
+ * @details Kernel-related info.
  * @{
  */
 

--- a/os/rt/include/chmem.h
+++ b/os/rt/include/chmem.h
@@ -80,7 +80,7 @@
 /**
  * @brief   Global RAM affinity macro.
  * @details Global RAM, the memory is optimally accessed by all cores.
- * @note    This is equivalent to a normal C non-initialized variable, the
+ * @note    This is equivalent to a normal C uninitialized variable, the
  *          port layer has the option to enforce some kind of attribute when
  *          this modifier is used.
  * @note    Only uninitialized variables can be tagged with this attribute.

--- a/os/rt/include/chmsg.h
+++ b/os/rt/include/chmsg.h
@@ -114,7 +114,7 @@ static inline thread_t *chMsgWait(void) {
  * @note    The reference counter of the sender thread is not increased, the
  *          returned pointer is a temporary reference.
  *
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are handled:
  *                      - @a TIME_INFINITE no timeout.
  *                      - @a TIME_IMMEDIATE this value is not allowed.

--- a/os/rt/include/chobjects.h
+++ b/os/rt/include/chobjects.h
@@ -197,7 +197,7 @@ struct ch_thread {
   stkline_t                     *wabase;
   /**
    * @brief   Working area end address.
-   * @note    It is the 1st address after the working area.
+   * @note    It is the first address after the working area.
    */
   stkline_t                    *waend;
   /**
@@ -229,7 +229,7 @@ struct ch_thread {
   thread_dispose_t              dispose;
   /**
    * @brief   Thread controller object or @p NULL.
-   * @note    This field can be used to associate an user object to the
+   * @note    This field can be used to associate a user object to the
    *          thread.
    */
   void                          *object;

--- a/os/rt/include/chsys.h
+++ b/os/rt/include/chsys.h
@@ -401,7 +401,7 @@ static inline void chSysUnlock(void) {
 /**
  * @brief   Enters the kernel lock state from within an interrupt handler.
  * @note    This API may do nothing on some architectures, it is required
- *          because on ports that support preemptable interrupt handlers
+ *          because on ports that support preemptible interrupt handlers
  *          it is required to raise the interrupt mask to the same level of
  *          the system mutual exclusion zone.<br>
  *          It is good practice to invoke this API before invoking any I-class
@@ -423,7 +423,7 @@ static inline void chSysLockFromISR(void) {
  * @brief   Leaves the kernel lock state from within an interrupt handler.
  *
  * @note    This API may do nothing on some architectures, it is required
- *          because on ports that support preemptable interrupt handlers
+ *          because on ports that support preemptible interrupt handlers
  *          it is required to raise the interrupt mask to the same level of
  *          the system mutual exclusion zone.<br>
  *          It is good practice to invoke this API after invoking any I-class

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -618,7 +618,7 @@ static inline thread_t *chThdStartI(thread_t *tp) {
  * @brief   Suspends the invoking thread for the specified number of ticks.
  *
  * @param[in] ticks     the delay in system ticks, the special values are
- *                      handled as follow:
+ *                      handled as follows:
  *                      - @a TIME_INFINITE the thread enters an infinite sleep
  *                        state.
  *                      - @a TIME_IMMEDIATE this value is not allowed.

--- a/os/rt/include/chvt.h
+++ b/os/rt/include/chvt.h
@@ -326,8 +326,8 @@ static inline void chVTReset(virtual_timer_t *vtp) {
  *          or @p chVTDoSetI().
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
- * @param[in] delay     the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] delay     the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE is allowed but interpreted as a
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
@@ -354,8 +354,8 @@ static inline void chVTSetI(virtual_timer_t *vtp, sysinterval_t delay,
  *          or @p chVTDoSetI().
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
- * @param[in] delay     the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] delay     the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE is allowed but interpreted as a
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
@@ -383,8 +383,8 @@ static inline void chVTSet(virtual_timer_t *vtp, sysinterval_t delay,
  *          or @p chVTDoSetI().
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
- * @param[in] delay     the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] delay     the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE is allowed but interpreted as a
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
@@ -411,8 +411,8 @@ static inline void chVTSetContinuousI(virtual_timer_t *vtp, sysinterval_t delay,
  *          or @p chVTDoSetI().
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
- * @param[in] delay     the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] delay     the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE is allowed but interpreted as a
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.

--- a/os/rt/src/chcond.c
+++ b/os/rt/src/chcond.c
@@ -268,8 +268,8 @@ msg_t chCondWaitS(condition_variable_t *cp) {
  *          mutex, the mutex ownership is lost.
  *
  * @param[in] cp        pointer to a @p condition_variable_t object
- * @param[in] timeout   the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] timeout   the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE no timeout.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
  * @return              A message specifying how the invoking thread has been
@@ -305,8 +305,8 @@ msg_t chCondWaitTimeout(condition_variable_t *cp, sysinterval_t timeout) {
  *          mutex, the mutex ownership is lost.
  *
  * @param[in] cp        pointer to a @p condition_variable_t object
- * @param[in] timeout   the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] timeout   the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE no timeout.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
  * @return              A message specifying how the invoking thread has been

--- a/os/rt/src/chevents.c
+++ b/os/rt/src/chevents.c
@@ -46,9 +46,8 @@
  *          a thread or an interrupt service routine. Broadcasting an Event
  *          Source has the effect that all the threads registered on the
  *          Event Source will be signaled with an events mask.<br>
- *          An unlimited number of Event Sources can exists in a system and
- *          each thread can be listening on an unlimited number of
- *          them.
+ *          An unlimited number of Event Sources can exist in a system and
+ *          each thread can listen on an unlimited number of them.
  * @pre     In order to use the Events APIs the @p CH_CFG_USE_EVENTS option
  *          must be enabled in @p chconf.h.
  * @post    Enabling events requires 1-4 (depending on the architecture)
@@ -560,7 +559,7 @@ eventmask_t chEvtWaitAll(eventmask_t events) {
  *
  * @param[in] events    events that the function should wait
  *                      for, @p ALL_EVENTS enables all the events
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -602,7 +601,7 @@ eventmask_t chEvtWaitOneTimeout(eventmask_t events, sysinterval_t timeout) {
  *
  * @param[in] events    events that the function should wait
  *                      for, @p ALL_EVENTS enables all the events
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -642,7 +641,7 @@ eventmask_t chEvtWaitAnyTimeout(eventmask_t events, sysinterval_t timeout) {
  *
  * @param[in] events    events that the function should wait
  *                      for, @p ALL_EVENTS requires all the events
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/rt/src/chmsg.c
+++ b/os/rt/src/chmsg.c
@@ -145,7 +145,7 @@ thread_t *chMsgWaitS(void) {
  * @note    The reference counter of the sender thread is not increased, the
  *          returned pointer is a temporary reference.
  *
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are handled:
  *                      - @a TIME_INFINITE no timeout.
  *                      - @a TIME_IMMEDIATE this value is not allowed.

--- a/os/rt/src/chschd.c
+++ b/os/rt/src/chschd.c
@@ -349,8 +349,8 @@ void chSchGoSleepS(tstate_t newstate) {
  *          @ref thread_states are defined into @p chschd.h.
  *
  * @param[in] newstate  the new thread state
- * @param[in] timeout   the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] timeout   the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE the thread enters an infinite sleep
  *                        state, this is equivalent to invoking
  *                        @p chSchGoSleepS() but, of course, less efficient.

--- a/os/rt/src/chsem.c
+++ b/os/rt/src/chsem.c
@@ -242,7 +242,7 @@ msg_t chSemWaitS(semaphore_t *sp) {
  * @brief   Performs a wait operation on a semaphore with timeout specification.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
@@ -270,7 +270,7 @@ msg_t chSemWaitTimeout(semaphore_t *sp, sysinterval_t timeout) {
  * @brief   Performs a wait operation on a semaphore with timeout specification.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
- * @param[in] timeout   the number of ticks before the operation timeouts,
+ * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are allowed:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -857,7 +857,7 @@ void chThdTerminate(thread_t *tp) {
  * @brief   Suspends the invoking thread for the specified time.
  *
  * @param[in] time      the delay in system ticks, the special values are
- *                      handled as follow:
+ *                      handled as follows:
  *                      - @a TIME_INFINITE the thread enters an infinite sleep
  *                        state.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
@@ -942,7 +942,7 @@ void chThdYield(void) {
  *          context.
  *
  * @param[in] trp       a pointer to a thread reference object
- * @return              The wake up message.
+ * @return              The wakeup message.
  *
  * @sclass
  */
@@ -965,13 +965,13 @@ msg_t chThdSuspendS(thread_reference_t *trp) {
  *
  * @param[in] trp       a pointer to a thread reference object
  * @param[in] timeout   the timeout in system ticks, the special values are
- *                      handled as follow:
+ *                      handled as follows:
  *                      - @a TIME_INFINITE the thread enters an infinite sleep
  *                        state.
  *                      - @a TIME_IMMEDIATE the thread is not suspended and
  *                        the function returns @p MSG_TIMEOUT as if a timeout
  *                        occurred.
- * @return              The wake up message.
+ * @return              The wakeup message.
  * @retval MSG_TIMEOUT  if the operation timed out.
  *
  * @sclass
@@ -1099,11 +1099,11 @@ void chThdQueueObjectDispose(threads_queue_t *tqp) {
 /**
  * @brief   Enqueues the caller thread on a threads queue object.
  * @details The caller thread is enqueued and put to sleep until it is
- *          dequeued or the specified timeouts expires.
+ *          dequeued or the specified timeout expires.
  *
  * @param[in] tqp       pointer to a @p threads_queue_t object
  * @param[in] timeout   the timeout in system ticks, the special values are
- *                      handled as follow:
+ *                      handled as follows:
  *                      - @a TIME_INFINITE the thread enters an infinite sleep
  *                        state.
  *                      - @a TIME_IMMEDIATE the thread is not enqueued and

--- a/os/rt/src/chtrace.c
+++ b/os/rt/src/chtrace.c
@@ -204,7 +204,7 @@ void __trace_halt(const char *reason) {
 }
 
 /**
- * @brief   Adds an user trace record to the trace buffer.
+ * @brief   Adds a user trace record to the trace buffer.
  *
  * @param[in] up1       user parameter 1
  * @param[in] up2       user parameter 2
@@ -226,7 +226,7 @@ void chTraceWriteI(void *up1, void *up2) {
 }
 
 /**
- * @brief   Adds an user trace record to the trace buffer.
+ * @brief   Adds a user trace record to the trace buffer.
  *
  * @param[in] up1       user parameter 1
  * @param[in] up2       user parameter 2

--- a/os/rt/src/chvt.c
+++ b/os/rt/src/chvt.c
@@ -318,8 +318,8 @@ void chVTObjectDispose(virtual_timer_t *vtp) {
  * @note    The callback function is invoked from interrupt context.
  *
  * @param[out] vtp      pointer to a @p virtual_timer_t object
- * @param[in] delay     the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] delay     the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE is allowed but interpreted as a
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
@@ -355,8 +355,8 @@ void chVTDoSetI(virtual_timer_t *vtp, sysinterval_t delay,
  * @note    The callback function is invoked from interrupt context.
  *
  * @param[out] vtp      pointer to a @p virtual_timer_t object
- * @param[in] delay     the number of ticks before the operation timeouts, the
- *                      special values are handled as follow:
+ * @param[in] delay     the number of ticks before the operation times out, the
+ *                      special values are handled as follows:
  *                      - @a TIME_INFINITE is allowed but interpreted as a
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.

--- a/os/rt/templates/chconf.h
+++ b/os/rt/templates/chconf.h
@@ -18,10 +18,10 @@
  * @file    rt/templates/chconf.h
  * @brief   Configuration file template.
  * @details A copy of this file must be placed in each project directory, it
- *          contains the application specific kernel settings.
+ *          contains the application-specific kernel settings.
  *
  * @addtogroup config
- * @details Kernel related settings and hooks.
+ * @details Kernel-related settings and hooks.
  * @{
  */
 
@@ -41,7 +41,7 @@
 /**
  * @brief   Handling of instances.
  * @note    If enabled then threads assigned to various instances can
- *          interact each other using the same synchronization objects.
+ *          interact with each other using the same synchronization objects.
  *          If disabled then each OS instance is a separate world, no
  *          direct interactions are handled by the OS.
  */
@@ -52,7 +52,7 @@
 /**
  * @brief   Kernel hardening level.
  * @details This option is the level of functional-safety checks enabled
- *          in the kerkel. The meaning is:
+ *          in the kernel. The meaning is:
  *          - 0: No checks, maximum performance.
  *          - 1: Reasonable checks.
  *          - 2: All checks.
@@ -664,7 +664,7 @@
 /**
  * @brief   Debug option, threads profiling.
  * @details If enabled then a field is added to the @p thread_t structure that
- *          counts the system ticks occurred while executing the thread.
+ *          counts the system ticks that occurred while executing the thread.
  *
  * @note    The default is @p FALSE.
  * @note    This debug option is not currently compatible with the

--- a/os/vfs/include/vfschecks.h
+++ b/os/vfs/include/vfschecks.h
@@ -17,7 +17,7 @@
 */
 
 /**
- * @file    vfs/include/vfschchecks.h
+ * @file    vfs/include/vfschecks.h
  * @brief   Configuration file checks header.
  *
  * @addtogroup VFS_CHECKS

--- a/os/xhal/codegen/hal_cb_driver.xml
+++ b/os/xhal/codegen/hal_cb_driver.xml
@@ -173,7 +173,7 @@ return self->cb;]]></implementation>
               <details><![CDATA[The @p HAL_DRV_STATE_HALF state is used by
                 those drivers triggering multiple callbacks for a single
                 asynchronous operation, it marks the filling of the first
-                half of the tranfer buffer.]]></details>
+                half of the transfer buffer.]]></details>
               <note><![CDATA[This function is meant to be called exclusively
                 from the driver callback.]]></note>
               <return>The check result.</return>
@@ -189,7 +189,7 @@ return (bool)(self->state == HAL_DRV_STATE_HALF);]]></implementation>
               <details><![CDATA[The @p HAL_DRV_STATE_COMPLETE state is used by
                 those drivers triggering multiple callbacks for a single
                 asynchronous operation, it marks the complete filling of the
-                tranfer buffer.]]></details>
+                transfer buffer.]]></details>
               <note><![CDATA[This function is meant to be called exclusively
                 from the driver callback.]]></note>
               <return>The check result.</return>

--- a/os/xhal/codegen/hal_eth.xml
+++ b/os/xhal/codegen/hal_eth.xml
@@ -65,11 +65,11 @@
         <basetype ctype="uintptr_t" />
       </typedef>
       <typedef name="hal_eth_driver_c">
-        <brief>Type of structure representing a ETH driver.</brief>
+        <brief>Type of structure representing an ETH driver.</brief>
         <basetype ctype="struct hal_eth_driver" />
       </typedef>
       <typedef name="hal_eth_config_t">
-        <brief>Type of structure representing a ETH configuration.</brief>
+        <brief>Type of structure representing an ETH configuration.</brief>
         <basetype ctype="struct hal_eth_config" />
       </typedef>
       <verbatim><![CDATA[
@@ -95,7 +95,7 @@
           <verbatim><![CDATA[
 /* End of the mandatory fields.*/
 eth_lld_config_fields;]]></verbatim>
-          <condition check="defined(ETH_CONFIG_EXT_FIELS)">
+          <condition check="defined(ETH_CONFIG_EXT_FIELDS)">
             <verbatim><![CDATA[
 ETH_CONFIG_EXT_FIELDS]]></verbatim>
           </condition>
@@ -117,8 +117,8 @@ ETH_CONFIG_EXT_FIELDS]]></verbatim>
         </fields>
       </struct>
       <class type="regular" name="hal_eth_driver" namespace="eth"
-        ancestorname="hal_cb_driver" descr="ETH driver">
-        <brief>Class of a ETH driver.</brief>
+        ancestorname="hal_cb_driver" descr="network driver">
+        <brief>Class of an ETH driver.</brief>
         <fields>
           <condition check="ETH_USE_SYNCHRONIZATION == TRUE">
             <field name="txqueue" ctype="threads_queue_t">
@@ -137,7 +137,7 @@ ETH_CONFIG_EXT_FIELDS]]></verbatim>
             <brief>Cached ETH callback event flags.</brief>
           </field>
           <verbatim><![CDATA[
-#if defined(ETH_DRIVER_EXT_FIELS)
+#if defined(ETH_DRIVER_EXT_FIELDS)
 ETH_DRIVER_EXT_FIELDS
 #endif
 /* End of the mandatory fields.*/

--- a/os/xhal/codegen/hal_sio.xml
+++ b/os/xhal/codegen/hal_sio.xml
@@ -740,7 +740,7 @@ return events;]]></implementation>
                 </retval>
                 <retval value="MSG_TIMEOUT">If synchronization timed out.
                 </retval>
-                <retval value="MSG_RESET">It the driver has been stopped
+                <retval value="MSG_RESET">If the driver has been stopped
                   while
                   waiting.
                 </retval>
@@ -793,7 +793,7 @@ return msg;]]></implementation>
                 </retval>
                 <retval value="MSG_TIMEOUT">If synchronization timed out.
                 </retval>
-                <retval value="MSG_RESET">It the driver has been stopped
+                <retval value="MSG_RESET">If the driver has been stopped
                   while
                   waiting.
                 </retval>
@@ -850,7 +850,7 @@ return msg;]]></implementation>
                 </retval>
                 <retval value="MSG_TIMEOUT">If synchronization timed out.
                 </retval>
-                <retval value="MSG_RESET">It the driver has been stopped
+                <retval value="MSG_RESET">If the driver has been stopped
                   while
                   waiting.
                 </retval>
@@ -894,7 +894,7 @@ return msg;]]></implementation>
                 </retval>
                 <retval value="MSG_TIMEOUT">If synchronization timed out.
                 </retval>
-                <retval value="MSG_RESET">It the driver has been stopped
+                <retval value="MSG_RESET">If the driver has been stopped
                   while
                   waiting.
                 </retval>
@@ -1172,7 +1172,7 @@ osalEventBroadcastFlagsI(&self->event, flags);]]></implementation>
               <implementation><![CDATA[
 msg_t msg;
 
-/* Starting the undelying SIO driver.*/
+/* Starting the underlying SIO driver.*/
 msg = drvStart(self->siop, config);
 if (msg == HAL_RET_SUCCESS) {
   self->config = self->siop->config;

--- a/os/xhal/include/hal_cb_driver.h
+++ b/os/xhal/include/hal_cb_driver.h
@@ -324,7 +324,7 @@ static inline drv_cb_t drvGetCallbackX(void *ip) {
  * @details     The @p HAL_DRV_STATE_HALF state is used by those drivers
  *              triggering multiple callbacks for a single asynchronous
  *              operation, it marks the filling of the first half of the
- *              tranfer buffer.
+ *              transfer buffer.
  * @note        This function is meant to be called exclusively from the driver
  *              callback.
  *
@@ -347,7 +347,8 @@ static inline bool drvStateIsHalfX(void *ip) {
  * @brief       Checks for @p HAL_DRV_STATE_COMPLETE state.
  * @details     The @p HAL_DRV_STATE_COMPLETE state is used by those drivers
  *              triggering multiple callbacks for a single asynchronous
- *              operation, it marks the complete filling of the tranfer buffer.
+ *              operation, it marks the complete filling of the transfer
+ *              buffer.
  * @note        This function is meant to be called exclusively from the driver
  *              callback.
  *

--- a/os/xhal/include/hal_eth.h
+++ b/os/xhal/include/hal_eth.h
@@ -141,12 +141,12 @@ typedef uintptr_t eth_receive_handle_t;
 typedef uintptr_t eth_transmit_handle_t;
 
 /**
- * @brief       Type of structure representing a ETH driver.
+ * @brief       Type of structure representing an ETH driver.
  */
 typedef struct hal_eth_driver hal_eth_driver_c;
 
 /**
- * @brief       Type of structure representing a ETH configuration.
+ * @brief       Type of structure representing an ETH configuration.
  */
 typedef struct hal_eth_config hal_eth_config_t;
 
@@ -173,9 +173,9 @@ struct hal_eth_config {
   const uint8_t             *mac_address;
   /* End of the mandatory fields.*/
   eth_lld_config_fields;
-#if (defined(ETH_CONFIG_EXT_FIELS)) || defined (__DOXYGEN__)
+#if (defined(ETH_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
   ETH_CONFIG_EXT_FIELDS
-#endif /* defined(ETH_CONFIG_EXT_FIELS) */
+#endif /* defined(ETH_CONFIG_EXT_FIELDS) */
 };
 
 /**
@@ -201,14 +201,14 @@ struct eth_configurations {
  * @class       hal_eth_driver_c
  * @extends     hal_cb_driver_c
  *
- * @brief       Class of a ETH driver.
+ * @brief       Class of an ETH driver.
  *
  * @name        Class @p hal_eth_driver_c structures
  * @{
  */
 
 /**
- * @brief       Type of a ETH driver class.
+ * @brief       Type of a network driver class.
  */
 typedef struct hal_eth_driver hal_eth_driver_c;
 
@@ -229,7 +229,7 @@ struct hal_eth_driver_vmt {
 };
 
 /**
- * @brief       Structure representing a ETH driver class.
+ * @brief       Structure representing a network driver class.
  */
 struct hal_eth_driver {
   /**
@@ -293,7 +293,7 @@ struct hal_eth_driver {
    * @brief       Cached ETH callback event flags.
    */
   eventflags_t              lastflags;
-#if defined(ETH_DRIVER_EXT_FIELS)
+#if defined(ETH_DRIVER_EXT_FIELDS)
   ETH_DRIVER_EXT_FIELDS
 #endif
   /* End of the mandatory fields.*/

--- a/os/xhal/ports/STM32/LLD/DMA3v1/stm32_dma3.h
+++ b/os/xhal/ports/STM32/LLD/DMA3v1/stm32_dma3.h
@@ -419,7 +419,7 @@ extern const stm32_dma3_channel_t __stm32_dma3_channels[STM32_DMA3_NUM_CHANNELS]
    the symbol needs to be aligned to a 64k boundary and marks the base of an
    area where all symbols with names starting with __dma3_ are collected.
    On devices with data cache this area shall be placed at beginning of a
-   non-cachable area.*/
+   non-cacheable area.*/
 extern uint32_t __dma3_base__;
 
 #ifdef __cplusplus

--- a/os/xhal/ports/STM32/LLD/ETHv2/hal_eth_lld.c
+++ b/os/xhal/ports/STM32/LLD/ETHv2/hal_eth_lld.c
@@ -724,7 +724,7 @@ void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
  * @brief       Releases and transmits a frame.
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
- * @param[in]     txh           Transmi] handle.
+ * @param[in]     txh           Transmit handle.
  *
  * @notapi
  */

--- a/os/xhal/ports/STM32/LLD/SYSTICKv1/hal_st_lld.c
+++ b/os/xhal/ports/STM32/LLD/SYSTICKv1/hal_st_lld.c
@@ -56,18 +56,7 @@
 #define ST_NUMBER                           STM32_TIM1_CC_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM1(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM1_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX) || defined(STM32WLXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM1_STOP
-#elif defined(STM32G0XX)
-#define ST_ENABLE_STOP()                    DBG->APBFZ1 |= DBG_APB_FZ1_DBG_TIM1_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM1
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM1_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM1_STOP()
 
 #elif STM32_ST_USE_TIMER == 2
 
@@ -83,18 +72,7 @@
 #define ST_NUMBER                           STM32_TIM2_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM2(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM2_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX) || defined(STM32WLXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM2_STOP
-#elif defined(STM32G0XX)
-#define ST_ENABLE_STOP()                    DBG->APBFZ1 |= DBG_APB_FZ1_DBG_TIM2_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM2
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM2_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM2_STOP()
 
 #elif STM32_ST_USE_TIMER == 3
 
@@ -110,18 +88,7 @@
 #define ST_NUMBER                           STM32_TIM3_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM3(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM3_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM3_STOP
-#elif defined(STM32G0XX)
-#define ST_ENABLE_STOP()                    DBG->APBFZ1 |= DBG_APB_FZ1_DBG_TIM3_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM3
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM3_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM3_STOP()
 
 #elif STM32_ST_USE_TIMER == 4
 
@@ -137,16 +104,7 @@
 #define ST_NUMBER                           STM32_TIM4_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM4(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM4_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM4_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM4
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM4_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM4_STOP()
 
 #elif STM32_ST_USE_TIMER == 5
 
@@ -162,16 +120,7 @@
 #define ST_NUMBER                           STM32_TIM5_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM5(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM5_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM5_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM5
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM5_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM5_STOP()
 
 #elif STM32_ST_USE_TIMER == 8
 
@@ -187,18 +136,7 @@
 #define ST_NUMBER                           STM32_TIM8_CC_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM8(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM8_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX) || defined(STM32WLXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM8_STOP
-#elif defined(STM32G0XX)
-#define ST_ENABLE_STOP()                    DBG->APBFZ1 |= DBG_APB_FZ1_DBG_TIM8_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM8
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM8_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM8_STOP()
 
 #elif STM32_ST_USE_TIMER == 9
 
@@ -214,16 +152,7 @@
 #define ST_NUMBER                           STM32_TIM9_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK2
 #define ST_ENABLE_CLOCK()                   rccEnableTIM9(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM9_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZR1 |= DBGMCU_APB2FZR1_DBG_TIM9_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2LFZ1 |= DBGMCU_APB2LFZ1_DBG_TIM9
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2_FZ_DBG_TIM9_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM9_STOP()
 
 #elif STM32_ST_USE_TIMER == 10
 
@@ -239,16 +168,7 @@
 #define ST_NUMBER                           STM32_TIM10_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK2
 #define ST_ENABLE_CLOCK()                   rccEnableTIM10(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM10_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZR1 |= DBGMCU_APB2FZR1_DBG_TIM10_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2LFZ1 |= DBGMCU_APB2LFZ1_DBG_TIM10
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2_FZ_DBG_TIM10_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM10_STOP()
 
 #elif STM32_ST_USE_TIMER == 11
 
@@ -264,16 +184,7 @@
 #define ST_NUMBER                           STM32_TIM11_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK2
 #define ST_ENABLE_CLOCK()                   rccEnableTIM11(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM11_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZR1 |= DBGMCU_APB2FZR1_DBG_TIM11_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2LFZ1 |= DBGMCU_APB2LFZ1_DBG_TIM11
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2_FZ_DBG_TIM11_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM11_STOP()
 
 #elif STM32_ST_USE_TIMER == 12
 
@@ -289,16 +200,7 @@
 #define ST_NUMBER                           STM32_TIM12_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM12(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM12_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM12_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM12
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM12_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM12_STOP()
 
 #elif STM32_ST_USE_TIMER == 13
 
@@ -314,16 +216,7 @@
 #define ST_NUMBER                           STM32_TIM13_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM13(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM13_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM13_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM13
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM13_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM13_STOP()
 
 #elif STM32_ST_USE_TIMER == 14
 
@@ -339,16 +232,7 @@
 #define ST_NUMBER                           STM32_TIM14_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK1
 #define ST_ENABLE_CLOCK()                   rccEnableTIM14(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM14_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZR1 |= DBGMCU_APB1FZR1_DBG_TIM14_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB1LFZ1 |= DBGMCU_APB1LFZ1_DBG_TIM14
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB1FZ |= DBGMCU_APB1_FZ_DBG_TIM14_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM14_STOP()
 
 #elif STM32_ST_USE_TIMER == 15
 
@@ -364,16 +248,7 @@
 #define ST_NUMBER                           STM32_TIM15_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK2
 #define ST_ENABLE_CLOCK()                   rccEnableTIM15(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM15_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2FZ_DBG_TIM15_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ1 |= DBGMCU_APB2FZ1_DBG_TIM15
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2_FZ_DBG_TIM15_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM15_STOP()
 
 #elif STM32_ST_USE_TIMER == 16
 
@@ -389,18 +264,7 @@
 #define ST_NUMBER                           STM32_TIM16_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK2
 #define ST_ENABLE_CLOCK()                   rccEnableTIM16(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM16_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WLXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2FZ_DBG_TIM16_STOP
-#elif defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZR |= DBGMCU_APB2FZR_DBG_TIM16_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ1 |= DBGMCU_APB2FZ1_DBG_TIM16
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2_FZ_DBG_TIM16_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM16_STOP()
 
 #elif STM32_ST_USE_TIMER == 17
 
@@ -416,18 +280,7 @@
 #define ST_NUMBER                           STM32_TIM17_NUMBER
 #define ST_CLOCK_SRC                        STM32_TIMCLK2
 #define ST_ENABLE_CLOCK()                   rccEnableTIM17(true)
-#if defined(STM32F1XX)
-#define ST_ENABLE_STOP()                    DBGMCU->CR |= DBGMCU_CR_DBG_TIM17_STOP
-#elif defined(STM32L4XX) || defined(STM32L4XXP) || defined(STM32G4XX) ||    \
-      defined(STM32L5XX) || defined(STM32WLXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2FZ_DBG_TIM17_STOP
-#elif defined(STM32WBXX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZR |= DBGMCU_APB2FZR_DBG_TIM17_STOP
-#elif defined(STM32H7XX)
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ1 |= DBGMCU_APB2FZ1_DBG_TIM17
-#else
-#define ST_ENABLE_STOP()                    DBGMCU->APB2FZ |= DBGMCU_APB2_FZ_DBG_TIM17_STOP
-#endif
+#define ST_ENABLE_STOP()                    STM32_DBGMCU_TIM17_STOP()
 
 #elif STM32_ST_USE_TIMER == 21
 

--- a/os/xhal/src/hal_eth.c
+++ b/os/xhal/src/hal_eth.c
@@ -191,7 +191,7 @@ const void *__eth_selcfg_impl(void *ip, unsigned cfgnum) {
 /** @} */
 
 /**
- * @brief       VMT structure of ETH driver class.
+ * @brief       VMT structure of network driver class.
  * @note        It is public because accessed by the inlined constructor.
  */
 const struct hal_eth_driver_vmt __hal_eth_driver_vmt = {

--- a/os/xhal/src/hal_sio.c
+++ b/os/xhal/src/hal_sio.c
@@ -736,7 +736,7 @@ sioevents_t sioGetEvents(void *ip) {
  * @return                      The synchronization result.
  * @retval MSG_OK               If there is data in the RX FIFO.
  * @retval MSG_TIMEOUT          If synchronization timed out.
- * @retval MSG_RESET            It the driver has been stopped while waiting.
+ * @retval MSG_RESET            If the driver has been stopped while waiting.
  * @retval SIO_MSG_ERRORS       It RX errors occurred before or during wait.
  *
  * @api
@@ -783,7 +783,7 @@ msg_t sioSynchronizeRX(void *ip, sysinterval_t timeout) {
  * @return                      The synchronization result.
  * @retval MSG_OK               If there is data in the RX FIFO.
  * @retval MSG_TIMEOUT          If synchronization timed out.
- * @retval MSG_RESET            It the driver has been stopped while waiting.
+ * @retval MSG_RESET            If the driver has been stopped while waiting.
  * @retval SIO_MSG_ERRORS       It RX errors occurred before or during wait.
  *
  * @api
@@ -832,7 +832,7 @@ msg_t sioSynchronizeRXIdle(void *ip, sysinterval_t timeout) {
  * @return                      The synchronization result.
  * @retval MSG_OK               If there is space in the TX FIFO.
  * @retval MSG_TIMEOUT          If synchronization timed out.
- * @retval MSG_RESET            It the driver has been stopped while waiting.
+ * @retval MSG_RESET            If the driver has been stopped while waiting.
  *
  * @api
  */
@@ -872,7 +872,7 @@ msg_t sioSynchronizeTX(void *ip, sysinterval_t timeout) {
  * @return                      The synchronization result.
  * @retval MSG_OK               If there is space in the TX FIFO.
  * @retval MSG_TIMEOUT          If synchronization timed out.
- * @retval MSG_RESET            It the driver has been stopped while waiting.
+ * @retval MSG_RESET            If the driver has been stopped while waiting.
  *
  * @api
  */
@@ -1212,7 +1212,7 @@ msg_t __bsio_start_impl(void *ip, const void *config) {
   hal_buffered_sio_c *self = (hal_buffered_sio_c *)ip;
   msg_t msg;
 
-  /* Starting the undelying SIO driver.*/
+  /* Starting the underlying SIO driver.*/
   msg = drvStart(self->siop, config);
   if (msg == HAL_RET_SUCCESS) {
     self->config = self->siop->config;


### PR DESCRIPTION
## Summary
- Fix comment and documentation typos across XHAL, RT, NIL, OSLIB, and VFS
- Update XML/FTL sources first where generated files are involved, then regenerate outputs
- Simplify XHAL STM32 SYSTICKv1 debug-stop handling through registry helpers

## Validation
- xmllint validation for XHAL and VFS XML codegen inputs
- fmpp regeneration for XHAL and VFS generated files
- stylecheck.py on touched C/header/template files
- git diff --check
- testxhal/TRNG builds for stm32h563zi_nucleo144 and stm32g474re_nucleo64