### PR TITLE
STM32U5: initialize integrated OTG HS PHY

### DIFF
--- a/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.c
+++ b/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.c
@@ -886,10 +886,33 @@ void usb_lld_start(USBDriver *usbp) {
 
 #if STM32_USB_USE_OTG2
     if (&USBD2 == usbp) {
+#if defined(STM32U5XX)
+      /* The USB power booster must be ready before clocking the PHY.*/
+      PWR->VOSR &= ~PWR_VOSR_VDD11USBDIS;
+      PWR->VOSR |= PWR_VOSR_USBPWREN | PWR_VOSR_USBBOOSTEN;
+      while ((PWR->VOSR & PWR_VOSR_USBBOOSTRDY) == 0U) {
+      }
+
+      /* Integrated high-speed PHY clocks.*/
+      rccEnableSYSCFG(true);
+      rccEnableUSBPHYC(true);
+#endif
+
       /* OTG HS clock enable and reset.*/
       rccEnableOTG_HS(true);
       rccResetOTG_HS();
 
+#if defined(STM32U5XX)
+      /* Reference clock and mandatory PHY tuning values from the RM.*/
+      SYSCFG->OTGHSPHYCR = STM32_OTGHS_PHY_CLKSEL;
+      SYSCFG->OTGHSPHYTUNER2 =
+        (SYSCFG->OTGHSPHYTUNER2 &
+         ~(SYSCFG_OTGHSPHYTUNER2_COMPDISTUNE_Msk |
+           SYSCFG_OTGHSPHYTUNER2_SQRXTUNE_Msk)) |
+        SYSCFG_OTGHSPHYTUNER2_COMPDISTUNE_1;
+      SYSCFG->OTGHSPHYCR |= SYSCFG_OTGHSPHYCR_EN;
+
+#else /* !defined(STM32U5XX) */
       /* ULPI clock is managed depending on the presence of an external
          PHY.*/
 #if defined(BOARD_OTG2_USES_ULPI)
@@ -899,13 +922,17 @@ void usb_lld_start(USBDriver *usbp) {
          http://forum.chibios.org/phpbb/viewtopic.php?f=16&t=1798.*/
       rccDisableOTG_HSULPI();
 #endif
+#endif /* !defined(STM32U5XX) */
 
       /* Enables IRQ vector.*/
       nvicEnableVector(STM32_OTG2_NUMBER, STM32_USB_OTG2_IRQ_PRIORITY);
 
       /* - Forced device mode.
          - USB turn-around time = TRDT_VALUE_HS or TRDT_VALUE_FS.*/
-#if defined(BOARD_OTG2_USES_ULPI)
+#if defined(STM32U5XX)
+      /* Integrated high-speed UTMI PHY.*/
+      otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_HS);
+#elif defined(BOARD_OTG2_USES_ULPI)
       /* High speed ULPI PHY.*/
       otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_HS) |
                       GUSBCFG_SRPCAP | GUSBCFG_HNPCAP;
@@ -914,7 +941,15 @@ void usb_lld_start(USBDriver *usbp) {
                       GUSBCFG_PHYSEL;
 #endif
 
-#if defined(BOARD_OTG2_USES_ULPI)
+#if defined(STM32U5XX)
+#if STM32_USE_USB_OTG2_HS
+      /* Integrated PHY in high-speed mode.*/
+      otgp->DCFG = 0x02200000 | DCFG_DSPD_HS;
+#else
+      /* Integrated high-speed PHY operating at full speed.*/
+      otgp->DCFG = 0x02200000 | DCFG_DSPD_HS_FS;
+#endif
+#elif defined(BOARD_OTG2_USES_ULPI)
 #if STM32_USE_USB_OTG2_HS
       /* USB 2.0 High Speed PHY in HS mode.*/
       otgp->DCFG = 0x02200000 | DCFG_DSPD_HS | BOARD_OTG2_ULPI_CHIRP_DELAY_MASK;
@@ -1014,7 +1049,14 @@ void usb_lld_stop(USBDriver *usbp) {
 #if STM32_USB_USE_OTG2
     if (&USBD2 == usbp) {
       nvicDisableVector(STM32_OTG2_NUMBER);
+#if defined(STM32U5XX)
+      SYSCFG->OTGHSPHYCR &= ~SYSCFG_OTGHSPHYCR_EN;
+#endif
       rccDisableOTG_HS();
+#if defined(STM32U5XX)
+      rccDisableUSBPHYC();
+      PWR->VOSR &= ~(PWR_VOSR_USBPWREN | PWR_VOSR_USBBOOSTEN);
+#endif
 #if defined(BOARD_OTG2_USES_ULPI)
       rccDisableOTG_HSULPI();
 #endif

--- a/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.h
+++ b/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.h
@@ -103,7 +103,7 @@
 /**
  * @brief   Enables HS mode on OTG2 else FS mode.
  * @note    The default is @p TRUE.
- * @note    Has effect only if @p BOARD_OTG2_USES_ULPI is defined.
+ * @note    Has effect only when OTG2 uses a high-speed PHY.
  */
 #if !defined(STM32_USE_USB_OTG2_HS) || defined(__DOXYGEN__)
 #define STM32_USE_USB_OTG2_HS               TRUE
@@ -233,7 +233,7 @@
 #elif defined(STM32F10X_CL)
 #define STM32_USBCLK                        STM32_OTGFSCLK
 #elif defined(STM32L4XX) || defined(STM32L4XXP)
-/**/
+/* RCC operations and clock definitions are provided by the L4 platform.*/
 #elif  defined(STM32H7XX)
 /* Defines directly STM32_USBCLK.*/
 #define rccEnableOTG_FS                     rccEnableUSB2_OTG_FS
@@ -245,6 +245,8 @@
 #define rccEnableOTG_HSULPI                 rccEnableUSB1_HSULPI
 #define rccDisableOTG_HSULPI                rccDisableUSB1_HSULPI
 #define rccDisableOTG_FSULPI                rccDisableUSB2_HSULPI
+#elif defined(STM32U5XX)
+/* RCC operations and clock definitions are provided by the U5 platform.*/
 #else
 #error "unsupported STM32 platform for OTG functionality"
 #endif
@@ -252,6 +254,33 @@
 #if (STM32_USB_HOST_WAKEUP_DURATION < 2) || (STM32_USB_HOST_WAKEUP_DURATION > 15)
 #error "invalid STM32_USB_HOST_WAKEUP_DURATION setting, it must be between 2 and 15"
 #endif
+
+#if defined(STM32U5XX)
+
+/* The integrated OTG_HS transceiver requires voltage range 1 or 2.*/
+#if (STM32_CFG_PWR_VOSR != PWR_VOSR_VOS_RANGE1) &&                         \
+    (STM32_CFG_PWR_VOSR != PWR_VOSR_VOS_RANGE2)
+#error "the STM32 OTG_HS PHY requires voltage range 1 or 2"
+#endif
+
+/* Integrated OTG_HS PHY reference frequency selection.*/
+#if STM32_OTGHSCLK == 16000000U
+#define STM32_OTGHS_PHY_CLKSEL              (3U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 19200000U
+#define STM32_OTGHS_PHY_CLKSEL              (8U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 20000000U
+#define STM32_OTGHS_PHY_CLKSEL              (9U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 24000000U
+#define STM32_OTGHS_PHY_CLKSEL              (10U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 26000000U
+#define STM32_OTGHS_PHY_CLKSEL              (14U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 32000000U
+#define STM32_OTGHS_PHY_CLKSEL              (11U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#else
+#error "invalid STM32 OTG_HS PHY reference clock"
+#endif
+
+#else /* !defined(STM32U5XX) */
 
 /* Allowing for a small tolerance.*/
 #if (STM32_USB_48MHZ_DELTA < 0) || (STM32_USB_48MHZ_DELTA > 120000)
@@ -262,6 +291,8 @@
     (STM32_USBCLK > (48000000 + STM32_USB_48MHZ_DELTA))
 #error "the USB USBv1 driver requires a 48MHz clock"
 #endif
+
+#endif /* !defined(STM32U5XX) */
 
 /*===========================================================================*/
 /* Driver data structures and types.                                         */

--- a/os/hal/ports/STM32/STM32U5xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U5xx/hal_lld.c
@@ -543,6 +543,12 @@ __STATIC_INLINE void hal_lld_pll_setup(uint32_t pll,
  */
 static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   uint32_t cr, wtmask;
+#if defined(PWR_VOSR_USBPWREN)
+  uint32_t usbpower;
+
+  /* Preserve an active OTG_HS transceiver across dynamic clock changes.*/
+  usbpower = PWR->VOSR & (PWR_VOSR_USBPWREN | PWR_VOSR_USBBOOSTEN);
+#endif
 
   /* Use the safest flash latency while the current clock tree is unknown.*/
   halRegWrite32X(&FLASH->ACR, FLASH_ACR_LATENCY_15WS, true);
@@ -573,7 +579,13 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   halRegWrite32X(&FLASH->ACR, STM32_FLASH_ACR_RESET, true);
 
   /* Voltage scaling must be ready before high-frequency clocks are used.*/
+#if defined(PWR_VOSR_USBPWREN)
+  halRegWrite32X(&PWR->VOSR,
+                 (ccp->pwr_vosr & ~PWR_VOSR_BOOSTEN) | usbpower,
+                 true);
+#else
   halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr & ~PWR_VOSR_BOOSTEN, true);
+#endif
   if (halRegWaitAllSet32X(&PWR->VOSR,
                           PWR_VOSR_VOSRDY,
                           STM32_REGULATORS_TRANSITION_TIME,
@@ -636,7 +648,11 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   hal_lld_pll_setup(2U, &ccp->plls[2]);
 
   if ((ccp->pwr_vosr & PWR_VOSR_BOOSTEN) != 0U) {
+#if defined(PWR_VOSR_USBPWREN)
+    halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr | usbpower, true);
+#else
     halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr, true);
+#endif
     if (halRegWaitAllSet32X(&PWR->VOSR,
                             PWR_VOSR_BOOSTRDY,
                             STM32_REGULATORS_TRANSITION_TIME,

--- a/os/hal/ports/STM32/STM32U5xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32U5xx/hal_lld.h
@@ -447,7 +447,7 @@
 #define STM32_MDF1CLK                       STM32_MDF1_CLOCK
 #define STM32_ADF1CLK                       STM32_ADF1_CLOCK
 #define STM32_HSPI1CLK                      STM32_HSPI1_CLOCK
-#define STM32_OTGHSCLK                      STM32_USBPHYC_CLOCK
+#define STM32_OTGHSCLK                      STM32_USBPHYC_FREQ
 #define STM32_DSICLK                        STM32_DSI_CLOCK
 #define STM32_LTDCCLK                       STM32_LTDC_CLOCK
 #define STM32_SAESCLK                       STM32_SAES_CLOCK

--- a/os/hal/ports/STM32/STM32U5xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_rcc.h
@@ -670,6 +670,13 @@
 #define rccDisableUSB() rccDisableAHB2R1(RCC_AHB2ENR1_OTGEN)
 #define rccResetUSB() rccResetAHB2R1(RCC_AHB2RSTR1_OTGRST)
 
+#define rccEnableUSBPHYC(lp) rccEnableAHB2R1(RCC_AHB2ENR1_USBPHYCEN, lp)
+#define rccDisableUSBPHYC() rccDisableAHB2R1(RCC_AHB2ENR1_USBPHYCEN)
+
+#define rccEnableOTG_HS(lp) rccEnableUSB(lp)
+#define rccDisableOTG_HS() rccDisableUSB()
+#define rccResetOTG_HS() rccResetUSB()
+
 #define rccEnableUCPD1(lp) rccEnableAPB1R2(RCC_APB1ENR2_UCPD1EN, lp)
 #define rccDisableUCPD1() rccDisableAPB1R2(RCC_APB1ENR2_UCPD1EN)
 #define rccResetUCPD1() rccResetAPB1R2(RCC_APB1RSTR2_UCPD1RST)


### PR DESCRIPTION
## Summary
- add STM32U5 integrated OTG_HS PHY power, clock, tuning, and shutdown sequencing
- validate voltage range and supported PHY reference frequencies
- support internal UTMI high-speed/full-speed modes and preserve USB power across dynamic clock changes

## Verification
- U5A5 static USB build at -O0
- U5A5 dynamic USB build at -O0
- U575 regression build at -O0
- style checks and git diff --check