### PR TITLE
I2Cv4: document that the DMA CTR config fields default to zero

### DIFF
--- a/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.h
@@ -410,18 +410,22 @@ struct hal_i2c_config {
 #if defined(STM32_DMA3_PRESENT)
   /**
    * @brief   DMA RX CTR1 register settings.
+   * @note    Leave to zero for standard operation.
    */
   uint32_t                          dtr1rx;
   /**
    * @brief   DMA TX CTR1 register settings.
+   * @note    Leave to zero for standard operation.
    */
   uint32_t                          dtr1tx;
   /**
    * @brief   DMA RX CTR2 register settings.
+   * @note    Leave to zero for standard operation.
    */
   uint32_t                          dtr2rx;
   /**
    * @brief   DMA TX CTR2 register settings.
+   * @note    Leave to zero for standard operation.
    */
   uint32_t                          dtr2tx;
 #endif


### PR DESCRIPTION
### Summary

Adds a doxygen `@note` to the four `I2CConfig` DMA-CTR fields (`dtr1rx`, `dtr1tx`, `dtr2rx`, `dtr2tx`) in the I2Cv4 driver, stating that they should be left at zero for standard operation. Documentation only — no code change.

### Rationale

These fields exist only on `STM32_DMA3_PRESENT` parts (U5-class) with `STM32_I2C_USE_DMA`, and the driver ORs them with the mandatory CTR1/CTR2 flags it supplies itself:

```c
dmatr1 = (i2cp->config->dtr1rx | STM32_DMA3_CTR1_DAP_MEM | ...);
```

So zero is the correct default. Contributors porting from older STM32 I2C ports (which initialize only `timingr`/`cr1`/`cr2`) were unsure whether these needed explicit values, and hit `-Wmissing-field-initializers` under `-Wextra`. The note mirrors the existing "*Leave to zero unless you know what you are doing*" note already on `cr1`.

### Origin

Reported by a contributor porting to the U5 I2Cv4 driver.

### Gates

- `tools/style/stylecheck.py` clean.
- `demos/STM32/RT-STM32-MULTI` on `stm32u575zi_nucleo144` builds clean, ARM GCC 14.3.1.

No changelog entry: documentation only, no behavior change.

---
🤖 chibios-sheriff — first-layer review (advisory). This is an automated first-layer patch; a human maintainer decides on merge. The sheriff does not review or merge its own PRs.
