### PR TITLE
RT: make working-area reuse checks atomic

### DIFF
--- a/os/rt/include/chregistry.h
+++ b/os/rt/include/chregistry.h
@@ -128,6 +128,7 @@ extern "C" {
   thread_t *chRegNextThread(thread_t *tp);
   thread_t *chRegFindThreadByName(const char *name);
   thread_t *chRegFindThreadByPointer(thread_t *tp);
+  bool chRegIsWorkingAreaInUseI(stkline_t *wa);
   thread_t *chRegFindThreadByWorkingArea(stkline_t *wa);
 #ifdef __cplusplus
 }

--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -283,6 +283,35 @@ thread_t *chRegFindThreadByWorkingArea(stkline_t *wa) {
   return NULL;
 }
 
+/**
+ * @brief   Confirms that a working area is being used by some active thread.
+ *
+ * @param[in] wa        pointer to a static working area
+ * @retval true         if a matching thread has been found.
+ * @retval false        if a matching thread has not been found.
+ *
+ * @iclass
+ */
+bool chRegIsWorkingAreaInUseI(stkline_t *wa) {
+  ch_queue_t *tqp;
+
+  chDbgCheckClassI();
+
+  /* Scanning registry.*/
+  tqp = REG_HEADER(currcore)->next;
+  while (tqp != REG_HEADER(currcore)) {
+    thread_t *ctp = __CH_OWNEROF((uint8_t *)tqp, thread_t, rqueue);
+
+    if (chThdGetWorkingAreaX(ctp) == wa) {
+      return true;
+    }
+
+    tqp = tqp->next;
+  }
+
+  return false;
+}
+
 #endif /* CH_CFG_USE_REGISTRY == TRUE */
 
 /** @} */

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -262,6 +262,11 @@ thread_t *chThdSpawnSuspendedI(thread_t *tp,
              (tdp->wend > tdp->wbase) &&
              (((size_t)tdp->wend - (size_t)tdp->wbase) >= THD_STACK_SIZE(0)));
 
+#if CH_CFG_USE_REGISTRY == TRUE
+  chDbgAssert(!chRegIsWorkingAreaInUseI(tdp->wbase),
+              "working area in use");
+#endif
+
   /* Thread object initialization.*/
   tp = chThdObjectInit(tp, tdp);
 
@@ -294,11 +299,6 @@ thread_t *chThdSpawnSuspendedI(thread_t *tp,
  */
 thread_t *chThdSpawnSuspended(thread_t *tp,
                               const thread_descriptor_t *tdp) {
-
-#if CH_CFG_USE_REGISTRY == TRUE
-  chDbgAssert(chRegFindThreadByWorkingArea((void *)tdp->wbase) == NULL,
-              "working area in use");
-#endif
 
   thd_clear(tdp);
 
@@ -346,12 +346,6 @@ thread_t *chThdSpawnRunningI(thread_t *tp, const thread_descriptor_t *tdp) {
  * @iclass
  */
 thread_t *chThdSpawnRunning(thread_t *tp, const thread_descriptor_t *tdp) {
-
-#if (CH_CFG_USE_REGISTRY == TRUE) &&                                        \
-    ((CH_DBG_ENABLE_STACK_CHECK == TRUE) || (CH_CFG_USE_DYNAMIC == TRUE))
-  chDbgAssert(chRegFindThreadByWorkingArea((void *)tdp->wbase) == NULL,
-              "working area in use");
-#endif
 
   thd_clear(tdp);
 
@@ -407,6 +401,11 @@ thread_t *chThdCreateSuspendedI(const thread_descriptor_t *tdp) {
   chDbgCheck(MEM_IS_ALIGNED(stkbase, PORT_WORKING_AREA_ALIGN) &&
              MEM_IS_ALIGNED(stktop, PORT_STACK_ALIGN));
 
+#if CH_CFG_USE_REGISTRY == TRUE
+  chDbgAssert(!chRegIsWorkingAreaInUseI(tdp->wbase),
+              "working area in use");
+#endif
+
   /* The thread object is initialized but not started.*/
   tp = chThdObjectInit(threadref(stktop), tdp);
 
@@ -439,11 +438,6 @@ thread_t *chThdCreateSuspendedI(const thread_descriptor_t *tdp) {
  */
 thread_t *chThdCreateSuspended(const thread_descriptor_t *tdp) {
   thread_t *tp;
-
-#if CH_CFG_USE_REGISTRY == TRUE
-  chDbgAssert(chRegFindThreadByWorkingArea(tdp->wbase) == NULL,
-              "working area in use");
-#endif
 
 #if CH_DBG_FILL_THREADS == TRUE
   __thd_stackfill((uint8_t *)tdp->wbase, (uint8_t *)tdp->wend);
@@ -495,12 +489,6 @@ thread_t *chThdCreateI(const thread_descriptor_t *tdp) {
 thread_t *chThdCreate(const thread_descriptor_t *tdp) {
   thread_t *tp;
 
-#if (CH_CFG_USE_REGISTRY == TRUE) &&                                        \
-    ((CH_DBG_ENABLE_STACK_CHECK == TRUE) || (CH_CFG_USE_DYNAMIC == TRUE))
-  chDbgAssert(chRegFindThreadByWorkingArea(tdp->wbase) == NULL,
-              "working area in use");
-#endif
-
 #if CH_DBG_FILL_THREADS == TRUE
   __thd_stackfill((uint8_t *)tdp->wbase, (uint8_t *)tdp->wend);
 #endif
@@ -545,13 +533,6 @@ thread_t *chThdCreateStatic(stkline_t *wbase, size_t wsize,
   /* Other checks.*/
   chDbgCheck((prio <= HIGHPRIO) && (func != NULL));
 
-#if CH_CFG_USE_REGISTRY == TRUE
-  /* Special situation where the working area is already in use by an
-     active thread.*/
-  chDbgAssert(chRegFindThreadByWorkingArea(wbase) == NULL,
-              "working area in use");
-#endif
-
   /* Working area end address.*/
   wend = (uint8_t *)wbase + wsize;
 
@@ -579,6 +560,11 @@ thread_t *chThdCreateStatic(stkline_t *wbase, size_t wsize,
   chSysLock();
 
 #if CH_CFG_USE_REGISTRY == TRUE
+  /* Special situation where the working area is already in use by an
+     active thread.*/
+  chDbgAssert(!chRegIsWorkingAreaInUseI(wbase),
+              "working area in use");
+
   REG_INSERT(tp->owner, tp);
 #endif
 


### PR DESCRIPTION
## Summary
- add an I-class boolean registry scan for working-area presence without touching references
- move thread working-area reuse assertions into locked creation paths, immediately before registry insertion
- remove the non-atomic public-wrapper checks that used the reference-taking registry finder

## Testing
- git diff --check
- make -C test/rt/testbuild -j$(nproc)
- ./build/ch from test/rt/testbuild

Note: please check stable-21.11.x too and apply the same fix there if affected.