### PR TITLE
Add STM32U5A5 multi-demo target

### DIFF
--- a/demos/STM32/RT-STM32-MULTI/.cproject
+++ b/demos/STM32/RT-STM32-MULTI/.cproject
@@ -616,6 +616,47 @@
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
+		<cconfiguration id="0.1570569554.1629784558.1356569442.1386098086.1595385271.1805958376.468953910.u5a5zj">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="0.1570569554.1629784558.1356569442.1386098086.1595385271.1805958376.468953910.u5a5zj" moduleId="org.eclipse.cdt.core.settings" name="Build for STM32U5A5ZJ-Nucleo144">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.VCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="0.1570569554.1629784558.1356569442.1386098086.1595385271.1805958376.468953910.u5a5zj" name="Build for STM32U5A5ZJ-Nucleo144" parent="org.eclipse.cdt.build.core.prefbase.cfg">
+					<folderInfo id="0.1570569554.1629784558.1356569442.1386098086.1595385271.1805958376.468953910.u5a5zj." name="/" resourcePath="">
+						<toolChain id="org.eclipse.cdt.build.core.prefbase.toolchain.582267256.u5a5zj" name="No ToolChain" resourceTypeBasedDiscovery="false" superClass="org.eclipse.cdt.build.core.prefbase.toolchain">
+							<targetPlatform binaryParser="org.eclipse.cdt.core.ELF" id="org.eclipse.cdt.build.core.prefbase.toolchain.582267256.u5a5zj.2052140885" name=""/>
+							<builder arguments="-f make/stm32u5a5zj_nucleo144.make" command="make" id="org.eclipse.cdt.build.core.settings.default.builder.461208428.u5a5zj" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="org.eclipse.cdt.build.core.settings.default.builder"/>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.libs.2050635073.u5a5zj" name="holder for library settings" superClass="org.eclipse.cdt.build.core.settings.holder.libs"/>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.806963803.u5a5zj" name="Assembly" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.1653405183.u5a5zj" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths"/>
+								<option id="org.eclipse.cdt.build.core.settings.holder.undef.incpaths.1693816550.u5a5zj" name="Undefined Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.undef.incpaths"/>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.1009213139.u5a5zj" languageId="org.eclipse.cdt.core.assembly" languageName="Assembly" sourceContentType="org.eclipse.cdt.core.asmSource" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.1484600377.u5a5zj" name="GNU C++" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.571575260.u5a5zj" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths"/>
+								<option id="org.eclipse.cdt.build.core.settings.holder.undef.incpaths.1399242376.u5a5zj" name="Undefined Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.undef.incpaths"/>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.368369654.u5a5zj" languageId="org.eclipse.cdt.core.g++" languageName="GNU C++" sourceContentType="org.eclipse.cdt.core.cxxSource,org.eclipse.cdt.core.cxxHeader" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+							<tool id="org.eclipse.cdt.build.core.settings.holder.285285641.u5a5zj" name="GNU C" superClass="org.eclipse.cdt.build.core.settings.holder">
+								<option id="org.eclipse.cdt.build.core.settings.holder.incpaths.99333105.u5a5zj" name="Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.incpaths"/>
+								<option id="org.eclipse.cdt.build.core.settings.holder.undef.incpaths.1868837507.u5a5zj" name="Undefined Include Paths" superClass="org.eclipse.cdt.build.core.settings.holder.undef.incpaths"/>
+								<inputType id="org.eclipse.cdt.build.core.settings.holder.inType.1517011921.u5a5zj" languageId="org.eclipse.cdt.core.gcc" languageName="GNU C" sourceContentType="org.eclipse.cdt.core.cSource,org.eclipse.cdt.core.cHeader" superClass="org.eclipse.cdt.build.core.settings.holder.inType"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
 		<cconfiguration id="0.1570569554.1629784558.1356569442.1386098086.1595385271.1805958376.2101204439">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="0.1570569554.1629784558.1356569442.1386098086.1595385271.1805958376.2101204439" moduleId="org.eclipse.cdt.core.settings" name="Build for STM32H563ZI-Nucleo144">
 				<externalSettings/>

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/chconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 10000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 2
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/halconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      TRUE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/mcuconf.h
@@ -1,0 +1,530 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * STM32U5xx drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in halconf.h.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...3        Lowest...Highest.
+ */
+
+#define STM32U5xx_MCUCONF
+#define STM32U595_MCUCONF
+#define STM32U599_MCUCONF
+#define STM32U5A5_MCUCONF
+#define STM32U5A9_MCUCONF
+
+/*
+ * HAL driver general settings.
+ */
+#define STM32_NO_INIT                       FALSE
+#define STM32_CFG_CLOCK_DYNAMIC             FALSE
+
+/*
+ * ICache settings.
+ */
+#define STM32_ICACHE_CR                     (ICACHE_CR_WAYSEL | ICACHE_CR_EN)
+#define STM32_ICACHE_CRR0                   (0U)
+#define STM32_ICACHE_CRR1                   (0U)
+#define STM32_ICACHE_CRR2                   (0U)
+#define STM32_ICACHE_CRR3                   (0U)
+
+/*
+ * PWR settings.
+ */
+#define STM32_PWR_CR1                       (0U)
+#define STM32_PWR_CR2                       (0U)
+#define STM32_PWR_CR3                       (0U)
+#define STM32_PWR_SVMCR                     (0U)
+#define STM32_PWR_WUCR1                     (0U)
+#define STM32_PWR_WUCR2                     (0U)
+#define STM32_PWR_WUCR3                     (0U)
+#define STM32_PWR_BDCR1                     (0U)
+#define STM32_PWR_BDCR2                     (0U)
+#define STM32_PWR_UCPDR                     (0U)
+#define STM32_PWR_SECCFGR                   (0U)
+#define STM32_PWR_PRIVCFGR                  (0U)
+#define STM32_PWR_APCR                      (0U)
+#define STM32_PWR_PUCRA                     (0U)
+#define STM32_PWR_PDCRA                     (0U)
+#define STM32_PWR_PUCRB                     (0U)
+#define STM32_PWR_PDCRB                     (0U)
+#define STM32_PWR_PUCRC                     (0U)
+#define STM32_PWR_PDCRC                     (0U)
+#define STM32_PWR_PUCRD                     (0U)
+#define STM32_PWR_PDCRD                     (0U)
+#define STM32_PWR_PUCRE                     (0U)
+#define STM32_PWR_PDCRE                     (0U)
+#define STM32_PWR_PUCRF                     (0U)
+#define STM32_PWR_PDCRF                     (0U)
+#define STM32_PWR_PUCRG                     (0U)
+#define STM32_PWR_PDCRG                     (0U)
+#define STM32_PWR_PUCRH                     (0U)
+#define STM32_PWR_PDCRH                     (0U)
+#define STM32_PWR_PUCRI                     (0U)
+#define STM32_PWR_PDCRI                     (0U)
+#define STM32_PWR_PUCRJ                     (0U)
+#define STM32_PWR_PDCRJ                     (0U)
+
+/*
+ * FLASH settings.
+ */
+#define STM32_FLASH_ACR                     (FLASH_ACR_PRFTEN | FLASH_ACR_LATENCY_4WS)
+
+/*
+ * Clock settings.
+ */
+#define STM32_CFG_PWR_VOSR                  PWR_VOSR_VOS_RANGE1
+#define STM32_CFG_LSI_PREDIV                RCC_BDCR_LSIPREDIV_DIV1
+#define STM32_CFG_AUDIOCLK                  0U
+#define STM32_CFG_DSIPHYCLK                 0U
+#define STM32_CFG_MSIS_RANGE                RCC_ICSCR1_MSISRANGE_RANGE0_48M
+#define STM32_CFG_MSIK_RANGE                RCC_ICSCR1_MSIKRANGE_RANGE0_48M
+#define STM32_CFG_MSIBIAS                   RCC_ICSCR1_MSIBIAS_CONTINUOUS
+#define STM32_CFG_TIMICSEL                  RCC_CCIPR1_TIMICSEL_NOCLOCK
+#define STM32_CFG_STOPWUCK                  RCC_CFGR1_STOPWUCK_MSIS
+#define STM32_CFG_STOPKERWUCK               RCC_CFGR1_STOPKERWUCK_MSIK
+#define STM32_CFG_HSI16_ENABLE              FALSE
+#define STM32_CFG_HSI48_ENABLE              TRUE
+#define STM32_CFG_SHSI_ENABLE               FALSE
+#define STM32_CFG_HSE_ENABLE                FALSE
+#define STM32_CFG_LSE_ENABLE                FALSE
+#define STM32_CFG_LSI_ENABLE                FALSE
+#define STM32_CFG_PLL1IN_SEL                RCC_PLL1CFGR_PLL1SRC_MSIS
+#define STM32_CFG_PLL1REF_VALUE             3
+#define STM32_CFG_PLL1VCO_VALUE             10
+#define STM32_CFG_PLL1P_VALUE               1
+#define STM32_CFG_PLL1Q_VALUE               1
+#define STM32_CFG_PLL1R_VALUE               1
+#define STM32_CFG_PLL2IN_SEL                RCC_PLL2CFGR_PLL2SRC_MSIS
+#define STM32_CFG_PLL2REF_VALUE             1
+#define STM32_CFG_PLL2VCO_VALUE             32
+#define STM32_CFG_PLL2P_VALUE               4
+#define STM32_CFG_PLL2Q_VALUE               4
+#define STM32_CFG_PLL2R_VALUE               4
+#define STM32_CFG_PLL3IN_SEL                RCC_PLL3CFGR_PLL3SRC_MSIS
+#define STM32_CFG_PLL3REF_VALUE             1
+#define STM32_CFG_PLL3VCO_VALUE             32
+#define STM32_CFG_PLL3P_VALUE               4
+#define STM32_CFG_PLL3Q_VALUE               4
+#define STM32_CFG_PLL3R_VALUE               4
+#define STM32_CFG_SYSCLK_SEL                RCC_CFGR1_SW_PLL1R
+#define STM32_CFG_HCLK_VALUE                1
+#define STM32_CFG_PCLK1_VALUE               1
+#define STM32_CFG_PCLK2_VALUE               1
+#define STM32_CFG_PCLK3_VALUE               1
+#define STM32_CFG_DPHY_VALUE                8
+#define STM32_CFG_MCODIV_SEL                RCC_CFGR1_MCOSEL_NOCLOCK
+#define STM32_CFG_MCO_VALUE                 1
+#define STM32_CFG_RTC_SEL                   RCC_BDCR_RTCSEL_NOCLOCK
+#define STM32_CFG_LSCO_SEL                  RCC_BDCR_LSCOSEL_NOCLOCK
+
+/*
+ * Peripheral clock demand modes.
+ */
+#define STM32_CFG_PLL1P_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL1Q_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL1R_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL2P_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL2Q_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL2R_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL3P_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL3Q_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_PLL3R_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_USART1_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_USART2_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_USART3_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_UART4_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_UART5_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_USART6_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_LPUART1_CLOCK_MODE        STM32_CLOCK_AUTO
+#define STM32_CFG_I2C1_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_I2C2_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_I2C3_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_I2C4_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_I2C5_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_I2C6_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_SPI1_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_SPI2_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_SPI3_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_FDCAN1_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_SYSTICK_CLOCK_MODE        STM32_CLOCK_AUTO
+#define STM32_CFG_OTGHS_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_SDMMC1_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_SDMMC2_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_OCTOSPI_CLOCK_MODE        STM32_CLOCK_AUTO
+#define STM32_CFG_HSPI1_CLOCK_MODE          STM32_CLOCK_AUTO
+#define STM32_CFG_DSI_CLOCK_MODE            STM32_CLOCK_AUTO
+#define STM32_CFG_LTDC_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_SAES_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_RNG_CLOCK_MODE            STM32_CLOCK_AUTO
+#define STM32_CFG_SAI1_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_SAI2_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_MDF1_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_ADF1_CLOCK_MODE           STM32_CLOCK_AUTO
+#define STM32_CFG_ADCDAC_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_DAC1SH_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_LPTIM1_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_LPTIM2_CLOCK_MODE         STM32_CLOCK_AUTO
+#define STM32_CFG_LPTIM34_CLOCK_MODE        STM32_CLOCK_AUTO
+#define STM32_CFG_IWDG_CLOCK_MODE           STM32_CLOCK_AUTO
+
+/*
+ * Peripherals clock sources.
+ */
+#define STM32_CFG_USART1_SEL                RCC_CCIPR1_USART1SEL_PCLK2
+#define STM32_CFG_USART2_SEL                RCC_CCIPR1_USART2SEL_PCLK1
+#define STM32_CFG_USART3_SEL                RCC_CCIPR1_USART3SEL_PCLK1
+#define STM32_CFG_UART4_SEL                 RCC_CCIPR1_UART4SEL_PCLK1
+#define STM32_CFG_UART5_SEL                 RCC_CCIPR1_UART5SEL_PCLK1
+#define STM32_CFG_USART6_SEL                RCC_CCIPR2_USART6SEL_PCLK1
+#define STM32_CFG_LPUART1_SEL               RCC_CCIPR3_LPUART1SEL_PCLK3
+#define STM32_CFG_I2C1_SEL                  RCC_CCIPR1_I2C1SEL_PCLK1
+#define STM32_CFG_I2C2_SEL                  RCC_CCIPR1_I2C2SEL_PCLK1
+#define STM32_CFG_I2C3_SEL                  RCC_CCIPR3_I2C3SEL_PCLK3
+#define STM32_CFG_I2C4_SEL                  RCC_CCIPR1_I2C4SEL_PCLK1
+#define STM32_CFG_I2C5_SEL                  RCC_CCIPR2_I2C5SEL_PCLK1
+#define STM32_CFG_I2C6_SEL                  RCC_CCIPR2_I2C6SEL_PCLK1
+#define STM32_CFG_SPI1_SEL                  RCC_CCIPR1_SPI1SEL_PCLK2
+#define STM32_CFG_SPI2_SEL                  RCC_CCIPR1_SPI2SEL_PCLK1
+#define STM32_CFG_SPI3_SEL                  RCC_CCIPR3_SPI3SEL_PCLK3
+#define STM32_CFG_FDCAN1_SEL                RCC_CCIPR1_FDCANSEL_HSE
+#define STM32_CFG_SYSTICK_SEL               RCC_CCIPR1_SYSTICKSEL_HCLKDIV8
+#define STM32_CFG_ICLK_SEL                  RCC_CCIPR1_ICLKSEL_HSI48
+#define STM32_CFG_SDMMC_SEL                 RCC_CCIPR2_SDMMCSEL_PLL1P
+#define STM32_CFG_OCTOSPI_SEL               RCC_CCIPR2_OCTOSPISEL_SYSCLK
+#define STM32_CFG_HSPI1_SEL                 RCC_CCIPR2_HSPISEL_SYSCLK
+#define STM32_CFG_USBPHYC_SEL               RCC_CCIPR2_USBPHYCSEL_HSE
+#define STM32_CFG_DSI_SEL                   RCC_CCIPR2_DSIHOSTSEL_PLL3P
+#define STM32_CFG_LTDC_SEL                  RCC_CCIPR2_LTDCSEL_PLL3R
+#define STM32_CFG_SAES_SEL                  RCC_CCIPR2_SAESSEL_SHSI
+#define STM32_CFG_RNG_SEL                   RCC_CCIPR2_RNGSEL_HSI48
+#define STM32_CFG_SAI1_SEL                  RCC_CCIPR2_SAI1SEL_PLL2P
+#define STM32_CFG_SAI2_SEL                  RCC_CCIPR2_SAI2SEL_PLL2P
+#define STM32_CFG_MDF1_SEL                  RCC_CCIPR2_MDF1SEL_HCLK
+#define STM32_CFG_ADF1_SEL                  RCC_CCIPR3_ADF1SEL_HCLK
+#define STM32_CFG_ADCDAC_SEL                RCC_CCIPR3_ADCDACSEL_HCLK
+#define STM32_CFG_DAC1SH_SEL                RCC_CCIPR3_DAC1SEL_LSE
+#define STM32_CFG_LPTIM1_SEL                RCC_CCIPR3_LPTIM1SEL_MSIK
+#define STM32_CFG_LPTIM2_SEL                RCC_CCIPR1_LPTIM2SEL_PCLK1
+#define STM32_CFG_LPTIM34_SEL               RCC_CCIPR3_LPTIM34SEL_MSIK
+
+/*
+ * IRQ system settings.
+ */
+#define STM32_IRQ_DAC1_PRIORITY             9
+
+#define STM32_IRQ_EXTI0_PRIORITY            6
+#define STM32_IRQ_EXTI1_PRIORITY            6
+#define STM32_IRQ_EXTI2_PRIORITY            6
+#define STM32_IRQ_EXTI3_PRIORITY            6
+#define STM32_IRQ_EXTI4_PRIORITY            6
+#define STM32_IRQ_EXTI5_PRIORITY            6
+#define STM32_IRQ_EXTI6_PRIORITY            6
+#define STM32_IRQ_EXTI7_PRIORITY            6
+#define STM32_IRQ_EXTI8_PRIORITY            6
+#define STM32_IRQ_EXTI9_PRIORITY            6
+#define STM32_IRQ_EXTI10_PRIORITY           6
+#define STM32_IRQ_EXTI11_PRIORITY           6
+#define STM32_IRQ_EXTI12_PRIORITY           6
+#define STM32_IRQ_EXTI13_PRIORITY           6
+#define STM32_IRQ_EXTI14_PRIORITY           6
+#define STM32_IRQ_EXTI15_PRIORITY           6
+
+#define STM32_IRQ_FDCAN1_PRIORITY           10
+
+#define STM32_IRQ_I2C1_PRIORITY             5
+#define STM32_IRQ_I2C2_PRIORITY             5
+#define STM32_IRQ_I2C3_PRIORITY             5
+#define STM32_IRQ_I2C4_PRIORITY             5
+
+#define STM32_IRQ_SPI1_PRIORITY             10
+#define STM32_IRQ_SPI2_PRIORITY             10
+#define STM32_IRQ_SPI3_PRIORITY             10
+
+#define STM32_IRQ_SDMMC1_PRIORITY           10
+#define STM32_IRQ_SDMMC2_PRIORITY           10
+
+#define STM32_IRQ_TIM1_BRK_PRIORITY         7
+#define STM32_IRQ_TIM1_UP_PRIORITY          7
+#define STM32_IRQ_TIM1_TRGCO_PRIORITY       7
+#define STM32_IRQ_TIM1_CC_PRIORITY          7
+#define STM32_IRQ_TIM2_PRIORITY             7
+#define STM32_IRQ_TIM3_PRIORITY             7
+#define STM32_IRQ_TIM4_PRIORITY             7
+#define STM32_IRQ_TIM5_PRIORITY             7
+#define STM32_IRQ_TIM6_PRIORITY             7
+#define STM32_IRQ_TIM7_PRIORITY             7
+#define STM32_IRQ_TIM8_BRK_PRIORITY         7
+#define STM32_IRQ_TIM8_UP_PRIORITY          7
+#define STM32_IRQ_TIM8_CC_PRIORITY          7
+#define STM32_IRQ_TIM15_PRIORITY            7
+#define STM32_IRQ_TIM16_PRIORITY            7
+#define STM32_IRQ_TIM17_PRIORITY            7
+
+#define STM32_IRQ_USART1_PRIORITY           12
+#define STM32_IRQ_USART2_PRIORITY           12
+#define STM32_IRQ_USART3_PRIORITY           12
+#define STM32_IRQ_UART4_PRIORITY            12
+#define STM32_IRQ_UART5_PRIORITY            12
+#define STM32_IRQ_USART6_PRIORITY           12
+#define STM32_IRQ_LPUART1_PRIORITY          12
+
+/*
+ * ADC driver system settings.
+ */
+#define STM32_ADC_USE_ADC1                  FALSE
+#define STM32_ADC_USE_ADC2                  FALSE
+#define STM32_ADC_DUAL_MODE                 FALSE
+#define STM32_ADC_COMPACT_SAMPLES           FALSE
+#define STM32_ADC_ADC1_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_ADC_ADC2_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_ADC_ADC1_DMA_PRIORITY         2
+#define STM32_ADC_ADC2_DMA_PRIORITY         2
+#define STM32_ADC_ADC1_IRQ_PRIORITY         5
+#define STM32_ADC_ADC2_IRQ_PRIORITY         5
+#define STM32_ADC_ADC1_DMA_IRQ_PRIORITY     5
+#define STM32_ADC_ADC2_DMA_IRQ_PRIORITY     5
+#define STM32_ADC_ADC12_CLOCK_MODE          ADC_CCR_CKMODE_AHB_DIV4
+#define STM32_ADC_ADC12_PRESC               ADC_CCR_PRESC_DIV2
+
+/*
+ * CAN driver system settings.
+ */
+#define STM32_CAN_USE_FDCAN1                FALSE
+#define STM32_CAN_FDCAN_PRESC               FDCAN_CONFIG_CKDIV_PDIV_1
+
+/*
+ * DAC driver system settings.
+ */
+#define STM32_DAC_DUAL_MODE                 FALSE
+#define STM32_DAC_USE_DAC1_CH1              FALSE
+#define STM32_DAC_USE_DAC1_CH2              FALSE
+#define STM32_DAC_DAC1_CH1_DMA_PRIORITY     2
+#define STM32_DAC_DAC1_CH2_DMA_PRIORITY     2
+#define STM32_DAC_DAC1_CH1_DMA3_CHANNEL     STM32_DMA3_MASK_FIFO2
+#define STM32_DAC_DAC1_CH2_DMA3_CHANNEL     STM32_DMA3_MASK_FIFO2
+
+/*
+ * GPT driver system settings.
+ */
+#define STM32_GPT_USE_TIM1                  FALSE
+#define STM32_GPT_USE_TIM2                  FALSE
+#define STM32_GPT_USE_TIM3                  FALSE
+#define STM32_GPT_USE_TIM4                  FALSE
+#define STM32_GPT_USE_TIM5                  FALSE
+#define STM32_GPT_USE_TIM6                  FALSE
+#define STM32_GPT_USE_TIM7                  FALSE
+#define STM32_GPT_USE_TIM8                  FALSE
+#define STM32_GPT_USE_TIM15                 FALSE
+#define STM32_GPT_USE_TIM16                 FALSE
+#define STM32_GPT_USE_TIM17                 FALSE
+
+/*
+ * I2C driver system settings.
+ */
+#define STM32_I2C_USE_I2C1                  FALSE
+#define STM32_I2C_USE_I2C2                  FALSE
+#define STM32_I2C_USE_I2C3                  FALSE
+#define STM32_I2C_USE_I2C4                  FALSE
+#define STM32_I2C_BUSY_TIMEOUT              50
+#define STM32_I2C_USE_DMA                   TRUE
+#define STM32_I2C_I2C1_DMA_PRIORITY         1
+#define STM32_I2C_I2C2_DMA_PRIORITY         1
+#define STM32_I2C_I2C3_DMA_PRIORITY         1
+#define STM32_I2C_I2C4_DMA_PRIORITY         1
+#define STM32_I2C_I2C1_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_I2C_I2C2_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_I2C_I2C3_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_I2C_I2C4_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
+
+/*
+ * ICU driver system settings.
+ */
+#define STM32_ICU_USE_TIM1                  FALSE
+#define STM32_ICU_USE_TIM2                  FALSE
+#define STM32_ICU_USE_TIM3                  FALSE
+#define STM32_ICU_USE_TIM4                  FALSE
+#define STM32_ICU_USE_TIM5                  FALSE
+#define STM32_ICU_USE_TIM8                  FALSE
+#define STM32_ICU_USE_TIM15                 FALSE
+#define STM32_ICU_USE_TIM16                 FALSE
+#define STM32_ICU_USE_TIM17                 FALSE
+
+/*
+ * PWM driver system settings.
+ */
+#define STM32_PWM_USE_TIM1                  FALSE
+#define STM32_PWM_USE_TIM2                  FALSE
+#define STM32_PWM_USE_TIM3                  FALSE
+#define STM32_PWM_USE_TIM4                  FALSE
+#define STM32_PWM_USE_TIM5                  FALSE
+#define STM32_PWM_USE_TIM8                  FALSE
+#define STM32_PWM_USE_TIM15                 FALSE
+#define STM32_PWM_USE_TIM16                 FALSE
+#define STM32_PWM_USE_TIM17                 FALSE
+
+/*
+ * RTC driver system settings.
+ */
+#define STM32_RTC_PRESA_VALUE               32
+#define STM32_RTC_PRESS_VALUE               1024
+#define STM32_RTC_CR_INIT                   0
+#define STM32_TAMP_CR1_INIT                 0
+#define STM32_TAMP_CR2_INIT                 0
+#define STM32_TAMP_FLTCR_INIT               0
+#define STM32_TAMP_IER_INIT                 0
+
+/*
+ * SDC driver system settings.
+ */
+#define STM32_SDC_USE_SDMMC1                FALSE
+#define STM32_SDC_USE_SDMMC2                FALSE
+#define STM32_SDC_SDMMC_UNALIGNED_SUPPORT   TRUE
+#define STM32_SDC_SDMMC_WRITE_TIMEOUT       10000
+#define STM32_SDC_SDMMC_READ_TIMEOUT        10000
+#define STM32_SDC_SDMMC_CLOCK_DELAY         10
+#define STM32_SDC_SDMMC_PWRSAV              TRUE
+
+/*
+ * SERIAL driver system settings.
+ */
+#define STM32_SERIAL_USE_USART1             TRUE
+#define STM32_SERIAL_USE_USART2             FALSE
+#define STM32_SERIAL_USE_USART3             FALSE
+#define STM32_SERIAL_USE_UART4              FALSE
+#define STM32_SERIAL_USE_UART5              FALSE
+#define STM32_SERIAL_USE_USART6             FALSE
+#define STM32_SERIAL_USE_LPUART1            FALSE
+#define STM32_SERIAL_USART1_PRIORITY        12
+#define STM32_SERIAL_USART2_PRIORITY        12
+#define STM32_SERIAL_USART3_PRIORITY        12
+#define STM32_SERIAL_UART4_PRIORITY         12
+#define STM32_SERIAL_UART5_PRIORITY         12
+#define STM32_SERIAL_USART6_PRIORITY        12
+#define STM32_SERIAL_LPUART1_PRIORITY       12
+#define STM32_SERIAL_USART1_IN_BUF_SIZE     SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_USART1_OUT_BUF_SIZE    SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_USART2_IN_BUF_SIZE     SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_USART2_OUT_BUF_SIZE    SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_USART3_IN_BUF_SIZE     SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_USART3_OUT_BUF_SIZE    SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_UART4_IN_BUF_SIZE      SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_UART4_OUT_BUF_SIZE     SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_UART5_IN_BUF_SIZE      SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_UART5_OUT_BUF_SIZE     SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_USART6_IN_BUF_SIZE     SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_USART6_OUT_BUF_SIZE    SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_LPUART1_IN_BUF_SIZE    SERIAL_BUFFERS_SIZE
+#define STM32_SERIAL_LPUART1_OUT_BUF_SIZE   SERIAL_BUFFERS_SIZE
+
+/*
+ * SIO driver system settings.
+ */
+#define STM32_SIO_USE_USART1                FALSE
+#define STM32_SIO_USE_USART2                FALSE
+#define STM32_SIO_USE_USART3                FALSE
+#define STM32_SIO_USE_UART4                 FALSE
+#define STM32_SIO_USE_UART5                 FALSE
+#define STM32_SIO_USE_USART6                FALSE
+#define STM32_SIO_USE_LPUART1               FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define STM32_SPI_USE_SPI1                  FALSE
+#define STM32_SPI_USE_SPI2                  FALSE
+#define STM32_SPI_USE_SPI3                  FALSE
+#define STM32_SPI_FILLER_PATTERN            0xFFFFFFFFU
+#define STM32_SPI_SPI1_RX_DMA3_CHANNEL      STM32_DMA3_MASK_FIFO2
+#define STM32_SPI_SPI1_TX_DMA3_CHANNEL      STM32_DMA3_MASK_FIFO2
+#define STM32_SPI_SPI2_RX_DMA3_CHANNEL      STM32_DMA3_MASK_FIFO2
+#define STM32_SPI_SPI2_TX_DMA3_CHANNEL      STM32_DMA3_MASK_FIFO2
+#define STM32_SPI_SPI3_RX_DMA3_CHANNEL      STM32_DMA3_MASK_FIFO2
+#define STM32_SPI_SPI3_TX_DMA3_CHANNEL      STM32_DMA3_MASK_FIFO2
+#define STM32_SPI_SPI1_DMA_PRIORITY         1
+#define STM32_SPI_SPI2_DMA_PRIORITY         1
+#define STM32_SPI_SPI3_DMA_PRIORITY         1
+#define STM32_SPI_DMA_ERROR_HOOK(spip)      osalSysHalt("DMA failure")
+
+/*
+ * ST driver system settings.
+ */
+#define STM32_ST_IRQ_PRIORITY               8
+#define STM32_ST_USE_TIMER                  2
+#define STM32_ST_FREQUENCY_TOLERANCE        0
+
+/*
+ * TRNG driver system settings.
+ */
+#define STM32_TRNG_USE_RNG1                 FALSE
+#define STM32_TRNG_ERROR_CLEAR_ATTEMPTS     1000
+#define STM32_DATA_FETCH_ATTEMPTS           1000
+
+/*
+ * UART driver system settings.
+ */
+#define STM32_UART_USE_USART1               FALSE
+#define STM32_UART_USE_USART2               FALSE
+#define STM32_UART_USE_USART3               FALSE
+#define STM32_UART_USE_UART4                FALSE
+#define STM32_UART_USE_UART5                FALSE
+#define STM32_UART_USE_USART6               FALSE
+#define STM32_UART_USART1_IRQ_PRIORITY      12
+#define STM32_UART_USART2_IRQ_PRIORITY      12
+#define STM32_UART_USART3_IRQ_PRIORITY      12
+#define STM32_UART_UART4_IRQ_PRIORITY       12
+#define STM32_UART_UART5_IRQ_PRIORITY       12
+#define STM32_UART_USART6_IRQ_PRIORITY      12
+#define STM32_UART_USART1_DMA_PRIORITY      0
+#define STM32_UART_USART2_DMA_PRIORITY      0
+#define STM32_UART_USART3_DMA_PRIORITY      0
+#define STM32_UART_UART4_DMA_PRIORITY       0
+#define STM32_UART_UART5_DMA_PRIORITY       0
+#define STM32_UART_USART6_DMA_PRIORITY      0
+#define STM32_UART_DMA_ERROR_HOOK(uartp)    osalSysHalt("DMA failure")
+
+/*
+ * USB driver system settings.
+ */
+#define STM32_USB_USE_OTG2                  FALSE
+#define STM32_USB_OTG2_IRQ_PRIORITY         14
+#define STM32_USB_OTG2_RX_FIFO_SIZE         1024
+#define STM32_USB_HOST_WAKEUP_DURATION      2
+
+/*
+ * WDG driver system settings.
+ */
+#define STM32_WDG_USE_IWDG                  FALSE
+
+/*
+ * WSPI driver system settings.
+ */
+#define STM32_WSPI_USE_OCTOSPI1             FALSE
+#define STM32_WSPI_USE_OCTOSPI2             FALSE
+
+#endif /* MCUCONF_H */

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/portab.c
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/portab.c
@@ -1,0 +1,55 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.c
+ * @brief   Application portability module code.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#include "portab.h"
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+void portab_setup(void) {
+
+}
+
+/** @} */

--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/portab.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/portab.h
@@ -1,0 +1,73 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.h
+ * @brief   Application portability macros and structures.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+#define PORTAB_LINE_LED1            LINE_LED_GREEN
+
+#define PORTAB_LINE_BUTTON          LINE_BUTTON
+#define PORTAB_BUTTON_PRESSED       PAL_HIGH
+
+#define PORTAB_SD1                  SD1
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+#endif /* PORTAB_H */
+
+/** @} */

--- a/demos/STM32/RT-STM32-MULTI/make/stm32u5a5zj_nucleo144.make
+++ b/demos/STM32/RT-STM32-MULTI/make/stm32u5a5zj_nucleo144.make
@@ -1,0 +1,193 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer --specs=nano.specs -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x400
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x400
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+# FPU-related options.
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-sp-d16
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../..
+CONFDIR  := ./cfg/stm32u5a5zj_nucleo144
+BUILDDIR := ./build/stm32u5a5zj_nucleo144
+DEPDIR   := ./.dep/stm32u5a5zj_nucleo144
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_stm32u5xx.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/STM32/STM32U5xx/platform_type2.mk
+include $(CHIBIOS)/os/hal/boards/ST_NUCLEO144_U5A5ZJ_Q/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+#include $(CHIBIOS)/os/common/ports/ARMv8-M-ML/compilers/GCC/mk/port.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/test/test.mk
+include $(CHIBIOS)/test/rt/rt_test.mk
+include $(CHIBIOS)/test/oslib/oslib_test.mk
+#include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+#include $(CHIBIOS)/os/various/shell/shell.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/STM32U5A5xJ.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(TESTSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC) $(TESTINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes -Wcast-align=strict
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -D__TEST_RT -D__TEST_OSLIB -DSTM32U5A5xx
+
+# Define ASM defines here
+UADEFS = -DSTM32U5A5xx
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+#
+# Custom rules
+##############################################################################

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/STM32U5A5xJ.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/STM32U5A5xJ.ld
@@ -1,0 +1,102 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * STM32U5A5xJ memory setup.
+ */
+MEMORY
+{
+    flash0 (rx) : org = 0x08000000, len = 4M    /* Flash NS */
+    flash1 (rx) : org = 0x0C000000, len = 4M    /* Flash NSC */
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x20000000, len = 2496k /* SRAM1+SRAM2+SRAM3+SRAM5 NS */
+    ram1   (wx) : org = 0x20000000, len = 832k  /* SRAM1+SRAM2 NS */
+    ram2   (wx) : org = 0x200D0000, len = 1664k /* SRAM3+SRAM5 NS */
+    ram3   (wx) : org = 0x28000000, len = 16k   /* SRAM4 NS */
+    ram4   (wx) : org = 0x30000000, len = 2496k /* SRAM1+SRAM2+SRAM3+SRAM5 NSC */
+    ram5   (wx) : org = 0x30000000, len = 832k  /* SRAM1+SRAM2 NSC */
+    ram6   (wx) : org = 0x300D0000, len = 1664k /* SRAM3+SRAM5 NSC */
+    ram7   (wx) : org = 0x38000000, len = 16k   /* SRAM4 NSC */
+}
+
+/* For each data/text section two region are defined, a virtual region
+   and a load region (_LMA suffix).*/
+
+/* Flash region to be used for exception vectors.*/
+REGION_ALIAS("VECTORS_FLASH", flash0);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for constructors and destructors.*/
+REGION_ALIAS("XTORS_FLASH", flash0);
+REGION_ALIAS("XTORS_FLASH_LMA", flash0);
+
+/* Flash region to be used for code text.*/
+REGION_ALIAS("TEXT_FLASH", flash0);
+REGION_ALIAS("TEXT_FLASH_LMA", flash0);
+
+/* Flash region to be used for read only data.*/
+REGION_ALIAS("RODATA_FLASH", flash0);
+REGION_ALIAS("RODATA_FLASH_LMA", flash0);
+
+/* Flash region to be used for various.*/
+REGION_ALIAS("VARIOUS_FLASH", flash0);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash0);
+
+/* Flash region to be used for RAM(n) initialization data.*/
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash0);
+
+/* RAM region to be used for Main stack. This stack accommodates the processing
+   of all exceptions and interrupts.*/
+REGION_ALIAS("MAIN_STACK_RAM", ram0);
+
+/* RAM region to be used for the process stack. This is the stack used by
+   the main() function.*/
+REGION_ALIAS("PROCESS_STACK_RAM", ram0);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", flash0);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ram0);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ram0);
+
+/* RAM region to be used for DMA3 link structures.*/
+REGION_ALIAS("DMA3_RAM", ram0);
+
+SECTIONS
+{
+    /* Special section for GPDMA links, it must not exceed 64kB in size.*/
+    .dma3 (NOLOAD) : ALIGN(16)
+    {
+        __dma3_base__ = .;
+        *(.dma3)
+        *(.dma3.*)
+        *(.bss.__dma3_*)
+        . = ALIGN(4);
+        __dma3_end__ = .;
+    } > DMA3_RAM
+}
+
+/* Generic rules inclusion.*/
+INCLUDE rules.ld

--- a/os/hal/boards/ST_NUCLEO144_U5A5ZJ_Q/board.h
+++ b/os/hal/boards/ST_NUCLEO144_U5A5ZJ_Q/board.h
@@ -223,6 +223,23 @@
 #define GPIOI_PIN14                 14U
 #define GPIOI_PIN15                 15U
 
+#define GPIOJ_PIN0                  0U
+#define GPIOJ_PIN1                  1U
+#define GPIOJ_PIN2                  2U
+#define GPIOJ_PIN3                  3U
+#define GPIOJ_PIN4                  4U
+#define GPIOJ_PIN5                  5U
+#define GPIOJ_PIN6                  6U
+#define GPIOJ_PIN7                  7U
+#define GPIOJ_PIN8                  8U
+#define GPIOJ_PIN9                  9U
+#define GPIOJ_PIN10                 10U
+#define GPIOJ_PIN11                 11U
+#define GPIOJ_PIN12                 12U
+#define GPIOJ_PIN13                 13U
+#define GPIOJ_PIN14                 14U
+#define GPIOJ_PIN15                 15U
+
 /*
  * IO lines assignments.
  */
@@ -1484,6 +1501,139 @@
                                      PIN_LOCKR_DISABLED(GPIOI_PIN13) |      \
                                      PIN_LOCKR_DISABLED(GPIOI_PIN14) |      \
                                      PIN_LOCKR_DISABLED(GPIOI_PIN15))
+
+/*
+ * GPIOJ setup:
+ *
+ * PJ0  - PIN0                      (analog).
+ * PJ1  - PIN1                      (analog).
+ * PJ2  - PIN2                      (analog).
+ * PJ3  - PIN3                      (analog).
+ * PJ4  - PIN4                      (analog).
+ * PJ5  - PIN5                      (analog).
+ * PJ6  - PIN6                      (analog).
+ * PJ7  - PIN7                      (analog).
+ * PJ8  - PIN8                      (analog).
+ * PJ9  - PIN9                      (analog).
+ * PJ10 - PIN10                     (analog).
+ * PJ11 - PIN11                     (analog).
+ * PJ12 - PIN12                     (analog).
+ * PJ13 - PIN13                     (analog).
+ * PJ14 - PIN14                     (analog).
+ * PJ15 - PIN15                     (analog).
+ */
+#define VAL_GPIOJ_MODER             (PIN_MODE_ANALOG(GPIOJ_PIN0) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN1) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN2) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN3) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN4) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN5) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN6) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN7) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN8) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN9) |          \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN10) |         \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN11) |         \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN12) |         \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN13) |         \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN14) |         \
+                                     PIN_MODE_ANALOG(GPIOJ_PIN15))
+#define VAL_GPIOJ_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOJ_PIN0) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN1) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN2) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN3) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN4) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN5) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN6) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN7) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN8) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN9) |       \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN10) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN11) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN12) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN13) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN14) |      \
+                                     PIN_OTYPE_PUSHPULL(GPIOJ_PIN15))
+#define VAL_GPIOJ_OSPEEDR           (PIN_OSPEED_VERYLOW(GPIOJ_PIN0) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN1) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN2) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN3) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN4) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN5) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN6) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN7) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN8) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN9) |       \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN10) |      \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN11) |      \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN12) |      \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN13) |      \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN14) |      \
+                                     PIN_OSPEED_VERYLOW(GPIOJ_PIN15))
+#define VAL_GPIOJ_PUPDR             (PIN_PUPDR_FLOATING(GPIOJ_PIN0) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN1) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN2) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN3) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN4) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN5) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN6) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN7) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN8) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN9) |       \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN10) |      \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN11) |      \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN12) |      \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN13) |      \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN14) |      \
+                                     PIN_PUPDR_FLOATING(GPIOJ_PIN15))
+#define VAL_GPIOJ_ODR               (PIN_ODR_LOW(GPIOJ_PIN0) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN1) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN2) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN3) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN4) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN5) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN6) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN7) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN8) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN9) |              \
+                                     PIN_ODR_LOW(GPIOJ_PIN10) |             \
+                                     PIN_ODR_LOW(GPIOJ_PIN11) |             \
+                                     PIN_ODR_LOW(GPIOJ_PIN12) |             \
+                                     PIN_ODR_LOW(GPIOJ_PIN13) |             \
+                                     PIN_ODR_LOW(GPIOJ_PIN14) |             \
+                                     PIN_ODR_LOW(GPIOJ_PIN15))
+#define VAL_GPIOJ_AFRL              (PIN_AFIO_AF(GPIOJ_PIN0, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN1, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN2, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN3, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN4, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN5, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN6, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN7, 0U))
+#define VAL_GPIOJ_AFRH              (PIN_AFIO_AF(GPIOJ_PIN8, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN9, 0U) |          \
+                                     PIN_AFIO_AF(GPIOJ_PIN10, 0U) |         \
+                                     PIN_AFIO_AF(GPIOJ_PIN11, 0U) |         \
+                                     PIN_AFIO_AF(GPIOJ_PIN12, 0U) |         \
+                                     PIN_AFIO_AF(GPIOJ_PIN13, 0U) |         \
+                                     PIN_AFIO_AF(GPIOJ_PIN14, 0U) |         \
+                                     PIN_AFIO_AF(GPIOJ_PIN15, 0U))
+#define VAL_GPIOJ_LOCKR             (PIN_LOCKR_DISABLED(GPIOJ_PIN0) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN1) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN2) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN3) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN4) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN5) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN6) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN7) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN8) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN9) |       \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN10) |      \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN11) |      \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN12) |      \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN13) |      \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN14) |      \
+                                     PIN_LOCKR_DISABLED(GPIOJ_PIN15))
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/boards/ST_NUCLEO144_U5A5ZJ_Q/cfg/board.chcfg
+++ b/os/hal/boards/ST_NUCLEO144_U5A5ZJ_Q/cfg/board.chcfg
@@ -182,5 +182,23 @@
       <pin14 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
       <pin15 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
     </GPIOI>
+    <GPIOJ>
+      <pin0 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin1 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin2 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin3 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin4 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin5 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin6 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin7 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin8 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin9 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin10 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin11 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin12 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin13 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin14 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin15 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+    </GPIOJ>
   </ports>
 </board>

--- a/os/hal/ports/STM32/LLD/EXTIv1/stm32_exti.h
+++ b/os/hal/ports/STM32/LLD/EXTIv1/stm32_exti.h
@@ -48,7 +48,7 @@
 #if !defined(STM32H7XX) && !defined(STM32L4XX) && !defined(STM32L4XXP) &&   \
     !defined(STM32C0XX) && !defined(STM32G0XX) && !defined(STM32G4XX) &&    \
     !defined(STM32WBXX) && !defined(STM32WLXX) && !defined(STM32H5XX) &&    \
-    !defined(STM32U0XX) && !defined(STM32U3XX)
+    !defined(STM32U0XX) && !defined(STM32U3XX) && !defined(STM32U5XX)
 #define EMR1    EMR
 #define IMR1    IMR
 #define PR1     PR

--- a/os/hal/ports/STM32/STM32U5xx/platform_type2.mk
+++ b/os/hal/ports/STM32/STM32U5xx/platform_type2.mk
@@ -1,0 +1,49 @@
+# Required platform files.
+PLATFORMSRC := $(CHIBIOS)/os/hal/ports/common/ARMCMx/nvic.c \
+               $(CHIBIOS)/os/hal/ports/STM32/STM32U5xx/stm32_isr.c \
+               $(CHIBIOS)/os/hal/ports/STM32/STM32U5xx/hal_lld.c
+
+# Required include directories.
+PLATFORMINC := $(CHIBIOS)/os/hal/ports/common/ARMCMx \
+               $(CHIBIOS)/os/hal/ports/STM32/STM32U5xx
+
+# Optional platform files.
+ifeq ($(USE_SMART_BUILD),yes)
+
+# Configuration files directory
+ifeq ($(HALCONFDIR),)
+  ifeq ($(CONFDIR),)
+    HALCONFDIR = .
+  else
+    HALCONFDIR := $(CONFDIR)
+  endif
+endif
+
+HALCONF := $(strip $(shell cat $(HALCONFDIR)/halconf.h | egrep -e "\#define"))
+
+else
+endif
+
+# Drivers compatible with the platform.
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/ADCv7/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/DACv2/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/DMA3v1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/EXTIv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/FDCANv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/GPIOv2/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/I2Cv4/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/ICACHEv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/RCCv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/RTCv3/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/SPIv4/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/SDMMCv2/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/SYSTICKv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/RNGv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/TIMv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/USARTv3/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/OTGv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/STM32/LLD/xWDGv1/driver.mk
+
+# Shared variables.
+ALLCSRC += $(PLATFORMSRC)
+ALLINC  += $(PLATFORMINC)

--- a/os/hal/ports/STM32/STM32U5xx/stm32_isr.c
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_isr.c
@@ -101,9 +101,12 @@
 #include "stm32_usart3.inc"
 #include "stm32_uart4.inc"
 #include "stm32_uart5.inc"
+#include "stm32_usart6.inc"
 #include "stm32_lpuart1.inc"
 
+#if STM32_HAS_USB1
 #include "stm32_usb1.inc"
+#endif
 
 /*===========================================================================*/
 /* Driver exported functions.                                                */
@@ -166,9 +169,12 @@ void irqInit(void) {
   usart3_irq_init();
   uart4_irq_init();
   uart5_irq_init();
+  usart6_irq_init();
   lpuart1_irq_init();
 
+#if STM32_HAS_USB1
   usb1_irq_init();
+#endif
 }
 
 /**
@@ -228,9 +234,12 @@ void irqDeinit(void) {
   usart3_irq_deinit();
   uart4_irq_deinit();
   uart5_irq_deinit();
+  usart6_irq_deinit();
   lpuart1_irq_deinit();
 
+#if STM32_HAS_USB1
   usb1_irq_deinit();
+#endif
 }
 
 /** @} */

--- a/os/hal/ports/STM32/STM32U5xx/stm32_isr.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_isr.h
@@ -50,6 +50,7 @@
 #define STM32_USART3_SUPPRESS_ISR
 #define STM32_UART4_SUPPRESS_ISR
 #define STM32_UART5_SUPPRESS_ISR
+#define STM32_USART6_SUPPRESS_ISR
 #define STM32_LPUART1_SUPPRESS_ISR
 /** @} */
 
@@ -167,6 +168,10 @@
 #define STM32_I2C3_ER_HANDLER               Vector1A4
 #define STM32_I2C4_ER_HANDLER               Vector1D0
 #define STM32_I2C4_EV_HANDLER               Vector1D4
+#define STM32_I2C5_ER_HANDLER               Vector23C
+#define STM32_I2C5_EV_HANDLER               Vector240
+#define STM32_I2C6_ER_HANDLER               Vector244
+#define STM32_I2C6_EV_HANDLER               Vector248
 
 #define STM32_I2C1_EV_NUMBER                55
 #define STM32_I2C1_ER_NUMBER                56
@@ -176,6 +181,10 @@
 #define STM32_I2C3_ER_NUMBER                89
 #define STM32_I2C4_ER_NUMBER                100
 #define STM32_I2C4_EV_NUMBER                101
+#define STM32_I2C5_ER_NUMBER                127
+#define STM32_I2C5_EV_NUMBER                128
+#define STM32_I2C6_ER_NUMBER                129
+#define STM32_I2C6_EV_NUMBER                130
 
 /*
  * Low-power timer units.
@@ -302,6 +311,7 @@
 #define STM32_USART3_HANDLER                Vector13C
 #define STM32_UART4_HANDLER                 Vector140
 #define STM32_UART5_HANDLER                 Vector144
+#define STM32_USART6_HANDLER                Vector238
 #define STM32_LPUART1_HANDLER               Vector148
 
 #define STM32_USART1_NUMBER                 61
@@ -309,6 +319,7 @@
 #define STM32_USART3_NUMBER                 63
 #define STM32_UART4_NUMBER                  64
 #define STM32_UART5_NUMBER                  65
+#define STM32_USART6_NUMBER                 126
 #define STM32_LPUART1_NUMBER                66
 
 /*

--- a/tools/ftl/xml/stm32u5board.xml
+++ b/tools/ftl/xml/stm32u5board.xml
@@ -182,5 +182,23 @@
       <pin14 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
       <pin15 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
     </GPIOI>
+    <GPIOJ>
+      <pin0 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin1 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin2 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin3 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin4 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin5 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin6 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin7 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin8 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin9 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin10 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin11 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin12 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin13 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin14 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+      <pin15 ID="" Type="PushPull" Level="Low" Speed="Minimum" Resistor="Floating" Mode="Analog" Alternate="0" PinLock="Disabled" />
+    </GPIOJ>
   </ports>
 </board>


### PR DESCRIPTION
## Summary
- add the STM32U5A5ZJ Nucleo144 target, configuration, and linker memory map to RT-STM32-MULTI
- add a U5 type-2 platform using OTGv1 instead of USBv2
- complete U5A5 GPIOJ generation and type-2 USART/I2C interrupt metadata
- correct STM32U5 EXTI register-name handling

## Validation
- clean -O0 build of stm32u5a5zj_nucleo144
- clean -O0 build of stm32u575zi_nucleo144
- board XML/XSD and Eclipse .cproject validation
- style and whitespace checks

## Follow-up
Enabling OTG2 still requires an OTGv1 adaptation for the STM32U5 integrated HS PHY and its reference-clock requirements; this PR only selects the correct LLD family for type-2 devices.