### PR TITLE
readme: annotate the RT registry refcount fix as backported to 21.11.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -86,10 +86,10 @@ See .devcontainer/README.md for included tools and usage.
        and chRegNextThread() did not count the reference they hand out while
        chThdRelease() still released it, risking a reference-count underflow.
        The registry lookups now reference threads unconditionally (github
-       PR #51).
+       PR #51)(backported to 21.11.6).
 - FIX: NASA OSAL OS_TaskGetInfo() computed the task working-area size before
        validating the task id, dereferencing a possibly-invalid thread pointer;
-       the computation is now done after the validity check (github PR #51).
+       the computation is now done after the validity check (github PR #51)(backported to 21.11.6).
 - FIX: nvicSetSystemHandlerPriority() programmed the wrong SCB->SHPR field on
        Cortex-M0, M0+ and M23: the positive ChibiOS handler index was passed
        to the CMSIS _SHP_IDX()/_BIT_SHIFT() macros, which expect the negative


### PR DESCRIPTION
🤖 Sheriff-prepared, docs-only. Appends `(backported to 21.11.6)` to the two readme.txt entries for the RT registry reference-accounting fix + OS_TaskGetInfo deref fix (github PR #51, commit `b50574e7`), now that the backport landed on `stable-21.11.x` via **#54** (merged). Per the changelog-record convention.