### PR TITLE
STM32U3 registry: add device-not-specified fall-through guard (3 ports)

### DIFF
--- a/os/hal/ports/STM32/STM32U3xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U3xx/stm32_registry.h
@@ -388,6 +388,8 @@
 #define STM32_HAS_IWDG                      TRUE
 #define STM32_IWDG_IS_WINDOWED              TRUE
 
+#else
+#error "STM32U3xx device not specified"
 #endif /* defined(STM32U375xx) || defined(STM32U385xx) */
 
 /** @} */

--- a/os/hal/ports/STM32/STM32U3xx_TEST/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U3xx_TEST/stm32_registry.h
@@ -388,6 +388,8 @@
 #define STM32_HAS_IWDG                      TRUE
 #define STM32_IWDG_IS_WINDOWED              TRUE
 
+#else
+#error "STM32U3xx device not specified"
 #endif /* defined(STM32U375xx) || defined(STM32U385xx) */
 
 /** @} */

--- a/os/xhal/ports/STM32/STM32U3xx/stm32_registry.h
+++ b/os/xhal/ports/STM32/STM32U3xx/stm32_registry.h
@@ -388,6 +388,8 @@
 #define STM32_HAS_IWDG                      TRUE
 #define STM32_IWDG_IS_WINDOWED              TRUE
 
+#else
+#error "STM32U3xx device not specified"
 #endif /* defined(STM32U375xx) || defined(STM32U385xx) */
 
 /** @} */


### PR DESCRIPTION
### Summary

Follow-up to #76 (which added the guard to the STM32U5xx registry). The STM32U3xx registries have the identical fall-through gap: all capability attributes live inside a single `#if defined(STM32U375xx) || defined(STM32U385xx)` block with no `#else`, so any other U3 selection silently leaves `STM32_HAS_*`, `STM32_EXTI_NUM_LINES` and the rest undefined.

This adds the standard `#else #error "STM32U3xx device not specified"` guard (the idiom used by F0/F1/F4/L0/L1/WB) to all **three** U3 registry copies:

- `os/hal/ports/STM32/STM32U3xx/stm32_registry.h` — HAL port
- `os/hal/ports/STM32/STM32U3xx_TEST/stm32_registry.h` — clock-generator test port
- `os/xhal/ports/STM32/STM32U3xx/stm32_registry.h` — XHAL port

### Scope

No change for the supported `STM32U375xx`/`STM32U385xx` parts — the guard is on the `#else` branch only.

### Gates

- `tools/style/stylecheck.py` clean on all three files.
- Builds clean (ARM GCC 14.3.1):
  - `testhal/STM32/multi/RTC` on `stm32u385rg_nucleo64` (STM32U3xx port)
  - `demos/STM32/RT-STM32-MULTI` on `stm32u385rg_nucleo64_clocktree` (STM32U3xx_TEST port)

No changelog entry: no behavior change for supported parts.

---
🤖 chibios-sheriff — first-layer review (advisory). This is an automated first-layer patch; a human maintainer decides on merge. The sheriff does not review or merge its own PRs.
