### PR TITLE
ROMFS: backport chunked-read and seek guards (21.11.x)

### DIFF
--- a/os/vfs/drivers/romfs/drvromfs_impl.inc
+++ b/os/vfs/drivers/romfs/drvromfs_impl.inc
@@ -243,6 +243,10 @@ static ssize_t romfs_chunked_read(void *session, vfs_offset_t offset,
     return CH_RET_EINVAL;
   }
 
+  if ((offset == descp->size) || (n == 0U)) {
+    return 0;
+  }
+
   transferred = 0U;
   while (n > 0U) {
     size_t chunk_index;
@@ -265,6 +269,9 @@ static ssize_t romfs_chunked_read(void *session, vfs_offset_t offset,
     copied = reader(descp, chunk_index, chunk_offset, buf, chunk_available);
     if (CH_RET_IS_ERROR(copied)) {
       return copied;
+    }
+    if ((copied == (ssize_t)0) || ((size_t)copied > chunk_available)) {
+      return CH_RET_EINVAL;
     }
 
     transferred += (size_t)copied;
@@ -989,9 +996,19 @@ static msg_t __romfile_setpos_impl(void *ip, vfs_offset_t offset,
     newpos = offset;
     break;
   case VFS_SEEK_CUR:
+    if (((offset > (vfs_offset_t)0) &&
+         (offset > (self->size - self->position))) ||
+        ((offset < (vfs_offset_t)0) &&
+         (offset < ((vfs_offset_t)0 - self->position)))) {
+      return CH_RET_EINVAL;
+    }
     newpos = self->position + offset;
     break;
   case VFS_SEEK_END:
+    if ((offset > (vfs_offset_t)0) ||
+        (offset < ((vfs_offset_t)0 - self->size))) {
+      return CH_RET_EINVAL;
+    }
     newpos = self->size + offset;
     break;
   default:


### PR DESCRIPTION
🤖 chibios-sheriff — backport (advisory)

Backport of **#59** (main commit `0d1d4d0`) to `stable-21.11.x`.

**Fixes** (defensive guards in `drvromfs_impl.inc`)
- `romfs_chunked_read`: early return at EOF / zero-length; reject a misbehaving chunk backend (`copied == 0` → would spin; `copied > chunk_available` → would overrun).
- `__romfile_setpos_impl`: validate `SEEK_CUR`/`SEEK_END` bounds before the signed `vfs_offset_t` addition.

**Adaptation:** none — cherry-pick applied cleanly.

**Local gates** (stable has no CI, and stable currently has no in-tree VFS/ROMFS *consumer* to link-build — the driver was backported as source in #32): `drvromfs.c` `-fsyntax-only` compiles clean against the stable F302 header set; `stylecheck.py` clean. The change is byte-identical in effect to #59 on `main`, which passed full CI (it compiles `drvromfs.c` via the SB_HOST_SWITCHED demo there).

**Changelog:** none — VFS/ROMFS debuts on stable in the pending 21.11.6 (via #32), so this is pre-release refinement of an unreleased subsystem (same call as #59 on main).

Sheriff-authored backport — a human reviews/merges.
