### PR TITLE
[21.11] usbv1: preserve EP0 PMA across reconfiguration

### DIFF
--- a/os/hal/ports/STM32/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/STM32/LLD/USBv1/hal_usb_lld.c
@@ -121,6 +121,26 @@ static uint32_t usb_pm_alloc(USBDriver *usbp, size_t size) {
 }
 
 /**
+ * @brief   Resets the packet memory allocator while preserving EP0 buffers.
+ * @details Endpoint zero remains active when the other endpoints are
+ *          disabled, therefore its packet memory cannot be made available to
+ *          a subsequently initialized endpoint.
+ *
+ * @param[in] usbp      pointer to the @p USBDriver object
+ */
+static void usb_pm_reset_after_ep0(USBDriver *usbp) {
+  const USBEndpointConfig *epcp = usbp->epc[0];
+
+  usb_pm_reset(usbp);
+  if (epcp->in_state != NULL) {
+    (void)usb_pm_alloc(usbp, epcp->in_maxsize);
+  }
+  if (epcp->out_state != NULL) {
+    (void)usb_pm_alloc(usbp, epcp->out_maxsize);
+  }
+}
+
+/**
  * @brief   Reads from a dedicated packet buffer.
  *
  * @param[in] ep        endpoint number
@@ -682,8 +702,9 @@ void usb_lld_init_endpoint(USBDriver *usbp, usbep_t ep) {
 void usb_lld_disable_endpoints(USBDriver *usbp) {
   unsigned i;
 
-  /* Resets the packet memory allocator.*/
-  usb_pm_reset(usbp);
+  /* Resets the packet memory allocator without releasing the still-active
+     endpoint-zero buffers.*/
+  usb_pm_reset_after_ep0(usbp);
 
   /* Disabling all endpoints.*/
   for (i = 1; i <= USB_ENDPOINTS_NUMBER; i++) {


### PR DESCRIPTION
Backport of the USBv1 portion of #85 to `stable-21.11.x`.

When configuration endpoints are disabled, EP0 remains active. This resets the PMA allocator and immediately reserves EP0 IN/OUT buffers before endpoints 1..N are rebuilt, preventing active PMA overlap. The full bus-reset path remains unchanged.

Verification:
- applies independently to current `stable-21.11.x` tip `eb9a832bc52f`;
- ChibiOS style checker passes the changed file;
- the resulting USBv1 source is byte-identical to the source used by the sealed tinySA RC5 dependency;
- RC5 passed repeated configuration, CDC traffic, suspend/wakeup, STALL, reset/re-enumeration in the executable twin and USB operation on physical hardware;
- #85 contains current-master USBv1/USBv2 build and style coverage.

Runtime evidence is USBv1-only. This is intentionally draft so maintainers can select their preferred stable-backport workflow.