### PR TITLE
RT: backport dynamic-thread memory pool alignment test fix (21.11.x)

### DIFF
--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -3809,7 +3809,8 @@ test_assert(largest1 == largest2, "largest fragment size changed");]]></value>
           </condition>
           <various_code>
             <setup_code>
-              <value><![CDATA[chPoolObjectInit(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE), NULL);]]></value>
+              <value><![CDATA[chPoolObjectInitAligned(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),
+                        PORT_WORKING_AREA_ALIGN, NULL);]]></value>
             </setup_code>
             <teardown_code>
               <value />

--- a/test/rt/source/test/rt_test_sequence_011.c
+++ b/test/rt/source/test/rt_test_sequence_011.c
@@ -203,7 +203,8 @@ static const testcase_t rt_test_011_001 = {
  */
 
 static void rt_test_011_002_setup(void) {
-  chPoolObjectInit(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE), NULL);
+  chPoolObjectInitAligned(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE),
+                          PORT_WORKING_AREA_ALIGN, NULL);
 }
 
 static void rt_test_011_002_execute(void) {


### PR DESCRIPTION
🤖 chibios-sheriff — backport (advisory)

Backport of **#69** (main commit `fbbfad3`) to `stable-21.11.x`.

**Fix**
- The dynamic-thread test memory pool is initialized with `chPoolObjectInitAligned(&mp1, THD_WORKING_AREA_SIZE(THREADS_STACK_SIZE), PORT_WORKING_AREA_ALIGN, NULL)` instead of `chPoolObjectInit` (`PORT_NATURAL_ALIGN`), so the pooled thread working areas meet the port's WA alignment. Source regenerated from `test/rt/configuration.xml`.

**Adaptation:** none — cherry-pick auto-merged cleanly; `chPoolObjectInitAligned` and `PORT_WORKING_AREA_ALIGN` are present on stable.

**Local gates** (stable has no CI): regenerating `rt_test_sequence_011.c` from stable's `configuration.xml` reproduces the committed file with **zero drift**; `test/rt/testbuild` builds and runs `Final result: SUCCESS` (rt + oslib).

**Changelog:** none — test-suite-only change (matches #69 on main).

Sheriff-authored backport — a human reviews/merges.
