### PR TITLE
STM32: select OTG2 PHY through registry capabilities

### DIFF
--- a/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.c
+++ b/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.c
@@ -42,10 +42,11 @@
 #define USB_OTG_DCFG_XCVRDLY    (1U << 14)
 
 /**
-  * @brief some ULPI chip need additional delay for initial handshake,
-  *        namely microchip 334x series.
-  */
-#if defined(BOARD_OTG2_ULPI_ACTIVATE_CHIRP_DELAY)
+ * @brief some ULPI chip need additional delay for initial handshake,
+ *        namely microchip 334x series.
+ */
+#if (STM32_USB_OTG2_PHY == STM32_OTG_PHY_EXTERNAL_ULPI) &&                  \
+    defined(BOARD_OTG2_ULPI_ACTIVATE_CHIRP_DELAY)
 #define BOARD_OTG2_ULPI_CHIRP_DELAY_MASK USB_OTG_DCFG_XCVRDLY
 #else
 #define BOARD_OTG2_ULPI_CHIRP_DELAY_MASK 0
@@ -68,7 +69,7 @@
 
 #elif STM32_OTG_STEPPING == 3
 #if defined(BOARD_OTG_NOVBUSSENS)
-#define GCCFG_INIT_VALUE        0U
+#define GCCFG_INIT_VALUE        (GCCFG_VBVALOVAL | GCCFG_VBVALEXTOEN)
 #else
 #define GCCFG_INIT_VALUE        GCCFG_VBDEN
 #endif
@@ -170,6 +171,95 @@ static void otg_core_reset(USBDriver *usbp) {
   /* Wait AHB idle condition again.*/
   while ((otgp->GRSTCTL & GRSTCTL_AHBIDL) == 0)
     ;
+}
+
+static bool otg_uses_integrated_hs_phy(USBDriver *usbp) {
+
+#if STM32_USB_USE_OTG2 &&                                             \
+    (STM32_USB_OTG2_PHY == STM32_OTG_PHY_INTEGRATED_HS)
+  return &USBD2 == usbp;
+#else
+  (void)usbp;
+
+  return false;
+#endif
+}
+
+static void otg_device_configure(USBDriver *usbp) {
+  stm32_otg_t *otgp = usbp->otg;
+
+#if STM32_USB_USE_OTG1
+  if (&USBD1 == usbp) {
+    /* - Forced device mode.
+       - USB turn-around time = TRDT_VALUE_FS.
+       - Full Speed 1.1 PHY.*/
+    otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_FS) |
+                    GUSBCFG_PHYSEL;
+
+    /* 48MHz 1.1 PHY.*/
+    otgp->DCFG = 0x02200000 | DCFG_DSPD_FS11;
+  }
+#endif
+
+#if STM32_USB_USE_OTG2
+  if (&USBD2 == usbp) {
+    /* - Forced device mode.
+       - USB turn-around time = TRDT_VALUE_HS or TRDT_VALUE_FS.*/
+#if STM32_USB_OTG2_PHY == STM32_OTG_PHY_INTEGRATED_HS
+    /* Integrated high-speed PHY.*/
+    otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_HS);
+#elif STM32_USB_OTG2_PHY == STM32_OTG_PHY_EXTERNAL_ULPI
+    /* High speed ULPI PHY.*/
+    otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_HS) |
+                    GUSBCFG_SRPCAP | GUSBCFG_HNPCAP;
+#else
+    /* Embedded full-speed PHY.*/
+    otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_FS) |
+                    GUSBCFG_PHYSEL;
+#endif
+
+#if STM32_USB_OTG2_PHY == STM32_OTG_PHY_INTEGRATED_HS
+#if STM32_USE_USB_OTG2_HS
+    /* Integrated PHY in high-speed mode.*/
+    otgp->DCFG = 0x02200000 | DCFG_DSPD_HS;
+#else
+    /* Integrated high-speed PHY operating at full speed.*/
+    otgp->DCFG = 0x02200000 | DCFG_DSPD_HS_FS;
+#endif
+#elif STM32_USB_OTG2_PHY == STM32_OTG_PHY_EXTERNAL_ULPI
+#if STM32_USE_USB_OTG2_HS
+    /* USB 2.0 High Speed PHY in HS mode.*/
+    otgp->DCFG = 0x02200000 | DCFG_DSPD_HS |
+                 BOARD_OTG2_ULPI_CHIRP_DELAY_MASK;
+#else
+    /* USB 2.0 High Speed PHY in FS mode.*/
+    otgp->DCFG = 0x02200000 | DCFG_DSPD_HS_FS;
+#endif
+#else
+    /* 48MHz 1.1 PHY.*/
+    otgp->DCFG = 0x02200000 | DCFG_DSPD_FS11;
+#endif
+  }
+#endif
+}
+
+static void otg_vbus_configure(USBDriver *usbp) {
+  stm32_otg_t *otgp = usbp->otg;
+
+  /* VBUS sensing and transceiver enabled.*/
+  otgp->GOTGCTL = GOTGCTL_BVALOEN | GOTGCTL_BVALOVAL;
+
+#if STM32_USB_USE_OTG2 &&                                             \
+    (STM32_USB_OTG2_PHY == STM32_OTG_PHY_EXTERNAL_ULPI)
+  if (&USBD2 == usbp) {
+    otgp->GCCFG = 0U;
+  }
+  else {
+    otgp->GCCFG = GCCFG_INIT_VALUE;
+  }
+#else
+  otgp->GCCFG = GCCFG_INIT_VALUE;
+#endif
 }
 
 static void otg_disable_ep(USBDriver *usbp) {
@@ -662,14 +752,18 @@ irq_retry:
 
   /* Enumeration done.*/
   if (sts & GINTSTS_ENUMDNE) {
-    /* Full or High speed timing selection.*/
-    if ((otgp->DSTS & DSTS_ENUMSPD_MASK) == DSTS_ENUMSPD_HS_480) {
-      otgp->GUSBCFG = (otgp->GUSBCFG & ~(GUSBCFG_TRDT_MASK)) |
-                      GUSBCFG_TRDT(TRDT_VALUE_HS);
-    }
-    else {
-      otgp->GUSBCFG = (otgp->GUSBCFG & ~(GUSBCFG_TRDT_MASK)) |
-                      GUSBCFG_TRDT(TRDT_VALUE_FS);
+    /* An integrated HS PHY retains its HS interface timing even when the
+       device enumerates at full speed.*/
+    if (!otg_uses_integrated_hs_phy(usbp)) {
+      /* Full or High speed timing selection.*/
+      if ((otgp->DSTS & DSTS_ENUMSPD_MASK) == DSTS_ENUMSPD_HS_480) {
+        otgp->GUSBCFG = (otgp->GUSBCFG & ~(GUSBCFG_TRDT_MASK)) |
+                        GUSBCFG_TRDT(TRDT_VALUE_HS);
+      }
+      else {
+        otgp->GUSBCFG = (otgp->GUSBCFG & ~(GUSBCFG_TRDT_MASK)) |
+                        GUSBCFG_TRDT(TRDT_VALUE_FS);
+      }
     }
   }
 
@@ -872,123 +966,50 @@ void usb_lld_start(USBDriver *usbp) {
 
       /* Enables IRQ vector.*/
       nvicEnableVector(STM32_OTG1_NUMBER, STM32_USB_OTG1_IRQ_PRIORITY);
-
-      /* - Forced device mode.
-         - USB turn-around time = TRDT_VALUE_FS.
-         - Full Speed 1.1 PHY.*/
-      otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_FS) |
-                      GUSBCFG_PHYSEL;
-
-      /* 48MHz 1.1 PHY.*/
-      otgp->DCFG = 0x02200000 | DCFG_DSPD_FS11;
     }
 #endif
 
 #if STM32_USB_USE_OTG2
     if (&USBD2 == usbp) {
-#if defined(STM32U5XX)
-      /* The USB power booster must be ready before clocking the PHY.*/
-      PWR->VOSR &= ~PWR_VOSR_VDD11USBDIS;
-      PWR->VOSR |= PWR_VOSR_USBPWREN | PWR_VOSR_USBBOOSTEN;
-      while ((PWR->VOSR & PWR_VOSR_USBBOOSTRDY) == 0U) {
-      }
-
-      /* Integrated high-speed PHY clocks.*/
-      rccEnableSYSCFG(true);
-      rccEnableUSBPHYC(true);
+#if STM32_USB_OTG2_PHY == STM32_OTG_PHY_INTEGRATED_HS
+      /* The integrated PHY must be ready before clocking the OTG core.*/
+      stm32_otg2_phy_start();
 #endif
 
       /* OTG HS clock enable and reset.*/
       rccEnableOTG_HS(true);
       rccResetOTG_HS();
 
-#if defined(STM32U5XX)
-      /* Reference clock and mandatory PHY tuning values from the RM.*/
-      SYSCFG->OTGHSPHYCR = STM32_OTGHS_PHY_CLKSEL;
-      SYSCFG->OTGHSPHYTUNER2 =
-        (SYSCFG->OTGHSPHYTUNER2 &
-         ~(SYSCFG_OTGHSPHYTUNER2_COMPDISTUNE_Msk |
-           SYSCFG_OTGHSPHYTUNER2_SQRXTUNE_Msk)) |
-        SYSCFG_OTGHSPHYTUNER2_COMPDISTUNE_1;
-      SYSCFG->OTGHSPHYCR |= SYSCFG_OTGHSPHYCR_EN |
-                            SYSCFG_OTGHSPHYCR_PDCTRL;
-
-#else /* !defined(STM32U5XX) */
       /* ULPI clock is managed depending on the presence of an external
          PHY.*/
-#if defined(BOARD_OTG2_USES_ULPI)
+#if STM32_USB_OTG2_PHY == STM32_OTG_PHY_EXTERNAL_ULPI
       rccEnableOTG_HSULPI(true);
-#else
+#elif STM32_USB_OTG2_PHY == STM32_OTG_PHY_EMBEDDED_FS
       /* Workaround for the problem described here:
          http://forum.chibios.org/phpbb/viewtopic.php?f=16&t=1798.*/
       rccDisableOTG_HSULPI();
 #endif
-#endif /* !defined(STM32U5XX) */
 
       /* Enables IRQ vector.*/
       nvicEnableVector(STM32_OTG2_NUMBER, STM32_USB_OTG2_IRQ_PRIORITY);
-
-      /* - Forced device mode.
-         - USB turn-around time = TRDT_VALUE_HS or TRDT_VALUE_FS.*/
-#if defined(STM32U5XX)
-      /* Integrated high-speed UTMI PHY.*/
-      otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_HS);
-#elif defined(BOARD_OTG2_USES_ULPI)
-      /* High speed ULPI PHY.*/
-      otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_HS) |
-                      GUSBCFG_SRPCAP | GUSBCFG_HNPCAP;
-#else
-      otgp->GUSBCFG = GUSBCFG_FDMOD | GUSBCFG_TRDT(TRDT_VALUE_FS) |
-                      GUSBCFG_PHYSEL;
-#endif
-
-#if defined(STM32U5XX)
-#if STM32_USE_USB_OTG2_HS
-      /* Integrated PHY in high-speed mode.*/
-      otgp->DCFG = 0x02200000 | DCFG_DSPD_HS;
-#else
-      /* Integrated high-speed PHY operating at full speed.*/
-      otgp->DCFG = 0x02200000 | DCFG_DSPD_HS_FS;
-#endif
-#elif defined(BOARD_OTG2_USES_ULPI)
-#if STM32_USE_USB_OTG2_HS
-      /* USB 2.0 High Speed PHY in HS mode.*/
-      otgp->DCFG = 0x02200000 | DCFG_DSPD_HS | BOARD_OTG2_ULPI_CHIRP_DELAY_MASK;
-#else
-      /* USB 2.0 High Speed PHY in FS mode.*/
-      otgp->DCFG = 0x02200000 | DCFG_DSPD_HS_FS;
-#endif
-#else
-      /* 48MHz 1.1 PHY.*/
-      otgp->DCFG = 0x02200000 | DCFG_DSPD_FS11;
-#endif
     }
 #endif
 
     /* PHY enabled.*/
     otgp->PCGCCTL = 0;
 
-    /* VBUS sensing and transceiver enabled.*/
-    otgp->GOTGCTL = GOTGCTL_BVALOEN | GOTGCTL_BVALOVAL;
-
-#if defined(BOARD_OTG2_USES_ULPI)
-#if STM32_USB_USE_OTG1
-    if (&USBD1 == usbp) {
-      otgp->GCCFG = GCCFG_INIT_VALUE;
+    if (otg_uses_integrated_hs_phy(usbp)) {
+      /* The integrated PHY clock is required by the soft core reset.*/
+      otg_core_reset(usbp);
+      otg_device_configure(usbp);
+      otg_vbus_configure(usbp);
     }
-#endif
-
-#if STM32_USB_USE_OTG2
-    if (&USBD2 == usbp) {
-      otgp->GCCFG = 0;
+    else {
+      /* Legacy PHY interface selection must precede the soft core reset.*/
+      otg_device_configure(usbp);
+      otg_vbus_configure(usbp);
+      otg_core_reset(usbp);
     }
-#endif
-#else
-    otgp->GCCFG = GCCFG_INIT_VALUE;
-#endif
-
-    /* Soft core reset.*/
-    otg_core_reset(usbp);
 
     /* Interrupts on TXFIFOs half empty.*/
     otgp->GAHBCFG = 0;
@@ -1050,15 +1071,11 @@ void usb_lld_stop(USBDriver *usbp) {
 #if STM32_USB_USE_OTG2
     if (&USBD2 == usbp) {
       nvicDisableVector(STM32_OTG2_NUMBER);
-#if defined(STM32U5XX)
-      SYSCFG->OTGHSPHYCR &= ~SYSCFG_OTGHSPHYCR_EN;
-#endif
       rccDisableOTG_HS();
-#if defined(STM32U5XX)
-      rccDisableUSBPHYC();
-      PWR->VOSR &= ~(PWR_VOSR_USBPWREN | PWR_VOSR_USBBOOSTEN);
+#if STM32_USB_OTG2_PHY == STM32_OTG_PHY_INTEGRATED_HS
+      stm32_otg2_phy_stop();
 #endif
-#if defined(BOARD_OTG2_USES_ULPI)
+#if STM32_USB_OTG2_PHY == STM32_OTG_PHY_EXTERNAL_ULPI
       rccDisableOTG_HSULPI();
 #endif
     }

--- a/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.h
+++ b/os/hal/ports/STM32/LLD/OTGv1/hal_usb_lld.h
@@ -34,6 +34,15 @@
 /*===========================================================================*/
 
 /**
+ * @name    OTG PHY types
+ * @{
+ */
+#define STM32_OTG_PHY_EMBEDDED_FS           (1U << 0)
+#define STM32_OTG_PHY_EXTERNAL_ULPI         (1U << 1)
+#define STM32_OTG_PHY_INTEGRATED_HS         (1U << 2)
+/** @} */
+
+/**
  * @brief   Status stage handling method.
  */
 #define USB_EP0_STATUS_STAGE                USB_EP0_STATUS_STAGE_SW
@@ -68,6 +77,19 @@
  */
 #if !defined(STM32_USB_USE_OTG2) || defined(__DOXYGEN__)
 #define STM32_USB_USE_OTG2                  FALSE
+#endif
+
+/**
+ * @brief   PHY selected for the OTG2 instance.
+ */
+#if !defined(STM32_USB_OTG2_PHY) || defined(__DOXYGEN__)
+#if defined(STM32_OTG2_PHY_DEFAULT)
+#define STM32_USB_OTG2_PHY                  STM32_OTG2_PHY_DEFAULT
+#elif defined(BOARD_OTG2_USES_ULPI)
+#define STM32_USB_OTG2_PHY                  STM32_OTG_PHY_EXTERNAL_ULPI
+#else
+#define STM32_USB_OTG2_PHY                  STM32_OTG_PHY_EMBEDDED_FS
+#endif
 #endif
 
 /**
@@ -157,6 +179,23 @@
 
 #if !defined(STM32_HAS_OTG1) || !defined(STM32_HAS_OTG2)
 #error "STM32_HAS_OTGx not defined in registry"
+#endif
+
+/* PHY capability default for legacy registries.*/
+#if !defined(STM32_OTG2_PHY_CAPABILITIES)
+#define STM32_OTG2_PHY_CAPABILITIES         (STM32_OTG_PHY_EMBEDDED_FS |     \
+                                             STM32_OTG_PHY_EXTERNAL_ULPI)
+#endif
+
+/* PHY selection check.*/
+#if ((STM32_USB_OTG2_PHY != STM32_OTG_PHY_EMBEDDED_FS) &&                   \
+     (STM32_USB_OTG2_PHY != STM32_OTG_PHY_EXTERNAL_ULPI) &&                 \
+     (STM32_USB_OTG2_PHY != STM32_OTG_PHY_INTEGRATED_HS))
+#error "invalid OTG2 PHY selection"
+#endif
+
+#if (STM32_USB_OTG2_PHY & STM32_OTG2_PHY_CAPABILITIES) == 0
+#error "selected OTG2 PHY is not supported"
 #endif
 
 #if STM32_HAS_OTG1 && !defined(STM32_OTG1_ENDPOINTS)
@@ -255,34 +294,9 @@
 #error "invalid STM32_USB_HOST_WAKEUP_DURATION setting, it must be between 2 and 15"
 #endif
 
-#if defined(STM32U5XX)
-
-/* The integrated OTG_HS transceiver requires voltage range 1 or 2.*/
-#if (STM32_CFG_PWR_VOSR != PWR_VOSR_VOS_RANGE1) &&                         \
-    (STM32_CFG_PWR_VOSR != PWR_VOSR_VOS_RANGE2)
-#error "the STM32 OTG_HS PHY requires voltage range 1 or 2"
-#endif
-
-/* Integrated OTG_HS PHY reference frequency selection.*/
-#if STM32_OTGHSCLK == 16000000U
-#define STM32_OTGHS_PHY_CLKSEL              (3U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
-#elif STM32_OTGHSCLK == 19200000U
-#define STM32_OTGHS_PHY_CLKSEL              (8U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
-#elif STM32_OTGHSCLK == 20000000U
-#define STM32_OTGHS_PHY_CLKSEL              (9U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
-#elif STM32_OTGHSCLK == 24000000U
-#define STM32_OTGHS_PHY_CLKSEL              (10U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
-#elif STM32_OTGHSCLK == 26000000U
-#define STM32_OTGHS_PHY_CLKSEL              (14U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
-#elif STM32_OTGHSCLK == 32000000U
-#define STM32_OTGHS_PHY_CLKSEL              (11U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
-#else
-#error "invalid STM32 OTG_HS PHY reference clock"
-#endif
-
-#else /* !defined(STM32U5XX) */
-
 /* Allowing for a small tolerance.*/
+#if STM32_USB_USE_OTG1 ||                                                   \
+    (STM32_USB_OTG2_PHY != STM32_OTG_PHY_INTEGRATED_HS)
 #if (STM32_USB_48MHZ_DELTA < 0) || (STM32_USB_48MHZ_DELTA > 120000)
 #error "invalid STM32_USB_48MHZ_DELTA setting, it must not exceed 120000"
 #endif
@@ -291,8 +305,7 @@
     (STM32_USBCLK > (48000000 + STM32_USB_48MHZ_DELTA))
 #error "the USB USBv1 driver requires a 48MHz clock"
 #endif
-
-#endif /* !defined(STM32U5XX) */
+#endif
 
 /*===========================================================================*/
 /* Driver data structures and types.                                         */

--- a/os/hal/ports/STM32/LLD/OTGv1/stm32_otg.h
+++ b/os/hal/ports/STM32/LLD/OTGv1/stm32_otg.h
@@ -428,6 +428,10 @@ typedef struct {
 /* Definitions for stepping 2.*/
 #define GCCFG_VBDEN             (1U << 21)  /**< VBUS sensing enable.       */
 #define GCCFG_PWRDWN            (1U << 16)  /**< Power down.                */
+
+/* Definitions for stepping 3.*/
+#define GCCFG_VBVALOVAL         (1U << 23)  /**< Override VBUS B-session.   */
+#define GCCFG_VBVALEXTOEN       (1U << 24)  /**< Enable B-session override. */
 /** @} */
 
 /**

--- a/os/hal/ports/STM32/STM32U5xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U5xx/hal_lld.c
@@ -1184,6 +1184,53 @@ void hal_lld_init(void) {
   irqInit();
 }
 
+#if (HAL_USE_USB == TRUE) && STM32_HAS_OTG2
+/**
+ * @brief   Enables and starts the integrated OTG2 high-speed PHY.
+ *
+ * @notapi
+ */
+void stm32_otg2_phy_start(void) {
+
+  /* The USB power booster must be ready before clocking the PHY.*/
+  PWR->VOSR &= ~PWR_VOSR_VDD11USBDIS;
+  PWR->VOSR |= PWR_VOSR_USBPWREN | PWR_VOSR_USBBOOSTEN;
+  while ((PWR->VOSR & PWR_VOSR_USBBOOSTRDY) == 0U) {
+  }
+
+  /* Integrated high-speed PHY clocks.*/
+  rccEnableSYSCFG(true);
+  rccEnableUSBPHYC(true);
+
+  /* Reference clock and mandatory PHY tuning values from the RM.*/
+  SYSCFG->OTGHSPHYCR = STM32_OTGHS_PHY_CLKSEL;
+  SYSCFG->OTGHSPHYTUNER2 =
+    (SYSCFG->OTGHSPHYTUNER2 &
+     ~(SYSCFG_OTGHSPHYTUNER2_COMPDISTUNE_Msk |
+       SYSCFG_OTGHSPHYTUNER2_SQRXTUNE_Msk)) |
+    SYSCFG_OTGHSPHYTUNER2_COMPDISTUNE_1;
+
+  /* The digital and analog PHY blocks require separate startup delays.*/
+  SYSCFG->OTGHSPHYCR |= SYSCFG_OTGHSPHYCR_EN;
+  osalSysPolledDelayX(OSAL_MS2RTC(STM32_HCLK, 2U));
+  SYSCFG->OTGHSPHYCR |= SYSCFG_OTGHSPHYCR_PDCTRL;
+  osalSysPolledDelayX(OSAL_MS2RTC(STM32_HCLK, 2U));
+}
+
+/**
+ * @brief   Stops and disables the integrated OTG2 high-speed PHY.
+ *
+ * @notapi
+ */
+void stm32_otg2_phy_stop(void) {
+
+  SYSCFG->OTGHSPHYCR &= ~(SYSCFG_OTGHSPHYCR_EN |
+                          SYSCFG_OTGHSPHYCR_PDCTRL);
+  rccDisableUSBPHYC();
+  PWR->VOSR &= ~(PWR_VOSR_USBPWREN | PWR_VOSR_USBBOOSTEN);
+}
+#endif
+
 /**
  * @brief   STM32U5xx clocks and PLL initialization.
  * @note    This function is invoked early by the startup files, non-automatic

--- a/os/hal/ports/STM32/STM32U5xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32U5xx/hal_lld.h
@@ -461,6 +461,31 @@
 #define STM32_ADC4_CLOCK                    STM32_ADCDAC_CLOCK
 #define STM32_DAC1_CLOCK                    STM32_ADCDAC_CLOCK
 
+#if ((HAL_USE_USB == TRUE) && STM32_HAS_OTG2) || defined(__DOXYGEN__)
+/* The integrated OTG_HS transceiver requires voltage range 1 or 2.*/
+#if (STM32_CFG_PWR_VOSR != PWR_VOSR_VOS_RANGE1) &&                         \
+    (STM32_CFG_PWR_VOSR != PWR_VOSR_VOS_RANGE2)
+#error "the STM32 OTG_HS PHY requires voltage range 1 or 2"
+#endif
+
+/* Integrated OTG_HS PHY reference frequency selection.*/
+#if STM32_OTGHSCLK == 16000000U
+#define STM32_OTGHS_PHY_CLKSEL              (3U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 19200000U
+#define STM32_OTGHS_PHY_CLKSEL              (8U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 20000000U
+#define STM32_OTGHS_PHY_CLKSEL              (9U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 24000000U
+#define STM32_OTGHS_PHY_CLKSEL              (10U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 26000000U
+#define STM32_OTGHS_PHY_CLKSEL              (14U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#elif STM32_OTGHSCLK == 32000000U
+#define STM32_OTGHS_PHY_CLKSEL              (11U << SYSCFG_OTGHSPHYCR_CLKSEL_Pos)
+#else
+#error "invalid STM32 OTG_HS PHY reference clock"
+#endif
+#endif
+
 /**
  * @brief   Maximum allowed SDMMC kernel clock frequency.
  */
@@ -545,6 +570,10 @@ extern "C" {
 #endif
   void hal_lld_init(void);
   void stm32_clock_init(void);
+#if ((HAL_USE_USB == TRUE) && STM32_HAS_OTG2) || defined(__DOXYGEN__)
+  void stm32_otg2_phy_start(void);
+  void stm32_otg2_phy_stop(void);
+#endif
 #if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
   bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp);
   halfreq_t hal_lld_get_clock_point(halclkpt_t clkpt);

--- a/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
@@ -461,6 +461,8 @@
 #define STM32_HAS_OTG1                      FALSE
 #define STM32_HAS_OTG2                      TRUE
 #define STM32_OTG2_ENDPOINTS                9
+#define STM32_OTG2_PHY_CAPABILITIES         STM32_OTG_PHY_INTEGRATED_HS
+#define STM32_OTG2_PHY_DEFAULT              STM32_OTG_PHY_INTEGRATED_HS
 #endif
 
 /* LTDC attributes.*/


### PR DESCRIPTION
## Summary

- Add registry capabilities and configuration selection for embedded FS,
  external ULPI, and integrated HS OTG2 PHYs.
- Preserve compatibility by falling back to `BOARD_OTG2_USES_ULPI`, then to
  the embedded FS PHY, when registry settings are absent.
- Move STM32U5 integrated PHY power, clock, tuning, and startup sequencing into
  platform hooks.
- Apply PHY-specific core reset ordering, turnaround timing, and stepping-3
  VBUS override handling without family checks in the generic driver.

## Related

- Issue(s): None.
- Notes for reviewers: STM32F723/F733 continue using the existing embedded-FS
  fallback. Their integrated HS PHY should be advertised after its F7-specific
  PLL/LDO and `GCCFG.PHYHSEN` startup sequence is implemented.

## Target Branch Check

- [x] This PR targets `master`, the current integration branch for these
  STM32U5 changes.

## Scope

- [x] Change is focused and does not bundle unrelated work.
- [x] I reviewed impact on other ports/configurations where relevant.

## Mechanical Checks

- [x] `git diff --check` passed.
- [x] Relevant ARM target builds passed.

## Testing

- [x] STM32U5A5 integrated-HS build with HSE bypass.
- [x] STM32F407 embedded-FS build.
- [x] STM32F746 external-ULPI build.
- [x] STM32H723 embedded-FS build.
- [x] STM32L476 OTG1 build.
- Hardware testing was not performed.

## Compatibility and Risk

- [x] No intentional public API/ABI break.
- Existing registries and ULPI board definitions retain their previous
  behavior through compatibility defaults.
- Clock-family dispatch cleanup is intentionally deferred.
