### PR TITLE
STM32 RTCv3 HAL: name correct date-register fields in month decode

### DIFF
--- a/os/hal/ports/STM32/LLD/RTCv3/hal_rtc_lld.c
+++ b/os/hal/ports/STM32/LLD/RTCv3/hal_rtc_lld.c
@@ -123,8 +123,8 @@ static void rtc_decode_date(uint32_t dr, RTCDateTime *timespec) {
 
   timespec->year  = (((dr >> RTC_DR_YT_OFFSET) & 15) * 10) +
                      ((dr >> RTC_DR_YU_OFFSET) & 15);
-  timespec->month = (((dr >> RTC_TR_MNT_OFFSET) & 1) * 10) +
-                     ((dr >> RTC_TR_MNU_OFFSET) & 15);
+  timespec->month = (((dr >> RTC_DR_MT_OFFSET) & 1) * 10) +
+                     ((dr >> RTC_DR_MU_OFFSET) & 15);
   timespec->day   = (((dr >> RTC_DR_DT_OFFSET) & 3) * 10) +
                      ((dr >> RTC_DR_DU_OFFSET) & 15);
   timespec->dayofweek = ((dr >> RTC_DR_WDU_OFFSET) & 7) + 1;


### PR DESCRIPTION
### Summary

`rtc_decode_date()` in the STM32 RTCv3 HAL driver reads the **date register** (`dr`) but shifts the month field by the **time-register** offsets `RTC_TR_MNT_OFFSET` / `RTC_TR_MNU_OFFSET`. This PR names the correct date-register fields, `RTC_DR_MT_OFFSET` / `RTC_DR_MU_OFFSET`.

### Is this a functional bug?

No — and that is why it went unnoticed. The decoded month is correct today because the bit positions coincide on every RTCv3 part (month units at bit 8, month tens at bit 12, identical in the `TR` and `DR` layouts), and the masks (`& 1` on tens, `& 15` on units) already match the date-register field widths. So no month value was ever misdecoded. This is a naming/intent fix so the code names the register it actually decodes.

The XHAL RTCv3 driver (`os/xhal/ports/STM32/LLD/RTCv3/hal_rtc_lld.c`) already uses the `RTC_DR_*` offsets here; this brings the legacy HAL driver in line.

### Origin

Spotted during an STM32U375 port bring-up reported on the forum (geoffrey.brown). The same report also flagged the U3 RTC APB-clock bus, which is already fixed on master by #31.

### Gates

- `tools/style/stylecheck.py` clean on the changed file.
- Builds clean: `testhal/STM32/multi/RTC` on `stm32u385rg_nucleo64` (RTCv3), ARM GCC 14.3.1.

No changelog entry: no observable behavior change.

---
🤖 chibios-sheriff — first-layer review (advisory). This is an automated first-layer patch; a human maintainer decides on merge. The sheriff does not review or merge its own PRs.
