### PR TITLE
RT: fix registry thread reference accounting (backport to 21.11.6)

### DIFF
--- a/os/common/abstractions/nasa_cfe/osal/src/osapi.c
+++ b/os/common/abstractions/nasa_cfe/osal/src/osapi.c
@@ -1902,7 +1902,8 @@ int32 OS_TaskDelete(uint32 task_id) {
   funcptr_t fp;
 
   /* Check for thread validity, getting a reference.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -1946,7 +1947,8 @@ int32 OS_TaskWait(uint32 task_id) {
   thread_t *tp = (thread_t *)task_id;
 
   /* Check for thread validity, getting a reference.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -2000,7 +2002,8 @@ int32 OS_TaskSetPriority(uint32 task_id, uint32 new_priority) {
   }
 
   /* Check for thread validity.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
 
@@ -2125,7 +2128,7 @@ int32 OS_TaskGetIdByName(uint32 *task_id, const char *task_name) {
  */
 int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop) {
   thread_t *tp = (thread_t *)task_id;
-  size_t wasize = (size_t)tp - (size_t)tp->wabase + sizeof (thread_t);
+  size_t wasize;
 
   /* NULL pointer checks.*/
   if (task_prop == NULL) {
@@ -2133,9 +2136,12 @@ int32 OS_TaskGetInfo(uint32 task_id, OS_task_prop_t *task_prop) {
   }
 
   /* Check for thread validity.*/
-  if (chRegFindThreadByPointer(tp) == NULL) {
+  tp = chRegFindThreadByPointer(tp);
+  if (tp == NULL) {
     return OS_ERR_INVALID_ID;
   }
+
+  wasize = (size_t)tp - (size_t)tp->wabase + sizeof (thread_t);
 
   strncpy(task_prop->name, tp->name, OS_MAX_API_NAME - 1);
   task_prop->creator    = (uint32)chSysGetIdleThreadX();

--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -97,11 +97,7 @@ ROMCONST chdebug_t ch_debug = {
 #endif
   .off_state                = (uint8_t)__CH_OFFSETOF(thread_t, state),
   .off_flags                = (uint8_t)__CH_OFFSETOF(thread_t, flags),
-#if CH_CFG_USE_DYNAMIC == TRUE
   .off_refs                 = (uint8_t)__CH_OFFSETOF(thread_t, refs),
-#else
-  .off_refs                 = (uint8_t)0,
-#endif
 #if CH_CFG_TIME_QUANTUM > 0
   .off_preempt              = (uint8_t)__CH_OFFSETOF(thread_t, ticks),
 #else
@@ -164,9 +160,9 @@ thread_t *chRegFirstThread(void) {
   /*lint -save -e413 [1.3] Safe to subtract a calculated offset.*/
   tp = threadref((p - __CH_OFFSETOF(thread_t, rqueue)));
   /*lint -restore*/
-#if CH_CFG_USE_DYNAMIC == TRUE
+  chDbgAssert(tp->refs < (trefs_t)255, "too many references");
+
   tp->refs++;
-#endif
   chSysUnlock();
 
   return tp;
@@ -200,16 +196,12 @@ thread_t *chRegNextThread(thread_t *tp) {
     ntp = threadref((p - __CH_OFFSETOF(thread_t, rqueue)));
     /*lint -restore*/
 
-#if CH_CFG_USE_DYNAMIC == TRUE
     chDbgAssert(ntp->refs < (trefs_t)255, "too many references");
 
     ntp->refs++;
-#endif
   }
   chSysUnlock();
-#if CH_CFG_USE_DYNAMIC == TRUE
   chThdRelease(tp);
-#endif
 
   return ntp;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,15 @@
 *****************************************************************************
 
 *** 21.11.6 ***
+- FIX: RT thread registry reference accounting was inconsistent when dynamic
+       threads are disabled (CH_CFG_USE_DYNAMIC = FALSE): chRegFirstThread()
+       and chRegNextThread() did not count the reference they hand out while
+       chThdRelease() still released it, risking a reference-count underflow.
+       The registry lookups now reference threads unconditionally (github
+       PR #51).
+- FIX: NASA OSAL OS_TaskGetInfo() computed the task working-area size before
+       validating the task id, dereferencing a possibly-invalid thread pointer;
+       the computation is now done after the validity check (github PR #51).
 - FIX: nvicSetSystemHandlerPriority() programmed the wrong SCB->SHPR field on
        Cortex-M0, M0+ and M23: the positive ChibiOS handler index was passed
        to the CMSIS _SHP_IDX()/_BIT_SHIFT() macros, which expect the negative


### PR DESCRIPTION
🤖 Sheriff-prepared backport, for human review/merge.

Backport to **stable-21.11.x** (21.11.6) of github PR #51, merged on `main` as `b50574e7`.

`chRegFirstThread()`/`chRegNextThread()` counted the reference they hand out only under `CH_CFG_USE_DYNAMIC == TRUE`, while `chThdRelease()` (always compiled) still released it — a reference-count underflow when dynamic threads are disabled. Registry lookups now reference unconditionally; `off_refs` is always the real offset. Also fixes NASA OSAL `OS_TaskGetInfo()` dereferencing the thread working area before validating the task id.

**Adaptation:** kept the 21.11.x `threadref()`/`__CH_OFFSETOF` idiom in `chRegFirstThread()` (the main commit uses the kernel-8-only `__CH_OWNEROF`). On 21.11.x `refs` is registry-gated and `chThdRelease()` is always compiled, so the unconditional accounting is sound.

**Gates (local):** `RT-STM32F407-DISCOVERY` builds clean default **and** with `CH_CFG_USE_DYNAMIC=FALSE` (the fix's target path); stylecheck clean on changed lines. (The RT SIM runner couldn't be built here — Akane lacks 32-bit multilib for the 21.11.x SIMIA32 sim — unrelated to this change.)