### PR TITLE
stm32: restore standalone TIM14 GPT ISR

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/hal_gpt_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_gpt_lld.c
@@ -406,7 +406,17 @@ OSAL_IRQ_HANDLER(STM32_TIM8_UP_HANDLER) {
 
 #if STM32_GPT_USE_TIM14 || defined(__DOXYGEN__)
 #if !defined(STM32_TIM14_SUPPRESS_ISR)
-#error "TIM14 ISR not defined by platform"
+#if !defined(STM32_TIM14_HANDLER)
+#error "STM32_TIM14_HANDLER not defined"
+#endif
+OSAL_IRQ_HANDLER(STM32_TIM14_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  gpt_lld_serve_interrupt(&GPTD14);
+
+  OSAL_IRQ_EPILOGUE();
+}
 #endif /* !defined(STM32_TIM14_SUPPRESS_ISR) */
 #endif /* STM32_GPT_USE_TIM14 */
 


### PR DESCRIPTION
## Summary

Restore the generic standalone `STM32_TIM14_HANDLER` in the STM32 TIMv1 GPT low-level driver. STM32F0 platforms already provide the handler and IRQ number, but enabling `STM32_GPT_USE_TIM14` currently stops at `#error "TIM14 ISR not defined by platform"`.

The handler remains under the existing `STM32_GPT_USE_TIM14` and `!STM32_TIM14_SUPPRESS_ISR` guards and dispatches `GPTD14` using the standard OSAL IRQ prologue/epilogue.

## Related

- Issue(s): None.
- Notes for reviewers: this is independent of the USB PMA allocator finding. A stable-21.11.x backport, if desired, is maintainer-selected.

## Target Branch Check

- [x] This PR targets `master`, the current/default integration branch.

## Scope

- [x] Change is focused and does not bundle unrelated work.
- [x] Shared-vector and application-suppressed ISR configurations are unchanged.

## Mechanical Checks

- [x] `git diff --check` passed.
- [x] `tools/style/stylecheck.pl` passed on the changed C file.
- [x] POSIX simulator build passed.
- [x] STM32F072RB NUCLEO64 ARM build passed with GPT and TIM14 enabled.

## Testing

- [x] Current unpatched `master` reproduces the documented compile-time error.
- [x] Patched build succeeds and its ELF contains `GPTD14`.
- [x] The same correction is integrated in reproducible tinySA F072 and F303 ChibiOS 21.11.5 builds.
- Hardware callback timing was not tested on F072 hardware.

## Compatibility and Risk

- [x] No intentional public API/ABI break.
- The change only supplies the previously missing generic handler when TIM14 GPT is enabled and not suppressed.