### PR TITLE
Build RP .uf2 images during "all" only when picotool is available

### DIFF
--- a/demos/RP/RT-RP2040-PICO/Makefile
+++ b/demos/RP/RT-RP2040-PICO/Makefile
@@ -89,6 +89,7 @@ include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
 # HAL-OSAL files (optional).
 include $(CHIBIOS)/os/hal/hal.mk
 include $(CHIBIOS)/os/hal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
 include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
 include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
 # RTOS files (optional).
@@ -174,11 +175,8 @@ include $(RULESPATH)/rules.mk
 # Custom rules
 #
 
-PICOTOOL ?= picotool
-
-$(BUILDDIR)/$(PROJECT).uf2: $(BUILDDIR)/$(PROJECT).elf
-	$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
-
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
 upload: $(BUILDDIR)/$(PROJECT).uf2
 	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
 

--- a/demos/RP/RT-RP2350-PICO2/Makefile
+++ b/demos/RP/RT-RP2350-PICO2/Makefile
@@ -89,6 +89,7 @@ include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
 # HAL-OSAL files (optional).
 include $(CHIBIOS)/os/hal/hal.mk
 include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
 include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
 include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
 # RTOS files (optional).
@@ -174,11 +175,8 @@ include $(RULESPATH)/rules.mk
 # Custom rules
 #
 
-PICOTOOL ?= picotool
-
-$(BUILDDIR)/$(PROJECT).uf2: $(BUILDDIR)/$(PROJECT).elf
-	$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
-
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
 upload: $(BUILDDIR)/$(PROJECT).uf2
 	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
 

--- a/os/hal/ports/RP/rp_uf2_image.mk
+++ b/os/hal/ports/RP/rp_uf2_image.mk
@@ -1,0 +1,42 @@
+# Make rules for building an .uf2 image, suitable for use with the bootloader
+# on the RP MCUs.
+
+# These make rules should be included _BEFORE_ $(RULESPATH)/rules.mk.
+
+# Path to the picotool binary, can be overridden.
+# picotool is distributed by Raspberry Pi at
+# https://github.com/raspberrypi/picotool
+PICOTOOL ?= picotool
+
+# Rules defined below would otherwise become the default goal because this
+# file is included before $(RULESPATH)/rules.mk, ensure the default goal
+# stays "all" as defined there.
+ifeq ($(.DEFAULT_GOAL),)
+.DEFAULT_GOAL := all
+endif
+
+# The .uf2 image is only built if picotool is already installed, it is never
+# downloaded or installed automatically. If picotool is not found the .uf2
+# image is simply not built as part of the "all" target.
+ifneq ($(shell command -v $(PICOTOOL) 2>/dev/null),)
+
+# Build a .uf2 file out of the .elf to use with the bootloader of the RP MCUs.
+$(BUILDDIR)/$(PROJECT).uf2: $(BUILDDIR)/$(PROJECT).elf
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
+else
+	@echo Creating $@
+	@$(PICOTOOL) uf2 convert $(BUILDDIR)/$(PROJECT).elf $(BUILDDIR)/$(PROJECT).uf2
+endif
+
+# Build the .uf2 as part of the regular build target ("all").
+ADDITIONAL_OUTFILES += $(BUILDDIR)/$(PROJECT).uf2
+
+else
+
+# picotool not available, targets explicitly requiring the .uf2 image fail
+# with a clear message.
+$(BUILDDIR)/$(PROJECT).uf2:
+	$(error picotool not found. Download it from https://github.com/raspberrypi/picotool and either install it in $$PATH or set the PICOTOOL variable to its location)
+
+endif

--- a/os/hal/ports/RP/rp_uf2_image.mk
+++ b/os/hal/ports/RP/rp_uf2_image.mk
@@ -36,6 +36,7 @@ else
 
 # picotool not available, targets explicitly requiring the .uf2 image fail
 # with a clear message.
+.PHONY: $(BUILDDIR)/$(PROJECT).uf2
 $(BUILDDIR)/$(PROJECT).uf2:
 	$(error picotool not found. Download it from https://github.com/raspberrypi/picotool and either install it in $$PATH or set the PICOTOOL variable to its location)
 


### PR DESCRIPTION
## Summary

Rework of #72 (reverted in #73) thank you https://github.com/electroniceel for the original change! Adds Makefile rules to build the .uf2 image for the RP2040 and RP2350 demos as part of the "all" target, but only when `picotool` is already installed and found in `$PATH` (or pointed at via the `PICOTOOL` variable). If picotool is not found, the .uf2 image is simply not built — it is **never downloaded or installed automatically**, and the regular build completes normally without it. Targets that explicitly require the .uf2 image (e.g. `make upload`) fail with a clear message pointing at the official picotool repository.

This also fixes a latent bug in the original #72: because `rp_uf2_image.mk` is included before `rules.mk`, its .uf2 rule became the first explicit target and therefore the default goal, so a plain `make` built only the .elf and .uf2 and silently skipped the .hex/.bin/.dmp/.list outputs. The file now pins the default goal to `all`.

## Related

- MR(s): #72, #73

## Target Branch Check

- [x] This PR targets the default branch — all changes land there first (upstream-first policy); `stable-*` branches only receive maintainer-selected backports of commits already merged

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files (no C sources touched)
- [x] Build check passed (RP2040 and RP2350 demo compile)

## Testing

- [x] Test run successfully locally
- RP2040 demo, picotool installed: `make` produces .elf/.hex/.bin/.dmp/.list **and** .uf2
- RP2040 demo, picotool absent (`PICOTOOL=no-such-tool`): `make` exits 0 with all regular outputs and no .uf2
- RP2040 demo, picotool absent: `make upload` fails with a clear "picotool not found" message
- RP2350 demo: clean build produces .uf2; incremental `make` reports nothing to be done for `all`
- `USE_VERBOSE_COMPILE=yes` prints the picotool convert command line

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] Risks/limitations are documented below

Risk: none for users without picotool — the build behaves as before #72, just without a .uf2. No network access, no tool installation.