### PR TITLE
Fix registry thread reference accounting

### DIFF
--- a/os/common/abstractions/nasa_cfe/osal/src/osapi.c
+++ b/os/common/abstractions/nasa_cfe/osal/src/osapi.c
@@ -1903,7 +1903,8 @@ int32 OS_TaskDelete(uint32 task_id) {
   funcptr_t fp;
 
   /* Check for thread validity, getting a reference.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -1947,7 +1948,8 @@ int32 OS_TaskWait(uint32 task_id) {
   thread_t *tp = (thread_t *)task_id;
 
   /* Check for thread validity, getting a reference.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -2001,7 +2003,8 @@ int32 OS_TaskSetPriority(uint32 task_id, uint32 new_priority) {
   }
 
   /* Check for thread validity.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -2126,7 +2129,7 @@ int32 OS_TaskGetIdByName(uint32 *task_id, const char *task_name) {
  */
 int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop) {
   thread_t *tp = (thread_t *)task_id;
-  size_t wasize = (size_t)tp - (size_t)tp->wabase + sizeof (thread_t);
+  size_t wasize;
 
   /* NULL pointer checks.*/
   if (task_prop == NULL) {
@@ -2134,9 +2137,12 @@ int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop) {
   }
 
   /* Check for thread validity.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
+
+  wasize = (size_t)tp - (size_t)tp->wabase + sizeof (thread_t);
 
   strncpy(task_prop->name, tp->name, OS_MAX_API_NAME - 1);
   task_prop->creator    = (uint32)chSysGetIdleThreadX();

--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -97,11 +97,7 @@ ROMCONST chdebug_t ch_debug = {
 #endif
   .off_state                = (uint8_t)__CH_OFFSETOF(thread_t, state),
   .off_flags                = (uint8_t)__CH_OFFSETOF(thread_t, flags),
-#if CH_CFG_USE_DYNAMIC == TRUE
   .off_refs                 = (uint8_t)__CH_OFFSETOF(thread_t, refs),
-#else
-  .off_refs                 = (uint8_t)0,
-#endif
 #if CH_CFG_TIME_QUANTUM > 0
   .off_preempt              = (uint8_t)__CH_OFFSETOF(thread_t, ticks),
 #else
@@ -162,9 +158,9 @@ thread_t *chRegFirstThread(void) {
   chSysLock();
   p = (uint8_t *)REG_HEADER(currcore)->next;
   tp = __CH_OWNEROF(p, thread_t, rqueue);
-#if CH_CFG_USE_DYNAMIC == TRUE
+  chDbgAssert(tp->refs < (trefs_t)255, "too many references");
+
   tp->refs++;
-#endif
   chSysUnlock();
 
   return tp;
@@ -196,16 +192,12 @@ thread_t *chRegNextThread(thread_t *tp) {
     uint8_t *p = (uint8_t *)nqp;
     ntp = __CH_OWNEROF(p, thread_t, rqueue);
 
-#if CH_CFG_USE_DYNAMIC == TRUE
     chDbgAssert(ntp->refs < (trefs_t)255, "too many references");
 
     ntp->refs++;
-#endif
   }
   chSysUnlock();
-#if CH_CFG_USE_DYNAMIC == TRUE
   chThdRelease(tp);
-#endif
 
   return ntp;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,15 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: RT thread registry reference accounting was inconsistent when dynamic
+       threads are disabled (CH_CFG_USE_DYNAMIC = FALSE): chRegFirstThread()
+       and chRegNextThread() did not count the reference they hand out while
+       chThdRelease() still released it, risking a reference-count underflow.
+       The registry lookups now reference threads unconditionally (github
+       PR #51).
+- FIX: NASA OSAL OS_TaskGetInfo() computed the task working-area size before
+       validating the task id, dereferencing a possibly-invalid thread pointer;
+       the computation is now done after the validity check (github PR #51).
 - FIX: nvicSetSystemHandlerPriority() programmed the wrong SCB->SHPR field on
        Cortex-M0, M0+ and M23: the positive ChibiOS handler index was passed
        to the CMSIS _SHP_IDX()/_BIT_SHIFT() macros, which expect the negative


### PR DESCRIPTION
Summary:
- Count thread references consistently in registry lookup/addref paths even when dynamic threads are disabled.
- Keep OSAL thread release behavior aligned with the updated reference accounting.

Testing:
- Covered by the RT testbuild assertion and coverage runs performed during the RT coverage work.

Back-port note:
- This fixes a reference-accounting footgun that also exists on 21.11.x; it should be back-ported to the 21.11.x maintenance branch as a separate PR.