### PR TITLE
ARMv6-M: keep IRQ trampoline literal in range

### DIFF
--- a/os/common/ports/ARMv6-M/chcore.h
+++ b/os/common/ports/ARMv6-M/chcore.h
@@ -432,9 +432,10 @@ struct port_context {
  *          itself) is folded.
  *          @n@n
  *          The body is reached with @p "ldr/bx" rather than a plain @p b
- *          because, with @p -ffunction-sections, the linker may place the
- *          body outside the @p +/-2KB range of the only unconditional Thumb
- *          branch available on ARMv6-M.
+ *          because the linker may place the body outside the @p +/-2KB range
+ *          of the only unconditional Thumb branch available on ARMv6-M. The
+ *          address literal is emitted immediately after the trampoline so the
+ *          Thumb-1 literal load is independent of assembler pool placement.
  */
 #if defined(__GNUC__) || defined(__DOXYGEN__)
   #ifdef __cplusplus
@@ -447,8 +448,10 @@ struct port_context {
     PORT_IRQ_HANDLER_LINKAGE __attribute__((naked, used))                  \
     void id(void) {                                                        \
       __asm volatile ("mov   r0, lr            \n\t"                       \
-                      "ldr   r1, =" #id "_isr  \n\t"                       \
-                      "bx    r1                \n\t");                     \
+                      "ldr   r1, 1f            \n\t"                       \
+                      "bx    r1                \n\t"                       \
+                      ".balign 4               \n\t"                       \
+                      "1: .word " #id "_isr    \n\t");                     \
     }                                                                      \
     static __attribute__((used)) void id##_isr(uint32_t _saved_lr)
 #else /* IAR (__ICCARM__) / ARMCC5 (__CC_ARM): EXC_RETURN captured in the


### PR DESCRIPTION
## Summary

- emit the ARMv6-M IRQ handler address as an explicitly adjacent, aligned literal
- preserve the first-instruction `LR` capture and tail `BX` semantics
- document why the local literal is required

## Root cause

The IRQ trampoline currently uses `ldr r1, =id_isr`. GAS materializes that pseudo-instruction as a Thumb-1 PC-relative load from an assembler-managed literal pool.

When functions share a large `.text` section, such as when `USE_LINK_GC=no` removes `-ffunction-sections`, the pool can be beyond Thumb-1's maximum `0x3fc` forward reach. Enabling the RP2040 PIO implementation reproduces four `invalid offset, value too big` assembler errors.

The new sequence keeps the same executed instructions and places the address word immediately after the non-returning `BX`. Entry `LR` is still copied into `r0` by the first instruction and `BX` still leaves `LR` unchanged.

## Validation

- built the complete `RT-RP2040-PICO` demo with PIO enabled, `USE_LINK_GC=no`, `USE_LTO=no`, and `-Og`
- compiled `rp_pio.c` successfully at `-O0`, `-Og`, `-Os`, `-O2`, and `-O3`
- compiled successfully with both `USE_LINK_GC=yes` and `USE_LINK_GC=no`
- verified the generated trampoline is `mov r0, lr; ldr r1, [pc, #4]; bx r1` followed by the aligned handler-address relocation
