### PR TITLE
test/rt: link the RT test SIM variants on strict linkers (--defsym main-thread stack)

### DIFF
--- a/test/rt/variant/common.mk
+++ b/test/rt/variant/common.mk
@@ -33,8 +33,13 @@ ifeq ($(USE_LINK_GC),)
 endif
 
 # Linker extra options here.
+# The SIM ports have no linker script, so the main-thread stack-boundary
+# symbols referenced by ch_core0_cfg (chsys.c) are not provided; define them
+# as 0 (the simulator does not use the main-thread stack bounds), matching the
+# RT-Posix-Simulator demo. Without this the RT test binaries fail to link on
+# strict linkers (e.g. binutils 2.42).
 ifeq ($(USE_LDOPT),)
-  USE_LDOPT = 
+  USE_LDOPT = --defsym=__main_thread_stack_base__=0,--defsym=__main_thread_stack_end__=0
 endif
 
 # Enable this if you want link time optimizations (LTO).


### PR DESCRIPTION
🤖 Sheriff-prepared, for human review/merge. Test-build fix (no production code, no functional change).

**Problem:** the RT test SIM variants (`test/rt/variant/make/cfg*`, all via `common.mk` → SIM ports, no linker script) fail to link on strict linkers:
```
chsys.o ch_core0_cfg: undefined reference to `__main_thread_stack_base__' / `__main_thread_stack_end__'
```
`ch_core0_cfg` (chsys.c) references those symbols unconditionally; the SIM ports can't provide them. `RT-Posix-Simulator/Makefile` already carries the `--defsym=…=0` workaround, but the test variants don't — so they only link on lenient/older toolchains (reproduced failing on binutils 2.42 / default-PIE, succeeding elsewhere).

**Fix:** set the same `USE_LDOPT = --defsym=__main_thread_stack_base__=0,--defsym=__main_thread_stack_end__=0` default in `test/rt/variant/common.mk` (0 is fine — the simulator doesn't use the main-thread stack bounds), covering all variants.

**Verified:** `cfg25` and `cfg2` link with no override; the `cfg25` RT suite runs to `Final result: SUCCESS`.