### PR TITLE
Add ARMv7-R platform support scaffolding

### DIFF
--- a/demos/various/RT-ARMCR8-GENERIC/Makefile
+++ b/demos/various/RT-ARMCR8-GENERIC/Makefile
@@ -122,7 +122,7 @@ include $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/mk/startup_armcr8.mk
 #include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
 # RTOS files (optional).
 include $(CHIBIOS)/os/rt/rt.mk
-include $(CHIBIOS)/os/common/ports/ARMv7-R/compilers/GCC/mk/port.mk
+include $(CHIBIOS)/os/common/ports/ARMv7-R/compilers/GCC/mk/port_simulator.mk
 # Auto-build files in ./source recursively.
 include $(CHIBIOS)/tools/mk/autobuild.mk
 # Other files (optional).
@@ -185,9 +185,7 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
-UDEFS = -DARMCR8_HAS_GIC=1                                   \
-        -DGIC_INTERFACE_BASE=0xAE000100U                      \
-        -DGIC_DISTRIBUTOR_BASE=0xAE001000U
+UDEFS =
 
 # The generic Renode Cortex-R8 model has an FPU. When the demo is built with
 # USE_FPU enabled then declare the generic device as FPU-capable.

--- a/demos/various/RT-ARMCR8-GENERIC/main.c
+++ b/demos/various/RT-ARMCR8-GENERIC/main.c
@@ -14,11 +14,9 @@
     limitations under the License.
 */
 
-#include "armcr8.h"
 #include "ch.h"
 
 #define R8_RENODE_PRIVATE_TIMER_BASE 0xAE000600U
-#define R8_RENODE_PRIVATE_TIMER_IRQ  29U
 #define R8_RENODE_PRIVATE_TIMER_FREQ 667000000U
 
 #define PTIMER_CONTROL_ENABLE        (1U << 0)
@@ -44,37 +42,27 @@ static volatile uint32_t fpu_error_counter;
 #endif
 
 /*
- * Demo-private IRQ dispatcher.
+ * Demo-private timer interrupt handler.
  */
-bool __port_irq_dispatch(void) {
-  IRQn_Type irqn;
+bool port_platform_timer_irq_handler(uint32_t intid) {
   bool preemption_required;
 
+  (void)intid;
+
   preemption_required = false;
-  irqn = GIC_AcknowledgePending();
+  R8_PRIVATE_TIMER->ISR = PTIMER_ISR_EVENT;
 
-  if (irqn == (IRQn_Type)R8_RENODE_PRIVATE_TIMER_IRQ) {
-    R8_PRIVATE_TIMER->ISR = PTIMER_ISR_EVENT;
-
-    chSysLockFromISR();
-    chSysTimerHandlerI();
-    preemption_required = chSchIsPreemptionRequired();
-    chSysUnlockFromISR();
-  }
-
-  GIC_EndInterrupt(irqn);
+  chSysLockFromISR();
+  chSysTimerHandlerI();
+  preemption_required = chSchIsPreemptionRequired();
+  chSysUnlockFromISR();
 
   return preemption_required;
 }
 
-static void gic_init(void) {
-
-  GIC_Enable();
-  GIC_SetPriority((IRQn_Type)R8_RENODE_PRIVATE_TIMER_IRQ, 0x80U);
-  GIC_SetTarget((IRQn_Type)R8_RENODE_PRIVATE_TIMER_IRQ, 1U);
-  GIC_EnableIRQ((IRQn_Type)R8_RENODE_PRIVATE_TIMER_IRQ);
-}
-
+/*
+ * Demo-private timer setup.
+ */
 static void timer_init(void) {
   uint32_t interval;
 
@@ -146,14 +134,13 @@ int main(void) {
   double expected;
 #endif
 
-  gic_init();
-  timer_init();
-
   /*
    * System initialization, the main() function becomes a thread and the
    * RTOS is active.
    */
   chSysInit();
+
+  timer_init();
 
   (void) chThdCreateStatic(waThread1,
                            sizeof(waThread1),

--- a/os/common/ports/ARM-common/GICv2/arm_gicv2.c
+++ b/os/common/ports/ARM-common/GICv2/arm_gicv2.c
@@ -1,0 +1,283 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARM-common/GICv2/arm_gicv2.c
+ * @brief   ARM Generic Interrupt Controller v2 support code.
+ *
+ * @addtogroup COMMON_ARM_GICV2
+ * @{
+ */
+
+#include "arm_gicv2.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#if !defined(GICV2_DISTRIBUTOR_BASE)
+#error "GICV2_DISTRIBUTOR_BASE or GIC_DISTRIBUTOR_BASE not defined"
+#endif
+
+#if !defined(GICV2_INTERFACE_BASE)
+#error "GICV2_INTERFACE_BASE or GIC_INTERFACE_BASE not defined"
+#endif
+
+#define GICD                            ((volatile uint32_t *)GICV2_DISTRIBUTOR_BASE)
+#define GICC                            ((volatile uint32_t *)GICV2_INTERFACE_BASE)
+
+#define GICD_CTLR                       (0x000U / 4U)
+#define GICD_ISENABLER                  (0x100U / 4U)
+#define GICD_ICENABLER                  (0x180U / 4U)
+#define GICD_ISPENDR                    (0x200U / 4U)
+#define GICD_ICPENDR                    (0x280U / 4U)
+#define GICD_IPRIORITYR                 (0x400U / 4U)
+#define GICD_ITARGETSR                  (0x800U / 4U)
+#define GICD_ICFGR                      (0xC00U / 4U)
+
+#define GICC_CTLR                       (0x000U / 4U)
+#define GICC_PMR                        (0x004U / 4U)
+#define GICC_IAR                        (0x00CU / 4U)
+#define GICC_EOIR                       (0x010U / 4U)
+
+#define GICC_PMR_ENABLE_ALL             0xFFU
+#define GIC_INTID_MASK                  0x3FFU
+
+/*===========================================================================*/
+/* Driver local types.                                                       */
+/*===========================================================================*/
+
+typedef struct {
+  uint32_t              intid;
+  gicv2_handler_t       handler;
+} gicv2_entry_t;
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+static gicv2_entry_t    gicv2_table[GICV2_MAX_HANDLERS];
+static uint32_t         gicv2_count;
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static gicv2_handler_t gicv2_find_handler(uint32_t intid) {
+  uint32_t i;
+
+  for (i = 0U; i < gicv2_count; i++) {
+    if (gicv2_table[i].intid == intid) {
+      return gicv2_table[i].handler;
+    }
+  }
+
+  return (gicv2_handler_t)0;
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes the GICv2 distributor and CPU interface.
+ * @details Per-interrupt routing is performed separately by the platform or
+ *          by individual drivers.
+ */
+void gicv2Init(void) {
+
+  gicv2_count = 0U;
+
+  GICD[GICD_CTLR] = 1U;
+  GICC[GICC_PMR]  = GICC_PMR_ENABLE_ALL;
+  GICC[GICC_CTLR] = 1U;
+}
+
+/**
+ * @brief   Registers an interrupt handler for an interrupt ID.
+ *
+ * @param[in] intid     the interrupt ID
+ * @param[in] handler   the interrupt handler
+ *
+ * @return              The operation status.
+ * @retval true         handler registered or replaced.
+ * @retval false        registration table full or invalid handler.
+ */
+bool gicv2RegisterHandler(uint32_t intid, gicv2_handler_t handler) {
+  uint32_t i;
+
+  if (handler == (gicv2_handler_t)0) {
+    return false;
+  }
+
+  for (i = 0U; i < gicv2_count; i++) {
+    if (gicv2_table[i].intid == intid) {
+      gicv2_table[i].handler = handler;
+      return true;
+    }
+  }
+
+  if (gicv2_count >= GICV2_MAX_HANDLERS) {
+    return false;
+  }
+
+  gicv2_table[gicv2_count].intid   = intid;
+  gicv2_table[gicv2_count].handler = handler;
+  gicv2_count++;
+
+  return true;
+}
+
+/**
+ * @brief   Unregisters an interrupt handler.
+ *
+ * @param[in] intid     the interrupt ID
+ */
+void gicv2UnregisterHandler(uint32_t intid) {
+  uint32_t i;
+
+  for (i = 0U; i < gicv2_count; i++) {
+    if (gicv2_table[i].intid == intid) {
+      gicv2_count--;
+      gicv2_table[i] = gicv2_table[gicv2_count];
+      return;
+    }
+  }
+}
+
+/**
+ * @brief   Acknowledges, dispatches and completes the current interrupt.
+ *
+ * @return              The registered handler return value, or @p false if no
+ *                      handler is registered for the acknowledged interrupt.
+ */
+bool gicv2Dispatch(void) {
+  gicv2_handler_t handler;
+  uint32_t iar;
+  uint32_t intid;
+  bool result;
+
+  result = false;
+  iar    = GICC[GICC_IAR];
+  intid  = iar & GIC_INTID_MASK;
+
+  if (intid != GICV2_SPURIOUS_IRQ) {
+    handler = gicv2_find_handler(intid);
+    if (handler != (gicv2_handler_t)0) {
+      result = handler(intid);
+    }
+    GICC[GICC_EOIR] = iar;
+  }
+
+  return result;
+}
+
+/**
+ * @brief   Sets the priority of an interrupt.
+ *
+ * @param[in] intid     the interrupt ID
+ * @param[in] priority  the interrupt priority byte, lower is higher priority
+ */
+void gicv2SetPriority(uint32_t intid, uint32_t priority) {
+  uint32_t shift;
+
+  shift = (intid % 4U) * 8U;
+  GICD[GICD_IPRIORITYR + (intid / 4U)] =
+    (GICD[GICD_IPRIORITYR + (intid / 4U)] & ~(0xFFU << shift)) |
+    ((priority & 0xFFU) << shift);
+}
+
+/**
+ * @brief   Sets interrupt CPU targets.
+ * @note    In GICv2, SGI/PPI target fields can be read-only or banked by CPU.
+ *
+ * @param[in] intid     the interrupt ID
+ * @param[in] targets   the CPU target mask byte
+ */
+void gicv2SetTargets(uint32_t intid, uint32_t targets) {
+  uint32_t shift;
+
+  shift = (intid % 4U) * 8U;
+  GICD[GICD_ITARGETSR + (intid / 4U)] =
+    (GICD[GICD_ITARGETSR + (intid / 4U)] & ~(0xFFU << shift)) |
+    ((targets & 0xFFU) << shift);
+}
+
+/**
+ * @brief   Sets the trigger configuration of an interrupt.
+ *
+ * @param[in] intid     the interrupt ID
+ * @param[in] config    @p GICV2_CONFIG_LEVEL or @p GICV2_CONFIG_EDGE
+ */
+void gicv2SetConfiguration(uint32_t intid, uint32_t config) {
+  uint32_t shift;
+
+  shift = (intid % 16U) * 2U;
+  GICD[GICD_ICFGR + (intid / 16U)] =
+    (GICD[GICD_ICFGR + (intid / 16U)] & ~(3U << shift)) |
+    ((config & 3U) << shift);
+}
+
+/**
+ * @brief   Configures and enables an interrupt.
+ *
+ * @param[in] intid     the interrupt ID
+ * @param[in] priority  the interrupt priority byte, lower is higher priority
+ * @param[in] config    @p GICV2_CONFIG_LEVEL or @p GICV2_CONFIG_EDGE
+ * @param[in] targets   the CPU target mask byte
+ */
+void gicv2EnableInterrupt(uint32_t intid,
+                          uint32_t priority,
+                          uint32_t config,
+                          uint32_t targets) {
+
+  gicv2SetConfiguration(intid, config);
+  gicv2SetPriority(intid, priority);
+  gicv2SetTargets(intid, targets);
+  GICD[GICD_ISENABLER + (intid / 32U)] = 1U << (intid % 32U);
+}
+
+/**
+ * @brief   Disables an interrupt.
+ *
+ * @param[in] intid     the interrupt ID
+ */
+void gicv2DisableInterrupt(uint32_t intid) {
+
+  GICD[GICD_ICENABLER + (intid / 32U)] = 1U << (intid % 32U);
+}
+
+/**
+ * @brief   Clears the pending state of an interrupt.
+ *
+ * @param[in] intid     the interrupt ID
+ */
+void gicv2ClearPending(uint32_t intid) {
+
+  GICD[GICD_ICPENDR + (intid / 32U)] = 1U << (intid % 32U);
+}
+
+/**
+ * @brief   Sets the pending state of an interrupt.
+ *
+ * @param[in] intid     the interrupt ID
+ */
+void gicv2SetPending(uint32_t intid) {
+
+  GICD[GICD_ISPENDR + (intid / 32U)] = 1U << (intid % 32U);
+}
+
+/** @} */

--- a/os/common/ports/ARM-common/GICv2/arm_gicv2.h
+++ b/os/common/ports/ARM-common/GICv2/arm_gicv2.h
@@ -1,0 +1,118 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARM-common/GICv2/arm_gicv2.h
+ * @brief   ARM Generic Interrupt Controller v2 support macros and functions.
+ *
+ * @addtogroup COMMON_ARM_GICV2
+ * @{
+ */
+
+#ifndef ARM_GICV2_H
+#define ARM_GICV2_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Interrupt ID returned by the CPU interface when no interrupt of
+ *          sufficient priority is pending.
+ */
+#define GICV2_SPURIOUS_IRQ             1023U
+
+/**
+ * @name    Interrupt trigger configurations
+ * @{
+ */
+#define GICV2_CONFIG_LEVEL             0U
+#define GICV2_CONFIG_EDGE              2U
+/** @} */
+
+/**
+ * @brief   CPU target mask.
+ */
+#define GICV2_CPU_TARGET(n)            (1U << (n))
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Maximum number of interrupt handlers that can be registered.
+ */
+#if !defined(GICV2_MAX_HANDLERS) || defined(__DOXYGEN__)
+#define GICV2_MAX_HANDLERS             32U
+#endif
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*
+ * CMSIS device headers conventionally define GIC_DISTRIBUTOR_BASE and
+ * GIC_INTERFACE_BASE. Platforms may define GICV2_* names directly instead.
+ */
+#if !defined(GICV2_DISTRIBUTOR_BASE) && defined(GIC_DISTRIBUTOR_BASE)
+#define GICV2_DISTRIBUTOR_BASE         GIC_DISTRIBUTOR_BASE
+#endif
+
+#if !defined(GICV2_INTERFACE_BASE) && defined(GIC_INTERFACE_BASE)
+#define GICV2_INTERFACE_BASE           GIC_INTERFACE_BASE
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Type of an interrupt handler.
+ * @return              The dispatcher return value.
+ */
+typedef bool (*gicv2_handler_t)(uint32_t intid);
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+  void gicv2Init(void);
+  bool gicv2RegisterHandler(uint32_t intid, gicv2_handler_t handler);
+  void gicv2UnregisterHandler(uint32_t intid);
+  bool gicv2Dispatch(void);
+  void gicv2SetPriority(uint32_t intid, uint32_t priority);
+  void gicv2SetTargets(uint32_t intid, uint32_t targets);
+  void gicv2SetConfiguration(uint32_t intid, uint32_t config);
+  void gicv2EnableInterrupt(uint32_t intid,
+                            uint32_t priority,
+                            uint32_t config,
+                            uint32_t targets);
+  void gicv2DisableInterrupt(uint32_t intid);
+  void gicv2ClearPending(uint32_t intid);
+  void gicv2SetPending(uint32_t intid);
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* ARM_GICV2_H */
+
+/** @} */

--- a/os/common/ports/ARM-common/GICv2/gicv2.mk
+++ b/os/common/ports/ARM-common/GICv2/gicv2.mk
@@ -1,0 +1,4 @@
+# List of the ARM GICv2 common support files.
+ALLCSRC += $(CHIBIOS)/os/common/ports/ARM-common/GICv2/arm_gicv2.c
+
+ALLINC  += $(CHIBIOS)/os/common/ports/ARM-common/GICv2

--- a/os/common/ports/ARMv7-R/chcore.h
+++ b/os/common/ports/ARMv7-R/chcore.h
@@ -475,6 +475,16 @@
 #else /* CH_CFG_SMP_MODE != TRUE */
 #endif /* CH_CFG_SMP_MODE != TRUE */
 
+/* Inclusion of platform sub-port support, if present.*/
+#if defined(PORT_HAS_PLATFORM) || defined(__DOXYGEN__)
+#if (PORT_HAS_PLATFORM != TRUE) && !defined(__DOXYGEN__)
+#error "PORT_HAS_PLATFORM must be set to TRUE when defined"
+#endif
+#if !defined(_FROM_ASM_)
+#include "port_platform.h"
+#endif
+#endif
+
 /*===========================================================================*/
 /* Module data structures and types.                                         */
 /*===========================================================================*/
@@ -646,6 +656,10 @@ static inline void port_init(os_instance_t *oip) {
 
 #if PORT_MPU_INITIALIZE == TRUE
   __port_mpu_init();
+#endif
+
+#if defined(port_platform_init)
+  port_platform_init(oip);
 #endif
 
 #if defined(port_smp_init)

--- a/os/common/ports/ARMv7-R/compilers/GCC/mk/port_simulator.mk
+++ b/os/common/ports/ARMv7-R/compilers/GCC/mk/port_simulator.mk
@@ -1,0 +1,20 @@
+# List of the ChibiOS/RT ARMv7-R simulator port files.
+
+# Generic ARMv7-R port.
+include $(CHIBIOS)/os/common/ports/ARMv7-R/compilers/GCC/mk/port.mk
+
+# Simulator interrupt controller support.
+include $(CHIBIOS)/os/common/ports/ARM-common/GICv2/gicv2.mk
+
+DDEFS += -DARMCR8_HAS_GIC=1                                   \
+         -DPORT_HAS_PLATFORM=TRUE                             \
+         -DGICV2_INTERFACE_BASE=0xAE000100U                    \
+         -DGICV2_DISTRIBUTOR_BASE=0xAE001000U
+
+PORTSIMSRC = $(CHIBIOS)/os/common/ports/ARMv7-R/platforms/simulator/port_platform.c
+
+PORTSIMINC = $(CHIBIOS)/os/common/ports/ARMv7-R/platforms/simulator
+
+# Shared variables.
+ALLCSRC += $(PORTSIMSRC)
+ALLINC  += $(PORTSIMINC)

--- a/os/common/ports/ARMv7-R/platforms/simulator/port_platform.c
+++ b/os/common/ports/ARMv7-R/platforms/simulator/port_platform.c
@@ -1,0 +1,85 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARMv7-R/platforms/simulator/port_platform.c
+ * @brief   ARMv7-R simulator sub-port support code.
+ *
+ * @addtogroup ARMV7R_SIMULATOR
+ * @{
+ */
+
+#include "arm_gicv2.h"
+#include "ch.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define R8_RENODE_PRIVATE_TIMER_IRQ     29U
+#define R8_RENODE_PRIVATE_TIMER_PRIO    0x80U
+
+/*===========================================================================*/
+/* Driver local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Simulator IRQ dispatcher adapter.
+ *
+ * @return              The preemption-required flag.
+ *
+ * @notapi
+ */
+bool __port_irq_dispatch(void) {
+
+  return gicv2Dispatch();
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+extern bool port_platform_timer_irq_handler(uint32_t intid);
+
+/**
+ * @brief   Initializes simulator interrupt-controller support.
+ */
+void __port_platform_init(os_instance_t *oip) {
+
+  (void)oip;
+
+  gicv2Init();
+  (void) gicv2RegisterHandler(R8_RENODE_PRIVATE_TIMER_IRQ,
+                              port_platform_timer_irq_handler);
+  gicv2EnableInterrupt(R8_RENODE_PRIVATE_TIMER_IRQ,
+                       R8_RENODE_PRIVATE_TIMER_PRIO,
+                       GICV2_CONFIG_LEVEL,
+                       GICV2_CPU_TARGET(0U));
+}
+
+/** @} */

--- a/os/common/ports/ARMv7-R/platforms/simulator/port_platform.h
+++ b/os/common/ports/ARMv7-R/platforms/simulator/port_platform.h
@@ -1,0 +1,54 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARMv7-R/platforms/simulator/port_platform.h
+ * @brief   ARMv7-R simulator sub-port support.
+ *
+ * @addtogroup ARMV7R_SIMULATOR
+ * @{
+ */
+
+#ifndef PORT_PLATFORM_H
+#define PORT_PLATFORM_H
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Platform-related port initialization.
+ * @note    The port checks on presence of this macro so this must be a macro.
+ *
+ * @param[in, out] oip  pointer to the @p os_instance_t structure
+ */
+#define port_platform_init(oip) __port_platform_init(oip)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+  void __port_platform_init(os_instance_t *oip);
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* PORT_PLATFORM_H */
+
+/** @} */

--- a/os/common/startup/ARMCRx/compilers/GCC/ld/RZV2H_CR8.ld
+++ b/os/common/startup/ARMCRx/compilers/GCC/ld/RZV2H_CR8.ld
@@ -1,0 +1,107 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * Renesas RZ/V2H Cortex-R8 (CR8) memory setup - TCM-resident bring-up image.
+ *
+ * The CR8 is a sub-core started by the application processor (RZ Multi-OS
+ * Package) or by the debugger; it has no private boot flash. It boots only
+ * from TCM and fetches the reset vector at core address 0x0 (VINITHI = low,
+ * fixed) - the core view of its 128 KB I-TCM. The D-TCM is disabled out of
+ * reset and is not used here.
+ *
+ * Everything is RAM: vectors, code, data, stacks and heap all live in the one
+ * 128 KB I-TCM region, so there is no separate load/flash region and no fixed
+ * code/data boundary - the heap takes whatever I-TCM is left after code, data
+ * and stacks. Data in I-TCM is safe because the ARMv7-R port uses no
+ * LDREX/STREX (which the I-TCM forbids). All the rules' *_FLASH region aliases
+ * therefore point to the same RAM region, .data is loaded at its run address
+ * (LMA = VMA), and rules_code is included first so the vector table stays at
+ * 0x0.
+ *
+ * Memory map (HW manual 2.2.4.5 / 2.2.4.6.3):
+ *   I-TCM core view : 0x00000000, 128 KB  (system view 0x12040000).
+ *   D-TCM           : system view 0x12060000, 128 KB, disabled out of reset.
+ *   DDR0            : 0x40000000.. - not mapped here.
+ *
+ * Larger images can use the separate DDR-resident script
+ * (RZV2H_CR8_DDR.ld) together with a suitable MPU/cache setup.
+ */
+
+__und_stack_size__ = DEFINED(__und_stack_size__) ? __und_stack_size__ : 0x100;
+__abt_stack_size__ = DEFINED(__abt_stack_size__) ? __abt_stack_size__ : 0x100;
+__fiq_stack_size__ = DEFINED(__fiq_stack_size__) ? __fiq_stack_size__ : 0x100;
+__irq_stack_size__ = DEFINED(__irq_stack_size__) ? __irq_stack_size__ : 0x400;
+__svc_stack_size__ = DEFINED(__svc_stack_size__) ? __svc_stack_size__ : 0x100;
+__sys_stack_size__ = DEFINED(__sys_stack_size__) ? __sys_stack_size__ : 0x800;
+
+MEMORY
+{
+    ram0   (wx) : org = 0x00000000, len = 128k  /* I-TCM, core view: all.*/
+    flash0 (rx) : org = 0x00000000, len = 0
+    flash1 (rx) : org = 0x00000000, len = 0
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram1   (wx) : org = 0x00000000, len = 0
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x00000000, len = 0
+    ram5   (wx) : org = 0x00000000, len = 0
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x00000000, len = 0
+}
+
+/* All sections live in the single I-TCM region (ram0); the rules' *_FLASH
+   aliases (load regions) point there too, so load address equals run address.*/
+REGION_ALIAS("VECTORS_FLASH", ram0);
+REGION_ALIAS("VECTORS_FLASH_LMA", ram0);
+REGION_ALIAS("XTORS_FLASH", ram0);
+REGION_ALIAS("XTORS_FLASH_LMA", ram0);
+REGION_ALIAS("TEXT_FLASH", ram0);
+REGION_ALIAS("TEXT_FLASH_LMA", ram0);
+REGION_ALIAS("RODATA_FLASH", ram0);
+REGION_ALIAS("RODATA_FLASH_LMA", ram0);
+REGION_ALIAS("VARIOUS_FLASH", ram0);
+REGION_ALIAS("VARIOUS_FLASH_LMA", ram0);
+REGION_ALIAS("RAM_INIT_FLASH_LMA", ram0);
+REGION_ALIAS("STACKS_RAM", ram0);
+REGION_ALIAS("C1_STACKS_RAM", ram0);
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", ram0);
+REGION_ALIAS("BSS_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* No non-cacheable DMA slice in this (TCM-resident) image: the two symbols
+   coincide so platform MPU setup code can skip the non-cacheable region.*/
+__nocache_base__ = ORIGIN(ram0);
+__nocache_end__  = ORIGIN(ram0);
+
+/* Code rules first so .vectors lands at 0x0 (the reset fetch address).*/
+INCLUDE rules_code.ld
+
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
+
+/* Stack rules inclusion.*/
+INCLUDE rules_stacks.ld
+INCLUDE rules_stacks_c1.ld
+
+/* Memory rules inclusion (the heap takes the rest of the region).*/
+INCLUDE rules_memory.ld

--- a/os/common/startup/ARMCRx/compilers/GCC/ld/RZV2H_CR8_DDR.ld
+++ b/os/common/startup/ARMCRx/compilers/GCC/ld/RZV2H_CR8_DDR.ld
@@ -1,0 +1,129 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * Renesas RZ/V2H Cortex-R8 (CR8) memory setup - DDR-resident image.
+ *
+ * The CR8 is a sub-core with no boot flash. Hardware facts that shape this
+ * script (HW manual R01UH1032EJ0130, Table 2.2-39):
+ *   - The CR8 boots from TCM (INITRAM0 = 1, "value is fixed") and the
+ *     exception vector base is the low address 0x0 (VINITHI = 0, "value is
+ *     fixed"); the core has no VBAR. So at run time the exception vector table
+ *     MUST reside at core address 0x0 - the core view of the 128 KB I-TCM.
+ *     DDR is at 0x40000000 and can never appear at 0x0.
+ *   - Everything else (crt0, exception handlers, code, data, stacks, heap) is
+ *     free to live in DDR: the reset table at 0x0 reaches the handlers with
+ *     absolute "ldr pc, =handler", so the TCM->DDR jump has no range limit.
+ *
+ * Image model - the whole ELF loads into DDR (only the ~64 byte vector table
+ * ends up in TCM, copied there at start-up):
+ *   - .vectors runs at VMA 0x0 (I-TCM) but is LOADED in DDR (region "vec").
+ *     crt0 copies the table from DDR to 0x0 on start-up; this REQUIRES
+ *     CRT0_INIT_VECTORS = TRUE in the demo. CRT0_VBAR_INIT stays FALSE (the
+ *     CR8 has no VBAR).
+ *   - All other sections have LMA = VMA in DDR, so "gdb load" writes DDR only.
+ *     For development the CR8 starts with "setpc <entry>" (not "setpc 0": the
+ *     I-TCM is empty until crt0 has run the vector copy).
+ *
+ * DDR window (bench-confirmed via U-Boot bdinfo): normal-world DRAM bank 0
+ * starts at 0x48000000 - the low 0x40000000-0x47FFFFFF is the secure TF-A
+ * carve-out, not reachable by the non-secure CR8 - and 0x48000000-0x57FFFFFF
+ * (256 MiB) is free. This script maps a 128 MiB slice from 0x48000000; the CR8
+ * was bench-verified to read and write this window.
+ *
+ * Data in DDR is safe for the ARMv7-R port (it uses no LDREX/STREX). The
+ * platform code is expected to provide the required MPU/cache setup.
+ */
+
+__und_stack_size__ = DEFINED(__und_stack_size__) ? __und_stack_size__ : 0x100;
+__abt_stack_size__ = DEFINED(__abt_stack_size__) ? __abt_stack_size__ : 0x100;
+__fiq_stack_size__ = DEFINED(__fiq_stack_size__) ? __fiq_stack_size__ : 0x100;
+__irq_stack_size__ = DEFINED(__irq_stack_size__) ? __irq_stack_size__ : 0x400;
+__svc_stack_size__ = DEFINED(__svc_stack_size__) ? __svc_stack_size__ : 0x100;
+__sys_stack_size__ = DEFINED(__sys_stack_size__) ? __sys_stack_size__ : 0x800;
+
+MEMORY
+{
+    itcm   (wx) : org = 0x00000000, len = 128k          /* I-TCM core view: runtime vector table.*/
+    vec    (rx) : org = 0x48000000, len = 0x100         /* DDR: load image (LMA) of .vectors.*/
+    ram0   (wx) : org = 0x48000100, len = 120M - 0x100  /* DDR: code/rodata/data/bss/stacks/heap.*/
+    flash0 (rx) : org = 0x00000000, len = 0
+    flash1 (rx) : org = 0x00000000, len = 0
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram1   (wx) : org = 0x4F800000, len = 8M             /* DDR: non-cacheable DMA slice.*/
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x00000000, len = 0
+    ram5   (wx) : org = 0x00000000, len = 0
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x00000000, len = 0
+}
+
+/* .vectors runs at 0x0 (I-TCM) with its load copy in DDR (vec); crt0 copies it
+   to 0x0 (CRT0_INIT_VECTORS=TRUE). Every other section lives entirely in DDR
+   (LMA = VMA), so the loadable image is DDR-only.*/
+REGION_ALIAS("VECTORS_FLASH", itcm);
+REGION_ALIAS("VECTORS_FLASH_LMA", vec);
+REGION_ALIAS("XTORS_FLASH", ram0);
+REGION_ALIAS("XTORS_FLASH_LMA", ram0);
+REGION_ALIAS("TEXT_FLASH", ram0);
+REGION_ALIAS("TEXT_FLASH_LMA", ram0);
+REGION_ALIAS("RODATA_FLASH", ram0);
+REGION_ALIAS("RODATA_FLASH_LMA", ram0);
+REGION_ALIAS("VARIOUS_FLASH", ram0);
+REGION_ALIAS("VARIOUS_FLASH_LMA", ram0);
+REGION_ALIAS("RAM_INIT_FLASH_LMA", ram0);
+REGION_ALIAS("STACKS_RAM", ram0);
+REGION_ALIAS("C1_STACKS_RAM", ram0);
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", ram0);
+REGION_ALIAS("BSS_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* DDR slice for the non-cacheable DMA area (.nocache / __nocache_* variables).
+   __nocache_base__/__nocache_end__ size the matching MPU region as the whole
+   power-of-2 slice for platform MPU setup code.*/
+REGION_ALIAS("NOCACHE_RAM", ram1);
+__nocache_base__ = ORIGIN(ram1);
+__nocache_end__  = ORIGIN(ram1) + LENGTH(ram1);
+
+SECTIONS
+{
+    .nocache (NOLOAD) : ALIGN(4)
+    {
+        *(.nocache)
+        *(.nocache.*)
+        *(.bss.__nocache_*)
+    } > NOCACHE_RAM
+}
+
+/* Code rules first; .vectors maps to the I-TCM (VMA 0x0), load copy in DDR.*/
+INCLUDE rules_code.ld
+
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
+
+/* Stack rules inclusion.*/
+INCLUDE rules_stacks.ld
+INCLUDE rules_stacks_c1.ld
+
+/* Memory rules inclusion (the heap takes the rest of ram0).*/
+INCLUDE rules_memory.ld

--- a/os/common/startup/ARMCRx/compilers/GCC/mk/startup_rzv2h.mk
+++ b/os/common/startup/ARMCRx/compilers/GCC/mk/startup_rzv2h.mk
@@ -1,0 +1,17 @@
+# List of the ChibiOS Renesas RZ/V2H Cortex-R8 startup and CMSIS files.
+STARTUPSRC = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/crt1.c
+
+STARTUPASM = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/crt0_v7r.S \
+             $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/vectors.S
+
+STARTUPINC = $(CHIBIOS)/os/common/portability/GCC \
+             $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC \
+             $(CHIBIOS)/os/common/startup/ARMCRx/devices/RZV2H \
+             $(CHIBIOS)/os/common/ext/ARM/CMSIS6/Include
+
+STARTUPLD  = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/ld
+
+# Shared variables
+ALLXASMSRC += $(STARTUPASM)
+ALLCSRC    += $(STARTUPSRC)
+ALLINC     += $(STARTUPINC)

--- a/os/common/startup/ARMCRx/devices/RZV2H/crparams.h
+++ b/os/common/startup/ARMCRx/devices/RZV2H/crparams.h
@@ -1,0 +1,86 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RZV2H/crparams.h
+ * @brief   ARM Cortex-R8 parameters for the Renesas RZ/V2H.
+ *
+ * @defgroup ARMCRx_RZV2H RZ/V2H Specific Parameters
+ * @ingroup ARMCRx_SPECIFIC
+ * @details This file contains the Cortex-R8 specific parameters for the
+ *          Renesas RZ/V2H platform.
+ * @{
+ */
+
+#ifndef CRPARAMS_H
+#define CRPARAMS_H
+
+/**
+ * @brief   Cortex core model.
+ */
+#define CORTEX_MODEL            8
+
+/**
+ * @brief   Floating Point unit presence.
+ */
+#define ARMCR8_HAS_FPU          1
+#define CORTEX_HAS_FPU          ARMCR8_HAS_FPU
+
+/**
+ * @brief   Generic Interrupt Controller presence.
+ */
+#define ARMCR8_HAS_GIC          1
+
+/**
+ * @brief   Vectored Interrupt Controller presence.
+ */
+#define ARMCR8_HAS_VIC          0
+
+/**
+ * @brief   MPU presence.
+ */
+#define ARMCR8_HAS_MPU          1
+#define CORTEX_HAS_MPU          ARMCR8_HAS_MPU
+
+/**
+ * @brief   Number of MPU regions.
+ */
+#define ARMCR8_MPU_REGIONS      16
+#define CORTEX_MPU_REGIONS      ARMCR8_MPU_REGIONS
+
+/**
+ * @brief   Instruction cache presence.
+ */
+#define ARMCR8_HAS_ICACHE       1
+
+/**
+ * @brief   Data cache presence.
+ */
+#define ARMCR8_HAS_DCACHE       1
+
+/**
+ * @brief   DTCM presence.
+ */
+#define ARMCR8_HAS_DTCM         1
+
+/**
+ * @brief   ECC presence.
+ */
+#define ARMCR8_HAS_ECC          1
+
+#endif /* CRPARAMS_H */
+
+/** @} */

--- a/os/common/startup/ARMCRx/devices/RZV2H/rzv2h.h
+++ b/os/common/startup/ARMCRx/devices/RZV2H/rzv2h.h
@@ -1,0 +1,61 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RZV2H/rzv2h.h
+ * @brief   ARM Cortex-R8 CMSIS device header for the Renesas RZ/V2H.
+ *
+ * @addtogroup ARMCRx_RZV2H
+ * @{
+ */
+
+#ifndef RZV2H_H
+#define RZV2H_H
+
+#include "crparams.h"
+
+#define __CR8_REV              0x0003U
+#define __FPU_PRESENT          ARMCR8_HAS_FPU
+#define __VIC_PRESENT          ARMCR8_HAS_VIC
+#define __GIC_PRESENT          ARMCR8_HAS_GIC
+#define __MPU_PRESENT          ARMCR8_HAS_MPU
+#define __ICACHE_PRESENT       ARMCR8_HAS_ICACHE
+#define __DCACHE_PRESENT       ARMCR8_HAS_DCACHE
+#define __DTCM_PRESENT         ARMCR8_HAS_DTCM
+#define __ECC_PRESENT          ARMCR8_HAS_ECC
+
+/* GIC base addresses. The Cortex-R8 GIC lives in the MPCore private space at
+   PERIPHBASE = 0x12C10000 (CPU interface +0x100, distributor +0x1000). They
+   are defined here, before core_cr8.h, because the CMSIS GICv2 register set
+   and interrupt-controller support code consume them. */
+#define GIC_INTERFACE_BASE     0x12C10100U
+#define GIC_DISTRIBUTOR_BASE   0x12C11000U
+
+/**
+ * @brief   Placeholder interrupt number type.
+ * @details The Cortex-R8 GIC interrupt IDs are handled directly by the port
+ *          GIC driver; the CMSIS @p IRQn_Type enumeration is not used for the
+ *          SoC interrupt map.
+ */
+typedef enum {
+  RZV2H_GenericIRQ0_IRQn = 0
+} IRQn_Type;
+
+#include "core_cr8.h"
+
+#endif /* RZV2H_H */
+
+/** @} */


### PR DESCRIPTION
## Summary
- add optional ARM-common GICv2 support with full-width interrupt IDs
- add ARMv7-R platform hook support and a simulator platform module
- move the generic R8 simulator demo to the simulator sub-port
- add RZ/V2H Cortex-R8 startup headers and linker scripts

## Testing
- make -C demos/various/RT-ARMCR8-GENERIC
- Renode 0.5s smoke: main_counter=3, thread_counter=4
- make -C demos/various/RT-ARMCR8-GENERIC USE_FPU=softfp
- Renode 3s FPU smoke: fpu_error_counter=0, counters advancing
- make -C demos/various/RT-ARMCR8-GENERIC clean