### PR TITLE
XHAL: add missing config extension fields

### DIFF
--- a/os/xhal/codegen/hal_efl.xml
+++ b/os/xhal/codegen/hal_efl.xml
@@ -32,6 +32,10 @@ typedef struct hal_efl_config EFlashConfig;
           <verbatim><![CDATA[
 /* End of the mandatory fields.*/
 efl_lld_config_fields;]]></verbatim>
+          <condition check="defined(EFL_CONFIG_EXT_FIELDS)">
+            <verbatim><![CDATA[
+EFL_CONFIG_EXT_FIELDS]]></verbatim>
+          </condition>
         </fields>
       </struct>
       <class type="regular" name="hal_efl_driver" namespace="efl"

--- a/os/xhal/codegen/hal_trng.xml
+++ b/os/xhal/codegen/hal_trng.xml
@@ -32,6 +32,10 @@ typedef struct hal_trng_config TRNGConfig;
           <verbatim><![CDATA[
 /* End of the mandatory fields.*/
 trng_lld_config_fields;]]></verbatim>
+          <condition check="defined(TRNG_CONFIG_EXT_FIELDS)">
+            <verbatim><![CDATA[
+TRNG_CONFIG_EXT_FIELDS]]></verbatim>
+          </condition>
         </fields>
       </struct>
       <class type="regular" name="hal_trng_driver" namespace="trng"

--- a/os/xhal/codegen/hal_usb_cdc.xml
+++ b/os/xhal/codegen/hal_usb_cdc.xml
@@ -93,6 +93,9 @@ struct hal_usb_cdc_config {
   uint16_t                  bulk_in_maxsize;
   uint16_t                  bulk_out_maxsize;
   uint16_t                  int_in_maxsize;
+#if (defined(USB_CDC_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  USB_CDC_CONFIG_EXT_FIELDS
+#endif /* defined(USB_CDC_CONFIG_EXT_FIELDS) */
 };]]></verbatim>
       <class type="abstract" name="hal_usb_cdc_service" namespace="cdcsvc"
         ancestorname="hal_usb_service" descr="USB CDC service">

--- a/os/xhal/codegen/hal_wdg.xml
+++ b/os/xhal/codegen/hal_wdg.xml
@@ -42,6 +42,10 @@ typedef struct hal_wdg_config WDGConfig;
           <verbatim><![CDATA[
 /* End of the mandatory fields.*/
 wdg_lld_config_fields;]]></verbatim>
+          <condition check="defined(WDG_CONFIG_EXT_FIELDS)">
+            <verbatim><![CDATA[
+WDG_CONFIG_EXT_FIELDS]]></verbatim>
+          </condition>
         </fields>
       </struct>
       <class type="regular" name="hal_wdg_driver" namespace="wdg"

--- a/os/xhal/include/hal_efl.h
+++ b/os/xhal/include/hal_efl.h
@@ -73,6 +73,9 @@ typedef struct hal_efl_config EFlashConfig;
 struct hal_efl_config {
   /* End of the mandatory fields.*/
   efl_lld_config_fields;
+#if (defined(EFL_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  EFL_CONFIG_EXT_FIELDS
+#endif /* defined(EFL_CONFIG_EXT_FIELDS) */
 };
 
 /**

--- a/os/xhal/include/hal_trng.h
+++ b/os/xhal/include/hal_trng.h
@@ -73,6 +73,9 @@ typedef struct hal_trng_config TRNGConfig;
 struct hal_trng_config {
   /* End of the mandatory fields.*/
   trng_lld_config_fields;
+#if (defined(TRNG_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  TRNG_CONFIG_EXT_FIELDS
+#endif /* defined(TRNG_CONFIG_EXT_FIELDS) */
 };
 
 /**

--- a/os/xhal/include/hal_usb_cdc.h
+++ b/os/xhal/include/hal_usb_cdc.h
@@ -157,6 +157,9 @@ struct hal_usb_cdc_config {
   uint16_t                  bulk_in_maxsize;
   uint16_t                  bulk_out_maxsize;
   uint16_t                  int_in_maxsize;
+#if (defined(USB_CDC_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  USB_CDC_CONFIG_EXT_FIELDS
+#endif /* defined(USB_CDC_CONFIG_EXT_FIELDS) */
 };
 
 /**

--- a/os/xhal/include/hal_wdg.h
+++ b/os/xhal/include/hal_wdg.h
@@ -88,6 +88,9 @@ typedef struct hal_wdg_config WDGConfig;
 struct hal_wdg_config {
   /* End of the mandatory fields.*/
   wdg_lld_config_fields;
+#if (defined(WDG_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  WDG_CONFIG_EXT_FIELDS
+#endif /* defined(WDG_CONFIG_EXT_FIELDS) */
 };
 
 /**

--- a/os/xhal/lib/complex/mmc-spi/hal_mmc_spi.h
+++ b/os/xhal/lib/complex/mmc-spi/hal_mmc_spi.h
@@ -155,6 +155,9 @@ struct hal_mmc_spi_config {
    * @brief Opaque callback argument.
    */
   void                     *arg;
+#if (defined(MMC_SPI_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  MMC_SPI_CONFIG_EXT_FIELDS
+#endif /* defined(MMC_SPI_CONFIG_EXT_FIELDS) */
 };
 
 /**

--- a/os/xhal/lib/complex/sensors/codegen/lis302dl.xml
+++ b/os/xhal/lib/complex/sensors/codegen/lis302dl.xml
@@ -204,6 +204,10 @@ typedef enum {
               <brief>Accelerometer high-pass filter selection.</brief>
             </field>
           </condition>
+          <condition check="defined(LIS302DL_CONFIG_EXT_FIELDS)">
+            <verbatim><![CDATA[
+LIS302DL_CONFIG_EXT_FIELDS]]></verbatim>
+          </condition>
         </fields>
       </struct>
       <class type="regular" name="lis302dl_driver" namespace="lis302dl"

--- a/os/xhal/lib/complex/sensors/devices/ST/lis302dl.h
+++ b/os/xhal/lib/complex/sensors/devices/ST/lis302dl.h
@@ -341,6 +341,9 @@ struct lis302dl_config {
    */
   lis302dl_acc_hp_t         acchighpass;
 #endif /* LIS302DL_USE_ADVANCED == TRUE */
+#if (defined(LIS302DL_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  LIS302DL_CONFIG_EXT_FIELDS
+#endif /* defined(LIS302DL_CONFIG_EXT_FIELDS) */
 };
 
 /**

--- a/os/xhal/lib/complex/xsnor/codegen/hal_xsnor_base.xml
+++ b/os/xhal/lib/complex/xsnor/codegen/hal_xsnor_base.xml
@@ -176,6 +176,10 @@
           <field name="options" ctype="int">
             <brief>Device-dependent options, used by subclasses only.</brief>
           </field>
+          <condition check="defined(XSNOR_CONFIG_EXT_FIELDS)">
+            <verbatim><![CDATA[
+XSNOR_CONFIG_EXT_FIELDS]]></verbatim>
+          </condition>
         </fields>
       </struct>
       <class name="hal_xsnor_base" type="abstract" namespace="xsnor"

--- a/os/xhal/lib/complex/xsnor/include/hal_xsnor_base.h
+++ b/os/xhal/lib/complex/xsnor/include/hal_xsnor_base.h
@@ -269,6 +269,9 @@ struct xsnor_config {
    * @brief       Device-dependent options, used by subclasses only.
    */
   int                       options;
+#if (defined(XSNOR_CONFIG_EXT_FIELDS)) || defined (__DOXYGEN__)
+  XSNOR_CONFIG_EXT_FIELDS
+#endif /* defined(XSNOR_CONFIG_EXT_FIELDS) */
 };
 
 /**


### PR DESCRIPTION
Summary:
- Add missing XXX_CONFIG_EXT_FIELDS hooks to generated XHAL configuration structures.
- Update XML sources and regenerate the affected XHAL, XSNOR, and LIS302DL headers.
- Add MMC_SPI_CONFIG_EXT_FIELDS to the hand-maintained MMC-SPI configuration structure.

Validation:
- fmpp -C config.fmpp in os/xhal/codegen
- fmpp -C config.fmpp in os/xhal/lib/complex/xsnor/codegen
- fmpp -C config.fmpp in os/xhal/lib/complex/sensors/codegen
- xmllint --noout on affected codegen XML sets
- git diff --check
- make -C demos/STM32/RT-STM32H563ZI-NUCLEO144-SB_HOST_SWITCHED -j4