### PR TITLE
[21.11] stm32: restore TIM14 GPT ISR

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/hal_gpt_lld.c
+++ b/os/hal/ports/STM32/LLD/TIMv1/hal_gpt_lld.c
@@ -406,7 +406,17 @@ OSAL_IRQ_HANDLER(STM32_TIM8_UP_HANDLER) {
 
 #if STM32_GPT_USE_TIM14 || defined(__DOXYGEN__)
 #if !defined(STM32_TIM14_SUPPRESS_ISR)
-#error "TIM14 ISR not defined by platform"
+#if !defined(STM32_TIM14_HANDLER)
+#error "STM32_TIM14_HANDLER not defined"
+#endif
+OSAL_IRQ_HANDLER(STM32_TIM14_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  gpt_lld_serve_interrupt(&GPTD14);
+
+  OSAL_IRQ_EPILOGUE();
+}
 #endif /* !defined(STM32_TIM14_SUPPRESS_ISR) */
 #endif /* STM32_GPT_USE_TIM14 */
 


### PR DESCRIPTION
Backport of #84 to `stable-21.11.x`.

This replaces the unconditional TIM14 GPT compile-time error with the standard ChibiOS IRQ handler shape and dispatches `GPTD14` through `gpt_lld_serve_interrupt()`. The change is vendor-neutral and limited to one file.

Verification:
- applies independently to current `stable-21.11.x` tip `eb9a832bc52f`;
- ChibiOS style checker passes the changed file;
- #84 contains the unpatched F072 reproducer, patched F072 build with `GPTD14`, POSIX build, and current-master checks;
- the equivalent code was consumed by the physically exercised tinySA ChibiOS 21.11.5 port.

This is intentionally draft so maintainers can select their preferred stable-backport workflow.