### PR TITLE
RT: remove unused thread descriptor dispose parameter

### DIFF
--- a/demos/various/RT-ARMCM4-USELIB/rt/ch.h
+++ b/demos/various/RT-ARMCM4-USELIB/rt/ch.h
@@ -1209,10 +1209,10 @@ typedef struct {
 #define __THD_DECL_DATA(tname,twbase,twend,tprio,tfunc,targ,towner) { .name = (tname), .wbase = (stkline_t *)(void *)(twbase), .wend = (stkline_t *)(void *)(twend), .prio = (tprio), .funcp = (tfunc), .arg = (targ), .owner = (towner) }
 #define THD_DECL(var,tname,twbase,twend,tprio,tfunc,targ,towner) thread_descriptor_t var = __THD_DECL_DATA(tname, twbase, twend, tprio, tfunc, targ, towner)
 #define THD_DECL_STATIC(var,tname,twname,tprio,tfunc,targ,towner) thread_descriptor_t var = __THD_DECL_DATA(tname, THD_WORKING_AREA_BASE(twname), THD_WORKING_AREA_END(twname), tprio, tfunc, targ, towner)
-#define __THD_DESC_DATA(tname,twbase,twend,tprio,tfunc,targ,towner,tdispose) { .name = (tname), .wbase = (stkline_t *)(void *)(twbase), .wend = (stkline_t *)(void *)(twend), .prio = (tprio), .funcp = (tfunc), .arg = (targ), .owner = (towner), }
-#define THD_DESC_DECL(var,tname,twbase,twend,tprio,tfunc,targ,towner,tdispose) thread_descriptor_t var = __THD_DESC_DATA(tname, twbase, twend, tprio, tfunc, targ, towner, tdispose)
-#define THD_DESCRIPTOR(tname,wb,we,tprio,tfunc,targ) __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, NULL, NULL)
-#define THD_DESCRIPTOR_AFFINITY(tname,wb,we,tprio,tfunc,targ,oip) __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, oip, NULL)
+#define __THD_DESC_DATA(tname,twbase,twend,tprio,tfunc,targ,towner) { .name = (tname), .wbase = (stkline_t *)(void *)(twbase), .wend = (stkline_t *)(void *)(twend), .prio = (tprio), .funcp = (tfunc), .arg = (targ), .owner = (towner), }
+#define THD_DESC_DECL(var,tname,twbase,twend,tprio,tfunc,targ,towner) thread_descriptor_t var = __THD_DESC_DATA(tname, twbase, twend, tprio, tfunc, targ, towner)
+#define THD_DESCRIPTOR(tname,wb,we,tprio,tfunc,targ) __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, NULL)
+#define THD_DESCRIPTOR_AFFINITY(tname,wb,we,tprio,tfunc,targ,oip) __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, oip)
 #define chThdSleepSeconds(sec) chThdSleep(TIME_S2I(sec))
 #define chThdSleepMilliseconds(msec) chThdSleep(TIME_MS2I(msec))
 #define chThdSleepMicroseconds(usec) chThdSleep(TIME_US2I(usec))

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -308,7 +308,7 @@ typedef struct {
  * @deprecated
  */
 #define __THD_DESC_DATA(tname, twbase, twend, tprio,                        \
-                        tfunc, targ, towner, tdispose) {                    \
+                        tfunc, targ, towner) {                              \
   .name         = (tname),                                                  \
   .wbase        = (stkline_t *)(void *)(twbase),                            \
   .wend         = (stkline_t *)(void *)(twend),                             \
@@ -329,14 +329,13 @@ typedef struct {
  * @param[in] tfunc     thread function pointer
  * @param[in] targ      thread function argument
  * @param[in] towner    thread owner OS instance or @p NULL
- * @param[in] tdispose  thread dispose function or @p NULL
  *
  * @deprecated
  */
 #define THD_DESC_DECL(var, tname, twbase, twend, tprio,                     \
-                      tfunc, targ, towner, tdispose)                        \
+                      tfunc, targ, towner)                                  \
   thread_descriptor_t var = __THD_DESC_DATA(tname, twbase, twend, tprio,    \
-                                            tfunc, targ, towner, tdispose)
+                                            tfunc, targ, towner)
 
 /**
  * @brief   Thread descriptor initializer with no affinity.
@@ -351,7 +350,7 @@ typedef struct {
  * @deprecated
  */
 #define THD_DESCRIPTOR(tname, wb, we, tprio, tfunc, targ)                   \
-  __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, NULL, NULL)
+  __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, NULL)
 
 /**
  * @brief   Thread descriptor initializer with no affinity.
@@ -367,7 +366,7 @@ typedef struct {
  * @deprecated
  */
 #define THD_DESCRIPTOR_AFFINITY(tname, wb, we, tprio, tfunc, targ, oip)     \
-  __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, oip, NULL)
+  __THD_DESC_DATA(tname, wb, we, tprio, tfunc, targ, oip)
 /** @} */
 
 /**

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -570,7 +570,7 @@ thread_t *chThdCreateStatic(stkline_t *wbase, size_t wsize,
 #endif
 
   /* Initializing the thread_t structure using the passed parameters.*/
-  THD_DESC_DECL(desc, "noname", wbase, wend, prio, func, arg, currcore, NULL);
+  THD_DESC_DECL(desc, "noname", wbase, wend, prio, func, arg, currcore);
   tp = chThdObjectInit(threadref(stktop), &desc);
 
   /* Setting up the port-dependent part of the working area.*/


### PR DESCRIPTION
## Summary
- remove the unused tdispose parameter from deprecated RT thread descriptor macros
- update the internal static-thread descriptor call and the USELIB header mirror

## Testing
- rg -n "tdispose" os demos test
- make -C test/rt/testbuild -j$(nproc)
- ./build/ch from test/rt/testbuild

Note: please check stable-21.11.x too to see whether this cleanup should be applied there.