### PR TITLE
Add Makefile rules to build .uf2 images for RP MCUs as part of the main make target ("all")

### DIFF
--- a/demos/RP/RT-RP2040-PICO/Makefile
+++ b/demos/RP/RT-RP2040-PICO/Makefile
@@ -89,6 +89,7 @@ include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
 # HAL-OSAL files (optional).
 include $(CHIBIOS)/os/hal/hal.mk
 include $(CHIBIOS)/os/hal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
 include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
 include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
 # RTOS files (optional).
@@ -174,11 +175,7 @@ include $(RULESPATH)/rules.mk
 # Custom rules
 #
 
-PICOTOOL ?= picotool
-
-$(BUILDDIR)/$(PROJECT).uf2: $(BUILDDIR)/$(PROJECT).elf
-	$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
-
+# basic firmware uploading via bootloader, requires uf2 build via rp_uf2_image.mk
 upload: $(BUILDDIR)/$(PROJECT).uf2
 	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
 

--- a/demos/RP/RT-RP2350-PICO2/Makefile
+++ b/demos/RP/RT-RP2350-PICO2/Makefile
@@ -89,6 +89,7 @@ include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
 # HAL-OSAL files (optional).
 include $(CHIBIOS)/os/hal/hal.mk
 include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
 include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
 include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
 # RTOS files (optional).
@@ -174,11 +175,7 @@ include $(RULESPATH)/rules.mk
 # Custom rules
 #
 
-PICOTOOL ?= picotool
-
-$(BUILDDIR)/$(PROJECT).uf2: $(BUILDDIR)/$(PROJECT).elf
-	$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
-
+# basic firmware uploading via bootloader, requires uf2 build via rp_uf2_image.mk
 upload: $(BUILDDIR)/$(PROJECT).uf2
 	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
 

--- a/os/hal/ports/RP/rp_uf2_image.mk
+++ b/os/hal/ports/RP/rp_uf2_image.mk
@@ -1,0 +1,24 @@
+# make rules for building an .uf2 image, suitable for use with the bootloader on the RP MCUs
+
+# these make rules should be included _BEFORE_ $(RULESPATH)/rules.mk
+
+# path to the picotool binary, can be overridden
+# picotool is distributed as part of the Raspberry Pi Pico SDK
+# https://github.com/raspberrypi/pico-sdk
+PICOTOOL ?= picotool
+
+# check if picotool binary is available & executable
+$(if $(shell $(PICOTOOL)), , $(error picotool not found. Download it from https://github.com/raspberrypi/picotool\
+ and either install it in $$PATH or set the PICOTOOL variable to the location))
+
+# build a .uf2 file out of the .elf to use with the bootloader of the RP MCUs
+$(BUILDDIR)/$(PROJECT).uf2: $(BUILDDIR)/$(PROJECT).elf
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
+else
+	@echo Creating $@
+	@$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
+endif
+
+# always build the .uf2 as part of the regular build target ("all")
+ADDITIONAL_OUTFILES += $(BUILDDIR)/$(PROJECT).uf2


### PR DESCRIPTION
## Summary

Adds Makefile rules to build .uf2 images for RP MCUs as part of the main make target ("all").
These Makefile rules are then used in the two demo projects for the RP2040 and RP2350.

## Target Branch Check

<!-- put a x instead of the space in the [ ] to check the box [x] -->

- [x] This PR targets `main` — all changes land on `main` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `main`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [x] Test run successfully locally
- [x] Demo .uf2 for the RP2040 uploaded and ran successfully
- [x] Demo .uf2 for the RP2350 uploaded and ran successfully

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] Risks/limitations are documented below

Risk:

Building the  RP2040 and RP2350 demo projects now requires the `picotool` binary, as distributed by Raspberry Pi at https://github.com/raspberrypi/picotool. In the past this was not strictly required just for building. But for uploading the binary to a Pico or Pico2 the integrated bootloader is the most common way, and for this users already needed picotool. If this is really an issue, the new make rules file can just be commented out from the demo project Makefile.

So I think this change is acceptable.
