### PR TITLE
RT: fix memory pool alignment in dynamic thread test

### DIFF
--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -4902,7 +4902,8 @@ test_assert(largest1 == largest2, "largest fragment size changed");]]></value>
           </condition>
           <various_code>
             <setup_code>
-              <value><![CDATA[chPoolObjectInit(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE), NULL);]]></value>
+              <value><![CDATA[chPoolObjectInitAligned(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),
+                        PORT_WORKING_AREA_ALIGN, NULL);]]></value>
             </setup_code>
             <teardown_code>
               <value><![CDATA[chPoolObjectDispose(&mp1);]]></value>

--- a/test/rt/source/test/rt_test_sequence_011.c
+++ b/test/rt/source/test/rt_test_sequence_011.c
@@ -209,7 +209,8 @@ static const testcase_t rt_test_011_001 = {
  */
 
 static void rt_test_011_002_setup(void) {
-  chPoolObjectInit(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE), NULL);
+  chPoolObjectInitAligned(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),
+                          PORT_WORKING_AREA_ALIGN, NULL);
 }
 
 static void rt_test_011_002_teardown(void) {


### PR DESCRIPTION
## Summary
- initialize the dynamic-thread memory pool test with PORT_WORKING_AREA_ALIGN
- regenerate the RT test source from test/rt/configuration.xml

## Testing
- fmpp -C config.fmpp in test/rt
- make in test/rt/testbuild
- ./build/ch in test/rt/testbuild
- make clean in test/rt/testbuild

## Back-port
Required for 21.11.x.