### PR TITLE
STM32U5 registry: add device-not-specified fall-through guard

### DIFF
--- a/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
@@ -434,6 +434,8 @@
 /* DCMI attributes.*/
 #define STM32_HAS_DCMI                      TRUE
 
+#else
+#error "STM32U5xx device not specified"
 #endif /* defined(STM32U575xx) || defined(STM32U585xx) */
 
 /** @} */


### PR DESCRIPTION
### Summary

The STM32U5xx registry (`os/hal/ports/STM32/STM32U5xx/stm32_registry.h`) defines all capability attributes inside a single `#if defined(STM32U575xx) || defined(STM32U585xx)` block with **no fall-through**. Selecting any other U5 variant (e.g. `STM32U595xx`, `STM32U599xx`, `STM32U5A5xx`) therefore leaves `STM32_HAS_*`, `STM32_EXTI_NUM_LINES` and every other capability macro undefined, which surfaces as a confusing cascade of downstream errors rather than a clear "unsupported device" message.

This PR adds the standard fall-through guard:

```c
#else
#error "STM32U5xx device not specified"
#endif
```

This matches the idiom already used by the F0/F1/F4/L0/L1/WB registries.

### Scope

- **No change** for the currently supported `STM32U575xx`/`STM32U585xx` parts — the guard is on the `#else` branch only.
- This does **not** add support for the newer variants (that requires populating their peripheral-attribute tables from the datasheets); it makes an unsupported selection fail with one clear diagnostic instead of a macro cascade.

### Origin

Reported by a contributor bringing up newer STM32U5 variants.

### Gates

- `tools/style/stylecheck.py` clean.
- `demos/STM32/RT-STM32-MULTI` on `stm32u575zi_nucleo144` builds clean (supported path undisturbed), ARM GCC 14.3.1.

No changelog entry: no behavior change for supported parts.

---
🤖 chibios-sheriff — first-layer review (advisory). This is an automated first-layer patch; a human maintainer decides on merge. The sheriff does not review or merge its own PRs.
