### PR TITLE
Improve RT coverage for core synchronization APIs

### DIFF
--- a/os/common/abstractions/nasa_cfe/osal/src/osapi.c
+++ b/os/common/abstractions/nasa_cfe/osal/src/osapi.c
@@ -1903,7 +1903,8 @@ int32 OS_TaskDelete(uint32 task_id) {
   funcptr_t fp;
 
   /* Check for thread validity, getting a reference.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -1947,7 +1948,8 @@ int32 OS_TaskWait(uint32 task_id) {
   thread_t *tp = (thread_t *)task_id;
 
   /* Check for thread validity, getting a reference.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -2001,7 +2003,8 @@ int32 OS_TaskSetPriority(uint32 task_id, uint32 new_priority) {
   }
 
   /* Check for thread validity.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -2126,7 +2129,7 @@ int32 OS_TaskGetIdByName(uint32 *task_id, const char *task_name) {
  */
 int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop) {
   thread_t *tp = (thread_t *)task_id;
-  size_t wasize = (size_t)tp - (size_t)tp->wabase + sizeof (thread_t);
+  size_t wasize;
 
   /* NULL pointer checks.*/
   if (task_prop == NULL) {
@@ -2134,9 +2137,12 @@ int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop) {
   }
 
   /* Check for thread validity.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
+
+  wasize = (size_t)tp - (size_t)tp->wabase + sizeof (thread_t);
 
   strncpy(task_prop->name, tp->name, OS_MAX_API_NAME - 1);
   task_prop->creator    = (uint32)chSysGetIdleThreadX();

--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -97,11 +97,7 @@ ROMCONST chdebug_t ch_debug = {
 #endif
   .off_state                = (uint8_t)__CH_OFFSETOF(thread_t, state),
   .off_flags                = (uint8_t)__CH_OFFSETOF(thread_t, flags),
-#if CH_CFG_USE_DYNAMIC == TRUE
   .off_refs                 = (uint8_t)__CH_OFFSETOF(thread_t, refs),
-#else
-  .off_refs                 = (uint8_t)0,
-#endif
 #if CH_CFG_TIME_QUANTUM > 0
   .off_preempt              = (uint8_t)__CH_OFFSETOF(thread_t, ticks),
 #else
@@ -162,9 +158,9 @@ thread_t *chRegFirstThread(void) {
   chSysLock();
   p = (uint8_t *)REG_HEADER(currcore)->next;
   tp = __CH_OWNEROF(p, thread_t, rqueue);
-#if CH_CFG_USE_DYNAMIC == TRUE
+  chDbgAssert(tp->refs < (trefs_t)255, "too many references");
+
   tp->refs++;
-#endif
   chSysUnlock();
 
   return tp;
@@ -196,16 +192,12 @@ thread_t *chRegNextThread(thread_t *tp) {
     uint8_t *p = (uint8_t *)nqp;
     ntp = __CH_OWNEROF(p, thread_t, rqueue);
 
-#if CH_CFG_USE_DYNAMIC == TRUE
     chDbgAssert(ntp->refs < (trefs_t)255, "too many references");
 
     ntp->refs++;
-#endif
   }
   chSysUnlock();
-#if CH_CFG_USE_DYNAMIC == TRUE
   chThdRelease(tp);
-#endif
 
   return ntp;
 }

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -6224,7 +6224,7 @@ test_println(" wait+signal/S");]]></value>
             </value>
           </description>
           <condition>
-            <value><![CDATA[CH_CFG_USE_MUTEXES ==TRUE]]></value>
+            <value><![CDATA[CH_CFG_USE_MUTEXES == TRUE]]></value>
           </condition>
           <various_code>
             <setup_code>

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -70,9 +70,29 @@
 #define WA_SIZE MEM_ALIGN_NEXT(THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),	\
                                PORT_WORKING_AREA_ALIGN)
 
-extern uint8_t test_buffer[WA_SIZE * 5];
+typedef union {
+  uint8_t wa[WA_SIZE];
+  struct {
+    stkline_t stack[THD_STACK_SIZE(THREADS_STACK_SIZE) / sizeof (stkline_t)];
+    thread_t thread;
+  } instance;
+} test_thread_slot_t;
+
+#define TEST_THREAD_STACK_BASE(n) ((stkline_t *)(void *)                  \
+                                   test_thread_slots[n].instance.stack)
+#define TEST_THREAD_STACK_END(n)  (TEST_THREAD_STACK_BASE(n) +            \
+                                   (THD_STACK_SIZE(THREADS_STACK_SIZE) /   \
+                                    sizeof (stkline_t)))
+#define TEST_THREAD_OBJECT(n)     (&test_thread_slots[n].instance.thread)
+#define TEST_THREAD_WA_BASE(n)    ((stkline_t *)(void *)test_thread_slots[n].wa)
+#define TEST_THREAD_WA_END(n)     ((stkline_t *)(void *)                 \
+                                   (test_thread_slots[n].wa + WA_SIZE))
+#define TEST_SHARED_BUFFER        ((void *)test_thread_slots)
+#define TEST_SHARED_BUFFER_SIZE   sizeof test_thread_slots
+
+extern test_thread_slot_t test_thread_slots[MAX_THREADS];
 extern thread_t *threads[MAX_THREADS];
-extern void * ROMCONST wa[5];
+extern void * ROMCONST wa[MAX_THREADS];
 
 void test_print_port_info(void);
 void test_terminate_threads(void);
@@ -81,9 +101,11 @@ systime_t test_wait_tick(void);]]></value>
     </global_definitions>
     <global_code>
       <value><![CDATA[/*
- * Global test buffer holding 5 working areas.
+ * Shared thread storage, usable as legacy working areas or as stack/object
+ * pairs for descriptor-based thread creation.
  */
-ALIGNED_VAR(PORT_WORKING_AREA_ALIGN) uint8_t test_buffer[WA_SIZE * 5];
+ALIGNED_VAR(PORT_WORKING_AREA_ALIGN) test_thread_slot_t
+  test_thread_slots[MAX_THREADS];
 
 /*
  * Pointers to the spawned threads.
@@ -93,11 +115,11 @@ thread_t *threads[MAX_THREADS];
 /*
  * Pointers to the working areas.
  */
-void * ROMCONST wa[5] = {test_buffer + (WA_SIZE * 0),
-                         test_buffer + (WA_SIZE * 1),
-                         test_buffer + (WA_SIZE * 2),
-                         test_buffer + (WA_SIZE * 3),
-                         test_buffer + (WA_SIZE * 4)};
+void * ROMCONST wa[MAX_THREADS] = {(void *)test_thread_slots[0].wa,
+                                   (void *)test_thread_slots[1].wa,
+                                   (void *)test_thread_slots[2].wa,
+                                   (void *)test_thread_slots[3].wa,
+                                   (void *)test_thread_slots[4].wa};
 
 /*
  * Sets a termination request in all the test-spawned threads.
@@ -993,6 +1015,22 @@ do {
         <value><![CDATA[static THD_FUNCTION(thread, p) {
 
   test_emit_token(*(char *)p);
+}
+
+static void setup_thread_descriptor(thread_descriptor_t *tdp,
+                                    const char *name,
+                                    stkline_t *wbase,
+                                    stkline_t *wend,
+                                    tprio_t prio,
+                                    void *arg) {
+
+  tdp->name  = name;
+  tdp->wbase = wbase;
+  tdp->wend  = wend;
+  tdp->prio  = prio;
+  tdp->funcp = thread;
+  tdp->arg   = arg;
+  tdp->owner = NULL;
 }]]></value>
       </shared_code>
       <cases>
@@ -1100,6 +1138,22 @@ test_assert_time_window(chTimeAddX(time, TIME_S2I(1)),
 chThdSleepUntil(chTimeAddX(time, 100));
 test_assert_time_window(chTimeAddX(time, 100),
                         chTimeAddX(time, 100 + CH_CFG_ST_TIMEDELTA + 1),
+                        "out of time window");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Function chThdSleepUntilWindowed() is tested with
+                  an active time window.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[time = chVTGetSystemTimeX();
+time = chThdSleepUntilWindowed(time, chTimeAddX(time, 20));
+test_assert_time_window(time,
+                        chTimeAddX(time, CH_CFG_ST_TIMEDELTA + 1),
                         "out of time window");]]></value>
               </code>
             </step>
@@ -1329,6 +1383,216 @@ chSysUnlock();]]></value>
         </case>
         <case>
           <brief>
+            <value>Thread spawning from descriptors.</value>
+          </brief>
+          <description>
+            <value>The new descriptor-based spawning APIs are tested using
+              stack-only buffers and explicit thread objects.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_descriptor_t td;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>A suspended thread is spawned then started using
+                  normal APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "spawn-suspended",
+                        TEST_THREAD_STACK_BASE(0), TEST_THREAD_STACK_END(0),
+                        chThdGetPriorityX() - 1, "A");
+threads[0] = chThdSpawnSuspended(TEST_THREAD_OBJECT(0), &td);
+test_assert(threads[0] == TEST_THREAD_OBJECT(0), "wrong thread object");
+test_assert(chThdGetWorkingAreaX(threads[0]) == TEST_THREAD_STACK_BASE(0),
+            "wrong stack base");
+chThdStart(threads[0]);
+test_wait_threads();
+test_assert_sequence("A", "invalid sequence");
+chThdObjectDispose(TEST_THREAD_OBJECT(0));]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A running thread is spawned using normal APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "spawn-running",
+                        TEST_THREAD_STACK_BASE(1), TEST_THREAD_STACK_END(1),
+                        chThdGetPriorityX() - 1, "B");
+threads[1] = chThdSpawnRunning(TEST_THREAD_OBJECT(1), &td);
+test_assert(threads[1] == TEST_THREAD_OBJECT(1), "wrong thread object");
+test_wait_threads();
+test_assert_sequence("B", "invalid sequence");
+chThdObjectDispose(TEST_THREAD_OBJECT(1));]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A suspended thread is spawned then started using
+                  I-class APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "spawn-suspended-i",
+                        TEST_THREAD_STACK_BASE(2), TEST_THREAD_STACK_END(2),
+                        chThdGetPriorityX() - 1, "C");
+chSysLock();
+threads[2] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(2), &td);
+chThdStartI(threads[2]);
+chSysUnlock();
+test_assert(threads[2] == TEST_THREAD_OBJECT(2), "wrong thread object");
+test_wait_threads();
+test_assert_sequence("C", "invalid sequence");
+chThdObjectDispose(TEST_THREAD_OBJECT(2));]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A running thread is spawned using I-class APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "spawn-running-i",
+                        TEST_THREAD_STACK_BASE(3), TEST_THREAD_STACK_END(3),
+                        chThdGetPriorityX() - 1, "D");
+chSysLock();
+threads[3] = chThdSpawnRunningI(TEST_THREAD_OBJECT(3), &td);
+chSysUnlock();
+test_assert(threads[3] == TEST_THREAD_OBJECT(3), "wrong thread object");
+test_wait_threads();
+test_assert_sequence("D", "invalid sequence");
+chThdObjectDispose(TEST_THREAD_OBJECT(3));]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Thread creation from descriptors.</value>
+          </brief>
+          <description>
+            <value>The new descriptor-based thread creation APIs are tested
+              using full working areas.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_descriptor_t td;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>A suspended thread is created then started using
+                  normal APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "create-suspended",
+                        TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                        chThdGetPriorityX() - 1, "E");
+threads[0] = chThdCreateSuspended(&td);
+test_assert(threads[0] != NULL, "thread creation failed");
+test_assert(chThdGetWorkingAreaX(threads[0]) == TEST_THREAD_WA_BASE(0),
+            "wrong working area");
+chThdStart(threads[0]);
+test_wait_threads();
+test_assert_sequence("E", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A running thread is created using normal APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "create-running",
+                        TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                        chThdGetPriorityX() - 1, "F");
+threads[0] = chThdCreate(&td);
+test_assert(threads[0] != NULL, "thread creation failed");
+test_wait_threads();
+test_assert_sequence("F", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A suspended thread is created then started using
+                  I-class APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "create-suspended-i",
+                        TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                        chThdGetPriorityX() - 1, "G");
+chSysLock();
+threads[0] = chThdCreateSuspendedI(&td);
+chThdStartI(threads[0]);
+chSysUnlock();
+test_assert(threads[0] != NULL, "thread creation failed");
+test_wait_threads();
+test_assert_sequence("G", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A running thread is created using I-class APIs.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "create-running-i",
+                        TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                        chThdGetPriorityX() - 1, "H");
+chSysLock();
+threads[0] = chThdCreateI(&td);
+chSysUnlock();
+test_assert(threads[0] != NULL, "thread creation failed");
+test_wait_threads();
+test_assert_sequence("H", "invalid sequence");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
             <value>Threads registry functionality.</value>
           </brief>
           <description>
@@ -1382,6 +1646,10 @@ test_assert(chRegGetThreadNameX(tp) == oldname, "name not restored");]]></value>
                 <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread, "R");
 test_assert(threads[0] != NULL, "thread creation failed");
 chRegSetThreadNameX(threads[0], "registry-worker");
+
+tp = chThdAddRef(threads[0]);
+test_assert(tp == threads[0], "wrong referenced thread");
+chThdRelease(tp);
 
 tp = chRegFindThreadByName("registry-worker");
 test_assert(tp == threads[0], "not found by name");
@@ -1443,12 +1711,39 @@ test_assert_sequence("R", "invalid sequence");]]></value>
       </condition>
       <shared_code>
         <value><![CDATA[static thread_reference_t tr1;
+static threads_queue_t tq1;
+static msg_t qmsg1;
+static msg_t qmsg2;
 
 static THD_FUNCTION(thread1, p) {
 
   chSysLock();
   chThdResumeI(&tr1, MSG_OK);
   chSchRescheduleS();
+  chSysUnlock();
+  test_emit_token(*(char *)p);
+}
+
+static THD_FUNCTION(thread2, p) {
+
+  chSysLock();
+  chThdResumeS(&tr1, MSG_RESET);
+  chSysUnlock();
+  test_emit_token(*(char *)p);
+}
+
+static THD_FUNCTION(queue_thread1, p) {
+
+  chSysLock();
+  qmsg1 = chThdEnqueueTimeoutS(&tq1, TIME_INFINITE);
+  chSysUnlock();
+  test_emit_token(*(char *)p);
+}
+
+static THD_FUNCTION(queue_thread2, p) {
+
+  chSysLock();
+  qmsg2 = chThdEnqueueTimeoutS(&tq1, TIME_INFINITE);
   chSysUnlock();
   test_emit_token(*(char *)p);
 }]]></value>
@@ -1460,7 +1755,8 @@ static THD_FUNCTION(thread1, p) {
           </brief>
           <description>
             <value>The functionality of chThdSuspendTimeoutS() and
-              chThdResumeI() is tested.</value>
+              chThdSuspendS() are tested together with chThdResumeI()
+              and chThdResumeS().</value>
           </description>
           <condition>
             <value />
@@ -1470,7 +1766,7 @@ static THD_FUNCTION(thread1, p) {
               <value><![CDATA[tr1 = NULL;]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[test_wait_threads();]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[systime_t time;
@@ -1495,7 +1791,29 @@ msg = chThdSuspendTimeoutS(&tr1, TIME_INFINITE);
 chSysUnlock();
 test_assert(NULL == tr1, "not NULL");
 test_assert(MSG_OK == msg,"wrong returned message");
-test_wait_threads();]]></value>
+test_wait_threads();
+test_assert_sequence("A", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The function chThdSuspendS() is invoked, the thread
+                  is remotely resumed with message @p MSG_RESET using
+                  chThdResumeS(). On return the message and the state of
+                  the reference are tested.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread2, "B");
+chSysLock();
+msg = chThdSuspendS(&tr1);
+chSysUnlock();
+test_assert(NULL == tr1, "not NULL");
+test_assert(MSG_RESET == msg, "wrong returned message");
+test_wait_threads();
+test_assert_sequence("B", "invalid sequence");]]></value>
               </code>
             </step>
             <step>
@@ -1518,6 +1836,120 @@ test_assert_time_window(chTimeAddX(time, TIME_MS2I(10)),
                         "out of time window");
 test_assert(NULL == tr1, "not NULL");
 test_assert(MSG_TIMEOUT == msg, "wrong returned message");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Threads queue object lifecycle.</value>
+          </brief>
+          <description>
+            <value>The lifecycle and normal wakeup operations of a threads
+              queue object are tested.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chThdQueueObjectInit(&tq1);
+qmsg1 = MSG_OK;
+qmsg2 = MSG_OK;]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();
+chThdQueueObjectDispose(&tq1);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[msg_t msg;
+bool empty;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>A threads queue is initialized, tested as empty,
+                  then touched with empty dequeue operations.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+empty = chThdQueueIsEmptyI(&tq1);
+chThdDequeueNextI(&tq1, MSG_OK);
+chThdDequeueAllI(&tq1, MSG_OK);
+chSysUnlock();
+test_assert(empty, "queue not empty");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Immediate timeout enqueue is tested on an empty
+                  queue.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+msg = chThdEnqueueTimeoutS(&tq1, TIME_IMMEDIATE);
+empty = chThdQueueIsEmptyI(&tq1);
+chSysUnlock();
+test_assert(msg == MSG_TIMEOUT, "wrong returned message");
+test_assert(empty, "queue not empty");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>One queued thread is resumed using
+                  chThdDequeueNextI().</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[qmsg1 = MSG_OK;
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX(),
+                               queue_thread1, "C");
+chThdYield();
+chSysLock();
+empty = chThdQueueIsEmptyI(&tq1);
+chThdDequeueNextI(&tq1, MSG_RESET);
+chSysUnlock();
+test_assert(!empty, "queue empty");
+test_wait_threads();
+test_assert(qmsg1 == MSG_RESET, "wrong returned message");
+test_assert_sequence("C", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Two queued threads are resumed using
+                  chThdDequeueAllI().</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[qmsg1 = MSG_OK;
+qmsg2 = MSG_OK;
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX(),
+                               queue_thread1, "D");
+threads[1] = chThdCreateStatic(wa[1], WA_SIZE, chThdGetPriorityX(),
+                               queue_thread2, "E");
+chThdYield();
+chSysLock();
+empty = chThdQueueIsEmptyI(&tq1);
+chThdDequeueAllI(&tq1, MSG_RESET);
+chSysUnlock();
+test_assert(!empty, "queue empty");
+test_wait_threads();
+test_assert(qmsg1 == MSG_RESET, "wrong returned message");
+test_assert(qmsg2 == MSG_RESET, "wrong returned message");
+test_assert_sequence("DE", "invalid sequence");]]></value>
               </code>
             </step>
           </steps>
@@ -2199,6 +2631,13 @@ static THD_FUNCTION(thread4B, p) {
   chSysUnlock();
 }
 
+static THD_FUNCTION(thread5, p) {
+
+  chMtxLock(&m2);
+  test_emit_token(*(char *)p);
+  chMtxUnlock(&m2);
+}
+
 #if CH_CFG_USE_CONDVARS || defined(__DOXYGEN__)
 static THD_FUNCTION(thread6, p) {
 
@@ -2609,6 +3048,139 @@ test_assert(chThdGetPriorityX() == pa, "wrong priority level");]]></value>
               <code>
                 <value><![CDATA[chMtxUnlock(&m1);
 test_assert(chThdGetPriorityX() == p, "wrong priority level");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Contended mutex handoff variants.</value>
+          </brief>
+          <description>
+            <value>Contended mutex handoff is tested for chMtxUnlockS()
+              and chMtxUnlockAllS(). A same-priority waiter is also used
+              to exercise the lock path without priority inheritance
+              boosting.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chMtxObjectInit(&m1);
+chMtxObjectInit(&m2);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();
+chMtxObjectDispose(&m1);
+chMtxObjectDispose(&m2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[tprio_t prio;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Getting current thread priority for later checks.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[prio = chThdGetPriorityX();]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A same-priority waiter is queued on the mutex,
+                  verifying that no priority boost is performed.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chMtxLock(&m1);
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio, thread1, "A");
+chThdYield();
+test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+chMtxUnlock(&m1);
+test_wait_threads();
+test_assert_sequence("A", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A higher-priority waiter is handed the mutex by
+                  chMtxUnlockS().</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chMtxLock(&m1);
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1, thread1, "B");
+test_assert(chThdGetPriorityX() == prio + 1, "wrong priority level");
+
+chSysLock();
+chMtxUnlockS(&m1);
+chSchRescheduleS();
+chSysUnlock();
+
+test_wait_threads();
+test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+test_assert_sequence("B", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A higher-priority waiter is handed the mutex by
+                  chMtxUnlockAllS().</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chMtxLock(&m1);
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1, thread1, "C");
+test_assert(chThdGetPriorityX() == prio + 1, "wrong priority level");
+
+chSysLock();
+chMtxUnlockAllS();
+chSysUnlock();
+
+test_wait_threads();
+test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+test_assert_sequence("C", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Priority is recomputed while chMtxUnlockS()
+                  hands off a mutex and another owned mutex still has a
+                  waiter.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chMtxLock(&m2);
+chMtxLock(&m1);
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1, thread5, "E");
+threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio + 2, thread1, "D");
+test_assert(chThdGetPriorityX() == prio + 2, "wrong priority level");
+
+chSysLock();
+chMtxUnlockS(&m1);
+chSchRescheduleS();
+chSysUnlock();
+
+test_assert(chThdGetPriorityX() == prio + 1, "wrong priority level");
+chMtxUnlock(&m2);
+test_wait_threads();
+test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+test_assert_sequence("DE", "invalid sequence");]]></value>
               </code>
             </step>
           </steps>
@@ -3606,6 +4178,129 @@ test_assert_sequence("ABC", "invalid sequence");]]></value>
         </case>
         <case>
           <brief>
+            <value>Event flags retrieval and pending waits.</value>
+          </brief>
+          <description>
+            <value>Listener flag retrieval and immediate completion of
+              pending event waits are tested.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_USE_EVENTS_TIMEOUT == TRUE]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chEvtGetAndClearEvents(ALL_EVENTS);
+chEvtObjectInit(&es1);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chEvtGetAndClearEvents(ALL_EVENTS);
+chEvtObjectDispose(&es1);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[eventflags_t f;
+eventmask_t m;
+event_listener_t el;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>A listener is registered with a restricted flag
+                  mask.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chEvtRegisterMaskWithFlags(&es1, &el, 1, (eventflags_t)5);
+test_assert_lock(chEvtIsListeningI(&es1), "no listener");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Unwanted and wanted flags are broadcast, the
+                  listener flags and pending events are verified.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chEvtBroadcastFlags(&es1, (eventflags_t)2);
+f = chEvtGetAndClearFlags(&el);
+test_assert(f == (eventflags_t)0, "unexpected flags");
+m = chEvtGetAndClearEvents(ALL_EVENTS);
+test_assert(m == 0, "spurious event");
+
+chEvtBroadcastFlags(&es1, (eventflags_t)1);
+f = chEvtGetAndClearFlags(&el);
+test_assert(f == (eventflags_t)1, "wrong flags");
+m = chEvtWaitOne(ALL_EVENTS);
+test_assert(m == 1, "event flag error");
+m = chEvtGetAndClearEvents(ALL_EVENTS);
+test_assert(m == 0, "stuck event");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The I-class broadcast and flag retrieval paths are
+                  exercised.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+chEvtBroadcastFlagsI(&es1, (eventflags_t)4);
+f = chEvtGetAndClearFlagsI(&el);
+chSchRescheduleS();
+chSysUnlock();
+
+test_assert(f == (eventflags_t)4, "wrong flags");
+m = chEvtWaitOne(ALL_EVENTS);
+test_assert(m == 1, "event flag error");
+m = chEvtGetAndClearEvents(ALL_EVENTS);
+test_assert(m == 0, "stuck event");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Timeout-capable wait functions are invoked with
+                  already-pending events.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chEvtAddEvents(7);
+m = chEvtWaitOneTimeout(ALL_EVENTS, TIME_INFINITE);
+test_assert(m == 1, "single event error");
+m = chEvtWaitAnyTimeout(ALL_EVENTS, TIME_INFINITE);
+test_assert(m == 6, "unexpected pending bit");
+
+chEvtAddEvents(5);
+m = chEvtWaitAllTimeout(5, TIME_INFINITE);
+test_assert(m == 5, "event flags error");
+m = chEvtGetAndClearEvents(ALL_EVENTS);
+test_assert(m == 0, "stuck event");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The listener is unregistered, the Event Source
+                  must not have listeners.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chEvtUnregister(&es1, &el);
+test_assert_lock(!chEvtIsListeningI(&es1), "stuck listener");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
             <value>Events Flags wait using chEvtWaitOne().</value>
           </brief>
           <description>
@@ -4079,7 +4774,8 @@ static THD_FUNCTION(dyn_thread1, p) {
           </condition>
           <various_code>
             <setup_code>
-              <value><![CDATA[chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);]]></value>
+              <value><![CDATA[chHeapObjectInit(&heap1, TEST_SHARED_BUFFER,
+                 TEST_SHARED_BUFFER_SIZE);]]></value>
             </setup_code>
             <teardown_code>
               <value><![CDATA[chHeapObjectDispose(&heap1);]]></value>
@@ -4316,7 +5012,8 @@ test_assert(chPoolAlloc(&mp1) == NULL, "pool list not empty");]]></value>
           </condition>
           <various_code>
             <setup_code>
-              <value><![CDATA[chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);]]></value>
+              <value><![CDATA[chHeapObjectInit(&heap1, TEST_SHARED_BUFFER,
+                 TEST_SHARED_BUFFER_SIZE);]]></value>
             </setup_code>
             <teardown_code>
               <value><![CDATA[{

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -670,7 +670,11 @@ chSysEnable();]]></value>
         <value />
       </condition>
       <shared_code>
-        <value><![CDATA[#include "ch.h"]]></value>
+        <value><![CDATA[#include "ch.h"
+
+#if CH_CFG_USE_TM || defined(__DOXYGEN__)
+static time_measurement_t tm1, tm2;
+#endif]]></value>
       </shared_code>
       <cases>
         <case>
@@ -803,6 +807,92 @@ test_assert(b == true, "not in range");
 b = chTimeIsInRangeX((systime_t)10, (systime_t)100, (systime_t)10);
 test_assert(b == false, "in range");
 ]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Time Measurement functionality.</value>
+          </brief>
+          <description>
+            <value>The functionality of Time Measurement objects is
+              tested.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_USE_TM == TRUE]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chTMObjectInit(&tm1);
+chTMObjectInit(&tm2);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chTMObjectDispose(&tm1);
+chTMObjectDispose(&tm2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[rtcnt_t first;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The initialized measurement objects are verified.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[test_assert(tm1.best == (rtcnt_t)-1, "invalid best");
+test_assert(tm1.worst == (rtcnt_t)0, "invalid worst");
+test_assert(tm1.last == (rtcnt_t)0, "invalid last");
+test_assert(tm1.n == (ucnt_t)0, "invalid counter");
+test_assert(tm1.cumulative == (rttime_t)0, "invalid cumulative");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A measurement is performed and its result is verified.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chTMStartMeasurementX(&tm1);
+chSysPolledDelayX((rtcnt_t)100);
+chTMStopMeasurementX(&tm1);
+
+test_assert(tm1.n == (ucnt_t)1, "invalid counter");
+test_assert(tm1.last > (rtcnt_t)0, "invalid last");
+test_assert(tm1.best == tm1.last, "invalid best");
+test_assert(tm1.worst == tm1.last, "invalid worst");
+test_assert(tm1.cumulative == (rttime_t)tm1.last, "invalid cumulative");
+first = tm1.last;]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The first measurement is chained to the second one
+                  and both objects are verified.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chTMChainMeasurementToX(&tm1, &tm2);
+chSysPolledDelayX((rtcnt_t)10);
+chTMStopMeasurementX(&tm2);
+
+test_assert(tm1.n == (ucnt_t)2, "invalid counter");
+test_assert(tm1.last > (rtcnt_t)0, "invalid last");
+test_assert(tm1.best <= tm1.worst, "invalid range");
+test_assert(tm1.cumulative >= (rttime_t)first, "invalid cumulative");
+test_assert(tm2.n == (ucnt_t)1, "invalid counter");
+test_assert(tm2.last > (rtcnt_t)0, "invalid last");
+test_assert(tm2.best == tm2.last, "invalid best");
+test_assert(tm2.worst == tm2.last, "invalid worst");]]></value>
               </code>
             </step>
           </steps>
@@ -1237,6 +1327,104 @@ chSysUnlock();]]></value>
             </step>
           </steps>
         </case>
+        <case>
+          <brief>
+            <value>Threads registry functionality.</value>
+          </brief>
+          <description>
+            <value>The functionality of the threads registry APIs is tested
+              together with static threads creation.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_USE_REGISTRY == TRUE]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_t *tp, *ntp;
+const char *oldname, *newname;
+bool found;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The current thread registry name is changed and then
+                  restored.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[tp = chThdGetSelfX();
+oldname = chRegGetThreadNameX(tp);
+newname = "registry-main";
+chRegSetThreadName(newname);
+test_assert(chRegGetThreadNameX(tp) == newname, "name not set");
+chRegSetThreadName(oldname);
+test_assert(chRegGetThreadNameX(tp) == oldname, "name not restored");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A static thread is created then retrieved by name,
+                  pointer and working area.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread, "R");
+test_assert(threads[0] != NULL, "thread creation failed");
+chRegSetThreadNameX(threads[0], "registry-worker");
+
+tp = chRegFindThreadByName("registry-worker");
+test_assert(tp == threads[0], "not found by name");
+chThdRelease(tp);
+
+tp = chRegFindThreadByPointer(threads[0]);
+test_assert(tp == threads[0], "not found by pointer");
+chThdRelease(tp);
+
+tp = chRegFindThreadByWorkingArea(wa[0]);
+test_assert(tp == threads[0], "not found by working area");
+chThdRelease(tp);
+
+tp = chRegFindThreadByName("registry-missing");
+test_assert(tp == NULL, "unexpected thread found");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The registry is scanned forward until the end and
+                  the created thread is found in the scan.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[found = false;
+tp = chRegFirstThread();
+do {
+  if (tp == threads[0]) {
+    found = true;
+  }
+  ntp = chRegNextThread(tp);
+  tp = ntp;
+} while (tp != NULL);
+
+test_assert(found, "not found in registry scan");
+test_wait_threads();
+test_assert_sequence("R", "invalid sequence");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
       </cases>
     </sequence>
     <sequence>
@@ -1400,7 +1588,8 @@ static THD_FUNCTION(thread4, p) {
               <value><![CDATA[chSemObjectInit(&sem1, 1);]]></value>
             </setup_code>
             <teardown_code>
-              <value><![CDATA[chSemReset(&sem1, 0);]]></value>
+              <value><![CDATA[chSemReset(&sem1, 0);
+chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
               <value />
@@ -1472,7 +1661,7 @@ test_assert_lock(chSemGetCounterI(&sem1) == 2, "wrong counter value");]]></value
               <value><![CDATA[chSemObjectInit(&sem1, 0);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
               <value />
@@ -1540,7 +1729,7 @@ test_assert_sequence("ABCDE", "invalid sequence");
               <value><![CDATA[chSemObjectInit(&sem1, 0);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[unsigned i;
@@ -1620,7 +1809,7 @@ test_assert_time_window(target_time,
               <value><![CDATA[chSemObjectInit(&sem1, 0);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
               <value />
@@ -1682,7 +1871,8 @@ test_assert_sequence("A", "invalid sequence");]]></value>
               <value><![CDATA[chSemObjectInit(&sem1, 0);]]></value>
             </setup_code>
             <teardown_code>
-              <value><![CDATA[test_wait_threads();]]></value>
+              <value><![CDATA[test_wait_threads();
+chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
               <value />
@@ -2060,7 +2250,7 @@ static THD_FUNCTION(thread9, p) {
               <value><![CDATA[chMtxObjectInit(&m1);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chMtxObjectDispose(&m1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[tprio_t prio;]]></value>
@@ -2145,7 +2335,7 @@ test_assert_sequence("ABCDE", "invalid sequence");]]></value>
               <value><![CDATA[chMtxObjectInit(&m1);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chMtxObjectDispose(&m1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[systime_t time;]]></value>
@@ -2219,7 +2409,8 @@ test_assert_sequence("ABC", "invalid sequence");]]></value>
 chMtxObjectInit(&m2); /* Mutex A.*/]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chMtxObjectDispose(&m1);
+chMtxObjectDispose(&m2);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[systime_t time;]]></value>
@@ -2297,7 +2488,9 @@ test_assert_sequence("ABCDE", "invalid sequence");]]></value>
 chMtxObjectInit(&m2);]]></value>
             </setup_code>
             <teardown_code>
-              <value><![CDATA[test_wait_threads();]]></value>
+              <value><![CDATA[test_wait_threads();
+chMtxObjectDispose(&m1);
+chMtxObjectDispose(&m2);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[tprio_t p, pa, pb;]]></value>
@@ -2436,7 +2629,7 @@ test_assert(chThdGetPriorityX() == p, "wrong priority level");]]></value>
               <value><![CDATA[chMtxObjectInit(&m1);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chMtxObjectDispose(&m1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[bool b;
@@ -2556,7 +2749,7 @@ test_assert(ch_queue_isempty(&m1.queue), "queue not empty");]]></value>
               <value><![CDATA[chMtxObjectInit(&m1);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chMtxObjectDispose(&m1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[bool b;
@@ -2724,7 +2917,8 @@ test_assert(m1.cnt == 0, "invalid recursion counter");]]></value>
 chMtxObjectInit(&m1);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chCondObjectDispose(&c1);
+chMtxObjectDispose(&m1);]]></value>
             </teardown_code>
             <local_variables>
               <value />
@@ -2795,7 +2989,8 @@ test_assert_sequence("ABCDE", "invalid sequence");]]></value>
 chMtxObjectInit(&m1);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chCondObjectDispose(&c1);
+chMtxObjectDispose(&m1);]]></value>
             </teardown_code>
             <local_variables>
               <value />
@@ -2860,7 +3055,9 @@ chMtxObjectInit(&m1);
 chMtxObjectInit(&m2);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chCondObjectDispose(&c1);
+chMtxObjectDispose(&m1);
+chMtxObjectDispose(&m2);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[tprio_t prio;]]></value>
@@ -2979,6 +3176,21 @@ test_assert_sequence("ABC", "invalid sequence");]]></value>
   chMsgSend(p, 'B');
   chMsgSend(p, 'C');
   chMsgSend(p, 'D');
+}
+
+static THD_FUNCTION(msg_thread2, p) {
+  msg_t msg;
+
+  msg = chMsgSend(p, 'E');
+  test_emit_token(msg);
+}
+
+static THD_FUNCTION(msg_thread3, p) {
+  msg_t msg;
+
+  chThdSleepMilliseconds(50);
+  msg = chMsgSend(p, 'F');
+  test_emit_token(msg);
 }]]></value>
       </shared_code>
       <cases>
@@ -3040,6 +3252,192 @@ for (i = 0; i < 4; i++) {
 }
 test_wait_threads();
 test_assert_sequence("ABCD", "invalid sequence");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Messages polling.</value>
+          </brief>
+          <description>
+            <value>Polling for incoming messages is tested both in the
+              no-message case and in the pending-message case.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_t *tp;
+msg_t msg;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Polling without pending messages, NULL is
+                  expected.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[tp = chMsgPoll();
+test_assert(tp == NULL, "unexpected message");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Starting a sender thread, it will queue one
+                  message and wait for a reply.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() + 1,
+                               msg_thread2, chThdGetSelfX());]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Polling with a pending message, the sender is
+                  expected and released with a reply.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[tp = chMsgPoll();
+test_assert(tp == threads[0], "wrong sender");
+msg = chMsgGet(tp);
+test_assert(msg == 'E', "wrong message");
+chMsgRelease(tp, 'e');
+test_wait_threads();
+test_assert_sequence("e", "invalid sequence");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Messages timeout.</value>
+          </brief>
+          <description>
+            <value>A message wait with timeout is tested when no sender
+              queues a message.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_t *tp;
+systime_t target_time;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Waiting for a message with timeout, NULL is
+                  expected after the timeout expires.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(50));
+tp = chMsgWaitTimeout(TIME_MS2I(50));
+test_assert(tp == NULL, "unexpected message");
+test_assert_time_window(target_time,
+                        chTimeAddX(target_time, ALLOWED_DELAY),
+                        "out of time window");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Messages timeout success.</value>
+          </brief>
+          <description>
+            <value>A message wait with timeout is tested when a sender
+              queues a message before the timeout expires and when a
+              message is already pending.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_t *tp;
+msg_t msg;
+systime_t target_time;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Starting a delayed sender thread then waiting for
+                  its message using a longer timeout.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(50));
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() - 1,
+                               msg_thread3, chThdGetSelfX());
+tp = chMsgWaitTimeout(TIME_MS2I(500));
+test_assert(tp == threads[0], "wrong sender");
+test_assert_time_window(target_time,
+                        chTimeAddX(target_time, ALLOWED_DELAY),
+                        "out of time window");
+msg = chMsgGet(tp);
+test_assert(msg == 'F', "wrong message");
+chMsgRelease(tp, 'f');
+test_wait_threads();
+test_assert_sequence("f", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Starting a sender thread at higher priority makes
+                  the message pending before the timeout wait is
+                  invoked.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() + 1,
+                               msg_thread2, chThdGetSelfX());
+tp = chMsgWaitTimeout(TIME_MS2I(500));
+test_assert(tp == threads[0], "wrong sender");
+msg = chMsgGet(tp);
+test_assert(msg == 'E', "wrong message");
+chMsgRelease(tp, 'e');
+test_wait_threads();
+test_assert_sequence("e", "invalid sequence");]]></value>
               </code>
             </step>
           </steps>
@@ -3561,7 +3959,8 @@ chEvtObjectInit(&es1);
 chEvtObjectInit(&es2);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chEvtObjectDispose(&es1);
+chEvtObjectDispose(&es2);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[eventmask_t m;
@@ -3683,7 +4082,7 @@ static THD_FUNCTION(dyn_thread1, p) {
               <value><![CDATA[chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chHeapObjectDispose(&heap1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[size_t n1, total1, largest1;
@@ -3810,7 +4209,7 @@ test_assert(largest1 == largest2, "largest fragment size changed");]]></value>
               <value><![CDATA[chPoolObjectInit(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE), NULL);]]></value>
             </setup_code>
             <teardown_code>
-              <value />
+              <value><![CDATA[chPoolObjectDispose(&mp1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[unsigned i;
@@ -3903,6 +4302,123 @@ test_assert(chPoolAlloc(&mp1) == NULL, "pool list not empty");]]></value>
             </step>
           </steps>
         </case>
+        <case>
+          <brief>
+            <value>Detached dynamic thread recovery.</value>
+          </brief>
+          <description>
+            <value>A dynamic thread allocated from a heap is detached while
+              still active. After termination its memory is recovered by a
+              registry scan.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_USE_HEAP == TRUE]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[{
+  thread_t *tp, *ntp;
+
+  tp = chRegFirstThread();
+  do {
+    ntp = chRegNextThread(tp);
+    tp = ntp;
+  } while (tp != NULL);
+}
+chHeapObjectDispose(&heap1);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[size_t n1, total1, largest1;
+size_t n2, total2, largest2;
+size_t n3, total3, largest3;
+thread_t *tp, *ntp, *dtp;
+tprio_t prio;
+bool found;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Getting heap status and base priority before the
+                  test.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[prio = chThdGetPriorityX();
+n1 = chHeapStatus(&heap1, &total1, &largest1);
+test_assert(n1 == 1, "heap fragmented");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A dynamic thread is created from the heap then its
+                  initial reference is released before it can run.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[dtp = chThdCreateFromHeap(&heap1,
+                            THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),
+                            "dyn-detached",
+                            prio-1, dyn_thread1, "D");
+test_assert(dtp != NULL, "thread creation failed");
+threads[0] = dtp;
+chThdRelease(dtp);
+threads[0] = NULL;]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The detached thread is allowed to terminate, it is
+                  expected to keep its heap allocation until the registry is
+                  scanned.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chThdSleepMilliseconds(50);
+test_assert_sequence("D", "invalid sequence");
+n2 = chHeapStatus(&heap1, &total2, &largest2);
+test_assert(total2 < total1, "memory already recovered");
+(void)n2;
+(void)largest2;]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The registry is scanned forward, the detached final
+                  thread is found and its memory is recovered.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[found = false;
+tp = chRegFirstThread();
+do {
+  if (tp == dtp) {
+    found = true;
+  }
+  ntp = chRegNextThread(tp);
+  tp = ntp;
+} while (tp != NULL);
+
+test_assert(found, "not found in registry scan");
+n3 = chHeapStatus(&heap1, &total3, &largest3);
+test_assert(n1 == n3, "fragmentation changed");
+test_assert(total1 == total3, "total free space changed");
+test_assert(largest1 == largest3, "largest fragment size changed");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
       </cases>
     </sequence>
     <sequence>
@@ -3937,6 +4453,17 @@ static void tmo(virtual_timer_t *vtp, void *param) {
 
   (void)vtp;
   (void)param;
+}
+
+static virtual_timer_t vt1, vt2;
+static volatile uint32_t vt_counter;
+
+static void vt_continuous_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)vtp;
+  (void)param;
+
+  vt_counter++;
 }
 
 #if CH_CFG_USE_MESSAGES
@@ -4637,6 +5164,208 @@ test_wait_threads();]]></value>
                 <value><![CDATA[test_print("--- Score : ");
 test_printn(n);
 test_println(" ctxswc/S");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Virtual Timer object lifecycle.</value>
+          </brief>
+          <description>
+            <value>Virtual timer objects are explicitly initialized, armed,
+              queried for remaining intervals, reset and disposed.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chVTObjectInit(&vt1);
+chVTObjectInit(&vt2);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chVTReset(&vt1);
+chVTReset(&vt2);
+chVTObjectDispose(&vt1);
+chVTObjectDispose(&vt2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[sysinterval_t remaining;
+bool armed;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The initialized timer is verified to be disarmed.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[test_assert(chVTIsArmed(&vt1) == false, "timer armed");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Two timers are armed, the second timer's remaining
+                  interval is queried, then both timers are reset.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+chVTDoSetI(&vt1, TIME_MS2I(100), tmo, NULL);
+chVTDoSetI(&vt2, TIME_MS2I(200), tmo, NULL);
+armed = chVTIsArmedI(&vt1) && chVTIsArmedI(&vt2);
+remaining = chVTGetRemainingIntervalI(&vt2);
+chVTDoResetI(&vt2);
+chVTDoResetI(&vt1);
+chSysUnlock();
+
+test_assert(armed, "timer not armed");
+test_assert(remaining > (sysinterval_t)0, "no remaining interval");
+test_assert(chVTIsArmed(&vt1) == false, "timer still armed");
+test_assert(chVTIsArmed(&vt2) == false, "timer still armed");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Continuous Virtual Timer.</value>
+          </brief>
+          <description>
+            <value>A continuous virtual timer is armed, allowed to fire
+              multiple times, then reset and checked for inactivity.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chVTObjectInit(&vt2);
+vt_counter = 0;]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chVTReset(&vt2);
+chVTObjectDispose(&vt2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[sysinterval_t remaining;
+uint32_t count;
+bool armed;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The continuous timer is armed and its remaining
+                  interval is queried.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+chVTDoSetContinuousI(&vt2, TIME_MS2I(10), vt_continuous_cb, NULL);
+armed = chVTIsArmedI(&vt2);
+remaining = chVTGetRemainingIntervalI(&vt2);
+chSysUnlock();
+
+test_assert(armed, "timer not armed");
+test_assert(remaining > (sysinterval_t)0, "no remaining interval");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The timer is allowed to reload and fire multiple
+                  times.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chThdSleepMilliseconds(50);
+count = vt_counter;
+test_assert(count >= 2U, "timer not reloaded");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The timer is reset and verified not to fire again.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+chVTDoResetI(&vt2);
+armed = chVTIsArmedI(&vt2);
+chSysUnlock();
+
+test_assert(!armed, "timer still armed");
+count = vt_counter;
+chThdSleepMilliseconds(30);
+test_assert(vt_counter == count, "timer still running");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Timestamp reset.</value>
+          </brief>
+          <description>
+            <value>The timestamp counter is reset and verified to remain
+              usable and monotonic.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_USE_TIMESTAMP == TRUE]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value />
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[systimestamp_t stamp1, stamp2;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The timestamp counter is reset from system-locked
+                  context.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+chVTResetTimeStampI();
+stamp1 = chVTGetTimeStampI();
+chSysUnlock();]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A later timestamp is verified to be monotonic.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chThdSleep(1);
+stamp2 = chVTGetTimeStamp();
+test_assert(stamp1 <= stamp2, "not monotonic");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_root.c
+++ b/test/rt/source/test/rt_test_root.c
@@ -94,9 +94,11 @@ const testsuite_t rt_test_suite = {
 /*===========================================================================*/
 
 /*
- * Global test buffer holding 5 working areas.
+ * Shared thread storage, usable as legacy working areas or as stack/object
+ * pairs for descriptor-based thread creation.
  */
-ALIGNED_VAR(PORT_WORKING_AREA_ALIGN) uint8_t test_buffer[WA_SIZE * 5];
+ALIGNED_VAR(PORT_WORKING_AREA_ALIGN) test_thread_slot_t
+  test_thread_slots[MAX_THREADS];
 
 /*
  * Pointers to the spawned threads.
@@ -106,11 +108,11 @@ thread_t *threads[MAX_THREADS];
 /*
  * Pointers to the working areas.
  */
-void * ROMCONST wa[5] = {test_buffer + (WA_SIZE * 0),
-                         test_buffer + (WA_SIZE * 1),
-                         test_buffer + (WA_SIZE * 2),
-                         test_buffer + (WA_SIZE * 3),
-                         test_buffer + (WA_SIZE * 4)};
+void * ROMCONST wa[MAX_THREADS] = {(void *)test_thread_slots[0].wa,
+                                   (void *)test_thread_slots[1].wa,
+                                   (void *)test_thread_slots[2].wa,
+                                   (void *)test_thread_slots[3].wa,
+                                   (void *)test_thread_slots[4].wa};
 
 /*
  * Sets a termination request in all the test-spawned threads.

--- a/test/rt/source/test/rt_test_root.h
+++ b/test/rt/source/test/rt_test_root.h
@@ -93,9 +93,29 @@ extern "C" {
 #define WA_SIZE MEM_ALIGN_NEXT(THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),	\
                                PORT_WORKING_AREA_ALIGN)
 
-extern uint8_t test_buffer[WA_SIZE * 5];
+typedef union {
+  uint8_t wa[WA_SIZE];
+  struct {
+    stkline_t stack[THD_STACK_SIZE(THREADS_STACK_SIZE) / sizeof (stkline_t)];
+    thread_t thread;
+  } instance;
+} test_thread_slot_t;
+
+#define TEST_THREAD_STACK_BASE(n) ((stkline_t *)(void *)                  \
+                                   test_thread_slots[n].instance.stack)
+#define TEST_THREAD_STACK_END(n)  (TEST_THREAD_STACK_BASE(n) +            \
+                                   (THD_STACK_SIZE(THREADS_STACK_SIZE) /   \
+                                    sizeof (stkline_t)))
+#define TEST_THREAD_OBJECT(n)     (&test_thread_slots[n].instance.thread)
+#define TEST_THREAD_WA_BASE(n)    ((stkline_t *)(void *)test_thread_slots[n].wa)
+#define TEST_THREAD_WA_END(n)     ((stkline_t *)(void *)                 \
+                                   (test_thread_slots[n].wa + WA_SIZE))
+#define TEST_SHARED_BUFFER        ((void *)test_thread_slots)
+#define TEST_SHARED_BUFFER_SIZE   sizeof test_thread_slots
+
+extern test_thread_slot_t test_thread_slots[MAX_THREADS];
 extern thread_t *threads[MAX_THREADS];
-extern void * ROMCONST wa[5];
+extern void * ROMCONST wa[MAX_THREADS];
 
 void test_print_port_info(void);
 void test_terminate_threads(void);

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -32,6 +32,7 @@
  * <h2>Test Cases</h2>
  * - @subpage rt_test_003_001
  * - @subpage rt_test_003_002
+ * - @subpage rt_test_003_003
  * .
  */
 
@@ -40,6 +41,10 @@
  ****************************************************************************/
 
 #include "ch.h"
+
+#if CH_CFG_USE_TM || defined(__DOXYGEN__)
+static time_measurement_t tm1, tm2;
+#endif
 
 /****************************************************************************
  * Test cases.
@@ -153,6 +158,95 @@ static const testcase_t rt_test_003_002 = {
   rt_test_003_002_execute
 };
 
+#if (CH_CFG_USE_TM == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_003_003 [3.3] Time Measurement functionality
+ *
+ * <h2>Description</h2>
+ * The functionality of Time Measurement objects is tested.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_TM == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [3.3.1] The initialized measurement objects are verified.
+ * - [3.3.2] A measurement is performed and its result is verified.
+ * - [3.3.3] The first measurement is chained to the second one and
+ *   both objects are verified.
+ * .
+ */
+
+static void rt_test_003_003_setup(void) {
+  chTMObjectInit(&tm1);
+  chTMObjectInit(&tm2);
+}
+
+static void rt_test_003_003_teardown(void) {
+  chTMObjectDispose(&tm1);
+  chTMObjectDispose(&tm2);
+}
+
+static void rt_test_003_003_execute(void) {
+  rtcnt_t first;
+
+  /* [3.3.1] The initialized measurement objects are verified.*/
+  test_set_step(1);
+  {
+    test_assert(tm1.best == (rtcnt_t)-1, "invalid best");
+    test_assert(tm1.worst == (rtcnt_t)0, "invalid worst");
+    test_assert(tm1.last == (rtcnt_t)0, "invalid last");
+    test_assert(tm1.n == (ucnt_t)0, "invalid counter");
+    test_assert(tm1.cumulative == (rttime_t)0, "invalid cumulative");
+  }
+  test_end_step(1);
+
+  /* [3.3.2] A measurement is performed and its result is verified.*/
+  test_set_step(2);
+  {
+    chTMStartMeasurementX(&tm1);
+    chSysPolledDelayX((rtcnt_t)100);
+    chTMStopMeasurementX(&tm1);
+
+    test_assert(tm1.n == (ucnt_t)1, "invalid counter");
+    test_assert(tm1.last > (rtcnt_t)0, "invalid last");
+    test_assert(tm1.best == tm1.last, "invalid best");
+    test_assert(tm1.worst == tm1.last, "invalid worst");
+    test_assert(tm1.cumulative == (rttime_t)tm1.last, "invalid cumulative");
+    first = tm1.last;
+  }
+  test_end_step(2);
+
+  /* [3.3.3] The first measurement is chained to the second one and
+     both objects are verified.*/
+  test_set_step(3);
+  {
+    chTMChainMeasurementToX(&tm1, &tm2);
+    chSysPolledDelayX((rtcnt_t)10);
+    chTMStopMeasurementX(&tm2);
+
+    test_assert(tm1.n == (ucnt_t)2, "invalid counter");
+    test_assert(tm1.last > (rtcnt_t)0, "invalid last");
+    test_assert(tm1.best <= tm1.worst, "invalid range");
+    test_assert(tm1.cumulative >= (rttime_t)first, "invalid cumulative");
+    test_assert(tm2.n == (ucnt_t)1, "invalid counter");
+    test_assert(tm2.last > (rtcnt_t)0, "invalid last");
+    test_assert(tm2.best == tm2.last, "invalid best");
+    test_assert(tm2.worst == tm2.last, "invalid worst");
+  }
+  test_end_step(3);
+}
+
+static const testcase_t rt_test_003_003 = {
+  "Time Measurement functionality",
+  rt_test_003_003_setup,
+  rt_test_003_003_teardown,
+  rt_test_003_003_execute
+};
+#endif /* CH_CFG_USE_TM == TRUE */
+
 /****************************************************************************
  * Exported data.
  ****************************************************************************/
@@ -163,6 +257,9 @@ static const testcase_t rt_test_003_002 = {
 const testcase_t * const rt_test_sequence_003_array[] = {
   &rt_test_003_001,
   &rt_test_003_002,
+#if (CH_CFG_USE_TM == TRUE) || defined(__DOXYGEN__)
+  &rt_test_003_003,
+#endif
   NULL
 };
 

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -35,6 +35,8 @@
  * - @subpage rt_test_005_003
  * - @subpage rt_test_005_004
  * - @subpage rt_test_005_005
+ * - @subpage rt_test_005_006
+ * - @subpage rt_test_005_007
  * .
  */
 
@@ -45,6 +47,22 @@
 static THD_FUNCTION(thread, p) {
 
   test_emit_token(*(char *)p);
+}
+
+static void setup_thread_descriptor(thread_descriptor_t *tdp,
+                                    const char *name,
+                                    stkline_t *wbase,
+                                    stkline_t *wend,
+                                    tprio_t prio,
+                                    void *arg) {
+
+  tdp->name  = name;
+  tdp->wbase = wbase;
+  tdp->wend  = wend;
+  tdp->prio  = prio;
+  tdp->funcp = thread;
+  tdp->arg   = arg;
+  tdp->owner = NULL;
 }
 
 /****************************************************************************
@@ -71,6 +89,8 @@ static THD_FUNCTION(thread, p) {
  *   for 1 second and on exit the system time is verified again.
  * - [5.1.5] Function chThdSleepUntil() is tested with a timeline of
  *   "now" + 100 ticks.
+ * - [5.1.6] Function chThdSleepUntilWindowed() is tested with an
+ *   active time window.
  * .
  */
 
@@ -139,6 +159,18 @@ static void rt_test_005_001_execute(void) {
                             "out of time window");
   }
   test_end_step(5);
+
+  /* [5.1.6] Function chThdSleepUntilWindowed() is tested with an
+     active time window.*/
+  test_set_step(6);
+  {
+    time = chVTGetSystemTimeX();
+    time = chThdSleepUntilWindowed(time, chTimeAddX(time, 20));
+    test_assert_time_window(time,
+                            chTimeAddX(time, CH_CFG_ST_TIMEDELTA + 1),
+                            "out of time window");
+  }
+  test_end_step(6);
 }
 
 static const testcase_t rt_test_005_001 = {
@@ -340,9 +372,201 @@ static const testcase_t rt_test_005_004 = {
 };
 #endif /* CH_CFG_USE_MUTEXES == TRUE */
 
+/**
+ * @page rt_test_005_005 [5.5] Thread spawning from descriptors
+ *
+ * <h2>Description</h2>
+ * The new descriptor-based spawning APIs are tested using stack-only
+ * buffers and explicit thread objects.
+ *
+ * <h2>Test Steps</h2>
+ * - [5.5.1] A suspended thread is spawned then started using normal
+ *   APIs.
+ * - [5.5.2] A running thread is spawned using normal APIs.
+ * - [5.5.3] A suspended thread is spawned then started using I-class
+ *   APIs.
+ * - [5.5.4] A running thread is spawned using I-class APIs.
+ * .
+ */
+
+static void rt_test_005_005_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_005_005_execute(void) {
+  thread_descriptor_t td;
+
+  /* [5.5.1] A suspended thread is spawned then started using normal
+     APIs.*/
+  test_set_step(1);
+  {
+    setup_thread_descriptor(&td, "spawn-suspended",
+                            TEST_THREAD_STACK_BASE(0), TEST_THREAD_STACK_END(0),
+                            chThdGetPriorityX() - 1, "A");
+    threads[0] = chThdSpawnSuspended(TEST_THREAD_OBJECT(0), &td);
+    test_assert(threads[0] == TEST_THREAD_OBJECT(0), "wrong thread object");
+    test_assert(chThdGetWorkingAreaX(threads[0]) == TEST_THREAD_STACK_BASE(0),
+                "wrong stack base");
+    chThdStart(threads[0]);
+    test_wait_threads();
+    test_assert_sequence("A", "invalid sequence");
+    chThdObjectDispose(TEST_THREAD_OBJECT(0));
+  }
+  test_end_step(1);
+
+  /* [5.5.2] A running thread is spawned using normal APIs.*/
+  test_set_step(2);
+  {
+    setup_thread_descriptor(&td, "spawn-running",
+                            TEST_THREAD_STACK_BASE(1), TEST_THREAD_STACK_END(1),
+                            chThdGetPriorityX() - 1, "B");
+    threads[1] = chThdSpawnRunning(TEST_THREAD_OBJECT(1), &td);
+    test_assert(threads[1] == TEST_THREAD_OBJECT(1), "wrong thread object");
+    test_wait_threads();
+    test_assert_sequence("B", "invalid sequence");
+    chThdObjectDispose(TEST_THREAD_OBJECT(1));
+  }
+  test_end_step(2);
+
+  /* [5.5.3] A suspended thread is spawned then started using I-class
+     APIs.*/
+  test_set_step(3);
+  {
+    setup_thread_descriptor(&td, "spawn-suspended-i",
+                            TEST_THREAD_STACK_BASE(2), TEST_THREAD_STACK_END(2),
+                            chThdGetPriorityX() - 1, "C");
+    chSysLock();
+    threads[2] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(2), &td);
+    chThdStartI(threads[2]);
+    chSysUnlock();
+    test_assert(threads[2] == TEST_THREAD_OBJECT(2), "wrong thread object");
+    test_wait_threads();
+    test_assert_sequence("C", "invalid sequence");
+    chThdObjectDispose(TEST_THREAD_OBJECT(2));
+  }
+  test_end_step(3);
+
+  /* [5.5.4] A running thread is spawned using I-class APIs.*/
+  test_set_step(4);
+  {
+    setup_thread_descriptor(&td, "spawn-running-i",
+                            TEST_THREAD_STACK_BASE(3), TEST_THREAD_STACK_END(3),
+                            chThdGetPriorityX() - 1, "D");
+    chSysLock();
+    threads[3] = chThdSpawnRunningI(TEST_THREAD_OBJECT(3), &td);
+    chSysUnlock();
+    test_assert(threads[3] == TEST_THREAD_OBJECT(3), "wrong thread object");
+    test_wait_threads();
+    test_assert_sequence("D", "invalid sequence");
+    chThdObjectDispose(TEST_THREAD_OBJECT(3));
+  }
+  test_end_step(4);
+}
+
+static const testcase_t rt_test_005_005 = {
+  "Thread spawning from descriptors",
+  NULL,
+  rt_test_005_005_teardown,
+  rt_test_005_005_execute
+};
+
+/**
+ * @page rt_test_005_006 [5.6] Thread creation from descriptors
+ *
+ * <h2>Description</h2>
+ * The new descriptor-based thread creation APIs are tested using full
+ * working areas.
+ *
+ * <h2>Test Steps</h2>
+ * - [5.6.1] A suspended thread is created then started using normal
+ *   APIs.
+ * - [5.6.2] A running thread is created using normal APIs.
+ * - [5.6.3] A suspended thread is created then started using I-class
+ *   APIs.
+ * - [5.6.4] A running thread is created using I-class APIs.
+ * .
+ */
+
+static void rt_test_005_006_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_005_006_execute(void) {
+  thread_descriptor_t td;
+
+  /* [5.6.1] A suspended thread is created then started using normal
+     APIs.*/
+  test_set_step(1);
+  {
+    setup_thread_descriptor(&td, "create-suspended",
+                            TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                            chThdGetPriorityX() - 1, "E");
+    threads[0] = chThdCreateSuspended(&td);
+    test_assert(threads[0] != NULL, "thread creation failed");
+    test_assert(chThdGetWorkingAreaX(threads[0]) == TEST_THREAD_WA_BASE(0),
+                "wrong working area");
+    chThdStart(threads[0]);
+    test_wait_threads();
+    test_assert_sequence("E", "invalid sequence");
+  }
+  test_end_step(1);
+
+  /* [5.6.2] A running thread is created using normal APIs.*/
+  test_set_step(2);
+  {
+    setup_thread_descriptor(&td, "create-running",
+                            TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                            chThdGetPriorityX() - 1, "F");
+    threads[0] = chThdCreate(&td);
+    test_assert(threads[0] != NULL, "thread creation failed");
+    test_wait_threads();
+    test_assert_sequence("F", "invalid sequence");
+  }
+  test_end_step(2);
+
+  /* [5.6.3] A suspended thread is created then started using I-class
+     APIs.*/
+  test_set_step(3);
+  {
+    setup_thread_descriptor(&td, "create-suspended-i",
+                            TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                            chThdGetPriorityX() - 1, "G");
+    chSysLock();
+    threads[0] = chThdCreateSuspendedI(&td);
+    chThdStartI(threads[0]);
+    chSysUnlock();
+    test_assert(threads[0] != NULL, "thread creation failed");
+    test_wait_threads();
+    test_assert_sequence("G", "invalid sequence");
+  }
+  test_end_step(3);
+
+  /* [5.6.4] A running thread is created using I-class APIs.*/
+  test_set_step(4);
+  {
+    setup_thread_descriptor(&td, "create-running-i",
+                            TEST_THREAD_WA_BASE(0), TEST_THREAD_WA_END(0),
+                            chThdGetPriorityX() - 1, "H");
+    chSysLock();
+    threads[0] = chThdCreateI(&td);
+    chSysUnlock();
+    test_assert(threads[0] != NULL, "thread creation failed");
+    test_wait_threads();
+    test_assert_sequence("H", "invalid sequence");
+  }
+  test_end_step(4);
+}
+
+static const testcase_t rt_test_005_006 = {
+  "Thread creation from descriptors",
+  NULL,
+  rt_test_005_006_teardown,
+  rt_test_005_006_execute
+};
+
 #if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_005_005 [5.5] Threads registry functionality
+ * @page rt_test_005_007 [5.7] Threads registry functionality
  *
  * <h2>Description</h2>
  * The functionality of the threads registry APIs is tested together
@@ -355,25 +579,25 @@ static const testcase_t rt_test_005_004 = {
  * .
  *
  * <h2>Test Steps</h2>
- * - [5.5.1] The current thread registry name is changed and then
+ * - [5.7.1] The current thread registry name is changed and then
  *   restored.
- * - [5.5.2] A static thread is created then retrieved by name, pointer
+ * - [5.7.2] A static thread is created then retrieved by name, pointer
  *   and working area.
- * - [5.5.3] The registry is scanned forward until the end and the
+ * - [5.7.3] The registry is scanned forward until the end and the
  *   created thread is found in the scan.
  * .
  */
 
-static void rt_test_005_005_teardown(void) {
+static void rt_test_005_007_teardown(void) {
   test_wait_threads();
 }
 
-static void rt_test_005_005_execute(void) {
+static void rt_test_005_007_execute(void) {
   thread_t *tp, *ntp;
   const char *oldname, *newname;
   bool found;
 
-  /* [5.5.1] The current thread registry name is changed and then
+  /* [5.7.1] The current thread registry name is changed and then
      restored.*/
   test_set_step(1);
   {
@@ -387,13 +611,17 @@ static void rt_test_005_005_execute(void) {
   }
   test_end_step(1);
 
-  /* [5.5.2] A static thread is created then retrieved by name, pointer
+  /* [5.7.2] A static thread is created then retrieved by name, pointer
      and working area.*/
   test_set_step(2);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread, "R");
     test_assert(threads[0] != NULL, "thread creation failed");
     chRegSetThreadNameX(threads[0], "registry-worker");
+
+    tp = chThdAddRef(threads[0]);
+    test_assert(tp == threads[0], "wrong referenced thread");
+    chThdRelease(tp);
 
     tp = chRegFindThreadByName("registry-worker");
     test_assert(tp == threads[0], "not found by name");
@@ -412,7 +640,7 @@ static void rt_test_005_005_execute(void) {
   }
   test_end_step(2);
 
-  /* [5.5.3] The registry is scanned forward until the end and the
+  /* [5.7.3] The registry is scanned forward until the end and the
      created thread is found in the scan.*/
   test_set_step(3);
   {
@@ -433,11 +661,11 @@ static void rt_test_005_005_execute(void) {
   test_end_step(3);
 }
 
-static const testcase_t rt_test_005_005 = {
+static const testcase_t rt_test_005_007 = {
   "Threads registry functionality",
   NULL,
-  rt_test_005_005_teardown,
-  rt_test_005_005_execute
+  rt_test_005_007_teardown,
+  rt_test_005_007_execute
 };
 #endif /* CH_CFG_USE_REGISTRY == TRUE */
 
@@ -455,8 +683,10 @@ const testcase_t * const rt_test_sequence_005_array[] = {
 #if (CH_CFG_USE_MUTEXES == TRUE) || defined(__DOXYGEN__)
   &rt_test_005_004,
 #endif
-#if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
   &rt_test_005_005,
+  &rt_test_005_006,
+#if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
+  &rt_test_005_007,
 #endif
   NULL
 };

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -34,6 +34,7 @@
  * - @subpage rt_test_005_002
  * - @subpage rt_test_005_003
  * - @subpage rt_test_005_004
+ * - @subpage rt_test_005_005
  * .
  */
 
@@ -339,6 +340,107 @@ static const testcase_t rt_test_005_004 = {
 };
 #endif /* CH_CFG_USE_MUTEXES == TRUE */
 
+#if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_005_005 [5.5] Threads registry functionality
+ *
+ * <h2>Description</h2>
+ * The functionality of the threads registry APIs is tested together
+ * with static threads creation.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_REGISTRY == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [5.5.1] The current thread registry name is changed and then
+ *   restored.
+ * - [5.5.2] A static thread is created then retrieved by name, pointer
+ *   and working area.
+ * - [5.5.3] The registry is scanned forward until the end and the
+ *   created thread is found in the scan.
+ * .
+ */
+
+static void rt_test_005_005_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_005_005_execute(void) {
+  thread_t *tp, *ntp;
+  const char *oldname, *newname;
+  bool found;
+
+  /* [5.5.1] The current thread registry name is changed and then
+     restored.*/
+  test_set_step(1);
+  {
+    tp = chThdGetSelfX();
+    oldname = chRegGetThreadNameX(tp);
+    newname = "registry-main";
+    chRegSetThreadName(newname);
+    test_assert(chRegGetThreadNameX(tp) == newname, "name not set");
+    chRegSetThreadName(oldname);
+    test_assert(chRegGetThreadNameX(tp) == oldname, "name not restored");
+  }
+  test_end_step(1);
+
+  /* [5.5.2] A static thread is created then retrieved by name, pointer
+     and working area.*/
+  test_set_step(2);
+  {
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread, "R");
+    test_assert(threads[0] != NULL, "thread creation failed");
+    chRegSetThreadNameX(threads[0], "registry-worker");
+
+    tp = chRegFindThreadByName("registry-worker");
+    test_assert(tp == threads[0], "not found by name");
+    chThdRelease(tp);
+
+    tp = chRegFindThreadByPointer(threads[0]);
+    test_assert(tp == threads[0], "not found by pointer");
+    chThdRelease(tp);
+
+    tp = chRegFindThreadByWorkingArea(wa[0]);
+    test_assert(tp == threads[0], "not found by working area");
+    chThdRelease(tp);
+
+    tp = chRegFindThreadByName("registry-missing");
+    test_assert(tp == NULL, "unexpected thread found");
+  }
+  test_end_step(2);
+
+  /* [5.5.3] The registry is scanned forward until the end and the
+     created thread is found in the scan.*/
+  test_set_step(3);
+  {
+    found = false;
+    tp = chRegFirstThread();
+    do {
+      if (tp == threads[0]) {
+        found = true;
+      }
+      ntp = chRegNextThread(tp);
+      tp = ntp;
+    } while (tp != NULL);
+
+    test_assert(found, "not found in registry scan");
+    test_wait_threads();
+    test_assert_sequence("R", "invalid sequence");
+  }
+  test_end_step(3);
+}
+
+static const testcase_t rt_test_005_005 = {
+  "Threads registry functionality",
+  NULL,
+  rt_test_005_005_teardown,
+  rt_test_005_005_execute
+};
+#endif /* CH_CFG_USE_REGISTRY == TRUE */
+
 /****************************************************************************
  * Exported data.
  ****************************************************************************/
@@ -352,6 +454,9 @@ const testcase_t * const rt_test_sequence_005_array[] = {
   &rt_test_005_003,
 #if (CH_CFG_USE_MUTEXES == TRUE) || defined(__DOXYGEN__)
   &rt_test_005_004,
+#endif
+#if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
+  &rt_test_005_005,
 #endif
   NULL
 };

--- a/test/rt/source/test/rt_test_sequence_006.c
+++ b/test/rt/source/test/rt_test_sequence_006.c
@@ -31,6 +31,7 @@
  *
  * <h2>Test Cases</h2>
  * - @subpage rt_test_006_001
+ * - @subpage rt_test_006_002
  * .
  */
 
@@ -39,12 +40,39 @@
  ****************************************************************************/
 
 static thread_reference_t tr1;
+static threads_queue_t tq1;
+static msg_t qmsg1;
+static msg_t qmsg2;
 
 static THD_FUNCTION(thread1, p) {
 
   chSysLock();
   chThdResumeI(&tr1, MSG_OK);
   chSchRescheduleS();
+  chSysUnlock();
+  test_emit_token(*(char *)p);
+}
+
+static THD_FUNCTION(thread2, p) {
+
+  chSysLock();
+  chThdResumeS(&tr1, MSG_RESET);
+  chSysUnlock();
+  test_emit_token(*(char *)p);
+}
+
+static THD_FUNCTION(queue_thread1, p) {
+
+  chSysLock();
+  qmsg1 = chThdEnqueueTimeoutS(&tq1, TIME_INFINITE);
+  chSysUnlock();
+  test_emit_token(*(char *)p);
+}
+
+static THD_FUNCTION(queue_thread2, p) {
+
+  chSysLock();
+  qmsg2 = chThdEnqueueTimeoutS(&tq1, TIME_INFINITE);
   chSysUnlock();
   test_emit_token(*(char *)p);
 }
@@ -57,14 +85,17 @@ static THD_FUNCTION(thread1, p) {
  * @page rt_test_006_001 [6.1] Suspend and Resume functionality
  *
  * <h2>Description</h2>
- * The functionality of chThdSuspendTimeoutS() and chThdResumeI() is
- * tested.
+ * The functionality of chThdSuspendTimeoutS() and chThdSuspendS() are
+ * tested together with chThdResumeI() and chThdResumeS().
  *
  * <h2>Test Steps</h2>
  * - [6.1.1] The function chThdSuspendTimeoutS() is invoked, the thread
  *   is remotely resumed with message @p MSG_OK. On return the message
  *   and the state of the reference are tested.
- * - [6.1.2] The function chThdSuspendTimeoutS() is invoked, the thread
+ * - [6.1.2] The function chThdSuspendS() is invoked, the thread is
+ *   remotely resumed with message @p MSG_RESET using chThdResumeS().
+ *   On return the message and the state of the reference are tested.
+ * - [6.1.3] The function chThdSuspendTimeoutS() is invoked, the thread
  *   is not resumed so a timeout must occur. On return the message and
  *   the state of the reference are tested.
  * .
@@ -72,6 +103,10 @@ static THD_FUNCTION(thread1, p) {
 
 static void rt_test_006_001_setup(void) {
   tr1 = NULL;
+}
+
+static void rt_test_006_001_teardown(void) {
+  test_wait_threads();
 }
 
 static void rt_test_006_001_execute(void) {
@@ -90,13 +125,30 @@ static void rt_test_006_001_execute(void) {
     test_assert(NULL == tr1, "not NULL");
     test_assert(MSG_OK == msg,"wrong returned message");
     test_wait_threads();
+    test_assert_sequence("A", "invalid sequence");
   }
   test_end_step(1);
 
-  /* [6.1.2] The function chThdSuspendTimeoutS() is invoked, the thread
+  /* [6.1.2] The function chThdSuspendS() is invoked, the thread is
+     remotely resumed with message @p MSG_RESET using chThdResumeS().
+     On return the message and the state of the reference are tested.*/
+  test_set_step(2);
+  {
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread2, "B");
+    chSysLock();
+    msg = chThdSuspendS(&tr1);
+    chSysUnlock();
+    test_assert(NULL == tr1, "not NULL");
+    test_assert(MSG_RESET == msg, "wrong returned message");
+    test_wait_threads();
+    test_assert_sequence("B", "invalid sequence");
+  }
+  test_end_step(2);
+
+  /* [6.1.3] The function chThdSuspendTimeoutS() is invoked, the thread
      is not resumed so a timeout must occur. On return the message and
      the state of the reference are tested.*/
-  test_set_step(2);
+  test_set_step(3);
   {
     chSysLock();
     time = chVTGetSystemTimeX();
@@ -108,14 +160,118 @@ static void rt_test_006_001_execute(void) {
     test_assert(NULL == tr1, "not NULL");
     test_assert(MSG_TIMEOUT == msg, "wrong returned message");
   }
-  test_end_step(2);
+  test_end_step(3);
 }
 
 static const testcase_t rt_test_006_001 = {
   "Suspend and Resume functionality",
   rt_test_006_001_setup,
-  NULL,
+  rt_test_006_001_teardown,
   rt_test_006_001_execute
+};
+
+/**
+ * @page rt_test_006_002 [6.2] Threads queue object lifecycle
+ *
+ * <h2>Description</h2>
+ * The lifecycle and normal wakeup operations of a threads queue object
+ * are tested.
+ *
+ * <h2>Test Steps</h2>
+ * - [6.2.1] A threads queue is initialized, tested as empty, then
+ *   touched with empty dequeue operations.
+ * - [6.2.2] Immediate timeout enqueue is tested on an empty queue.
+ * - [6.2.3] One queued thread is resumed using chThdDequeueNextI().
+ * - [6.2.4] Two queued threads are resumed using chThdDequeueAllI().
+ * .
+ */
+
+static void rt_test_006_002_setup(void) {
+  chThdQueueObjectInit(&tq1);
+  qmsg1 = MSG_OK;
+  qmsg2 = MSG_OK;
+}
+
+static void rt_test_006_002_teardown(void) {
+  test_wait_threads();
+  chThdQueueObjectDispose(&tq1);
+}
+
+static void rt_test_006_002_execute(void) {
+  msg_t msg;
+  bool empty;
+
+  /* [6.2.1] A threads queue is initialized, tested as empty, then
+     touched with empty dequeue operations.*/
+  test_set_step(1);
+  {
+    chSysLock();
+    empty = chThdQueueIsEmptyI(&tq1);
+    chThdDequeueNextI(&tq1, MSG_OK);
+    chThdDequeueAllI(&tq1, MSG_OK);
+    chSysUnlock();
+    test_assert(empty, "queue not empty");
+  }
+  test_end_step(1);
+
+  /* [6.2.2] Immediate timeout enqueue is tested on an empty queue.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    msg = chThdEnqueueTimeoutS(&tq1, TIME_IMMEDIATE);
+    empty = chThdQueueIsEmptyI(&tq1);
+    chSysUnlock();
+    test_assert(msg == MSG_TIMEOUT, "wrong returned message");
+    test_assert(empty, "queue not empty");
+  }
+  test_end_step(2);
+
+  /* [6.2.3] One queued thread is resumed using chThdDequeueNextI().*/
+  test_set_step(3);
+  {
+    qmsg1 = MSG_OK;
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX(),
+                                   queue_thread1, "C");
+    chThdYield();
+    chSysLock();
+    empty = chThdQueueIsEmptyI(&tq1);
+    chThdDequeueNextI(&tq1, MSG_RESET);
+    chSysUnlock();
+    test_assert(!empty, "queue empty");
+    test_wait_threads();
+    test_assert(qmsg1 == MSG_RESET, "wrong returned message");
+    test_assert_sequence("C", "invalid sequence");
+  }
+  test_end_step(3);
+
+  /* [6.2.4] Two queued threads are resumed using chThdDequeueAllI().*/
+  test_set_step(4);
+  {
+    qmsg1 = MSG_OK;
+    qmsg2 = MSG_OK;
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX(),
+                                   queue_thread1, "D");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, chThdGetPriorityX(),
+                                   queue_thread2, "E");
+    chThdYield();
+    chSysLock();
+    empty = chThdQueueIsEmptyI(&tq1);
+    chThdDequeueAllI(&tq1, MSG_RESET);
+    chSysUnlock();
+    test_assert(!empty, "queue empty");
+    test_wait_threads();
+    test_assert(qmsg1 == MSG_RESET, "wrong returned message");
+    test_assert(qmsg2 == MSG_RESET, "wrong returned message");
+    test_assert_sequence("DE", "invalid sequence");
+  }
+  test_end_step(4);
+}
+
+static const testcase_t rt_test_006_002 = {
+  "Threads queue object lifecycle",
+  rt_test_006_002_setup,
+  rt_test_006_002_teardown,
+  rt_test_006_002_execute
 };
 
 /****************************************************************************
@@ -127,6 +283,7 @@ static const testcase_t rt_test_006_001 = {
  */
 const testcase_t * const rt_test_sequence_006_array[] = {
   &rt_test_006_001,
+  &rt_test_006_002,
   NULL
 };
 

--- a/test/rt/source/test/rt_test_sequence_007.c
+++ b/test/rt/source/test/rt_test_sequence_007.c
@@ -110,6 +110,7 @@ static void rt_test_007_001_setup(void) {
 
 static void rt_test_007_001_teardown(void) {
   chSemReset(&sem1, 0);
+  chSemObjectDispose(&sem1);
 }
 
 static void rt_test_007_001_execute(void) {
@@ -174,6 +175,10 @@ static void rt_test_007_002_setup(void) {
   chSemObjectInit(&sem1, 0);
 }
 
+static void rt_test_007_002_teardown(void) {
+  chSemObjectDispose(&sem1);
+}
+
 static void rt_test_007_002_execute(void) {
 
   /* [7.2.1] Five threads are created with mixed priority levels (not
@@ -211,7 +216,7 @@ static void rt_test_007_002_execute(void) {
 static const testcase_t rt_test_007_002 = {
   "Semaphore enqueuing test",
   rt_test_007_002_setup,
-  NULL,
+  rt_test_007_002_teardown,
   rt_test_007_002_execute
 };
 
@@ -234,6 +239,10 @@ static const testcase_t rt_test_007_002 = {
 
 static void rt_test_007_003_setup(void) {
   chSemObjectInit(&sem1, 0);
+}
+
+static void rt_test_007_003_teardown(void) {
+  chSemObjectDispose(&sem1);
 }
 
 static void rt_test_007_003_execute(void) {
@@ -286,7 +295,7 @@ static void rt_test_007_003_execute(void) {
 static const testcase_t rt_test_007_003 = {
   "Semaphore timeout test",
   rt_test_007_003_setup,
-  NULL,
+  rt_test_007_003_teardown,
   rt_test_007_003_execute
 };
 
@@ -306,6 +315,10 @@ static const testcase_t rt_test_007_003 = {
 
 static void rt_test_007_004_setup(void) {
   chSemObjectInit(&sem1, 0);
+}
+
+static void rt_test_007_004_teardown(void) {
+  chSemObjectDispose(&sem1);
 }
 
 static void rt_test_007_004_execute(void) {
@@ -335,7 +348,7 @@ static void rt_test_007_004_execute(void) {
 static const testcase_t rt_test_007_004 = {
   "Testing chSemAddCounterI() functionality",
   rt_test_007_004_setup,
-  NULL,
+  rt_test_007_004_teardown,
   rt_test_007_004_execute
 };
 
@@ -368,6 +381,7 @@ static void rt_test_007_005_setup(void) {
 
 static void rt_test_007_005_teardown(void) {
   test_wait_threads();
+  chSemObjectDispose(&sem1);
 }
 
 static void rt_test_007_005_execute(void) {

--- a/test/rt/source/test/rt_test_sequence_008.c
+++ b/test/rt/source/test/rt_test_sequence_008.c
@@ -45,6 +45,7 @@
  * - @subpage rt_test_008_007
  * - @subpage rt_test_008_008
  * - @subpage rt_test_008_009
+ * - @subpage rt_test_008_010
  * .
  */
 
@@ -195,6 +196,13 @@ static THD_FUNCTION(thread4B, p) {
   chMtxUnlockS(&m2); /* For coverage of the chMtxUnlockS() function variant.*/
   chSchRescheduleS();
   chSysUnlock();
+}
+
+static THD_FUNCTION(thread5, p) {
+
+  chMtxLock(&m2);
+  test_emit_token(*(char *)p);
+  chMtxUnlock(&m2);
 }
 
 #if CH_CFG_USE_CONDVARS || defined(__DOXYGEN__)
@@ -596,9 +604,133 @@ static const testcase_t rt_test_008_004 = {
   rt_test_008_004_execute
 };
 
+/**
+ * @page rt_test_008_005 [8.5] Contended mutex handoff variants
+ *
+ * <h2>Description</h2>
+ * Contended mutex handoff is tested for chMtxUnlockS() and
+ * chMtxUnlockAllS(). A same-priority waiter is also used to exercise
+ * the lock path without priority inheritance boosting.
+ *
+ * <h2>Test Steps</h2>
+ * - [8.5.1] Getting current thread priority for later checks.
+ * - [8.5.2] A same-priority waiter is queued on the mutex, verifying
+ *   that no priority boost is performed.
+ * - [8.5.3] A higher-priority waiter is handed the mutex by
+ *   chMtxUnlockS().
+ * - [8.5.4] A higher-priority waiter is handed the mutex by
+ *   chMtxUnlockAllS().
+ * - [8.5.5] Priority is recomputed while chMtxUnlockS() hands off a
+ *   mutex and another owned mutex still has a waiter.
+ * .
+ */
+
+static void rt_test_008_005_setup(void) {
+  chMtxObjectInit(&m1);
+  chMtxObjectInit(&m2);
+}
+
+static void rt_test_008_005_teardown(void) {
+  test_wait_threads();
+  chMtxObjectDispose(&m1);
+  chMtxObjectDispose(&m2);
+}
+
+static void rt_test_008_005_execute(void) {
+  tprio_t prio;
+
+  /* [8.5.1] Getting current thread priority for later checks.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+  }
+  test_end_step(1);
+
+  /* [8.5.2] A same-priority waiter is queued on the mutex, verifying
+     that no priority boost is performed.*/
+  test_set_step(2);
+  {
+    chMtxLock(&m1);
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio, thread1, "A");
+    chThdYield();
+    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+    chMtxUnlock(&m1);
+    test_wait_threads();
+    test_assert_sequence("A", "invalid sequence");
+  }
+  test_end_step(2);
+
+  /* [8.5.3] A higher-priority waiter is handed the mutex by
+     chMtxUnlockS().*/
+  test_set_step(3);
+  {
+    chMtxLock(&m1);
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1, thread1, "B");
+    test_assert(chThdGetPriorityX() == prio + 1, "wrong priority level");
+
+    chSysLock();
+    chMtxUnlockS(&m1);
+    chSchRescheduleS();
+    chSysUnlock();
+
+    test_wait_threads();
+    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+    test_assert_sequence("B", "invalid sequence");
+  }
+  test_end_step(3);
+
+  /* [8.5.4] A higher-priority waiter is handed the mutex by
+     chMtxUnlockAllS().*/
+  test_set_step(4);
+  {
+    chMtxLock(&m1);
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1, thread1, "C");
+    test_assert(chThdGetPriorityX() == prio + 1, "wrong priority level");
+
+    chSysLock();
+    chMtxUnlockAllS();
+    chSysUnlock();
+
+    test_wait_threads();
+    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+    test_assert_sequence("C", "invalid sequence");
+  }
+  test_end_step(4);
+
+  /* [8.5.5] Priority is recomputed while chMtxUnlockS() hands off a
+     mutex and another owned mutex still has a waiter.*/
+  test_set_step(5);
+  {
+    chMtxLock(&m2);
+    chMtxLock(&m1);
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1, thread5, "E");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio + 2, thread1, "D");
+    test_assert(chThdGetPriorityX() == prio + 2, "wrong priority level");
+
+    chSysLock();
+    chMtxUnlockS(&m1);
+    chSchRescheduleS();
+    chSysUnlock();
+
+    test_assert(chThdGetPriorityX() == prio + 1, "wrong priority level");
+    chMtxUnlock(&m2);
+    test_wait_threads();
+    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+    test_assert_sequence("DE", "invalid sequence");
+  }
+  test_end_step(5);
+}
+
+static const testcase_t rt_test_008_005 = {
+  "Contended mutex handoff variants",
+  rt_test_008_005_setup,
+  rt_test_008_005_teardown,
+  rt_test_008_005_execute
+};
+
 #if (CH_CFG_USE_MUTEXES_RECURSIVE == FALSE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_008_005 [8.5] Repeated locks, non recursive scenario
+ * @page rt_test_008_006 [8.6] Repeated locks, non recursive scenario
  *
  * <h2>Description</h2>
  * The behavior of multiple mutex locks from the same thread is tested
@@ -611,133 +743,16 @@ static const testcase_t rt_test_008_004 = {
  * .
  *
  * <h2>Test Steps</h2>
- * - [8.5.1] Getting current thread priority for later checks.
- * - [8.5.2] Locking the mutex first time, it must be possible because
- *   it is not owned.
- * - [8.5.3] Locking the mutex second time, it must fail because it is
- *   already owned.
- * - [8.5.4] Unlocking the mutex then it must not be owned anymore and
- *   the queue must be empty.
- * - [8.5.5] Testing that priority has not changed after operations.
- * - [8.5.6] Testing chMtxUnlockAll() behavior.
- * - [8.5.7] Testing that priority has not changed after operations.
- * .
- */
-
-static void rt_test_008_005_setup(void) {
-  chMtxObjectInit(&m1);
-}
-
-static void rt_test_008_005_teardown(void) {
-  chMtxObjectDispose(&m1);
-}
-
-static void rt_test_008_005_execute(void) {
-  bool b;
-  tprio_t prio;
-
-  /* [8.5.1] Getting current thread priority for later checks.*/
-  test_set_step(1);
-  {
-    prio = chThdGetPriorityX();
-  }
-  test_end_step(1);
-
-  /* [8.5.2] Locking the mutex first time, it must be possible because
-     it is not owned.*/
-  test_set_step(2);
-  {
-    b = chMtxTryLock(&m1);
-    test_assert(b, "already locked");
-  }
-  test_end_step(2);
-
-  /* [8.5.3] Locking the mutex second time, it must fail because it is
-     already owned.*/
-  test_set_step(3);
-  {
-    b = chMtxTryLock(&m1);
-    test_assert(!b, "not locked");
-  }
-  test_end_step(3);
-
-  /* [8.5.4] Unlocking the mutex then it must not be owned anymore and
-     the queue must be empty.*/
-  test_set_step(4);
-  {
-    chMtxUnlock(&m1);
-    test_assert(m1.owner == NULL, "still owned");
-    test_assert(ch_queue_isempty(&m1.queue), "queue not empty");
-  }
-  test_end_step(4);
-
-  /* [8.5.5] Testing that priority has not changed after operations.*/
-  test_set_step(5);
-  {
-    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
-  }
-  test_end_step(5);
-
-  /* [8.5.6] Testing chMtxUnlockAll() behavior.*/
-  test_set_step(6);
-  {
-    b = chMtxTryLock(&m1);
-    test_assert(b, "already locked");
-    b = chMtxTryLock(&m1);
-    test_assert(!b, "not locked");
-
-    chMtxUnlockAll();
-    test_assert(m1.owner == NULL, "still owned");
-    test_assert(ch_queue_isempty(&m1.queue), "queue not empty");
-  }
-  test_end_step(6);
-
-  /* [8.5.7] Testing that priority has not changed after operations.*/
-  test_set_step(7);
-  {
-    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
-  }
-  test_end_step(7);
-}
-
-static const testcase_t rt_test_008_005 = {
-  "Repeated locks, non recursive scenario",
-  rt_test_008_005_setup,
-  rt_test_008_005_teardown,
-  rt_test_008_005_execute
-};
-#endif /* CH_CFG_USE_MUTEXES_RECURSIVE == FALSE */
-
-#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
-/**
- * @page rt_test_008_006 [8.6] Repeated locks using, recursive scenario
- *
- * <h2>Description</h2>
- * The behavior of multiple mutex locks from the same thread is tested
- * when recursion is enabled.
- *
- * <h2>Conditions</h2>
- * This test is only executed if the following preprocessor condition
- * evaluates to true:
- * - CH_CFG_USE_MUTEXES_RECURSIVE == TRUE
- * .
- *
- * <h2>Test Steps</h2>
  * - [8.6.1] Getting current thread priority for later checks.
  * - [8.6.2] Locking the mutex first time, it must be possible because
  *   it is not owned.
- * - [8.6.3] Locking the mutex second time, it must be possible because
- *   it is recursive.
- * - [8.6.4] Unlocking the mutex then it must be still owned because
- *   recursivity.
- * - [8.6.5] Unlocking the mutex then it must not be owned anymore and
+ * - [8.6.3] Locking the mutex second time, it must fail because it is
+ *   already owned.
+ * - [8.6.4] Unlocking the mutex then it must not be owned anymore and
  *   the queue must be empty.
- * - [8.6.6] Testing that priority has not changed after operations.
- * - [8.6.7] Testing consecutive chMtxTryLock()/chMtxTryLockS() calls
- *   and a final chMtxUnlockAllS().
- * - [8.6.8] Testing consecutive chMtxLock()/chMtxLockS() calls and a
- *   final chMtxUnlockAll().
- * - [8.6.9] Testing that priority has not changed after operations.
+ * - [8.6.5] Testing that priority has not changed after operations.
+ * - [8.6.6] Testing chMtxUnlockAll() behavior.
+ * - [8.6.7] Testing that priority has not changed after operations.
  * .
  */
 
@@ -769,7 +784,124 @@ static void rt_test_008_006_execute(void) {
   }
   test_end_step(2);
 
-  /* [8.6.3] Locking the mutex second time, it must be possible because
+  /* [8.6.3] Locking the mutex second time, it must fail because it is
+     already owned.*/
+  test_set_step(3);
+  {
+    b = chMtxTryLock(&m1);
+    test_assert(!b, "not locked");
+  }
+  test_end_step(3);
+
+  /* [8.6.4] Unlocking the mutex then it must not be owned anymore and
+     the queue must be empty.*/
+  test_set_step(4);
+  {
+    chMtxUnlock(&m1);
+    test_assert(m1.owner == NULL, "still owned");
+    test_assert(ch_queue_isempty(&m1.queue), "queue not empty");
+  }
+  test_end_step(4);
+
+  /* [8.6.5] Testing that priority has not changed after operations.*/
+  test_set_step(5);
+  {
+    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+  }
+  test_end_step(5);
+
+  /* [8.6.6] Testing chMtxUnlockAll() behavior.*/
+  test_set_step(6);
+  {
+    b = chMtxTryLock(&m1);
+    test_assert(b, "already locked");
+    b = chMtxTryLock(&m1);
+    test_assert(!b, "not locked");
+
+    chMtxUnlockAll();
+    test_assert(m1.owner == NULL, "still owned");
+    test_assert(ch_queue_isempty(&m1.queue), "queue not empty");
+  }
+  test_end_step(6);
+
+  /* [8.6.7] Testing that priority has not changed after operations.*/
+  test_set_step(7);
+  {
+    test_assert(chThdGetPriorityX() == prio, "wrong priority level");
+  }
+  test_end_step(7);
+}
+
+static const testcase_t rt_test_008_006 = {
+  "Repeated locks, non recursive scenario",
+  rt_test_008_006_setup,
+  rt_test_008_006_teardown,
+  rt_test_008_006_execute
+};
+#endif /* CH_CFG_USE_MUTEXES_RECURSIVE == FALSE */
+
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_008_007 [8.7] Repeated locks using, recursive scenario
+ *
+ * <h2>Description</h2>
+ * The behavior of multiple mutex locks from the same thread is tested
+ * when recursion is enabled.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_MUTEXES_RECURSIVE == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [8.7.1] Getting current thread priority for later checks.
+ * - [8.7.2] Locking the mutex first time, it must be possible because
+ *   it is not owned.
+ * - [8.7.3] Locking the mutex second time, it must be possible because
+ *   it is recursive.
+ * - [8.7.4] Unlocking the mutex then it must be still owned because
+ *   recursivity.
+ * - [8.7.5] Unlocking the mutex then it must not be owned anymore and
+ *   the queue must be empty.
+ * - [8.7.6] Testing that priority has not changed after operations.
+ * - [8.7.7] Testing consecutive chMtxTryLock()/chMtxTryLockS() calls
+ *   and a final chMtxUnlockAllS().
+ * - [8.7.8] Testing consecutive chMtxLock()/chMtxLockS() calls and a
+ *   final chMtxUnlockAll().
+ * - [8.7.9] Testing that priority has not changed after operations.
+ * .
+ */
+
+static void rt_test_008_007_setup(void) {
+  chMtxObjectInit(&m1);
+}
+
+static void rt_test_008_007_teardown(void) {
+  chMtxObjectDispose(&m1);
+}
+
+static void rt_test_008_007_execute(void) {
+  bool b;
+  tprio_t prio;
+
+  /* [8.7.1] Getting current thread priority for later checks.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+  }
+  test_end_step(1);
+
+  /* [8.7.2] Locking the mutex first time, it must be possible because
+     it is not owned.*/
+  test_set_step(2);
+  {
+    b = chMtxTryLock(&m1);
+    test_assert(b, "already locked");
+  }
+  test_end_step(2);
+
+  /* [8.7.3] Locking the mutex second time, it must be possible because
      it is recursive.*/
   test_set_step(3);
   {
@@ -778,7 +910,7 @@ static void rt_test_008_006_execute(void) {
   }
   test_end_step(3);
 
-  /* [8.6.4] Unlocking the mutex then it must be still owned because
+  /* [8.7.4] Unlocking the mutex then it must be still owned because
      recursivity.*/
   test_set_step(4);
   {
@@ -787,7 +919,7 @@ static void rt_test_008_006_execute(void) {
   }
   test_end_step(4);
 
-  /* [8.6.5] Unlocking the mutex then it must not be owned anymore and
+  /* [8.7.5] Unlocking the mutex then it must not be owned anymore and
      the queue must be empty.*/
   test_set_step(5);
   {
@@ -797,14 +929,14 @@ static void rt_test_008_006_execute(void) {
   }
   test_end_step(5);
 
-  /* [8.6.6] Testing that priority has not changed after operations.*/
+  /* [8.7.6] Testing that priority has not changed after operations.*/
   test_set_step(6);
   {
     test_assert(chThdGetPriorityX() == prio, "wrong priority level");
   }
   test_end_step(6);
 
-  /* [8.6.7] Testing consecutive chMtxTryLock()/chMtxTryLockS() calls
+  /* [8.7.7] Testing consecutive chMtxTryLock()/chMtxTryLockS() calls
      and a final chMtxUnlockAllS().*/
   test_set_step(7);
   {
@@ -824,7 +956,7 @@ static void rt_test_008_006_execute(void) {
   }
   test_end_step(7);
 
-  /* [8.6.8] Testing consecutive chMtxLock()/chMtxLockS() calls and a
+  /* [8.7.8] Testing consecutive chMtxLock()/chMtxLockS() calls and a
      final chMtxUnlockAll().*/
   test_set_step(8);
   {
@@ -842,7 +974,7 @@ static void rt_test_008_006_execute(void) {
   }
   test_end_step(8);
 
-  /* [8.6.9] Testing that priority has not changed after operations.*/
+  /* [8.7.9] Testing that priority has not changed after operations.*/
   test_set_step(9);
   {
     test_assert(chThdGetPriorityX() == prio, "wrong priority level");
@@ -850,17 +982,17 @@ static void rt_test_008_006_execute(void) {
   test_end_step(9);
 }
 
-static const testcase_t rt_test_008_006 = {
+static const testcase_t rt_test_008_007 = {
   "Repeated locks using, recursive scenario",
-  rt_test_008_006_setup,
-  rt_test_008_006_teardown,
-  rt_test_008_006_execute
+  rt_test_008_007_setup,
+  rt_test_008_007_teardown,
+  rt_test_008_007_execute
 };
 #endif /* CH_CFG_USE_MUTEXES_RECURSIVE == TRUE */
 
 #if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_008_007 [8.7] Condition Variable signal test
+ * @page rt_test_008_008 [8.8] Condition Variable signal test
  *
  * <h2>Description</h2>
  * Five threads take a mutex and then enter a conditional variable
@@ -876,87 +1008,11 @@ static const testcase_t rt_test_008_006 = {
  * .
  *
  * <h2>Test Steps</h2>
- * - [8.7.1] Starting the five threads with increasing priority, the
- *   threads will queue on the condition variable.
- * - [8.7.2] Atomically signaling the condition variable five times
- *   then waiting for the threads to terminate in priority order, the
- *   order is tested.
- * .
- */
-
-static void rt_test_008_007_setup(void) {
-  chCondObjectInit(&c1);
-  chMtxObjectInit(&m1);
-}
-
-static void rt_test_008_007_teardown(void) {
-  chCondObjectDispose(&c1);
-  chMtxObjectDispose(&m1);
-}
-
-static void rt_test_008_007_execute(void) {
-
-  /* [8.7.1] Starting the five threads with increasing priority, the
-     threads will queue on the condition variable.*/
-  test_set_step(1);
-  {
-    tprio_t prio = chThdGetPriorityX();
-    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio+1, thread6, "E");
-    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio+2, thread6, "D");
-    threads[2] = chThdCreateStatic(wa[2], WA_SIZE, prio+3, thread6, "C");
-    threads[3] = chThdCreateStatic(wa[3], WA_SIZE, prio+4, thread6, "B");
-    threads[4] = chThdCreateStatic(wa[4], WA_SIZE, prio+5, thread6, "A");
-  }
-  test_end_step(1);
-
-  /* [8.7.2] Atomically signaling the condition variable five times
-     then waiting for the threads to terminate in priority order, the
-     order is tested.*/
-  test_set_step(2);
-  {
-    chSysLock();
-    chCondSignalI(&c1);
-    chCondSignalI(&c1);
-    chCondSignalI(&c1);
-    chCondSignalI(&c1);
-    chCondSignalI(&c1);
-    chSchRescheduleS();
-    chSysUnlock();
-    test_wait_threads();
-    test_assert_sequence("ABCDE", "invalid sequence");
-  }
-  test_end_step(2);
-}
-
-static const testcase_t rt_test_008_007 = {
-  "Condition Variable signal test",
-  rt_test_008_007_setup,
-  rt_test_008_007_teardown,
-  rt_test_008_007_execute
-};
-#endif /* CH_CFG_USE_CONDVARS == TRUE */
-
-#if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
-/**
- * @page rt_test_008_008 [8.8] Condition Variable broadcast test
- *
- * <h2>Description</h2>
- * Five threads take a mutex and then enter a conditional variable
- * queue, the tester thread then proceeds to broadcast the conditional
- * variable.<br> The test expects the threads to reach their goal in
- * increasing priority order regardless of the initial order.
- *
- * <h2>Conditions</h2>
- * This test is only executed if the following preprocessor condition
- * evaluates to true:
- * - CH_CFG_USE_CONDVARS == TRUE
- * .
- *
- * <h2>Test Steps</h2>
  * - [8.8.1] Starting the five threads with increasing priority, the
  *   threads will queue on the condition variable.
- * - [8.8.2] Broarcasting on the condition variable then waiting for
- *   the threads to terminate in priority order, the order is tested.
+ * - [8.8.2] Atomically signaling the condition variable five times
+ *   then waiting for the threads to terminate in priority order, the
+ *   order is tested.
  * .
  */
 
@@ -985,7 +1041,83 @@ static void rt_test_008_008_execute(void) {
   }
   test_end_step(1);
 
-  /* [8.8.2] Broarcasting on the condition variable then waiting for
+  /* [8.8.2] Atomically signaling the condition variable five times
+     then waiting for the threads to terminate in priority order, the
+     order is tested.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    chCondSignalI(&c1);
+    chCondSignalI(&c1);
+    chCondSignalI(&c1);
+    chCondSignalI(&c1);
+    chCondSignalI(&c1);
+    chSchRescheduleS();
+    chSysUnlock();
+    test_wait_threads();
+    test_assert_sequence("ABCDE", "invalid sequence");
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_008_008 = {
+  "Condition Variable signal test",
+  rt_test_008_008_setup,
+  rt_test_008_008_teardown,
+  rt_test_008_008_execute
+};
+#endif /* CH_CFG_USE_CONDVARS == TRUE */
+
+#if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_008_009 [8.9] Condition Variable broadcast test
+ *
+ * <h2>Description</h2>
+ * Five threads take a mutex and then enter a conditional variable
+ * queue, the tester thread then proceeds to broadcast the conditional
+ * variable.<br> The test expects the threads to reach their goal in
+ * increasing priority order regardless of the initial order.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_CONDVARS == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [8.9.1] Starting the five threads with increasing priority, the
+ *   threads will queue on the condition variable.
+ * - [8.9.2] Broarcasting on the condition variable then waiting for
+ *   the threads to terminate in priority order, the order is tested.
+ * .
+ */
+
+static void rt_test_008_009_setup(void) {
+  chCondObjectInit(&c1);
+  chMtxObjectInit(&m1);
+}
+
+static void rt_test_008_009_teardown(void) {
+  chCondObjectDispose(&c1);
+  chMtxObjectDispose(&m1);
+}
+
+static void rt_test_008_009_execute(void) {
+
+  /* [8.9.1] Starting the five threads with increasing priority, the
+     threads will queue on the condition variable.*/
+  test_set_step(1);
+  {
+    tprio_t prio = chThdGetPriorityX();
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio+1, thread6, "E");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio+2, thread6, "D");
+    threads[2] = chThdCreateStatic(wa[2], WA_SIZE, prio+3, thread6, "C");
+    threads[3] = chThdCreateStatic(wa[3], WA_SIZE, prio+4, thread6, "B");
+    threads[4] = chThdCreateStatic(wa[4], WA_SIZE, prio+5, thread6, "A");
+  }
+  test_end_step(1);
+
+  /* [8.9.2] Broarcasting on the condition variable then waiting for
      the threads to terminate in priority order, the order is tested.*/
   test_set_step(2);
   {
@@ -996,17 +1128,17 @@ static void rt_test_008_008_execute(void) {
   test_end_step(2);
 }
 
-static const testcase_t rt_test_008_008 = {
+static const testcase_t rt_test_008_009 = {
   "Condition Variable broadcast test",
-  rt_test_008_008_setup,
-  rt_test_008_008_teardown,
-  rt_test_008_008_execute
+  rt_test_008_009_setup,
+  rt_test_008_009_teardown,
+  rt_test_008_009_execute
 };
 #endif /* CH_CFG_USE_CONDVARS == TRUE */
 
 #if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_008_009 [8.9] Condition Variable priority boost test
+ * @page rt_test_008_010 [8.10] Condition Variable priority boost test
  *
  * <h2>Description</h2>
  * This test case verifies the priority boost of a thread waiting on a
@@ -1023,44 +1155,44 @@ static const testcase_t rt_test_008_008 = {
  * .
  *
  * <h2>Test Steps</h2>
- * - [8.9.1] Reading current base priority.
- * - [8.9.2] Thread A is created at priority P(+1), it locks M2, locks
+ * - [8.10.1] Reading current base priority.
+ * - [8.10.2] Thread A is created at priority P(+1), it locks M2, locks
  *   M1 and goes to wait on C1.
- * - [8.9.3] Thread C is created at priority P(+2), it enqueues on M1
+ * - [8.10.3] Thread C is created at priority P(+2), it enqueues on M1
  *   and boosts TA priority at P(+2).
- * - [8.9.4] Thread B is created at priority P(+3), it enqueues on M2
+ * - [8.10.4] Thread B is created at priority P(+3), it enqueues on M2
  *   and boosts TA priority at P(+3).
- * - [8.9.5] Signaling C1: TA wakes up, unlocks M1 and priority goes to
- *   P(+2). TB locks M1, unlocks M1 and completes. TA unlocks M2 and
+ * - [8.10.5] Signaling C1: TA wakes up, unlocks M1 and priority goes
+ *   to P(+2). TB locks M1, unlocks M1 and completes. TA unlocks M2 and
  *   priority goes to P(+1). TC waits on C1. TA completes.
- * - [8.9.6] Signaling C1: TC wakes up, unlocks M1 and completes.
- * - [8.9.7] Checking the order of operations.
+ * - [8.10.6] Signaling C1: TC wakes up, unlocks M1 and completes.
+ * - [8.10.7] Checking the order of operations.
  * .
  */
 
-static void rt_test_008_009_setup(void) {
+static void rt_test_008_010_setup(void) {
   chCondObjectInit(&c1);
   chMtxObjectInit(&m1);
   chMtxObjectInit(&m2);
 }
 
-static void rt_test_008_009_teardown(void) {
+static void rt_test_008_010_teardown(void) {
   chCondObjectDispose(&c1);
   chMtxObjectDispose(&m1);
   chMtxObjectDispose(&m2);
 }
 
-static void rt_test_008_009_execute(void) {
+static void rt_test_008_010_execute(void) {
   tprio_t prio;
 
-  /* [8.9.1] Reading current base priority.*/
+  /* [8.10.1] Reading current base priority.*/
   test_set_step(1);
   {
     prio = chThdGetPriorityX();
   }
   test_end_step(1);
 
-  /* [8.9.2] Thread A is created at priority P(+1), it locks M2, locks
+  /* [8.10.2] Thread A is created at priority P(+1), it locks M2, locks
      M1 and goes to wait on C1.*/
   test_set_step(2);
   {
@@ -1068,7 +1200,7 @@ static void rt_test_008_009_execute(void) {
   }
   test_end_step(2);
 
-  /* [8.9.3] Thread C is created at priority P(+2), it enqueues on M1
+  /* [8.10.3] Thread C is created at priority P(+2), it enqueues on M1
      and boosts TA priority at P(+2).*/
   test_set_step(3);
   {
@@ -1076,7 +1208,7 @@ static void rt_test_008_009_execute(void) {
   }
   test_end_step(3);
 
-  /* [8.9.4] Thread B is created at priority P(+3), it enqueues on M2
+  /* [8.10.4] Thread B is created at priority P(+3), it enqueues on M2
      and boosts TA priority at P(+3).*/
   test_set_step(4);
   {
@@ -1084,8 +1216,8 @@ static void rt_test_008_009_execute(void) {
   }
   test_end_step(4);
 
-  /* [8.9.5] Signaling C1: TA wakes up, unlocks M1 and priority goes to
-     P(+2). TB locks M1, unlocks M1 and completes. TA unlocks M2 and
+  /* [8.10.5] Signaling C1: TA wakes up, unlocks M1 and priority goes
+     to P(+2). TB locks M1, unlocks M1 and completes. TA unlocks M2 and
      priority goes to P(+1). TC waits on C1. TA completes.*/
   test_set_step(5);
   {
@@ -1093,14 +1225,14 @@ static void rt_test_008_009_execute(void) {
   }
   test_end_step(5);
 
-  /* [8.9.6] Signaling C1: TC wakes up, unlocks M1 and completes.*/
+  /* [8.10.6] Signaling C1: TC wakes up, unlocks M1 and completes.*/
   test_set_step(6);
   {
     chCondSignal(&c1);
   }
   test_end_step(6);
 
-  /* [8.9.7] Checking the order of operations.*/
+  /* [8.10.7] Checking the order of operations.*/
   test_set_step(7);
   {
     test_wait_threads();
@@ -1109,11 +1241,11 @@ static void rt_test_008_009_execute(void) {
   test_end_step(7);
 }
 
-static const testcase_t rt_test_008_009 = {
+static const testcase_t rt_test_008_010 = {
   "Condition Variable priority boost test",
-  rt_test_008_009_setup,
-  rt_test_008_009_teardown,
-  rt_test_008_009_execute
+  rt_test_008_010_setup,
+  rt_test_008_010_teardown,
+  rt_test_008_010_execute
 };
 #endif /* CH_CFG_USE_CONDVARS == TRUE */
 
@@ -1133,13 +1265,11 @@ const testcase_t * const rt_test_sequence_008_array[] = {
   &rt_test_008_003,
 #endif
   &rt_test_008_004,
-#if (CH_CFG_USE_MUTEXES_RECURSIVE == FALSE) || defined(__DOXYGEN__)
   &rt_test_008_005,
-#endif
-#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == FALSE) || defined(__DOXYGEN__)
   &rt_test_008_006,
 #endif
-#if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
   &rt_test_008_007,
 #endif
 #if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
@@ -1147,6 +1277,9 @@ const testcase_t * const rt_test_sequence_008_array[] = {
 #endif
 #if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
   &rt_test_008_009,
+#endif
+#if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
+  &rt_test_008_010,
 #endif
   NULL
 };

--- a/test/rt/source/test/rt_test_sequence_008.c
+++ b/test/rt/source/test/rt_test_sequence_008.c
@@ -256,6 +256,10 @@ static void rt_test_008_001_setup(void) {
   chMtxObjectInit(&m1);
 }
 
+static void rt_test_008_001_teardown(void) {
+  chMtxObjectDispose(&m1);
+}
+
 static void rt_test_008_001_execute(void) {
   tprio_t prio;
 
@@ -301,7 +305,7 @@ static void rt_test_008_001_execute(void) {
 static const testcase_t rt_test_008_001 = {
   "Priority enqueuing test",
   rt_test_008_001_setup,
-  NULL,
+  rt_test_008_001_teardown,
   rt_test_008_001_execute
 };
 
@@ -335,6 +339,10 @@ static const testcase_t rt_test_008_001 = {
 
 static void rt_test_008_002_setup(void) {
   chMtxObjectInit(&m1);
+}
+
+static void rt_test_008_002_teardown(void) {
+  chMtxObjectDispose(&m1);
 }
 
 static void rt_test_008_002_execute(void) {
@@ -374,7 +382,7 @@ static void rt_test_008_002_execute(void) {
 static const testcase_t rt_test_008_002 = {
   "Priority inheritance, simple case",
   rt_test_008_002_setup,
-  NULL,
+  rt_test_008_002_teardown,
   rt_test_008_002_execute
 };
 #endif /* CH_DBG_THREADS_PROFILING == TRUE */
@@ -409,6 +417,11 @@ static const testcase_t rt_test_008_002 = {
 static void rt_test_008_003_setup(void) {
   chMtxObjectInit(&m1); /* Mutex B.*/
   chMtxObjectInit(&m2); /* Mutex A.*/
+}
+
+static void rt_test_008_003_teardown(void) {
+  chMtxObjectDispose(&m1);
+  chMtxObjectDispose(&m2);
 }
 
 static void rt_test_008_003_execute(void) {
@@ -450,7 +463,7 @@ static void rt_test_008_003_execute(void) {
 static const testcase_t rt_test_008_003 = {
   "Priority inheritance, complex case",
   rt_test_008_003_setup,
-  NULL,
+  rt_test_008_003_teardown,
   rt_test_008_003_execute
 };
 #endif /* CH_DBG_THREADS_PROFILING == TRUE */
@@ -494,6 +507,8 @@ static void rt_test_008_004_setup(void) {
 
 static void rt_test_008_004_teardown(void) {
   test_wait_threads();
+  chMtxObjectDispose(&m1);
+  chMtxObjectDispose(&m2);
 }
 
 static void rt_test_008_004_execute(void) {
@@ -613,6 +628,10 @@ static void rt_test_008_005_setup(void) {
   chMtxObjectInit(&m1);
 }
 
+static void rt_test_008_005_teardown(void) {
+  chMtxObjectDispose(&m1);
+}
+
 static void rt_test_008_005_execute(void) {
   bool b;
   tprio_t prio;
@@ -684,7 +703,7 @@ static void rt_test_008_005_execute(void) {
 static const testcase_t rt_test_008_005 = {
   "Repeated locks, non recursive scenario",
   rt_test_008_005_setup,
-  NULL,
+  rt_test_008_005_teardown,
   rt_test_008_005_execute
 };
 #endif /* CH_CFG_USE_MUTEXES_RECURSIVE == FALSE */
@@ -724,6 +743,10 @@ static const testcase_t rt_test_008_005 = {
 
 static void rt_test_008_006_setup(void) {
   chMtxObjectInit(&m1);
+}
+
+static void rt_test_008_006_teardown(void) {
+  chMtxObjectDispose(&m1);
 }
 
 static void rt_test_008_006_execute(void) {
@@ -830,7 +853,7 @@ static void rt_test_008_006_execute(void) {
 static const testcase_t rt_test_008_006 = {
   "Repeated locks using, recursive scenario",
   rt_test_008_006_setup,
-  NULL,
+  rt_test_008_006_teardown,
   rt_test_008_006_execute
 };
 #endif /* CH_CFG_USE_MUTEXES_RECURSIVE == TRUE */
@@ -864,6 +887,11 @@ static const testcase_t rt_test_008_006 = {
 static void rt_test_008_007_setup(void) {
   chCondObjectInit(&c1);
   chMtxObjectInit(&m1);
+}
+
+static void rt_test_008_007_teardown(void) {
+  chCondObjectDispose(&c1);
+  chMtxObjectDispose(&m1);
 }
 
 static void rt_test_008_007_execute(void) {
@@ -903,7 +931,7 @@ static void rt_test_008_007_execute(void) {
 static const testcase_t rt_test_008_007 = {
   "Condition Variable signal test",
   rt_test_008_007_setup,
-  NULL,
+  rt_test_008_007_teardown,
   rt_test_008_007_execute
 };
 #endif /* CH_CFG_USE_CONDVARS == TRUE */
@@ -937,6 +965,11 @@ static void rt_test_008_008_setup(void) {
   chMtxObjectInit(&m1);
 }
 
+static void rt_test_008_008_teardown(void) {
+  chCondObjectDispose(&c1);
+  chMtxObjectDispose(&m1);
+}
+
 static void rt_test_008_008_execute(void) {
 
   /* [8.8.1] Starting the five threads with increasing priority, the
@@ -966,7 +999,7 @@ static void rt_test_008_008_execute(void) {
 static const testcase_t rt_test_008_008 = {
   "Condition Variable broadcast test",
   rt_test_008_008_setup,
-  NULL,
+  rt_test_008_008_teardown,
   rt_test_008_008_execute
 };
 #endif /* CH_CFG_USE_CONDVARS == TRUE */
@@ -1009,6 +1042,12 @@ static void rt_test_008_009_setup(void) {
   chCondObjectInit(&c1);
   chMtxObjectInit(&m1);
   chMtxObjectInit(&m2);
+}
+
+static void rt_test_008_009_teardown(void) {
+  chCondObjectDispose(&c1);
+  chMtxObjectDispose(&m1);
+  chMtxObjectDispose(&m2);
 }
 
 static void rt_test_008_009_execute(void) {
@@ -1073,7 +1112,7 @@ static void rt_test_008_009_execute(void) {
 static const testcase_t rt_test_008_009 = {
   "Condition Variable priority boost test",
   rt_test_008_009_setup,
-  NULL,
+  rt_test_008_009_teardown,
   rt_test_008_009_execute
 };
 #endif /* CH_CFG_USE_CONDVARS == TRUE */

--- a/test/rt/source/test/rt_test_sequence_009.c
+++ b/test/rt/source/test/rt_test_sequence_009.c
@@ -37,6 +37,9 @@
  *
  * <h2>Test Cases</h2>
  * - @subpage rt_test_009_001
+ * - @subpage rt_test_009_002
+ * - @subpage rt_test_009_003
+ * - @subpage rt_test_009_004
  * .
  */
 
@@ -52,6 +55,21 @@ static THD_FUNCTION(msg_thread1, p) {
   chMsgSend(p, 'B');
   chMsgSend(p, 'C');
   chMsgSend(p, 'D');
+}
+
+static THD_FUNCTION(msg_thread2, p) {
+  msg_t msg;
+
+  msg = chMsgSend(p, 'E');
+  test_emit_token(msg);
+}
+
+static THD_FUNCTION(msg_thread3, p) {
+  msg_t msg;
+
+  chThdSleepMilliseconds(50);
+  msg = chMsgSend(p, 'F');
+  test_emit_token(msg);
 }
 
 /****************************************************************************
@@ -109,6 +127,179 @@ static const testcase_t rt_test_009_001 = {
   rt_test_009_001_execute
 };
 
+/**
+ * @page rt_test_009_002 [9.2] Messages polling
+ *
+ * <h2>Description</h2>
+ * Polling for incoming messages is tested both in the no-message case
+ * and in the pending-message case.
+ *
+ * <h2>Test Steps</h2>
+ * - [9.2.1] Polling without pending messages, NULL is expected.
+ * - [9.2.2] Starting a sender thread, it will queue one message and
+ *   wait for a reply.
+ * - [9.2.3] Polling with a pending message, the sender is expected and
+ *   released with a reply.
+ * .
+ */
+
+static void rt_test_009_002_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_009_002_execute(void) {
+  thread_t *tp;
+  msg_t msg;
+
+  /* [9.2.1] Polling without pending messages, NULL is expected.*/
+  test_set_step(1);
+  {
+    tp = chMsgPoll();
+    test_assert(tp == NULL, "unexpected message");
+  }
+  test_end_step(1);
+
+  /* [9.2.2] Starting a sender thread, it will queue one message and
+     wait for a reply.*/
+  test_set_step(2);
+  {
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() + 1,
+                                   msg_thread2, chThdGetSelfX());
+  }
+  test_end_step(2);
+
+  /* [9.2.3] Polling with a pending message, the sender is expected and
+     released with a reply.*/
+  test_set_step(3);
+  {
+    tp = chMsgPoll();
+    test_assert(tp == threads[0], "wrong sender");
+    msg = chMsgGet(tp);
+    test_assert(msg == 'E', "wrong message");
+    chMsgRelease(tp, 'e');
+    test_wait_threads();
+    test_assert_sequence("e", "invalid sequence");
+  }
+  test_end_step(3);
+}
+
+static const testcase_t rt_test_009_002 = {
+  "Messages polling",
+  NULL,
+  rt_test_009_002_teardown,
+  rt_test_009_002_execute
+};
+
+/**
+ * @page rt_test_009_003 [9.3] Messages timeout
+ *
+ * <h2>Description</h2>
+ * A message wait with timeout is tested when no sender queues a
+ * message.
+ *
+ * <h2>Test Steps</h2>
+ * - [9.3.1] Waiting for a message with timeout, NULL is expected after
+ *   the timeout expires.
+ * .
+ */
+
+static void rt_test_009_003_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_009_003_execute(void) {
+  thread_t *tp;
+  systime_t target_time;
+
+  /* [9.3.1] Waiting for a message with timeout, NULL is expected after
+     the timeout expires.*/
+  test_set_step(1);
+  {
+    target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(50));
+    tp = chMsgWaitTimeout(TIME_MS2I(50));
+    test_assert(tp == NULL, "unexpected message");
+    test_assert_time_window(target_time,
+                            chTimeAddX(target_time, ALLOWED_DELAY),
+                            "out of time window");
+  }
+  test_end_step(1);
+}
+
+static const testcase_t rt_test_009_003 = {
+  "Messages timeout",
+  NULL,
+  rt_test_009_003_teardown,
+  rt_test_009_003_execute
+};
+
+/**
+ * @page rt_test_009_004 [9.4] Messages timeout success
+ *
+ * <h2>Description</h2>
+ * A message wait with timeout is tested when a sender queues a message
+ * before the timeout expires and when a message is already pending.
+ *
+ * <h2>Test Steps</h2>
+ * - [9.4.1] Starting a delayed sender thread then waiting for its
+ *   message using a longer timeout.
+ * - [9.4.2] Starting a sender thread at higher priority makes the
+ *   message pending before the timeout wait is invoked.
+ * .
+ */
+
+static void rt_test_009_004_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_009_004_execute(void) {
+  thread_t *tp;
+  msg_t msg;
+  systime_t target_time;
+
+  /* [9.4.1] Starting a delayed sender thread then waiting for its
+     message using a longer timeout.*/
+  test_set_step(1);
+  {
+    target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(50));
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() - 1,
+                                   msg_thread3, chThdGetSelfX());
+    tp = chMsgWaitTimeout(TIME_MS2I(500));
+    test_assert(tp == threads[0], "wrong sender");
+    test_assert_time_window(target_time,
+                            chTimeAddX(target_time, ALLOWED_DELAY),
+                            "out of time window");
+    msg = chMsgGet(tp);
+    test_assert(msg == 'F', "wrong message");
+    chMsgRelease(tp, 'f');
+    test_wait_threads();
+    test_assert_sequence("f", "invalid sequence");
+  }
+  test_end_step(1);
+
+  /* [9.4.2] Starting a sender thread at higher priority makes the
+     message pending before the timeout wait is invoked.*/
+  test_set_step(2);
+  {
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() + 1,
+                                   msg_thread2, chThdGetSelfX());
+    tp = chMsgWaitTimeout(TIME_MS2I(500));
+    test_assert(tp == threads[0], "wrong sender");
+    msg = chMsgGet(tp);
+    test_assert(msg == 'E', "wrong message");
+    chMsgRelease(tp, 'e');
+    test_wait_threads();
+    test_assert_sequence("e", "invalid sequence");
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_009_004 = {
+  "Messages timeout success",
+  NULL,
+  rt_test_009_004_teardown,
+  rt_test_009_004_execute
+};
+
 /****************************************************************************
  * Exported data.
  ****************************************************************************/
@@ -118,6 +309,9 @@ static const testcase_t rt_test_009_001 = {
  */
 const testcase_t * const rt_test_sequence_009_array[] = {
   &rt_test_009_001,
+  &rt_test_009_002,
+  &rt_test_009_003,
+  &rt_test_009_004,
   NULL
 };
 

--- a/test/rt/source/test/rt_test_sequence_010.c
+++ b/test/rt/source/test/rt_test_sequence_010.c
@@ -42,6 +42,7 @@
  * - @subpage rt_test_010_005
  * - @subpage rt_test_010_006
  * - @subpage rt_test_010_007
+ * - @subpage rt_test_010_008
  * .
  */
 
@@ -180,101 +181,143 @@ static const testcase_t rt_test_010_002 = {
   rt_test_010_002_execute
 };
 
+#if (CH_CFG_USE_EVENTS_TIMEOUT == TRUE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_010_003 [10.3] Events Flags wait using chEvtWaitOne()
+ * @page rt_test_010_003 [10.3] Event flags retrieval and pending waits
  *
  * <h2>Description</h2>
- * Functionality of chEvtWaitOne() is tested under various scenarios.
+ * Listener flag retrieval and immediate completion of pending event
+ * waits are tested.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_EVENTS_TIMEOUT == TRUE
+ * .
  *
  * <h2>Test Steps</h2>
- * - [10.3.1] Setting three event flags.
- * - [10.3.2] Calling chEvtWaitOne() three times, each time a single
- *   flag must be returned in order of priority.
- * - [10.3.3] Getting current time and starting a signaler thread, the
- *   thread will set an event flag after 50mS.
- * - [10.3.4] Calling chEvtWaitOne() then verifying that the event has
- *   been received after 50mS and that the event flags mask has been
- *   emptied.
+ * - [10.3.1] A listener is registered with a restricted flag mask.
+ * - [10.3.2] Unwanted and wanted flags are broadcast, the listener
+ *   flags and pending events are verified.
+ * - [10.3.3] The I-class broadcast and flag retrieval paths are
+ *   exercised.
+ * - [10.3.4] Timeout-capable wait functions are invoked with
+ *   already-pending events.
+ * - [10.3.5] The listener is unregistered, the Event Source must not
+ *   have listeners.
  * .
  */
 
 static void rt_test_010_003_setup(void) {
   chEvtGetAndClearEvents(ALL_EVENTS);
+  chEvtObjectInit(&es1);
+}
+
+static void rt_test_010_003_teardown(void) {
+  chEvtGetAndClearEvents(ALL_EVENTS);
+  chEvtObjectDispose(&es1);
 }
 
 static void rt_test_010_003_execute(void) {
+  eventflags_t f;
   eventmask_t m;
-  systime_t target_time;
+  event_listener_t el;
 
-  /* [10.3.1] Setting three event flags.*/
+  /* [10.3.1] A listener is registered with a restricted flag mask.*/
   test_set_step(1);
   {
-    chEvtAddEvents(7);
+    chEvtRegisterMaskWithFlags(&es1, &el, 1, (eventflags_t)5);
+    test_assert_lock(chEvtIsListeningI(&es1), "no listener");
   }
   test_end_step(1);
 
-  /* [10.3.2] Calling chEvtWaitOne() three times, each time a single
-     flag must be returned in order of priority.*/
+  /* [10.3.2] Unwanted and wanted flags are broadcast, the listener
+     flags and pending events are verified.*/
   test_set_step(2);
   {
+    chEvtBroadcastFlags(&es1, (eventflags_t)2);
+    f = chEvtGetAndClearFlags(&el);
+    test_assert(f == (eventflags_t)0, "unexpected flags");
+    m = chEvtGetAndClearEvents(ALL_EVENTS);
+    test_assert(m == 0, "spurious event");
+
+    chEvtBroadcastFlags(&es1, (eventflags_t)1);
+    f = chEvtGetAndClearFlags(&el);
+    test_assert(f == (eventflags_t)1, "wrong flags");
     m = chEvtWaitOne(ALL_EVENTS);
-    test_assert(m == 1, "single event error");
-    m = chEvtWaitOne(ALL_EVENTS);
-    test_assert(m == 2, "single event error");
-    m = chEvtWaitOne(ALL_EVENTS);
-    test_assert(m == 4, "single event error");
+    test_assert(m == 1, "event flag error");
     m = chEvtGetAndClearEvents(ALL_EVENTS);
     test_assert(m == 0, "stuck event");
   }
   test_end_step(2);
 
-  /* [10.3.3] Getting current time and starting a signaler thread, the
-     thread will set an event flag after 50mS.*/
+  /* [10.3.3] The I-class broadcast and flag retrieval paths are
+     exercised.*/
   test_set_step(3);
   {
-    target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(50));
-    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() - 1,
-                                   evt_thread3, chThdGetSelfX());
-  }
-  test_end_step(3);
+    chSysLock();
+    chEvtBroadcastFlagsI(&es1, (eventflags_t)4);
+    f = chEvtGetAndClearFlagsI(&el);
+    chSchRescheduleS();
+    chSysUnlock();
 
-  /* [10.3.4] Calling chEvtWaitOne() then verifying that the event has
-     been received after 50mS and that the event flags mask has been
-     emptied.*/
-  test_set_step(4);
-  {
+    test_assert(f == (eventflags_t)4, "wrong flags");
     m = chEvtWaitOne(ALL_EVENTS);
-    test_assert_time_window(target_time,
-                            chTimeAddX(target_time, ALLOWED_DELAY),
-                            "out of time window");
     test_assert(m == 1, "event flag error");
     m = chEvtGetAndClearEvents(ALL_EVENTS);
     test_assert(m == 0, "stuck event");
-    test_wait_threads();
+  }
+  test_end_step(3);
+
+  /* [10.3.4] Timeout-capable wait functions are invoked with
+     already-pending events.*/
+  test_set_step(4);
+  {
+    chEvtAddEvents(7);
+    m = chEvtWaitOneTimeout(ALL_EVENTS, TIME_INFINITE);
+    test_assert(m == 1, "single event error");
+    m = chEvtWaitAnyTimeout(ALL_EVENTS, TIME_INFINITE);
+    test_assert(m == 6, "unexpected pending bit");
+
+    chEvtAddEvents(5);
+    m = chEvtWaitAllTimeout(5, TIME_INFINITE);
+    test_assert(m == 5, "event flags error");
+    m = chEvtGetAndClearEvents(ALL_EVENTS);
+    test_assert(m == 0, "stuck event");
   }
   test_end_step(4);
+
+  /* [10.3.5] The listener is unregistered, the Event Source must not
+     have listeners.*/
+  test_set_step(5);
+  {
+    chEvtUnregister(&es1, &el);
+    test_assert_lock(!chEvtIsListeningI(&es1), "stuck listener");
+  }
+  test_end_step(5);
 }
 
 static const testcase_t rt_test_010_003 = {
-  "Events Flags wait using chEvtWaitOne()",
+  "Event flags retrieval and pending waits",
   rt_test_010_003_setup,
-  NULL,
+  rt_test_010_003_teardown,
   rt_test_010_003_execute
 };
+#endif /* CH_CFG_USE_EVENTS_TIMEOUT == TRUE */
 
 /**
- * @page rt_test_010_004 [10.4] Events Flags wait using chEvtWaitAny()
+ * @page rt_test_010_004 [10.4] Events Flags wait using chEvtWaitOne()
  *
  * <h2>Description</h2>
- * Functionality of chEvtWaitAny() is tested under various scenarios.
+ * Functionality of chEvtWaitOne() is tested under various scenarios.
  *
  * <h2>Test Steps</h2>
- * - [10.4.1] Setting two, non contiguous, event flags.
- * - [10.4.2] Calling chEvtWaitAny() one time, the two flags must be
- *   returned.
+ * - [10.4.1] Setting three event flags.
+ * - [10.4.2] Calling chEvtWaitOne() three times, each time a single
+ *   flag must be returned in order of priority.
  * - [10.4.3] Getting current time and starting a signaler thread, the
  *   thread will set an event flag after 50mS.
- * - [10.4.4] Calling chEvtWaitAny() then verifying that the event has
+ * - [10.4.4] Calling chEvtWaitOne() then verifying that the event has
  *   been received after 50mS and that the event flags mask has been
  *   emptied.
  * .
@@ -288,19 +331,23 @@ static void rt_test_010_004_execute(void) {
   eventmask_t m;
   systime_t target_time;
 
-  /* [10.4.1] Setting two, non contiguous, event flags.*/
+  /* [10.4.1] Setting three event flags.*/
   test_set_step(1);
   {
-    chEvtAddEvents(5);
+    chEvtAddEvents(7);
   }
   test_end_step(1);
 
-  /* [10.4.2] Calling chEvtWaitAny() one time, the two flags must be
-     returned.*/
+  /* [10.4.2] Calling chEvtWaitOne() three times, each time a single
+     flag must be returned in order of priority.*/
   test_set_step(2);
   {
-    m = chEvtWaitAny(ALL_EVENTS);
-    test_assert(m == 5, "unexpected pending bit");
+    m = chEvtWaitOne(ALL_EVENTS);
+    test_assert(m == 1, "single event error");
+    m = chEvtWaitOne(ALL_EVENTS);
+    test_assert(m == 2, "single event error");
+    m = chEvtWaitOne(ALL_EVENTS);
+    test_assert(m == 4, "single event error");
     m = chEvtGetAndClearEvents(ALL_EVENTS);
     test_assert(m == 0, "stuck event");
   }
@@ -316,12 +363,12 @@ static void rt_test_010_004_execute(void) {
   }
   test_end_step(3);
 
-  /* [10.4.4] Calling chEvtWaitAny() then verifying that the event has
+  /* [10.4.4] Calling chEvtWaitOne() then verifying that the event has
      been received after 50mS and that the event flags mask has been
      emptied.*/
   test_set_step(4);
   {
-    m = chEvtWaitAny(ALL_EVENTS);
+    m = chEvtWaitOne(ALL_EVENTS);
     test_assert_time_window(target_time,
                             chTimeAddX(target_time, ALLOWED_DELAY),
                             "out of time window");
@@ -334,28 +381,27 @@ static void rt_test_010_004_execute(void) {
 }
 
 static const testcase_t rt_test_010_004 = {
-  "Events Flags wait using chEvtWaitAny()",
+  "Events Flags wait using chEvtWaitOne()",
   rt_test_010_004_setup,
   NULL,
   rt_test_010_004_execute
 };
 
 /**
- * @page rt_test_010_005 [10.5] Events Flags wait using chEvtWaitAll()
+ * @page rt_test_010_005 [10.5] Events Flags wait using chEvtWaitAny()
  *
  * <h2>Description</h2>
- * Functionality of chEvtWaitAll() is tested under various scenarios.
+ * Functionality of chEvtWaitAny() is tested under various scenarios.
  *
  * <h2>Test Steps</h2>
  * - [10.5.1] Setting two, non contiguous, event flags.
- * - [10.5.2] Calling chEvtWaitAll() one time, the two flags must be
+ * - [10.5.2] Calling chEvtWaitAny() one time, the two flags must be
  *   returned.
- * - [10.5.3] Setting one event flag.
- * - [10.5.4] Getting current time and starting a signaler thread, the
- *   thread will set another event flag after 50mS.
- * - [10.5.5] Calling chEvtWaitAll() then verifying that both event
- *   flags have been received after 50mS and that the event flags mask
- *   has been emptied.
+ * - [10.5.3] Getting current time and starting a signaler thread, the
+ *   thread will set an event flag after 50mS.
+ * - [10.5.4] Calling chEvtWaitAny() then verifying that the event has
+ *   been received after 50mS and that the event flags mask has been
+ *   emptied.
  * .
  */
 
@@ -374,7 +420,86 @@ static void rt_test_010_005_execute(void) {
   }
   test_end_step(1);
 
-  /* [10.5.2] Calling chEvtWaitAll() one time, the two flags must be
+  /* [10.5.2] Calling chEvtWaitAny() one time, the two flags must be
+     returned.*/
+  test_set_step(2);
+  {
+    m = chEvtWaitAny(ALL_EVENTS);
+    test_assert(m == 5, "unexpected pending bit");
+    m = chEvtGetAndClearEvents(ALL_EVENTS);
+    test_assert(m == 0, "stuck event");
+  }
+  test_end_step(2);
+
+  /* [10.5.3] Getting current time and starting a signaler thread, the
+     thread will set an event flag after 50mS.*/
+  test_set_step(3);
+  {
+    target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(50));
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() - 1,
+                                   evt_thread3, chThdGetSelfX());
+  }
+  test_end_step(3);
+
+  /* [10.5.4] Calling chEvtWaitAny() then verifying that the event has
+     been received after 50mS and that the event flags mask has been
+     emptied.*/
+  test_set_step(4);
+  {
+    m = chEvtWaitAny(ALL_EVENTS);
+    test_assert_time_window(target_time,
+                            chTimeAddX(target_time, ALLOWED_DELAY),
+                            "out of time window");
+    test_assert(m == 1, "event flag error");
+    m = chEvtGetAndClearEvents(ALL_EVENTS);
+    test_assert(m == 0, "stuck event");
+    test_wait_threads();
+  }
+  test_end_step(4);
+}
+
+static const testcase_t rt_test_010_005 = {
+  "Events Flags wait using chEvtWaitAny()",
+  rt_test_010_005_setup,
+  NULL,
+  rt_test_010_005_execute
+};
+
+/**
+ * @page rt_test_010_006 [10.6] Events Flags wait using chEvtWaitAll()
+ *
+ * <h2>Description</h2>
+ * Functionality of chEvtWaitAll() is tested under various scenarios.
+ *
+ * <h2>Test Steps</h2>
+ * - [10.6.1] Setting two, non contiguous, event flags.
+ * - [10.6.2] Calling chEvtWaitAll() one time, the two flags must be
+ *   returned.
+ * - [10.6.3] Setting one event flag.
+ * - [10.6.4] Getting current time and starting a signaler thread, the
+ *   thread will set another event flag after 50mS.
+ * - [10.6.5] Calling chEvtWaitAll() then verifying that both event
+ *   flags have been received after 50mS and that the event flags mask
+ *   has been emptied.
+ * .
+ */
+
+static void rt_test_010_006_setup(void) {
+  chEvtGetAndClearEvents(ALL_EVENTS);
+}
+
+static void rt_test_010_006_execute(void) {
+  eventmask_t m;
+  systime_t target_time;
+
+  /* [10.6.1] Setting two, non contiguous, event flags.*/
+  test_set_step(1);
+  {
+    chEvtAddEvents(5);
+  }
+  test_end_step(1);
+
+  /* [10.6.2] Calling chEvtWaitAll() one time, the two flags must be
      returned.*/
   test_set_step(2);
   {
@@ -385,14 +510,14 @@ static void rt_test_010_005_execute(void) {
   }
   test_end_step(2);
 
-  /* [10.5.3] Setting one event flag.*/
+  /* [10.6.3] Setting one event flag.*/
   test_set_step(3);
   {
     chEvtAddEvents(4);
   }
   test_end_step(3);
 
-  /* [10.5.4] Getting current time and starting a signaler thread, the
+  /* [10.6.4] Getting current time and starting a signaler thread, the
      thread will set another event flag after 50mS.*/
   test_set_step(4);
   {
@@ -402,7 +527,7 @@ static void rt_test_010_005_execute(void) {
   }
   test_end_step(4);
 
-  /* [10.5.5] Calling chEvtWaitAll() then verifying that both event
+  /* [10.6.5] Calling chEvtWaitAll() then verifying that both event
      flags have been received after 50mS and that the event flags mask
      has been emptied.*/
   test_set_step(5);
@@ -419,16 +544,16 @@ static void rt_test_010_005_execute(void) {
   test_end_step(5);
 }
 
-static const testcase_t rt_test_010_005 = {
+static const testcase_t rt_test_010_006 = {
   "Events Flags wait using chEvtWaitAll()",
-  rt_test_010_005_setup,
+  rt_test_010_006_setup,
   NULL,
-  rt_test_010_005_execute
+  rt_test_010_006_execute
 };
 
 #if (CH_CFG_USE_EVENTS_TIMEOUT == TRUE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_010_006 [10.6] Events Flags wait timeouts
+ * @page rt_test_010_007 [10.7] Events Flags wait timeouts
  *
  * <h2>Description</h2>
  * Timeout functionality is tested for chEvtWaitOneTimeout(),
@@ -441,21 +566,21 @@ static const testcase_t rt_test_010_005 = {
  * .
  *
  * <h2>Test Steps</h2>
- * - [10.6.1] The functions are invoked first with TIME_IMMEDIATE
+ * - [10.7.1] The functions are invoked first with TIME_IMMEDIATE
  *   timeout, the timeout condition is tested.
- * - [10.6.2] The functions are invoked first with a 50mS timeout, the
+ * - [10.7.2] The functions are invoked first with a 50mS timeout, the
  *   timeout condition is tested.
  * .
  */
 
-static void rt_test_010_006_setup(void) {
+static void rt_test_010_007_setup(void) {
   chEvtGetAndClearEvents(ALL_EVENTS);
 }
 
-static void rt_test_010_006_execute(void) {
+static void rt_test_010_007_execute(void) {
   eventmask_t m;
 
-  /* [10.6.1] The functions are invoked first with TIME_IMMEDIATE
+  /* [10.7.1] The functions are invoked first with TIME_IMMEDIATE
      timeout, the timeout condition is tested.*/
   test_set_step(1);
   {
@@ -468,7 +593,7 @@ static void rt_test_010_006_execute(void) {
   }
   test_end_step(1);
 
-  /* [10.6.2] The functions are invoked first with a 50mS timeout, the
+  /* [10.7.2] The functions are invoked first with a 50mS timeout, the
      timeout condition is tested.*/
   test_set_step(2);
   {
@@ -482,50 +607,50 @@ static void rt_test_010_006_execute(void) {
   test_end_step(2);
 }
 
-static const testcase_t rt_test_010_006 = {
+static const testcase_t rt_test_010_007 = {
   "Events Flags wait timeouts",
-  rt_test_010_006_setup,
+  rt_test_010_007_setup,
   NULL,
-  rt_test_010_006_execute
+  rt_test_010_007_execute
 };
 #endif /* CH_CFG_USE_EVENTS_TIMEOUT == TRUE */
 
 /**
- * @page rt_test_010_007 [10.7] Broadcasting using chEvtBroadcast()
+ * @page rt_test_010_008 [10.8] Broadcasting using chEvtBroadcast()
  *
  * <h2>Description</h2>
  * Functionality of chEvtBroadcast() is tested.
  *
  * <h2>Test Steps</h2>
- * - [10.7.1] Registering on two event sources associating them with
+ * - [10.8.1] Registering on two event sources associating them with
  *   flags 1 and 4.
- * - [10.7.2] Getting current time and starting a broadcaster thread,
+ * - [10.8.2] Getting current time and starting a broadcaster thread,
  *   the thread broadcast the first Event Source immediately and the
  *   other after 50mS.
- * - [10.7.3] Calling chEvtWaitAll() then verifying that both event
+ * - [10.8.3] Calling chEvtWaitAll() then verifying that both event
  *   flags have been received after 50mS and that the event flags mask
  *   has been emptied.
- * - [10.7.4] Unregistering from the Event Sources.
+ * - [10.8.4] Unregistering from the Event Sources.
  * .
  */
 
-static void rt_test_010_007_setup(void) {
+static void rt_test_010_008_setup(void) {
   chEvtGetAndClearEvents(ALL_EVENTS);
   chEvtObjectInit(&es1);
   chEvtObjectInit(&es2);
 }
 
-static void rt_test_010_007_teardown(void) {
+static void rt_test_010_008_teardown(void) {
   chEvtObjectDispose(&es1);
   chEvtObjectDispose(&es2);
 }
 
-static void rt_test_010_007_execute(void) {
+static void rt_test_010_008_execute(void) {
   eventmask_t m;
   event_listener_t el1, el2;
   systime_t target_time;
 
-  /* [10.7.1] Registering on two event sources associating them with
+  /* [10.8.1] Registering on two event sources associating them with
      flags 1 and 4.*/
   test_set_step(1);
   {
@@ -534,7 +659,7 @@ static void rt_test_010_007_execute(void) {
   }
   test_end_step(1);
 
-  /* [10.7.2] Getting current time and starting a broadcaster thread,
+  /* [10.8.2] Getting current time and starting a broadcaster thread,
      the thread broadcast the first Event Source immediately and the
      other after 50mS.*/
   test_set_step(2);
@@ -545,7 +670,7 @@ static void rt_test_010_007_execute(void) {
   }
   test_end_step(2);
 
-  /* [10.7.3] Calling chEvtWaitAll() then verifying that both event
+  /* [10.8.3] Calling chEvtWaitAll() then verifying that both event
      flags have been received after 50mS and that the event flags mask
      has been emptied.*/
   test_set_step(3);
@@ -560,7 +685,7 @@ static void rt_test_010_007_execute(void) {
   }
   test_end_step(3);
 
-  /* [10.7.4] Unregistering from the Event Sources.*/
+  /* [10.8.4] Unregistering from the Event Sources.*/
   test_set_step(4);
   {
     chEvtUnregister(&es1, &el1);
@@ -571,11 +696,11 @@ static void rt_test_010_007_execute(void) {
   test_end_step(4);
 }
 
-static const testcase_t rt_test_010_007 = {
+static const testcase_t rt_test_010_008 = {
   "Broadcasting using chEvtBroadcast()",
-  rt_test_010_007_setup,
-  rt_test_010_007_teardown,
-  rt_test_010_007_execute
+  rt_test_010_008_setup,
+  rt_test_010_008_teardown,
+  rt_test_010_008_execute
 };
 
 /****************************************************************************
@@ -588,13 +713,16 @@ static const testcase_t rt_test_010_007 = {
 const testcase_t * const rt_test_sequence_010_array[] = {
   &rt_test_010_001,
   &rt_test_010_002,
+#if (CH_CFG_USE_EVENTS_TIMEOUT == TRUE) || defined(__DOXYGEN__)
   &rt_test_010_003,
+#endif
   &rt_test_010_004,
   &rt_test_010_005,
-#if (CH_CFG_USE_EVENTS_TIMEOUT == TRUE) || defined(__DOXYGEN__)
   &rt_test_010_006,
-#endif
+#if (CH_CFG_USE_EVENTS_TIMEOUT == TRUE) || defined(__DOXYGEN__)
   &rt_test_010_007,
+#endif
+  &rt_test_010_008,
   NULL
 };
 

--- a/test/rt/source/test/rt_test_sequence_010.c
+++ b/test/rt/source/test/rt_test_sequence_010.c
@@ -515,6 +515,11 @@ static void rt_test_010_007_setup(void) {
   chEvtObjectInit(&es2);
 }
 
+static void rt_test_010_007_teardown(void) {
+  chEvtObjectDispose(&es1);
+  chEvtObjectDispose(&es2);
+}
+
 static void rt_test_010_007_execute(void) {
   eventmask_t m;
   event_listener_t el1, el2;
@@ -569,7 +574,7 @@ static void rt_test_010_007_execute(void) {
 static const testcase_t rt_test_010_007 = {
   "Broadcasting using chEvtBroadcast()",
   rt_test_010_007_setup,
-  NULL,
+  rt_test_010_007_teardown,
   rt_test_010_007_execute
 };
 

--- a/test/rt/source/test/rt_test_sequence_011.c
+++ b/test/rt/source/test/rt_test_sequence_011.c
@@ -38,6 +38,7 @@
  * <h2>Test Cases</h2>
  * - @subpage rt_test_011_001
  * - @subpage rt_test_011_002
+ * - @subpage rt_test_011_003
  * .
  */
 
@@ -93,6 +94,10 @@ static THD_FUNCTION(dyn_thread1, p) {
 
 static void rt_test_011_001_setup(void) {
   chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);
+}
+
+static void rt_test_011_001_teardown(void) {
+  chHeapObjectDispose(&heap1);
 }
 
 static void rt_test_011_001_execute(void) {
@@ -171,7 +176,7 @@ static void rt_test_011_001_execute(void) {
 static const testcase_t rt_test_011_001 = {
   "Threads creation from Memory Heap",
   rt_test_011_001_setup,
-  NULL,
+  rt_test_011_001_teardown,
   rt_test_011_001_execute
 };
 #endif /* CH_CFG_USE_HEAP == TRUE */
@@ -204,6 +209,10 @@ static const testcase_t rt_test_011_001 = {
 
 static void rt_test_011_002_setup(void) {
   chPoolObjectInit(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE), NULL);
+}
+
+static void rt_test_011_002_teardown(void) {
+  chPoolObjectDispose(&mp1);
 }
 
 static void rt_test_011_002_execute(void) {
@@ -271,10 +280,131 @@ static void rt_test_011_002_execute(void) {
 static const testcase_t rt_test_011_002 = {
   "Threads creation from Memory Pool",
   rt_test_011_002_setup,
-  NULL,
+  rt_test_011_002_teardown,
   rt_test_011_002_execute
 };
 #endif /* CH_CFG_USE_MEMPOOLS == TRUE */
+
+#if (CH_CFG_USE_HEAP == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_011_003 [11.3] Detached dynamic thread recovery
+ *
+ * <h2>Description</h2>
+ * A dynamic thread allocated from a heap is detached while still
+ * active. After termination its memory is recovered by a registry
+ * scan.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_HEAP == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [11.3.1] Getting heap status and base priority before the test.
+ * - [11.3.2] A dynamic thread is created from the heap then its
+ *   initial reference is released before it can run.
+ * - [11.3.3] The detached thread is allowed to terminate, it is
+ *   expected to keep its heap allocation until the registry is
+ *   scanned.
+ * - [11.3.4] The registry is scanned forward, the detached final
+ *   thread is found and its memory is recovered.
+ * .
+ */
+
+static void rt_test_011_003_setup(void) {
+  chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);
+}
+
+static void rt_test_011_003_teardown(void) {
+  {
+    thread_t *tp, *ntp;
+
+    tp = chRegFirstThread();
+    do {
+      ntp = chRegNextThread(tp);
+      tp = ntp;
+    } while (tp != NULL);
+  }
+  chHeapObjectDispose(&heap1);
+}
+
+static void rt_test_011_003_execute(void) {
+  size_t n1, total1, largest1;
+  size_t n2, total2, largest2;
+  size_t n3, total3, largest3;
+  thread_t *tp, *ntp, *dtp;
+  tprio_t prio;
+  bool found;
+
+  /* [11.3.1] Getting heap status and base priority before the test.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+    n1 = chHeapStatus(&heap1, &total1, &largest1);
+    test_assert(n1 == 1, "heap fragmented");
+  }
+  test_end_step(1);
+
+  /* [11.3.2] A dynamic thread is created from the heap then its
+     initial reference is released before it can run.*/
+  test_set_step(2);
+  {
+    dtp = chThdCreateFromHeap(&heap1,
+                                THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),
+                                "dyn-detached",
+                                prio-1, dyn_thread1, "D");
+    test_assert(dtp != NULL, "thread creation failed");
+    threads[0] = dtp;
+    chThdRelease(dtp);
+    threads[0] = NULL;
+  }
+  test_end_step(2);
+
+  /* [11.3.3] The detached thread is allowed to terminate, it is
+     expected to keep its heap allocation until the registry is
+     scanned.*/
+  test_set_step(3);
+  {
+    chThdSleepMilliseconds(50);
+    test_assert_sequence("D", "invalid sequence");
+    n2 = chHeapStatus(&heap1, &total2, &largest2);
+    test_assert(total2 < total1, "memory already recovered");
+    (void)n2;
+    (void)largest2;
+  }
+  test_end_step(3);
+
+  /* [11.3.4] The registry is scanned forward, the detached final
+     thread is found and its memory is recovered.*/
+  test_set_step(4);
+  {
+    found = false;
+    tp = chRegFirstThread();
+    do {
+      if (tp == dtp) {
+        found = true;
+      }
+      ntp = chRegNextThread(tp);
+      tp = ntp;
+    } while (tp != NULL);
+
+    test_assert(found, "not found in registry scan");
+    n3 = chHeapStatus(&heap1, &total3, &largest3);
+    test_assert(n1 == n3, "fragmentation changed");
+    test_assert(total1 == total3, "total free space changed");
+    test_assert(largest1 == largest3, "largest fragment size changed");
+  }
+  test_end_step(4);
+}
+
+static const testcase_t rt_test_011_003 = {
+  "Detached dynamic thread recovery",
+  rt_test_011_003_setup,
+  rt_test_011_003_teardown,
+  rt_test_011_003_execute
+};
+#endif /* CH_CFG_USE_HEAP == TRUE */
 
 /****************************************************************************
  * Exported data.
@@ -289,6 +419,9 @@ const testcase_t * const rt_test_sequence_011_array[] = {
 #endif
 #if (CH_CFG_USE_MEMPOOLS == TRUE) || defined(__DOXYGEN__)
   &rt_test_011_002,
+#endif
+#if (CH_CFG_USE_HEAP == TRUE) || defined(__DOXYGEN__)
+  &rt_test_011_003,
 #endif
   NULL
 };

--- a/test/rt/source/test/rt_test_sequence_011.c
+++ b/test/rt/source/test/rt_test_sequence_011.c
@@ -93,7 +93,8 @@ static THD_FUNCTION(dyn_thread1, p) {
  */
 
 static void rt_test_011_001_setup(void) {
-  chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);
+  chHeapObjectInit(&heap1, TEST_SHARED_BUFFER,
+                   TEST_SHARED_BUFFER_SIZE);
 }
 
 static void rt_test_011_001_teardown(void) {
@@ -313,7 +314,8 @@ static const testcase_t rt_test_011_002 = {
  */
 
 static void rt_test_011_003_setup(void) {
-  chHeapObjectInit(&heap1, test_buffer, sizeof test_buffer);
+  chHeapObjectInit(&heap1, TEST_SHARED_BUFFER,
+                   TEST_SHARED_BUFFER_SIZE);
 }
 
 static void rt_test_011_003_teardown(void) {

--- a/test/rt/source/test/rt_test_sequence_012.c
+++ b/test/rt/source/test/rt_test_sequence_012.c
@@ -1052,7 +1052,7 @@ static const testcase_t rt_test_012_013 = {
 };
 #endif /* CH_CFG_USE_SEMAPHORES == TRUE */
 
-#if (CH_CFG_USE_MUTEXES ==TRUE) || defined(__DOXYGEN__)
+#if (CH_CFG_USE_MUTEXES == TRUE) || defined(__DOXYGEN__)
 /**
  * @page rt_test_012_014 [12.14] Mutexes lock/unlock performance
  *
@@ -1065,7 +1065,7 @@ static const testcase_t rt_test_012_013 = {
  * <h2>Conditions</h2>
  * This test is only executed if the following preprocessor condition
  * evaluates to true:
- * - CH_CFG_USE_MUTEXES ==TRUE
+ * - CH_CFG_USE_MUTEXES == TRUE
  * .
  *
  * <h2>Test Steps</h2>
@@ -1124,7 +1124,7 @@ static const testcase_t rt_test_012_014 = {
   NULL,
   rt_test_012_014_execute
 };
-#endif /* CH_CFG_USE_MUTEXES ==TRUE */
+#endif /* CH_CFG_USE_MUTEXES == TRUE */
 
 /**
  * @page rt_test_012_015 [12.15] RAM Footprint
@@ -1281,7 +1281,7 @@ const testcase_t * const rt_test_sequence_012_array[] = {
 #if (CH_CFG_USE_SEMAPHORES == TRUE) || defined(__DOXYGEN__)
   &rt_test_012_013,
 #endif
-#if (CH_CFG_USE_MUTEXES ==TRUE) || defined(__DOXYGEN__)
+#if (CH_CFG_USE_MUTEXES == TRUE) || defined(__DOXYGEN__)
   &rt_test_012_014,
 #endif
   &rt_test_012_015,

--- a/test/rt/source/test/rt_test_sequence_012.c
+++ b/test/rt/source/test/rt_test_sequence_012.c
@@ -46,6 +46,9 @@
  * - @subpage rt_test_012_010
  * - @subpage rt_test_012_011
  * - @subpage rt_test_012_012
+ * - @subpage rt_test_012_013
+ * - @subpage rt_test_012_014
+ * - @subpage rt_test_012_015
  * .
  */
 
@@ -64,6 +67,17 @@ static void tmo(virtual_timer_t *vtp, void *param) {
 
   (void)vtp;
   (void)param;
+}
+
+static virtual_timer_t vt1, vt2;
+static volatile uint32_t vt_counter;
+
+static void vt_continuous_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)vtp;
+  (void)param;
+
+  vt_counter++;
 }
 
 #if CH_CFG_USE_MESSAGES
@@ -707,7 +721,203 @@ static const testcase_t rt_test_012_008 = {
 };
 
 /**
- * @page rt_test_012_009 [12.9] Virtual Timers set/reset performance
+ * @page rt_test_012_009 [12.9] Virtual Timer object lifecycle
+ *
+ * <h2>Description</h2>
+ * Virtual timer objects are explicitly initialized, armed, queried for
+ * remaining intervals, reset and disposed.
+ *
+ * <h2>Test Steps</h2>
+ * - [12.9.1] The initialized timer is verified to be disarmed.
+ * - [12.9.2] Two timers are armed, the second timer's remaining
+ *   interval is queried, then both timers are reset.
+ * .
+ */
+
+static void rt_test_012_009_setup(void) {
+  chVTObjectInit(&vt1);
+  chVTObjectInit(&vt2);
+}
+
+static void rt_test_012_009_teardown(void) {
+  chVTReset(&vt1);
+  chVTReset(&vt2);
+  chVTObjectDispose(&vt1);
+  chVTObjectDispose(&vt2);
+}
+
+static void rt_test_012_009_execute(void) {
+  sysinterval_t remaining;
+  bool armed;
+
+  /* [12.9.1] The initialized timer is verified to be disarmed.*/
+  test_set_step(1);
+  {
+    test_assert(chVTIsArmed(&vt1) == false, "timer armed");
+  }
+  test_end_step(1);
+
+  /* [12.9.2] Two timers are armed, the second timer's remaining
+     interval is queried, then both timers are reset.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    chVTDoSetI(&vt1, TIME_MS2I(100), tmo, NULL);
+    chVTDoSetI(&vt2, TIME_MS2I(200), tmo, NULL);
+    armed = chVTIsArmedI(&vt1) && chVTIsArmedI(&vt2);
+    remaining = chVTGetRemainingIntervalI(&vt2);
+    chVTDoResetI(&vt2);
+    chVTDoResetI(&vt1);
+    chSysUnlock();
+
+    test_assert(armed, "timer not armed");
+    test_assert(remaining > (sysinterval_t)0, "no remaining interval");
+    test_assert(chVTIsArmed(&vt1) == false, "timer still armed");
+    test_assert(chVTIsArmed(&vt2) == false, "timer still armed");
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_012_009 = {
+  "Virtual Timer object lifecycle",
+  rt_test_012_009_setup,
+  rt_test_012_009_teardown,
+  rt_test_012_009_execute
+};
+
+/**
+ * @page rt_test_012_010 [12.10] Continuous Virtual Timer
+ *
+ * <h2>Description</h2>
+ * A continuous virtual timer is armed, allowed to fire multiple times,
+ * then reset and checked for inactivity.
+ *
+ * <h2>Test Steps</h2>
+ * - [12.10.1] The continuous timer is armed and its remaining interval
+ *   is queried.
+ * - [12.10.2] The timer is allowed to reload and fire multiple times.
+ * - [12.10.3] The timer is reset and verified not to fire again.
+ * .
+ */
+
+static void rt_test_012_010_setup(void) {
+  chVTObjectInit(&vt2);
+  vt_counter = 0;
+}
+
+static void rt_test_012_010_teardown(void) {
+  chVTReset(&vt2);
+  chVTObjectDispose(&vt2);
+}
+
+static void rt_test_012_010_execute(void) {
+  sysinterval_t remaining;
+  uint32_t count;
+  bool armed;
+
+  /* [12.10.1] The continuous timer is armed and its remaining interval
+     is queried.*/
+  test_set_step(1);
+  {
+    chSysLock();
+    chVTDoSetContinuousI(&vt2, TIME_MS2I(10), vt_continuous_cb, NULL);
+    armed = chVTIsArmedI(&vt2);
+    remaining = chVTGetRemainingIntervalI(&vt2);
+    chSysUnlock();
+
+    test_assert(armed, "timer not armed");
+    test_assert(remaining > (sysinterval_t)0, "no remaining interval");
+  }
+  test_end_step(1);
+
+  /* [12.10.2] The timer is allowed to reload and fire multiple
+     times.*/
+  test_set_step(2);
+  {
+    chThdSleepMilliseconds(50);
+    count = vt_counter;
+    test_assert(count >= 2U, "timer not reloaded");
+  }
+  test_end_step(2);
+
+  /* [12.10.3] The timer is reset and verified not to fire again.*/
+  test_set_step(3);
+  {
+    chSysLock();
+    chVTDoResetI(&vt2);
+    armed = chVTIsArmedI(&vt2);
+    chSysUnlock();
+
+    test_assert(!armed, "timer still armed");
+    count = vt_counter;
+    chThdSleepMilliseconds(30);
+    test_assert(vt_counter == count, "timer still running");
+  }
+  test_end_step(3);
+}
+
+static const testcase_t rt_test_012_010 = {
+  "Continuous Virtual Timer",
+  rt_test_012_010_setup,
+  rt_test_012_010_teardown,
+  rt_test_012_010_execute
+};
+
+#if (CH_CFG_USE_TIMESTAMP == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_012_011 [12.11] Timestamp reset
+ *
+ * <h2>Description</h2>
+ * The timestamp counter is reset and verified to remain usable and
+ * monotonic.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_TIMESTAMP == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [12.11.1] The timestamp counter is reset from system-locked
+ *   context.
+ * - [12.11.2] A later timestamp is verified to be monotonic.
+ * .
+ */
+
+static void rt_test_012_011_execute(void) {
+  systimestamp_t stamp1, stamp2;
+
+  /* [12.11.1] The timestamp counter is reset from system-locked
+     context.*/
+  test_set_step(1);
+  {
+    chSysLock();
+    chVTResetTimeStampI();
+    stamp1 = chVTGetTimeStampI();
+    chSysUnlock();
+  }
+  test_end_step(1);
+
+  /* [12.11.2] A later timestamp is verified to be monotonic.*/
+  test_set_step(2);
+  {
+    chThdSleep(1);
+    stamp2 = chVTGetTimeStamp();
+    test_assert(stamp1 <= stamp2, "not monotonic");
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_012_011 = {
+  "Timestamp reset",
+  NULL,
+  NULL,
+  rt_test_012_011_execute
+};
+#endif /* CH_CFG_USE_TIMESTAMP == TRUE */
+
+/**
+ * @page rt_test_012_012 [12.12] Virtual Timers set/reset performance
  *
  * <h2>Description</h2>
  * A virtual timer is set and immediately reset into a continuous
@@ -715,18 +925,18 @@ static const testcase_t rt_test_012_008 = {
  * iterations after a second of continuous operations.
  *
  * <h2>Test Steps</h2>
- * - [12.9.1] Two timers are set then reset without waiting for their
+ * - [12.12.1] Two timers are set then reset without waiting for their
  *   counter to elapse. The operation is repeated continuously in a
  *   one-second time window.
- * - [12.9.2] The score is printed.
+ * - [12.12.2] The score is printed.
  * .
  */
 
-static void rt_test_012_009_execute(void) {
+static void rt_test_012_012_execute(void) {
   static virtual_timer_t vt1, vt2;
   uint32_t n;
 
-  /* [12.9.1] Two timers are set then reset without waiting for their
+  /* [12.12.1] Two timers are set then reset without waiting for their
      counter to elapse. The operation is repeated continuously in a
      one-second time window.*/
   test_set_step(1);
@@ -751,7 +961,7 @@ static void rt_test_012_009_execute(void) {
   }
   test_end_step(1);
 
-  /* [12.9.2] The score is printed.*/
+  /* [12.12.2] The score is printed.*/
   test_set_step(2);
   {
     test_print("--- Score : ");
@@ -761,16 +971,16 @@ static void rt_test_012_009_execute(void) {
   test_end_step(2);
 }
 
-static const testcase_t rt_test_012_009 = {
+static const testcase_t rt_test_012_012 = {
   "Virtual Timers set/reset performance",
   NULL,
   NULL,
-  rt_test_012_009_execute
+  rt_test_012_012_execute
 };
 
 #if (CH_CFG_USE_SEMAPHORES == TRUE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_012_010 [12.10] Semaphores wait/signal performance
+ * @page rt_test_012_013 [12.13] Semaphores wait/signal performance
  *
  * <h2>Description</h2>
  * A counting semaphore is taken/released into a continuous loop, no
@@ -785,20 +995,20 @@ static const testcase_t rt_test_012_009 = {
  * .
  *
  * <h2>Test Steps</h2>
- * - [12.10.1] A semaphore is teken and released. The operation is
+ * - [12.13.1] A semaphore is teken and released. The operation is
  *   repeated continuously in a one-second time window.
- * - [12.10.2] The score is printed.
+ * - [12.13.2] The score is printed.
  * .
  */
 
-static void rt_test_012_010_setup(void) {
+static void rt_test_012_013_setup(void) {
   chSemObjectInit(&sem1, 1);
 }
 
-static void rt_test_012_010_execute(void) {
+static void rt_test_012_013_execute(void) {
   uint32_t n;
 
-  /* [12.10.1] A semaphore is teken and released. The operation is
+  /* [12.13.1] A semaphore is teken and released. The operation is
      repeated continuously in a one-second time window.*/
   test_set_step(1);
   {
@@ -824,7 +1034,7 @@ static void rt_test_012_010_execute(void) {
   }
   test_end_step(1);
 
-  /* [12.10.2] The score is printed.*/
+  /* [12.13.2] The score is printed.*/
   test_set_step(2);
   {
     test_print("--- Score : ");
@@ -834,17 +1044,17 @@ static void rt_test_012_010_execute(void) {
   test_end_step(2);
 }
 
-static const testcase_t rt_test_012_010 = {
+static const testcase_t rt_test_012_013 = {
   "Semaphores wait/signal performance",
-  rt_test_012_010_setup,
+  rt_test_012_013_setup,
   NULL,
-  rt_test_012_010_execute
+  rt_test_012_013_execute
 };
 #endif /* CH_CFG_USE_SEMAPHORES == TRUE */
 
 #if (CH_CFG_USE_MUTEXES ==TRUE) || defined(__DOXYGEN__)
 /**
- * @page rt_test_012_011 [12.11] Mutexes lock/unlock performance
+ * @page rt_test_012_014 [12.14] Mutexes lock/unlock performance
  *
  * <h2>Description</h2>
  * A mutex is locked/unlocked into a continuous loop, no Context Switch
@@ -859,20 +1069,20 @@ static const testcase_t rt_test_012_010 = {
  * .
  *
  * <h2>Test Steps</h2>
- * - [12.11.1] A mutex is locked and unlocked. The operation is
+ * - [12.14.1] A mutex is locked and unlocked. The operation is
  *   repeated continuously in a one-second time window.
- * - [12.11.2] The score is printed.
+ * - [12.14.2] The score is printed.
  * .
  */
 
-static void rt_test_012_011_setup(void) {
+static void rt_test_012_014_setup(void) {
   chMtxObjectInit(&mtx1);
 }
 
-static void rt_test_012_011_execute(void) {
+static void rt_test_012_014_execute(void) {
   uint32_t n;
 
-  /* [12.11.1] A mutex is locked and unlocked. The operation is
+  /* [12.14.1] A mutex is locked and unlocked. The operation is
      repeated continuously in a one-second time window.*/
   test_set_step(1);
   {
@@ -898,7 +1108,7 @@ static void rt_test_012_011_execute(void) {
   }
   test_end_step(1);
 
-  /* [12.11.2] The score is printed.*/
+  /* [12.14.2] The score is printed.*/
   test_set_step(2);
   {
     test_print("--- Score : ");
@@ -908,36 +1118,36 @@ static void rt_test_012_011_execute(void) {
   test_end_step(2);
 }
 
-static const testcase_t rt_test_012_011 = {
+static const testcase_t rt_test_012_014 = {
   "Mutexes lock/unlock performance",
-  rt_test_012_011_setup,
+  rt_test_012_014_setup,
   NULL,
-  rt_test_012_011_execute
+  rt_test_012_014_execute
 };
 #endif /* CH_CFG_USE_MUTEXES ==TRUE */
 
 /**
- * @page rt_test_012_012 [12.12] RAM Footprint
+ * @page rt_test_012_015 [12.15] RAM Footprint
  *
  * <h2>Description</h2>
  * The memory size of the various kernel objects is printed.
  *
  * <h2>Test Steps</h2>
- * - [12.12.1] The size of the system area is printed.
- * - [12.12.2] The size of a thread structure is printed.
- * - [12.12.3] The size of a virtual timer structure is printed.
- * - [12.12.4] The size of a semaphore structure is printed.
- * - [12.12.5] The size of a mutex is printed.
- * - [12.12.6] The size of a condition variable is printed.
- * - [12.12.7] The size of an event source is printed.
- * - [12.12.8] The size of an event listener is printed.
- * - [12.12.9] The size of a mailbox is printed.
+ * - [12.15.1] The size of the system area is printed.
+ * - [12.15.2] The size of a thread structure is printed.
+ * - [12.15.3] The size of a virtual timer structure is printed.
+ * - [12.15.4] The size of a semaphore structure is printed.
+ * - [12.15.5] The size of a mutex is printed.
+ * - [12.15.6] The size of a condition variable is printed.
+ * - [12.15.7] The size of an event source is printed.
+ * - [12.15.8] The size of an event listener is printed.
+ * - [12.15.9] The size of a mailbox is printed.
  * .
  */
 
-static void rt_test_012_012_execute(void) {
+static void rt_test_012_015_execute(void) {
 
-  /* [12.12.1] The size of the system area is printed.*/
+  /* [12.15.1] The size of the system area is printed.*/
   test_set_step(1);
   {
     test_print("--- OS    : ");
@@ -946,7 +1156,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(1);
 
-  /* [12.12.2] The size of a thread structure is printed.*/
+  /* [12.15.2] The size of a thread structure is printed.*/
   test_set_step(2);
   {
     test_print("--- Thread: ");
@@ -955,7 +1165,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(2);
 
-  /* [12.12.3] The size of a virtual timer structure is printed.*/
+  /* [12.15.3] The size of a virtual timer structure is printed.*/
   test_set_step(3);
   {
     test_print("--- Timer : ");
@@ -964,7 +1174,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(3);
 
-  /* [12.12.4] The size of a semaphore structure is printed.*/
+  /* [12.15.4] The size of a semaphore structure is printed.*/
   test_set_step(4);
   {
 #if CH_CFG_USE_SEMAPHORES || defined(__DOXYGEN__)
@@ -975,7 +1185,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(4);
 
-  /* [12.12.5] The size of a mutex is printed.*/
+  /* [12.15.5] The size of a mutex is printed.*/
   test_set_step(5);
   {
 #if CH_CFG_USE_MUTEXES || defined(__DOXYGEN__)
@@ -986,7 +1196,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(5);
 
-  /* [12.12.6] The size of a condition variable is printed.*/
+  /* [12.15.6] The size of a condition variable is printed.*/
   test_set_step(6);
   {
 #if CH_CFG_USE_CONDVARS || defined(__DOXYGEN__)
@@ -997,7 +1207,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(6);
 
-  /* [12.12.7] The size of an event source is printed.*/
+  /* [12.15.7] The size of an event source is printed.*/
   test_set_step(7);
   {
 #if CH_CFG_USE_EVENTS || defined(__DOXYGEN__)
@@ -1008,7 +1218,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(7);
 
-  /* [12.12.8] The size of an event listener is printed.*/
+  /* [12.15.8] The size of an event listener is printed.*/
   test_set_step(8);
   {
 #if CH_CFG_USE_EVENTS || defined(__DOXYGEN__)
@@ -1019,7 +1229,7 @@ static void rt_test_012_012_execute(void) {
   }
   test_end_step(8);
 
-  /* [12.12.9] The size of a mailbox is printed.*/
+  /* [12.15.9] The size of a mailbox is printed.*/
   test_set_step(9);
   {
 #if CH_CFG_USE_MAILBOXES || defined(__DOXYGEN__)
@@ -1031,11 +1241,11 @@ static void rt_test_012_012_execute(void) {
   test_end_step(9);
 }
 
-static const testcase_t rt_test_012_012 = {
+static const testcase_t rt_test_012_015 = {
   "RAM Footprint",
   NULL,
   NULL,
-  rt_test_012_012_execute
+  rt_test_012_015_execute
 };
 
 /****************************************************************************
@@ -1063,13 +1273,18 @@ const testcase_t * const rt_test_sequence_012_array[] = {
 #endif
   &rt_test_012_008,
   &rt_test_012_009,
-#if (CH_CFG_USE_SEMAPHORES == TRUE) || defined(__DOXYGEN__)
   &rt_test_012_010,
-#endif
-#if (CH_CFG_USE_MUTEXES ==TRUE) || defined(__DOXYGEN__)
+#if (CH_CFG_USE_TIMESTAMP == TRUE) || defined(__DOXYGEN__)
   &rt_test_012_011,
 #endif
   &rt_test_012_012,
+#if (CH_CFG_USE_SEMAPHORES == TRUE) || defined(__DOXYGEN__)
+  &rt_test_012_013,
+#endif
+#if (CH_CFG_USE_MUTEXES ==TRUE) || defined(__DOXYGEN__)
+  &rt_test_012_014,
+#endif
+  &rt_test_012_015,
   NULL
 };
 


### PR DESCRIPTION
Summary:
- Add RT tests for descriptor-based thread APIs, thread queues, event flag retrieval and pending waits, dynamic detached thread recovery, virtual timer lifecycle paths, and mutex handoff variants.
- Rework shared RT test thread storage so legacy working areas and the newer stack/object APIs can share the same buffers safely.
- Keep generated RT test sources in sync with configuration.xml.

Testing:
- Assertion build/run: make XOPT="-ggdb -O0 -fomit-frame-pointer -DTEST_DELAY_BETWEEN_TESTS=0" XDEFS="-DCH_DBG_ENABLE_ASSERTS=TRUE"; ./build/ch
- Coverage build/run: make XOPT="-ggdb -O0 -fomit-frame-pointer -DTEST_DELAY_BETWEEN_TESTS=0 -fprofile-arcs -ftest-coverage" XDEFS="-DCH_DBG_ENABLE_ASSERTS=TRUE"; ./build/ch; make gcov
- Latest coverage: RT total 96.88% of 1669; chmtx.c 100.00% lines and branches executed.

Notes:
- This PR is stacked on the registry reference fix PR because some coverage additions exercise reference accounting behavior fixed there. After PR #51 lands, this branch can be retargeted/rebased to main.