### PR TITLE
stm32: preserve EP0 PMA across reconfiguration

### DIFF
--- a/os/hal/ports/STM32/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/STM32/LLD/USBv1/hal_usb_lld.c
@@ -121,6 +121,26 @@ static uint32_t usb_pm_alloc(USBDriver *usbp, size_t size) {
 }
 
 /**
+ * @brief   Resets the packet memory allocator while preserving EP0 buffers.
+ * @details Endpoint zero remains active when the other endpoints are
+ *          disabled, therefore its packet memory cannot be made available to
+ *          a subsequently initialized endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ */
+static void usb_pm_reset_after_ep0(USBDriver *usbp) {
+  const USBEndpointConfig *epcp = usbp->epc[0];
+
+  usb_pm_reset(usbp);
+  if (epcp->in_state != NULL) {
+    (void)usb_pm_alloc(usbp, epcp->in_maxsize);
+  }
+  if (epcp->out_state != NULL) {
+    (void)usb_pm_alloc(usbp, epcp->out_maxsize);
+  }
+}
+
+/**
  * @brief   Reads from a dedicated packet buffer.
  *
  * @param[in] ep        endpoint number
@@ -682,8 +702,9 @@ void usb_lld_init_endpoint(USBDriver *usbp, usbep_t ep) {
 void usb_lld_disable_endpoints(USBDriver *usbp) {
   unsigned i;
 
-  /* Resets the packet memory allocator.*/
-  usb_pm_reset(usbp);
+  /* Resets the packet memory allocator without releasing the still-active
+     endpoint-zero buffers.*/
+  usb_pm_reset_after_ep0(usbp);
 
   /* Disabling all endpoints.*/
   for (i = 1; i <= USB_ENDPOINTS_NUMBER; i++) {

--- a/os/hal/ports/STM32/LLD/USBv2/hal_usb_lld.c
+++ b/os/hal/ports/STM32/LLD/USBv2/hal_usb_lld.c
@@ -215,6 +215,26 @@ static uint32_t usb_pm_alloc(USBDriver *usbp, size_t size) {
 }
 
 /**
+ * @brief   Resets the packet memory allocator while preserving EP0 buffers.
+ * @details Endpoint zero remains active when the other endpoints are
+ *          disabled, therefore its packet memory cannot be made available to
+ *          a subsequently initialized endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ */
+static void usb_pm_reset_after_ep0(USBDriver *usbp) {
+  const USBEndpointConfig *epcp = usbp->epc[0];
+
+  usb_pm_reset(usbp);
+  if (epcp->in_state != NULL) {
+    (void)usb_pm_alloc(usbp, epcp->in_maxsize);
+  }
+  if (epcp->out_state != NULL) {
+    (void)usb_pm_alloc(usbp, epcp->out_maxsize);
+  }
+}
+
+/**
  * @brief   Reads from a dedicated packet buffer.
  *
  * @param[in] usbp      pointer to the @p USBDriver object
@@ -731,8 +751,9 @@ void usb_lld_init_endpoint(USBDriver *usbp, usbep_t ep) {
 void usb_lld_disable_endpoints(USBDriver *usbp) {
   unsigned i;
 
-  /* Resets the packet memory allocator.*/
-  usb_pm_reset(usbp);
+  /* Resets the packet memory allocator without releasing the still-active
+     endpoint-zero buffers.*/
+  usb_pm_reset_after_ep0(usbp);
 
   /* Disabling all endpoints.*/
   for (i = 1U; i <= (unsigned)USB_ENDPOINTS_NUMBER; i++) {


### PR DESCRIPTION
## Summary

`usb_lld_disable_endpoints()` preserves endpoint zero but reset the PMA allocation cursor to the descriptor-table boundary. Rebuilding a configuration could then allocate endpoint 1 over the still-live EP0 buffers.

Reset the allocator and immediately reserve the configured EP0 IN and OUT sizes before initializing data endpoints. Apply the same ownership rule to both maintained STM32 PMA drivers. The full bus-reset path remains a true allocator reset before EP0 initialization.

## Related

- Issue(s): None.
- Notes for reviewers: this is independent of the STM32F0 TIM14 change in #84. Stable backports are maintainer-selected.

## Target Branch Check

- [x] This PR targets `master`, the current/default integration branch.

## Scope

- [x] Change is focused and does not bundle unrelated work.
- [x] USBv1 and USBv2 allocator and endpoint-disable semantics were reviewed together.
- [x] Isochronous aliases still reserve one underlying buffer, matching endpoint initialization.

## Mechanical Checks

- [x] `git diff --check` passed.
- [x] ChibiOS style check passed independently for both changed C files.
- [x] POSIX simulator build passed.
- [x] STM32F303 USB CDC build passed through USBv1.
- [x] STM32G0B1 USB CDC build passed through USBv2.

## Testing

- The USBv1 defect is reproduced by an exact 21.11.5 firmware ELF: after a second `SET_CONFIGURATION(1)`, EP0 TX and EP1 TX both own PMA address `0x0040`.
- With this USBv1 correction, the same executable scenario passes `1 -> 1`, `1 -> 0 -> 1`, CDC traffic, suspend/wakeup, EP0 STALL, and final bus-reset re-enumeration with distinct active PMA addresses.
- The corrected USBv1 image also enumerated and transferred CDC data on STM32F303 hardware.
- USBv2 has matching source semantics and current-master build coverage; USBv2 runtime hardware was not tested.

## Compatibility and Risk

- [x] No intentional public API/ABI break.
- Full bus reset is unchanged and still initializes EP0 from a clean allocator.
- Only the endpoint-disable path that keeps EP0 active retains its packet-memory reservation.
- Disabling same-value configuration rebuilds is not used as a workaround; explicit `1 -> 0 -> 1` is covered.