### PR TITLE
RISC-V: add Hazard3 SMP support for RP2350

### DIFF
--- a/demos/RP/RT-RP2350-RISCV-BLINK/Makefile
+++ b/demos/RP/RT-RP2350-RISCV-BLINK/Makefile
@@ -1,0 +1,187 @@
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=4
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = no
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the RISC-V process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the RISC-V main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x400
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+# Hazard3 is RV32IMAC
+MCU  = rv32imac_zba_zbb_zbs_zbkb_zcb_zcmp
+
+# Imported source files and paths.
+CHIBIOS  := ../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform_riscv.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/test/test.mk
+include $(CHIBIOS)/test/rt/rt_test.mk
+include $(CHIBIOS)/test/oslib/oslib_test.mk
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+include $(CHIBIOS)/os/various/xshell/xshell.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_RISCV_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(TESTSRC) \
+       main.c c1_main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC) $(TESTINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_EXTRA_CORES_NUMBER=1 -DNDEBUG
+
+# Define ASM defines here
+UADEFS = -DCRT0_EXTRA_CORES_NUMBER=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk
+include $(RULESPATH)/riscv-none-elf.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/demos/RP/RT-RP2350-RISCV-BLINK/c1_main.c
+++ b/demos/RP/RT-RP2350-RISCV-BLINK/c1_main.c
@@ -1,0 +1,101 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+#include "xshell.h"
+
+#define SHELL_WA_SIZE   THD_WORKING_AREA_SIZE(2048)
+
+static const xshell_command_t commands[] = {
+  {NULL, NULL}
+};
+
+static const xshell_manager_config_t shell_cfg1 = {
+  .thread_name      = "shell",
+  .banner           = XSHELL_DEFAULT_BANNER_STR,
+  .prompt           = XSHELL_DEFAULT_PROMPT_STR,
+  .commands         = commands,
+  .use_heap         = true,
+  .stack.size       = SHELL_WA_SIZE
+};
+
+/*
+ * Green LED blinker thread, times are in milliseconds.
+ */
+static CH_MEM_PRIVATE_BSS(1) THD_WORKING_AREA(waThreadTimer, 128);
+static THD_FUNCTION(ThreadTimer, arg) {
+  extern semaphore_t blinker_sem;
+
+  (void)arg;
+  chRegSetThreadName("timer");
+  while (true) {
+    chThdSleepMilliseconds(500);
+    chSemSignal(&blinker_sem);
+  }
+}
+
+/**
+ * Core 1 entry point.
+ */
+void c1_main(void) {
+  static xshell_manager_t sm1;
+
+  /*
+   * Starting a new OS instance running on this core, we need to wait for
+   * system initialization on the other side.
+   */
+  chSysWaitSystemState(ch_sys_running);
+  chInstanceObjectInit(&ch1, &ch_core1_cfg);
+
+  /* It is alive now.*/
+  chSysUnlock();
+
+  /*
+   * Setting up GPIOs.
+   */
+  palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+
+  /*
+   * Activates the UART0 SIO driver using the default configuration.
+   */
+  sioStart(&SIOD0, NULL);
+
+  /*
+   * Creates the timer thread.
+   */
+  chThdCreateStatic(waThreadTimer, sizeof(waThreadTimer),
+                    NORMALPRIO + 10, ThreadTimer, NULL);
+
+  /*
+   * Shell manager initialization.
+   */
+  xshellObjectInit(&sm1, &shell_cfg1);
+
+  /*
+   * Normal main() thread activity, in this demo it does nothing except
+   * sleeping in a loop (re)spawning a shell.
+   */
+  while (true) {
+    xshell_t *shelltp = xshellSpawn(&sm1,
+                                    (BaseSequentialStream *)&SIOD0,
+                                    NORMALPRIO + 1, NULL);
+    xshellWait(shelltp);              /* Waiting termination.             */
+    chThdSleepMilliseconds(500);
+  }
+}

--- a/demos/RP/RT-RP2350-RISCV-BLINK/cfg/chconf.h
+++ b/demos/RP/RT-RP2350-RISCV-BLINK/cfg/chconf.h
@@ -1,0 +1,854 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     TRUE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kerkel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    MTIME runs at 1 MHz.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ * @note    20us minimum delta for MTIME tickless mode.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/demos/RP/RT-RP2350-RISCV-BLINK/cfg/halconf.h
+++ b/demos/RP/RT-RP2350-RISCV-BLINK/cfg/halconf.h
@@ -1,0 +1,568 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 115200
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_LINE
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/demos/RP/RT-RP2350-RISCV-BLINK/cfg/mcuconf.h
+++ b/demos/RP/RT-RP2350-RISCV-BLINK/cfg/mcuconf.h
@@ -1,0 +1,67 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * RP2350_MCUCONF drivers configuration.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      TRUE
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_TIMER0_PRIORITY              3
+#define RP_IRQ_TIMER1_PRIORITY              3
+#define RP_IRQ_UART0_PRIORITY               2
+#define RP_IRQ_UART1_PRIORITY               2
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    TRUE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+#define RP_SPI_SPI0_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_DMA_PRIORITY            1
+#define RP_SPI_SPI1_DMA_PRIORITY            1
+#define RP_SPI_DMA_ERROR_HOOK(spip)
+
+#endif /* MCUCONF_H */

--- a/demos/RP/RT-RP2350-RISCV-BLINK/main.c
+++ b/demos/RP/RT-RP2350-RISCV-BLINK/main.c
@@ -1,0 +1,73 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+semaphore_t blinker_sem;
+
+/*
+ * Green LED blinker thread, times are in milliseconds.
+ */
+static CH_MEM_PRIVATE_BSS(0) THD_WORKING_AREA(waThread1, 128);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (true) {
+    chSemWait(&blinker_sem);
+    palToggleLine(25U);
+  }
+}
+
+/*
+ * Application entry point.
+ */
+int main(void) {
+
+  /*
+   * Shared objects initialization.
+   */
+  chSemObjectInit(&blinker_sem, 0);
+
+  /*
+   * System initializations.
+   * - HAL initialization, this also initializes the configured device drivers
+   *   and performs the board-specific initializations.
+   * - Kernel initialization, the main() function becomes a thread and the
+   *   RTOS is active.
+   */
+  halInit();
+  chSysInit();
+
+  /*
+   * Setting up GPIOs.
+   */
+  palSetLineMode(25U, PAL_MODE_OUTPUT_PUSHPULL | PAL_RP_PAD_DRIVE12);
+
+  /*
+   * Creates the blinker thread.
+   */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /*
+   * Normal main() thread activity, in this demo it does nothing except
+   * sleeping in a loop.
+   */
+  while (true) {
+    chThdSleepMilliseconds(500);
+  }
+}

--- a/os/common/ext/RISCV/riscv.h
+++ b/os/common/ext/RISCV/riscv.h
@@ -1,0 +1,123 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RISCV/riscv.h
+ * @brief   Generic RISC-V CMSIS-compatible definitions.
+ * @note    Provides basic compiler utility macros for RISC-V ports. The
+ *          instruction barrier requires the Zifencei extension.
+ */
+
+#ifndef RISCV_H
+#define RISCV_H
+
+/* Register access qualifiers, matching the Arm CMSIS convention. */
+#define __I                               volatile const  /**< Read only    */
+#define __O                               volatile        /**< Write only   */
+#define __IO                              volatile        /**< Read/Write   */
+
+/* Compiler utility macros, matching Arm CMSIS cmsis_gcc.h definitions.
+   Guarded with #ifndef so that a prior definition is not overridden. */
+#ifndef   __ASM
+  #define __ASM                           __asm
+#endif
+#ifndef   __INLINE
+  #define __INLINE                        inline
+#endif
+#ifndef   __STATIC_INLINE
+  #define __STATIC_INLINE                 static inline
+#endif
+#ifndef   __STATIC_FORCEINLINE
+  #define __STATIC_FORCEINLINE            __attribute__((always_inline)) static inline
+#endif
+#ifndef   __NO_RETURN
+  #define __NO_RETURN                     __attribute__((__noreturn__))
+#endif
+#ifndef   __USED
+  #define __USED                          __attribute__((used))
+#endif
+#ifndef   __WEAK
+  #define __WEAK                          __attribute__((weak))
+#endif
+#ifndef   __PACKED
+  #define __PACKED                        __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_STRUCT
+  #define __PACKED_STRUCT                 struct __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __PACKED_UNION
+  #define __PACKED_UNION                  union __attribute__((packed, aligned(1)))
+#endif
+#ifndef   __ALIGNED
+  #define __ALIGNED(x)                    __attribute__((aligned(x)))
+#endif
+#ifndef   __RESTRICT
+  #define __RESTRICT                      __restrict
+#endif
+
+/*
+ * CMSIS-compatible intrinsic functions for RISC-V.
+ *
+ * These provide the same API as the ARM CMSIS core headers (core_cm33.h etc.)
+ * so that shared driver code can call __DSB(), __DMB(), __NOP() etc. without
+ * architecture #ifdefs.
+ *
+ * Note: __SEV() and __WFE() are intentionally absent here because they
+ * require core-specific instructions (e.g. Hazard3 h3.block / h3.unblock)
+ * and must be defined in the device header.
+ */
+
+/**
+ * @brief   No Operation instruction for RISC-V.
+ */
+__STATIC_FORCEINLINE void __NOP(void) {
+  __asm__ volatile ("nop");
+}
+
+/**
+ * @brief   Wait For Interrupt instruction for RISC-V.
+ */
+__STATIC_FORCEINLINE void __WFI(void) {
+  __asm__ volatile ("wfi" : : : "memory");
+}
+
+/**
+ * @brief   Data Synchronization Barrier for RISC-V.
+ * @note    RISC-V has no direct DSB equivalent; the strongest fence
+ *          (iorw,iorw) is used to order all memory and I/O accesses.
+ */
+__STATIC_FORCEINLINE void __DSB(void) {
+  __asm__ volatile ("fence iorw, iorw" : : : "memory");
+}
+
+/**
+ * @brief   Data Memory Barrier for RISC-V.
+ * @note    RISC-V does not distinguish between DSB and DMB; the same
+ *          full fence is used for both.
+ */
+__STATIC_FORCEINLINE void __DMB(void) {
+  __asm__ volatile ("fence iorw, iorw" : : : "memory");
+}
+
+/**
+ * @brief   Instruction Synchronization Barrier for RISC-V.
+ * @note    Requires the Zifencei extension.
+ */
+__STATIC_FORCEINLINE void __ISB(void) {
+  __asm__ volatile ("fence.i" : : : "memory");
+}
+
+#endif /* RISCV_H */

--- a/os/common/ext/RP/RP2350/rp2350.h
+++ b/os/common/ext/RP/RP2350/rp2350.h
@@ -35,21 +35,13 @@
 
 #include <stdint.h>
 
-#define __CM33_REV                        0x0100U  /* r1p0 */
-#define __MPU_PRESENT                     1U
-#define __VTOR_PRESENT                    1U
-#define __NVIC_PRIO_BITS                  4U
-#define __Vendor_SysTickConfig            0U
-#define __FPU_PRESENT                     1U
-#define __DSP_PRESENT                     1U
-#define __SAU_PRESENT                     1U
-#define __SAUREGION_PRESENT               8U
-
 /**
  * @brief   Interrupt vector numbers.
  * @note    See RP2350 Datasheet 3.2 Interrupts (Table 95)
  */
 typedef enum {
+#if !defined(__riscv)
+  /* ARM Cortex-M33 system exceptions. */
   NonMaskableInt_IRQn                   = -14,
   HardFault_IRQn                        = -13,
   MemoryManagement_IRQn                 = -12,
@@ -60,6 +52,7 @@ typedef enum {
   DebugMonitor_IRQn                     = -4,
   PendSV_IRQn                           = -2,
   SysTick_IRQn                          = -1,
+#endif
   TIMER0_IRQ_0n                         = 0,
   TIMER0_IRQ_1n                         = 1,
   TIMER0_IRQ_2n                         = 2,
@@ -114,9 +107,51 @@ typedef enum {
   SPARE_IRQ_5n                          = 51
 } IRQn_Type;
 
+#if defined(__riscv)
+/*===========================================================================*/
+/* RISC-V (Hazard3) specific definitions.                                    */
+/*===========================================================================*/
+
+#include "riscv.h"
+
+/**
+ * @brief   Send Event instruction equivalent for RISC-V.
+ * @note    Signal all cores to exit sleep.
+ */
+__STATIC_FORCEINLINE void __SEV(void) {
+  __asm__ volatile ("slt x0, x0, x1" : : : "memory");
+}
+
+/**
+ * @brief   Wait For Event instruction equivalent for RISC-V.
+ * @note    Blocks this core until an interrupt or an unblock event is
+ *          received. Pending unblock events are sticky on the RP2350.
+ */
+__STATIC_FORCEINLINE void __WFE(void) {
+  __asm__ volatile ("slt x0, x0, x0" : : : "memory");
+}
+
+#else /* ARM Cortex-M33 */
+/*===========================================================================*/
+/* ARM Cortex-M33 specific definitions.                                      */
+/*===========================================================================*/
+
+#define __CM33_REV                        0x0100U  /* r1p0 */
+#define __MPU_PRESENT                     1U
+#define __VTOR_PRESENT                    1U
+#define __NVIC_PRIO_BITS                  4U
+#define __Vendor_SysTickConfig            0U
+#define __FPU_PRESENT                     1U
+#define __DSP_PRESENT                     1U
+#define __SAU_PRESENT                     1U
+#define __SAUREGION_PRESENT               8U
+
 #define SVC_IRQn                          SVCall_IRQn
 
 #include "core_cm33.h"
+
+#endif /* __riscv */
+
 #include "system_rp2350.h"
 
 /**

--- a/os/common/ports/RISCV-HAZARD3/chcore.c
+++ b/os/common/ports/RISCV-HAZARD3/chcore.c
@@ -1,0 +1,414 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/chcore.c
+ * @brief   RISC-V Hazard3 port code.
+ *
+ * @addtogroup RISCV_HAZARD3_CORE
+ * @{
+ */
+
+#include <stddef.h>
+
+#include "ch.h"
+
+#if CH_CFG_ST_RESOLUTION != 32
+#error "the Hazard3 MTIME port requires 32-bit system time"
+#endif
+
+#if CH_CFG_ST_FREQUENCY == 0
+#error "CH_CFG_ST_FREQUENCY must be greater than zero"
+#endif
+
+#if CH_CFG_ST_TIMEDELTA == 0
+  #if CH_CFG_ST_FREQUENCY > RISCV_MTIME_FREQUENCY
+    #error "periodic system tick frequency exceeds the MTIME frequency"
+  #elif (RISCV_MTIME_FREQUENCY % CH_CFG_ST_FREQUENCY) != 0
+    #error "periodic system tick frequency must divide the MTIME frequency"
+  #endif
+#elif CH_CFG_ST_FREQUENCY != RISCV_MTIME_FREQUENCY
+  #error "tickless system time frequency must equal the MTIME frequency"
+#endif
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/* Stringify helpers for CSR numbers in inline asm.*/
+#define _PORT_XSTR(s)   _PORT_STR(s)
+#define _PORT_STR(s)    #s
+
+/* Compile-time verification of all layouts shared with assembly code.*/
+_Static_assert(sizeof (struct port_extctx) == PORT_EXTCTX_SIZE,
+               "invalid external context size");
+_Static_assert(offsetof(struct port_extctx, ra) == PORT_EXTCTX_RA_OFFSET,
+               "invalid ra offset");
+_Static_assert(offsetof(struct port_extctx, t0) == PORT_EXTCTX_T0_OFFSET,
+               "invalid t0 offset");
+_Static_assert(offsetof(struct port_extctx, a0) == PORT_EXTCTX_A0_OFFSET,
+               "invalid a0 offset");
+_Static_assert(offsetof(struct port_extctx, t6) == PORT_EXTCTX_T6_OFFSET,
+               "invalid t6 offset");
+_Static_assert(offsetof(struct port_extctx, mepc) == PORT_EXTCTX_MEPC_OFFSET,
+               "invalid mepc offset");
+_Static_assert(offsetof(struct port_extctx, meicontext) ==
+               PORT_EXTCTX_MEICONTEXT_OFFSET, "invalid meicontext offset");
+_Static_assert(offsetof(struct port_extctx, mstatus) ==
+               PORT_EXTCTX_MSTATUS_OFFSET, "invalid mstatus offset");
+_Static_assert(offsetof(struct port_extctx, _pad) == PORT_EXTCTX_PAD_OFFSET,
+               "invalid external context pad offset");
+_Static_assert(sizeof (struct port_intctx) == PORT_INTCTX_SIZE,
+               "invalid internal context size");
+_Static_assert(offsetof(struct port_intctx, ra) == PORT_INTCTX_RA_OFFSET,
+               "invalid internal ra offset");
+_Static_assert(offsetof(struct port_intctx, s0) == PORT_INTCTX_S0_OFFSET,
+               "invalid s0 offset");
+_Static_assert(offsetof(struct port_intctx, s1) == PORT_INTCTX_S1_OFFSET,
+               "invalid s1 offset");
+_Static_assert(offsetof(struct port_intctx, s11) == PORT_INTCTX_S11_OFFSET,
+               "invalid s11 offset");
+_Static_assert(offsetof(struct port_context, sp) == 0U,
+               "invalid port context layout");
+_Static_assert(offsetof(thread_t, ctx) == PORT_CONTEXT_OFFSET,
+               "invalid thread context offset");
+_Static_assert(sizeof (bool) == 1U,
+               "assembly requires one-byte boolean flags");
+
+/*===========================================================================*/
+/* Module exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local variables.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Flags indicating a pending context switch.
+ * @note    In SMP mode each core has its own preemption flag indexed
+ *          by SIO->CPUID.
+ * @note    Non-static: accessed directly from assembly in vectors_hazard3.S
+ *          and chcoreasm.S for inline preemption check/clear.
+ */
+#if CH_CFG_SMP_MODE == TRUE
+volatile bool port_preemption_pending[PORT_CORES_NUMBER];
+#define PREEMPT_PENDING port_preemption_pending[SIO->CPUID]
+#else
+volatile bool port_preemption_pending;
+#define PREEMPT_PENDING port_preemption_pending
+#endif
+
+/**
+ * @brief   ISR nesting counter.
+ * @details Incremented on ISR entry, decremented on exit. Supports preemptive
+ *          nesting (max ~4 levels with Xh3irq priorities).
+ * @note    Non-static: accessed from assembly in vectors_hazard3.S.
+ */
+#if CH_CFG_SMP_MODE == TRUE
+volatile uint8_t port_isr_nesting[PORT_CORES_NUMBER];
+#define ISR_NESTING port_isr_nesting[SIO->CPUID]
+#else
+volatile uint8_t port_isr_nesting;
+#define ISR_NESTING port_isr_nesting
+#endif
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+#if (CH_DBG_ENABLE_STACK_CHECK == TRUE) && (PORT_ENABLE_GUARD_PAGES == TRUE)
+/**
+ * @brief   One-time PMP guard region configuration.
+ * @details Sets the PMPADDR, PMPCFG (NAPOT, no permissions), and PMPCFGM0
+ *          bit for the chosen guard region. Called once per core in port_init.
+ *
+ * @param[in] base_addr   32-byte aligned base address of the guard region.
+ */
+static void __port_pmp_configure_guard(uint32_t base_addr) {
+  uint32_t cfg;
+
+  chDbgAssert((base_addr & (PORT_GUARD_PAGE_SIZE - 1U)) == 0U,
+              "guard alignment");
+
+  /* Set PMPADDR for the guard region. RP2350 hardwires 2 LSBs to 1,
+     giving NAPOT 32-byte granule automatically.*/
+  __asm__ volatile ("csrw " _PORT_XSTR(PORT_GUARD_PMPADDR_CSR) ", %0"
+                    : : "r"(base_addr >> 2) : "memory");
+
+  /* Read-modify-write PMPCFG: set NAPOT, no permissions for our entry.*/
+  __asm__ volatile ("csrr %0, " _PORT_XSTR(PORT_GUARD_PMPCFG_CSR)
+                    : "=r"(cfg));
+  cfg &= ~(0xFFU << PORT_GUARD_PMPCFG_SHIFT);
+  cfg |= (uint32_t)PMP_CFG_A_NAPOT << PORT_GUARD_PMPCFG_SHIFT;
+  __asm__ volatile ("csrw " _PORT_XSTR(PORT_GUARD_PMPCFG_CSR) ", %0"
+                    : : "r"(cfg) : "memory");
+
+  /* Enable M-mode enforcement for this region via PMPCFGM0.*/
+  __asm__ volatile ("csrs " _PORT_XSTR(CSR_PMPCFGM0) ", %0"
+                    : : "r"(1U << PORT_USE_GUARD_PMP_REGION) : "memory");
+}
+#endif
+
+/*===========================================================================*/
+/* Module interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local macros for timer access.                                     */
+/*===========================================================================*/
+
+/**
+ * @brief   Pointer to MTIME register (low 32 bits).
+ */
+#define MTIME       (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIME_OFFSET))
+
+/**
+ * @brief   Pointer to MTIMEH register (high 32 bits).
+ */
+#define MTIMEH      (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIMEH_OFFSET))
+
+/**
+ * @brief   Pointer to MTIMECMP register (low 32 bits).
+ */
+#define MTIMECMP    (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIMECMP_OFFSET))
+
+/**
+ * @brief   Pointer to MTIMECMPH register (high 32 bits).
+ */
+#define MTIMECMPH   (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIMECMPH_OFFSET))
+
+/**
+ * @brief   Pointer to MTIME_CTRL register.
+ */
+#define MTIME_CTRL  (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIME_CTRL_OFFSET))
+
+#if CH_CFG_ST_TIMEDELTA == 0
+/**
+ * @brief   Tick interval in MTIME counts (periodic mode only).
+ */
+#define TICK_INTERVAL   (RISCV_MTIME_FREQUENCY / CH_CFG_ST_FREQUENCY)
+#endif
+
+#if CH_CFG_ST_TIMEDELTA == 0
+/**
+ * @brief   Reads MTIME atomically on RV32.
+ *
+ * @param[out] hip      pointer to the high half destination
+ * @param[out] lop      pointer to the low half destination
+ */
+static void port_timer_read(uint32_t *hip, uint32_t *lop) {
+  uint32_t hi;
+  uint32_t lo;
+
+  do {
+    hi = MTIMEH;
+    lo = MTIME;
+  } while (hi != MTIMEH);
+
+  *hip = hi;
+  *lop = lo;
+}
+
+/**
+ * @brief   Writes the calling core's MTIMECMP without a transient match.
+ *
+ * @param[in] hi        target high half
+ * @param[in] lo        target low half
+ */
+static void port_timer_set_compare(uint32_t hi, uint32_t lo) {
+
+  MTIMECMP = 0xFFFFFFFFU;
+  MTIMECMPH = hi;
+  MTIMECMP = lo;
+}
+
+/**
+ * @brief   Machine timer interrupt handler (periodic mode).
+ */
+void _timer_interrupt_handler(void) {
+  uint32_t previous_lo;
+  uint32_t previous_hi;
+  uint32_t next_lo;
+  uint32_t next_hi;
+
+  CH_IRQ_PROLOGUE();
+
+  /* Advance from the previous deadline rather than from ISR entry time in
+     order to avoid accumulating interrupt latency as system-time drift.*/
+  previous_lo = MTIMECMP;
+  previous_hi = MTIMECMPH;
+  next_lo = previous_lo + TICK_INTERVAL;
+  next_hi = previous_hi + (next_lo < previous_lo ? 1U : 0U);
+
+  port_timer_set_compare(next_hi, next_lo);
+
+  chSysLockFromISR();
+  chSysTimerHandlerI();
+  chSysUnlockFromISR();
+
+  CH_IRQ_EPILOGUE();
+}
+#else /* CH_CFG_ST_TIMEDELTA > 0 */
+/**
+ * @brief   Machine timer interrupt handler (tickless mode).
+ * @note    Kernel reprograms MTIMECMP via port_timer_set_alarm().
+ *          Level-sensitive: auto-clears when MTIMECMP > MTIME.
+ */
+void _timer_interrupt_handler(void) {
+
+  CH_IRQ_PROLOGUE();
+
+  chSysLockFromISR();
+  chSysTimerHandlerI();
+  chSysUnlockFromISR();
+
+  CH_IRQ_EPILOGUE();
+}
+#endif /* CH_CFG_ST_TIMEDELTA */
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Port-related initialization code.
+ *
+ * @param[in, out] oip  pointer to the @p os_instance_t structure
+ *
+ * @notapi
+ */
+void port_init(os_instance_t *oip) {
+
+  (void)oip;
+
+  /* Starting in a known IRQ configuration.*/
+  port_suspend();
+
+  /* Initialize pending preemption flag and ISR nesting counter.*/
+  PREEMPT_PENDING = false;
+  ISR_NESTING = 0U;
+
+  /* Per-core ISR stack pointer.*/
+  {
+#if CH_CFG_SMP_MODE == TRUE
+    extern uint32_t __main_stack_end__;
+    extern uint32_t __c1_main_stack_end__;
+    uint32_t isr_sp = (SIO->CPUID == 0U)
+                    ? (uint32_t)&__main_stack_end__
+                    : (uint32_t)&__c1_main_stack_end__;
+    __asm__ volatile ("csrw mscratch, %0"
+                      : : "r"(isr_sp | PORT_MSCRATCH_THREAD_TAG));
+#else
+    extern uint32_t __main_stack_end__;
+    __asm__ volatile ("csrw mscratch, %0"
+                      : : "r"((uint32_t)&__main_stack_end__ |
+                              PORT_MSCRATCH_THREAD_TAG));
+#endif
+  }
+
+  /* The port time conversions assume the default 1MHz tick source.*/
+  MTIME_CTRL = (MTIME_CTRL & ~MTIME_CTRL_FULLSPEED) | MTIME_CTRL_EN;
+
+#if CH_CFG_ST_TIMEDELTA == 0
+  /* Periodic mode: arm first tick. */
+  {
+    uint32_t hi;
+    uint32_t lo;
+    uint32_t next_lo;
+    uint32_t next_hi;
+
+    port_timer_read(&hi, &lo);
+    next_lo = lo + TICK_INTERVAL;
+    next_hi = hi + (next_lo < lo ? 1U : 0U);
+    port_timer_set_compare(next_hi, next_lo);
+  }
+#else
+  /* Tickless mode: alarm disabled until kernel arms it. */
+  port_timer_stop_alarm();
+#endif
+
+  __asm__ volatile ("csrs mie, %0" : : "r"(MIE_MTIE | MIE_MEIE));
+
+#if (CH_DBG_ENABLE_STACK_CHECK == TRUE) && (PORT_ENABLE_GUARD_PAGES == TRUE)
+  /* Configure PMP guard page for the main thread's stack base.*/
+  {
+#if CH_CFG_SMP_MODE == TRUE
+    extern stkline_t __main_thread_stack_base__;
+    extern stkline_t __c1_main_thread_stack_base__;
+    uint32_t guard_base = (SIO->CPUID == 0U)
+                        ? (uint32_t)&__main_thread_stack_base__
+                        : (uint32_t)&__c1_main_thread_stack_base__;
+#else
+    extern stkline_t __main_thread_stack_base__;
+    uint32_t guard_base = (uint32_t)&__main_thread_stack_base__;
+#endif
+    __port_pmp_configure_guard(guard_base);
+  }
+#endif
+
+#if defined(port_smp_init)
+  port_smp_init(oip);
+#endif
+}
+
+#if (CH_DBG_ENABLE_STACK_CHECK == TRUE) && (PORT_ENABLE_GUARD_PAGES == TRUE)
+/**
+ * @brief   Updates the PMP guard region for the current thread.
+ * @details Called on every context switch to protect the switched-in thread's
+ *          stack base. Only the PMPADDR is updated; PMPCFG and PMPCFGM0 are
+ *          set once in port_init().
+ */
+void __port_set_region(void) {
+  uint32_t base_addr;
+
+  base_addr = (uint32_t)chThdGetSelfX()->wabase;
+  chDbgAssert((base_addr & (PORT_GUARD_PAGE_SIZE - 1U)) == 0U,
+              "guard alignment");
+
+  __asm__ volatile ("csrw " _PORT_XSTR(PORT_GUARD_PMPADDR_CSR) ", %0"
+                    : : "r"(base_addr >> 2) : "memory");
+}
+#endif
+
+/**
+ * @brief   Checks for and performs a context switch triggered by an ISR.
+ * @details Called from __port_switch_from_isr in assembly with the spinlock
+ *          held. Checks whether preemption is actually required before doing
+ *          the context switch, providing an early-out when the flag was set
+ *          speculatively by __port_irq_epilogue() but no preemption is needed.
+ */
+void __port_do_preemption(void) {
+
+  if (chSchIsPreemptionRequired()) {
+#if CH_DBG_SYSTEM_STATE_CHECK
+    __dbg_check_lock();
+#endif
+
+    chSchDoPreemption();
+
+#if CH_DBG_SYSTEM_STATE_CHECK
+    __dbg_check_unlock();
+#endif
+  }
+}
+
+/** @} */

--- a/os/common/ports/RISCV-HAZARD3/chcore.h
+++ b/os/common/ports/RISCV-HAZARD3/chcore.h
@@ -1,0 +1,837 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/chcore.h
+ * @brief   RISC-V Hazard3 port macros and structures.
+ *
+ * @addtogroup RISCV_HAZARD3_CORE
+ * @{
+ */
+
+#ifndef CHCORE_H
+#define CHCORE_H
+
+/* Inclusion of the RISC-V Hazard3 implementation specific parameters.*/
+#include "rvparams.h"
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/* The following code is not processed when the file is included from an
+   asm module because those intrinsic macros are not necessarily defined
+   by the assembler too.*/
+#if !defined(_FROM_ASM_)
+
+/**
+ * @brief   Compiler name and version.
+ */
+#if defined(__GNUC__) || defined(__DOXYGEN__)
+#define PORT_COMPILER_NAME              "GCC " __VERSION__
+
+#else
+#error "unsupported compiler"
+#endif
+
+#endif /* !defined(_FROM_ASM_) */
+/** @} */
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Stack size for the system idle thread.
+ * @details This size depends on the idle thread implementation, usually
+ *          the idle thread should take no more space than those reserved
+ *          by @p PORT_INT_REQUIRED_STACK.
+ * @note    In this port it is set to 64 because the idle thread does have
+ *          a stack frame when compiling without optimizations.
+ */
+#if !defined(PORT_IDLE_THREAD_STACK_SIZE) || defined(__DOXYGEN__)
+#define PORT_IDLE_THREAD_STACK_SIZE     256
+#endif
+
+/**
+ * @brief   Per-thread stack overhead for interrupts servicing.
+ * @details This constant is used in the calculation of the correct working
+ *          area size.
+ * @note    In this port this value is conservatively set to 256 because the
+ *          trap handler saves all caller-saved registers plus some extra.
+ */
+#if !defined(PORT_INT_REQUIRED_STACK) || defined(__DOXYGEN__)
+#define PORT_INT_REQUIRED_STACK         384
+#endif
+
+/**
+ * @brief   Enables the use of the WFI instruction in the idle thread loop.
+ */
+#if !defined(RISCV_ENABLE_WFI_IDLE)
+#define RISCV_ENABLE_WFI_IDLE           TRUE
+#endif
+
+/**
+ * @brief   Enables PMP-based guard pages for thread stacks.
+ * @note    Requires @p CH_DBG_ENABLE_STACK_CHECK == @p TRUE.
+ * @note    Uses a NAPOT PMP region to create a 32-byte no-access zone at
+ *          the base of each thread's working area.
+ */
+#if !defined(PORT_ENABLE_GUARD_PAGES)
+#define PORT_ENABLE_GUARD_PAGES         FALSE
+#endif
+
+/**
+ * @brief   PMP region used for the stack guard page.
+ * @note    Defaults to region zero because overlapping PMP entries are
+ *          resolved in ascending entry order.
+ */
+#if !defined(PORT_USE_GUARD_PMP_REGION)
+#define PORT_USE_GUARD_PMP_REGION       0
+#endif
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/**
+ * @name    Port Capabilities and Constants
+ * @{
+ */
+/**
+ * @brief   This port supports a realtime counter.
+ */
+#define PORT_SUPPORTS_RT                TRUE
+
+/**
+ * @brief   Natural alignment constant.
+ * @note    It is the minimum alignment for pointer-size variables.
+ */
+#define PORT_NATURAL_ALIGN              sizeof (void *)
+
+/**
+ * @brief   Stack initial alignment constant.
+ * @note    It is the alignment required for the initial stack pointer,
+ *          must be a multiple of sizeof (port_stkline_t).
+ * @note    RISC-V ABI requires 16-byte stack alignment.
+ */
+#define PORT_STACK_ALIGN                16U
+
+/**
+ * @brief   Working Areas alignment constant.
+ * @note    It is the alignment to be enforced for thread working areas,
+ *          must be a multiple of sizeof (port_stkline_t).
+ * @note    Set to 32 when guard pages are enabled for PMP NAPOT alignment.
+ */
+#if (PORT_ENABLE_GUARD_PAGES == TRUE)
+#define PORT_WORKING_AREA_ALIGN         32U
+#else
+#define PORT_WORKING_AREA_ALIGN         16U
+#endif
+
+/**
+ * @brief   RP2350 Hazard3 has four interrupt priority levels (0-3).
+ * @note    This is the ChibiOS logical priority range. The Xh3irq hardware
+ *          uses the opposite urgency ordering and stores the levels in the
+ *          upper two bits of each four-bit MEIPRA field.
+ */
+#define RISCV_HAZARD3_PRIORITY_LEVELS   4U
+
+/**
+ * @name    Context frame layout shared with assembly code
+ * @{
+ */
+#define PORT_EXTCTX_SIZE                80
+#define PORT_EXTCTX_RA_OFFSET           0
+#define PORT_EXTCTX_T0_OFFSET           4
+#define PORT_EXTCTX_T1_OFFSET           8
+#define PORT_EXTCTX_T2_OFFSET           12
+#define PORT_EXTCTX_A0_OFFSET           16
+#define PORT_EXTCTX_A1_OFFSET           20
+#define PORT_EXTCTX_A2_OFFSET           24
+#define PORT_EXTCTX_A3_OFFSET           28
+#define PORT_EXTCTX_A4_OFFSET           32
+#define PORT_EXTCTX_A5_OFFSET           36
+#define PORT_EXTCTX_A6_OFFSET           40
+#define PORT_EXTCTX_A7_OFFSET           44
+#define PORT_EXTCTX_T3_OFFSET           48
+#define PORT_EXTCTX_T4_OFFSET           52
+#define PORT_EXTCTX_T5_OFFSET           56
+#define PORT_EXTCTX_T6_OFFSET           60
+#define PORT_EXTCTX_MEPC_OFFSET         64
+#define PORT_EXTCTX_MEICONTEXT_OFFSET   68
+#define PORT_EXTCTX_MSTATUS_OFFSET      72
+#define PORT_EXTCTX_PAD_OFFSET          76
+
+#define PORT_INTCTX_SIZE                64
+#define PORT_INTCTX_RA_OFFSET           12
+#define PORT_INTCTX_S0_OFFSET           16
+#define PORT_INTCTX_S1_OFFSET           20
+#define PORT_INTCTX_S11_OFFSET          60
+
+/* Marks mscratch as containing an exception-stack pointer while execution is
+   in thread context. All RP2350 executable RAM addresses have bit 31 clear.*/
+#define PORT_MSCRATCH_THREAD_TAG        0x80000000
+
+#if defined(_CHIBIOS_RT_CONF_)
+#define PORT_CONTEXT_OFFSET             12
+#elif defined(_CHIBIOS_NIL_CONF_)
+#define PORT_CONTEXT_OFFSET             0
+#else
+#error "invalid chconf.h"
+#endif
+/** @} */
+
+/**
+ * @brief   Checks if a priority value is valid for external interrupts.
+ *
+ * @param[in] n         the priority value
+ * @return              The validity check result.
+ * @retval false        invalid priority.
+ * @retval true         valid priority.
+ */
+#define PORT_IRQ_IS_VALID_PRIORITY(n)                                       \
+  (((n) >= 0U) && ((n) < RISCV_HAZARD3_PRIORITY_LEVELS))
+
+/**
+ * @brief   Checks if a priority value is valid for kernel-level interrupts.
+ *
+ * @param[in] n         the priority value
+ * @return              The validity check result.
+ * @retval false        invalid priority.
+ * @retval true         valid priority.
+ */
+#define PORT_IRQ_IS_VALID_KERNEL_PRIORITY(n)                                \
+  (((n) >= 0U) && ((n) < RISCV_HAZARD3_PRIORITY_LEVELS))
+/** @} */
+
+/**
+ * @name    Architecture
+ * @{
+ */
+/**
+ * @brief   Macro defining the specific RISC-V architecture.
+ */
+#define PORT_ARCHITECTURE_RISCV_HAZARD3
+
+/**
+ * @brief   Name of the implemented architecture.
+ */
+#define PORT_ARCHITECTURE_NAME          "RISC-V Hazard3"
+
+/**
+ * @brief   Macro defining a generic RISC-V architecture.
+ */
+#define PORT_ARCHITECTURE_RISCV
+
+/**
+ * @brief   Name of the architecture variant.
+ */
+#define PORT_CORE_VARIANT_NAME          "Hazard3 RV32IMAC"
+
+/**
+ * @brief   Port-specific information string.
+ */
+#define PORT_INFO                       "Compact kernel mode"
+/** @} */
+
+/**
+ * @brief   Publishes initialization performed before a shared state flag.
+ * @details The RP2350 cores are coherent, but RVWMO still requires an explicit
+ *          release/acquire pair for message-passing through ordinary volatile
+ *          storage.
+ */
+#define PORT_SYSTEM_STATE_RELEASE()                                        \
+  __asm__ volatile ("fence rw, rw" : : : "memory")
+
+/**
+ * @brief   Acquires initialization after observing a shared state flag.
+ */
+#define PORT_SYSTEM_STATE_ACQUIRE()                                        \
+  __asm__ volatile ("fence rw, rw" : : : "memory")
+
+/*===========================================================================*/
+/* SMP support.                                                              */
+/*===========================================================================*/
+
+/* Inclusion of SMP support, if enabled.*/
+#if (CH_CFG_SMP_MODE == TRUE) || defined(__DOXYGEN__)
+#if !defined(_FROM_ASM_)
+#if !defined(__CHIBIOS_RT__)
+#error "SMP is supported in RT only"
+#endif
+
+#include "chcoresmp.h"
+
+#if !defined(PORT_CORES_NUMBER)
+#error "PORT_CORES_NUMBER not defined in chcoresmp.h"
+#endif
+
+#endif
+#else /* CH_CFG_SMP_MODE != TRUE */
+#endif /* CH_CFG_SMP_MODE != TRUE */
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/* The following code is not processed when the file is included from an
+   asm module.*/
+#if !defined(_FROM_ASM_)
+
+/**
+ * @brief   PMP guard page size.
+ */
+#if (PORT_ENABLE_GUARD_PAGES == TRUE) || defined(__DOXYGEN__)
+  #if CH_DBG_ENABLE_STACK_CHECK == FALSE
+    #error "PORT_ENABLE_GUARD_PAGES requires CH_DBG_ENABLE_STACK_CHECK"
+  #endif
+  #if !defined(RISCV_PMP_PRESENT) || (RISCV_PMP_PRESENT == 0)
+    #error "PORT_ENABLE_GUARD_PAGES requires PMP support"
+  #endif
+  #define PORT_GUARD_PAGE_SIZE          32U
+#else
+  #define PORT_GUARD_PAGE_SIZE          0U
+#endif
+
+/**
+ * @name    PMP CSR lookup for guard page region.
+ * @{
+ */
+#if (PORT_ENABLE_GUARD_PAGES == TRUE) || defined(__DOXYGEN__)
+  #if PORT_USE_GUARD_PMP_REGION == 0
+    #define PORT_GUARD_PMPADDR_CSR      0x3B0
+    #define PORT_GUARD_PMPCFG_CSR       0x3A0
+    #define PORT_GUARD_PMPCFG_SHIFT     0
+  #elif PORT_USE_GUARD_PMP_REGION == 1
+    #define PORT_GUARD_PMPADDR_CSR      0x3B1
+    #define PORT_GUARD_PMPCFG_CSR       0x3A0
+    #define PORT_GUARD_PMPCFG_SHIFT     8
+  #elif PORT_USE_GUARD_PMP_REGION == 2
+    #define PORT_GUARD_PMPADDR_CSR      0x3B2
+    #define PORT_GUARD_PMPCFG_CSR       0x3A0
+    #define PORT_GUARD_PMPCFG_SHIFT     16
+  #elif PORT_USE_GUARD_PMP_REGION == 3
+    #define PORT_GUARD_PMPADDR_CSR      0x3B3
+    #define PORT_GUARD_PMPCFG_CSR       0x3A0
+    #define PORT_GUARD_PMPCFG_SHIFT     24
+  #elif PORT_USE_GUARD_PMP_REGION == 4
+    #define PORT_GUARD_PMPADDR_CSR      0x3B4
+    #define PORT_GUARD_PMPCFG_CSR       0x3A1
+    #define PORT_GUARD_PMPCFG_SHIFT     0
+  #elif PORT_USE_GUARD_PMP_REGION == 5
+    #define PORT_GUARD_PMPADDR_CSR      0x3B5
+    #define PORT_GUARD_PMPCFG_CSR       0x3A1
+    #define PORT_GUARD_PMPCFG_SHIFT     8
+  #elif PORT_USE_GUARD_PMP_REGION == 6
+    #define PORT_GUARD_PMPADDR_CSR      0x3B6
+    #define PORT_GUARD_PMPCFG_CSR       0x3A1
+    #define PORT_GUARD_PMPCFG_SHIFT     16
+  #elif PORT_USE_GUARD_PMP_REGION == 7
+    #define PORT_GUARD_PMPADDR_CSR      0x3B7
+    #define PORT_GUARD_PMPCFG_CSR       0x3A1
+    #define PORT_GUARD_PMPCFG_SHIFT     24
+  #else
+    #error "PORT_USE_GUARD_PMP_REGION must be 0-7"
+  #endif
+#endif
+/** @} */
+
+/**
+ * @brief   Interrupt saved context.
+ * @details Stack frame saved during a preemption-capable interrupt handler.
+ * @note    Caller-saved regs + mepc/mstatus. The meicontext slot saves the
+ *          Xh3irq priority stack for hardware mret pop across context switches.
+ */
+struct port_extctx {
+  uint32_t              ra;
+  uint32_t              t0;
+  uint32_t              t1;
+  uint32_t              t2;
+  uint32_t              a0;
+  uint32_t              a1;
+  uint32_t              a2;
+  uint32_t              a3;
+  uint32_t              a4;
+  uint32_t              a5;
+  uint32_t              a6;
+  uint32_t              a7;
+  uint32_t              t3;
+  uint32_t              t4;
+  uint32_t              t5;
+  uint32_t              t6;
+  uint32_t              mepc;
+  uint32_t              meicontext;
+  uint32_t              mstatus;
+  uint32_t              _pad;     /* Pad to 20 words (80 bytes, 16-byte aligned) */
+};
+
+/**
+ * @brief   System saved context.
+ * @details This structure represents the inner stack frame during a context
+ *          switch. It contains callee-saved registers.
+ * @note    RISC-V calling convention: callee saved registers are s0-s11 and ra.
+ */
+struct port_intctx {
+  /* To allow use of zcmp cm.push {ra, s0-s11}, -64:
+     padding at bottom, then ra, s0-s11 in ascending address order. */
+  uint32_t              _pad[3];
+  uint32_t              ra;
+  uint32_t              s0;
+  uint32_t              s1;
+  uint32_t              s2;
+  uint32_t              s3;
+  uint32_t              s4;
+  uint32_t              s5;
+  uint32_t              s6;
+  uint32_t              s7;
+  uint32_t              s8;
+  uint32_t              s9;
+  uint32_t              s10;
+  uint32_t              s11;
+};
+
+/**
+ * @brief   Platform dependent part of the @p thread_t structure.
+ * @details In this port the structure just holds a pointer to the
+ *          @p port_intctx structure representing the stack pointer
+ *          at context switch time.
+ */
+struct port_context {
+  struct port_intctx    *sp;
+};
+
+#endif /* !defined(_FROM_ASM_) */
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Optimized thread function declaration macro.
+ */
+#define PORT_THD_FUNCTION(tname, arg) void tname(void *arg)
+
+/**
+ * @brief   Computes the thread working area global size.
+ * @note    There is no need to perform alignments in this macro.
+ */
+#define PORT_WA_SIZE(n) ((size_t)PORT_GUARD_PAGE_SIZE +                     \
+                         sizeof (struct port_intctx) +                      \
+                         sizeof (struct port_extctx) +                      \
+                         (size_t)(n) +                                      \
+                         (size_t)PORT_INT_REQUIRED_STACK)
+
+/**
+ * @brief   IRQ prologue code.
+ * @details This macro must be inserted at the start of all IRQ handlers
+ *          enabled to invoke system APIs.
+ */
+#define PORT_IRQ_PROLOGUE()
+
+/**
+ * @brief   IRQ epilogue code.
+ * @details This macro must be inserted at the end of all IRQ handlers
+ *          enabled to invoke system APIs.
+ */
+#define PORT_IRQ_EPILOGUE() __port_irq_epilogue()
+
+/**
+ * @brief   IRQ handler function declaration.
+ * @note    @p id can be a function name or a vector number depending on the
+ *          port implementation.
+ */
+#ifdef __cplusplus
+  #define PORT_IRQ_HANDLER(id) extern "C" void id(void)
+
+#else
+  #define PORT_IRQ_HANDLER(id) void id(void)
+#endif
+
+/**
+ * @brief   Fast IRQ handler function declaration.
+ * @note    @p id can be a function name or a vector number depending on the
+ *          port implementation.
+ */
+#ifdef __cplusplus
+  #define PORT_FAST_IRQ_HANDLER(id) extern "C" void id(void)
+
+#else
+  #define PORT_FAST_IRQ_HANDLER(id) void id(void)
+#endif
+
+/**
+ * @brief   Performs a context switch between two threads.
+ * @details This is the most critical code in any port, this function
+ *          is responsible for the context switch between 2 threads.
+ * @note    The implementation of this code affects <b>directly</b> the context
+ *          switch performance so optimize here as much as you can.
+ *
+ * @param[in] ntp       the thread to be switched in
+ * @param[in] otp       the thread to be switched out
+ */
+#if (CH_DBG_ENABLE_STACK_CHECK == FALSE) || defined(__DOXYGEN__)
+  #define port_switch(ntp, otp) __port_switch(ntp, otp)
+
+#else
+  #if PORT_ENABLE_GUARD_PAGES == FALSE
+    #define port_switch(ntp, otp) do {                                      \
+      struct port_intctx *_sp;                                              \
+      __asm__ volatile ("mv %0, sp" : "=r"(_sp));                          \
+      if (!MEM_IS_ALIGNED(_sp, PORT_STACK_ALIGN)) {                         \
+        chSysHalt("stack alignment");                                      \
+      }                                                                     \
+      if ((stkline_t *)(void *)(_sp - 1) < (otp)->wabase) {                 \
+        chSysHalt("stack overflow");                                       \
+      }                                                                     \
+      __port_switch(ntp, otp);                                             \
+    } while (false)
+
+  #else
+    #define port_switch(ntp, otp) do {                                      \
+      struct port_intctx *_sp;                                              \
+      __asm__ volatile ("mv %0, sp" : "=r"(_sp));                          \
+      if (!MEM_IS_ALIGNED(_sp, PORT_STACK_ALIGN)) {                         \
+        chSysHalt("stack alignment");                                      \
+      }                                                                     \
+      __port_switch(ntp, otp);                                              \
+                                                                            \
+      /* Setting up the guard page for the switched-in thread.*/            \
+      __port_set_region();                                                  \
+    } while (false)
+  #endif
+#endif
+
+/**
+ * @brief   Returns a word representing a critical section status.
+ *
+ * @return              The critical section status.
+ */
+#define port_get_lock_status() __port_get_irq_status()
+
+/**
+ * @brief   Determines if in a critical section.
+ *
+ * @param[in] sts       status word returned by @p port_get_lock_status()
+ * @return              The current status.
+ * @retval false        if running outside a critical section.
+ * @retval true         if running within a critical section.
+ */
+#define port_is_locked(sts) !__port_irq_enabled(sts)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if !defined(_FROM_ASM_)
+
+/*
+ * Port variables accessed from assembly and inline functions.
+ */
+#if CH_CFG_SMP_MODE == TRUE
+extern volatile bool port_preemption_pending[];
+extern volatile uint8_t port_isr_nesting[];
+#else
+extern volatile bool port_preemption_pending;
+extern volatile uint8_t port_isr_nesting;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void port_init(os_instance_t *oip);
+  void __port_switch(thread_t *ntp, thread_t *otp);
+  void __port_thread_start(void);
+  void __port_switch_from_isr(void);
+  void __port_exit_from_isr(void);
+#if (CH_DBG_ENABLE_STACK_CHECK == TRUE) && (PORT_ENABLE_GUARD_PAGES == TRUE)
+  void __port_set_region(void);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+/**
+ * @brief   Read the mstatus CSR.
+ *
+ * @return              The mstatus value.
+ */
+static inline uint32_t __port_read_mstatus(void) {
+  uint32_t result;
+  __asm__ volatile ("csrr %0, mstatus" : "=r"(result));
+  return result;
+}
+
+/**
+ * @brief   Write the mstatus CSR.
+ *
+ * @param[in] value     The value to write.
+ */
+static inline void __port_write_mstatus(uint32_t value) {
+  __asm__ volatile ("csrw mstatus, %0" : : "r"(value));
+}
+
+/**
+ * @brief   Set bits in mstatus CSR.
+ *
+ * @param[in] bits      The bits to set.
+ */
+static inline void __port_set_mstatus(uint32_t bits) {
+  __asm__ volatile ("csrs mstatus, %0" : : "r"(bits));
+}
+
+/**
+ * @brief   Clear bits in mstatus CSR.
+ *
+ * @param[in] bits      The bits to clear.
+ */
+static inline void __port_clear_mstatus(uint32_t bits) {
+  __asm__ volatile ("csrc mstatus, %0" : : "r"(bits));
+}
+
+/**
+ * @brief   Returns a word encoding the current interrupts status.
+ *
+ * @return              The interrupts status.
+ */
+static inline syssts_t __port_get_irq_status(void) {
+  return (syssts_t)__port_read_mstatus();
+}
+
+/**
+ * @brief   Checks the interrupt status.
+ *
+ * @param[in] sts       the interrupt status word
+ *
+ * @return              The interrupt status.
+ * @retval false        the word specified a disabled interrupts status.
+ * @retval true         the word specified an enabled interrupts status.
+ */
+static inline bool __port_irq_enabled(syssts_t sts) {
+  return (sts & MSTATUS_MIE) != 0U;
+}
+
+/**
+ * @brief   Determines the current execution context.
+ *
+ * @return              The execution context.
+ * @retval false        not running in ISR mode.
+ * @retval true         running in ISR mode.
+ *
+ * @note    Uses a per-core ISR nesting counter maintained by the trap
+ *          handler in vectors_hazard3.S. The previous mstatus-based
+ *          heuristic (MIE=0 && MPIE=1) gave false positives when
+ *          interrupts were disabled via port_lock().
+ */
+static inline bool port_is_isr_context(void) {
+#if CH_CFG_SMP_MODE == TRUE
+  return port_isr_nesting[SIO->CPUID] != 0U;
+#else
+  return port_isr_nesting != 0U;
+#endif
+}
+
+/**
+ * @brief   Exception exit redirection to @p __port_switch_from_isr().
+ * @details Sets the preemption pending flag unconditionally. The actual
+ *          preemption check happens later in @p __port_switch_from_isr()
+ *          under the spinlock.
+ *
+ * @note    Inlined to avoid function call overhead on every interrupt exit.
+ */
+static inline void __port_irq_epilogue(void) {
+#if CH_CFG_SMP_MODE == TRUE
+  port_preemption_pending[SIO->CPUID] = true;
+#else
+  port_preemption_pending = true;
+#endif
+}
+
+/**
+ * @brief   Kernel-lock action.
+ * @details In this port this function disables interrupts globally.
+ */
+static inline void port_lock(void) {
+  __port_clear_mstatus(MSTATUS_MIE);
+  __asm__ volatile ("" : : : "memory");
+#if CH_CFG_SMP_MODE == TRUE
+  port_spinlock_take();
+#endif
+}
+
+/**
+ * @brief   Kernel-unlock action.
+ * @details In this port this function enables interrupts globally.
+ */
+static inline void port_unlock(void) {
+#if CH_CFG_SMP_MODE == TRUE
+  port_spinlock_release();
+#endif
+  __asm__ volatile ("" : : : "memory");
+  __port_set_mstatus(MSTATUS_MIE);
+}
+
+/**
+ * @brief   Kernel-lock action from an interrupt handler.
+ * @details Clears MIE to prevent same-core preemption during I-class API calls.
+ *          SMP mode additionally takes the spinlock for cross-core exclusion.
+ */
+static inline void port_lock_from_isr(void) {
+  __port_clear_mstatus(MSTATUS_MIE);
+  __asm__ volatile ("" : : : "memory");
+#if CH_CFG_SMP_MODE == TRUE
+  port_spinlock_take();
+#endif
+}
+
+/**
+ * @brief   Kernel-unlock action from an interrupt handler.
+ * @details Re-enables MIE for preemptive nesting. The Xh3irq priority
+ *          threshold set by MEICONTEXT continues to gate same-priority
+ *          external IRQs while the dispatcher runs with MIE=1.
+ */
+static inline void port_unlock_from_isr(void) {
+#if CH_CFG_SMP_MODE == TRUE
+  port_spinlock_release();
+#endif
+  __asm__ volatile ("" : : : "memory");
+  __port_set_mstatus(MSTATUS_MIE);
+}
+
+/**
+ * @brief   Disables all the interrupt sources.
+ * @note    In this port it disables all the interrupt sources by clearing
+ *          the MIE bit in mstatus.
+ */
+static inline void port_disable(void) {
+  __port_clear_mstatus(MSTATUS_MIE);
+  __asm__ volatile ("" : : : "memory");
+}
+
+/**
+ * @brief   Disables the interrupt sources below kernel-level priority.
+ * @note    Hazard3 has only a single global interrupt enable (mstatus.MIE),
+ *          so this is identical to @p port_disable(). Kernel-level priority
+ *          masking is not implemented on this port.
+ */
+static inline void port_suspend(void) {
+  __port_clear_mstatus(MSTATUS_MIE);
+  __asm__ volatile ("" : : : "memory");
+}
+
+/**
+ * @brief   Enables all the interrupt sources.
+ * @note    In this port it enables all the interrupt sources by setting
+ *          the MIE bit in mstatus.
+ */
+static inline void port_enable(void) {
+  __asm__ volatile ("" : : : "memory");
+  __port_set_mstatus(MSTATUS_MIE);
+}
+
+/**
+ * @brief   Enters an architecture-dependent IRQ-waiting mode.
+ * @details The function is meant to return when an interrupt becomes pending.
+ *          The simplest implementation is an empty function or macro but this
+ *          would not take advantage of architecture-specific power saving
+ *          modes.
+ * @note    Implemented as an inlined @p WFI instruction.
+ */
+static inline void port_wait_for_interrupt(void) {
+#if RISCV_ENABLE_WFI_IDLE == TRUE
+  __asm__ volatile ("wfi");
+#endif
+}
+
+/**
+ * @brief   Initialization of the base part of a thread context.
+ * @details This function initializes those context fields which must be
+ *          valid also for thread objects representing already-running
+ *          execution flows (the boot thread of each instance), which do
+ *          not go through the full creation path. Only fields which are
+ *          read before being ever written by a context switch belong
+ *          here.
+ * @note    It is also invoked by @p port_setup_context() as part of the
+ *          full context initialization.
+ *
+ * @param[out] ctxp     pointer to the port-dependent context structure
+ */
+static inline void port_setup_context_base(struct port_context *ctxp) {
+
+  (void)ctxp;
+}
+
+/**
+ * @brief   Platform dependent thread context setup.
+ * @details This function is invoked by the thread creation APIs in order
+ *          to initialize the port-dependent part of the thread context.
+ *
+ * @param[out] ctxp     pointer to the port-dependent context structure
+ * @param[in] wbase     working area base address
+ * @param[in] wtop      working area top address
+ * @param[in] pf        thread function pointer
+ * @param[in] arg       thread function argument
+ */
+static inline void port_setup_context(struct port_context *ctxp,
+                                      void *wbase, void *wtop,
+                                      void (*pf)(void *), void *arg) {
+
+  port_setup_context_base(ctxp);
+
+  (void)wbase;
+
+  ctxp->sp = (struct port_intctx *)(void *)((uint8_t *)wtop -
+                                            sizeof (struct port_intctx));
+  ctxp->sp->s0 = (uint32_t)pf;
+  ctxp->sp->s1 = (uint32_t)arg;
+  ctxp->sp->ra = (uint32_t)__port_thread_start;
+}
+
+/**
+ * @brief   Returns the current value of the realtime counter.
+ *
+ * @return              The realtime counter value.
+ */
+#if !defined(port_rt_get_counter_value)
+static inline rtcnt_t port_rt_get_counter_value(void) {
+  /* Read MTIME from SIO */
+  return *((volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIME_OFFSET));
+}
+#endif
+
+#endif /* !defined(_FROM_ASM_) */
+
+/*===========================================================================*/
+/* Module late inclusions.                                                   */
+/*===========================================================================*/
+
+#if !defined(_FROM_ASM_)
+
+#if CH_CFG_ST_TIMEDELTA > 0
+#include "chcore_timer_hazard3.h"
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+
+#endif /* !defined(_FROM_ASM_) */
+
+#endif /* CHCORE_H */
+
+/** @} */

--- a/os/common/ports/RISCV-HAZARD3/chcore_timer_hazard3.h
+++ b/os/common/ports/RISCV-HAZARD3/chcore_timer_hazard3.h
@@ -1,0 +1,182 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/chcore_timer_hazard3.h
+ * @brief   System timer header file using MTIME/MTIMECMP.
+ *
+ * @addtogroup RISCV_HAZARD3_TIMER
+ * @{
+ */
+
+#ifndef CHCORE_TIMER_HAZARD3_H
+#define CHCORE_TIMER_HAZARD3_H
+
+#include "rvparams.h"
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Pointer to MTIME register (64-bit, lower 32 bits).
+ */
+#define MTIME_LO    (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIME_OFFSET))
+
+/**
+ * @brief   Pointer to MTIME register (64-bit, upper 32 bits).
+ */
+#define MTIME_HI    (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIMEH_OFFSET))
+
+/**
+ * @brief   Pointer to MTIMECMP register (64-bit, lower 32 bits).
+ */
+#define MTIMECMP_LO (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIMECMP_OFFSET))
+
+/**
+ * @brief   Pointer to MTIMECMP register (64-bit, upper 32 bits).
+ */
+#define MTIMECMP_HI (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIMECMPH_OFFSET))
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the timer for this OS instance (no-op, MTIMECMP is per-core).
+ */
+#define port_timer_enable(oip)
+
+/**
+ * @brief   Disables the timer for this OS instance (no-op, MTIMECMP is per-core).
+ */
+#define port_timer_disable(oip)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+/**
+ * @brief   Sets the alarm time.
+ * @note    MTIMECMP is 64-bit; writing the halves non-atomically can cause
+ *          a spurious match. Safe sequence per RP2350 datasheet 3.1.8:
+ *          1. Write 0xFFFFFFFF to the low word.
+ *          2. Write the new high word.
+ *          3. Write the new low word.
+ *
+ * @param[in] time      the time to be set for the next alarm
+ *
+ * @notapi
+ */
+static inline void port_timer_set_alarm(systime_t time) {
+  uint32_t hi, lo;
+
+  /* Stable 64-bit read: if MTIME_LO rolls over between the HI and LO
+     reads, MTIME_HI will have incremented and the loop retries. */
+  do {
+    hi = MTIME_HI;
+    lo = MTIME_LO;
+  } while (hi != MTIME_HI);
+
+  /* If alarm time wraps past current MTIME_LO, it fires after the
+     next low-word rollover. */
+  if ((uint32_t)time < lo) {
+    hi++;
+  }
+
+  MTIMECMP_LO = 0xFFFFFFFFU;
+  MTIMECMP_HI = hi;
+  MTIMECMP_LO = (uint32_t)time;
+}
+
+/**
+ * @brief   Starts the alarm.
+ * @note    Same behavior as @p port_timer_set_alarm. Kept as a distinct
+ *          symbol because some kernels (OSAL, NIL) distinguish "first arm"
+ *          from "reprogram".
+ *
+ * @param[in] time      the time to be set for the first alarm
+ *
+ * @notapi
+ */
+static inline void port_timer_start_alarm(systime_t time) {
+
+  port_timer_set_alarm(time);
+}
+
+/**
+ * @brief   Stops the alarm interrupt (sets MTIMECMP to max).
+ *
+ * @notapi
+ */
+static inline void port_timer_stop_alarm(void) {
+
+  MTIMECMP_LO = 0xFFFFFFFFU;
+  MTIMECMP_HI = 0xFFFFFFFFU;
+}
+
+/**
+ * @brief   Returns the system time.
+ *
+ * @return              The system time.
+ *
+ * @notapi
+ */
+static inline systime_t port_timer_get_time(void) {
+
+  return (systime_t)MTIME_LO;
+}
+
+/**
+ * @brief   Returns the current alarm time.
+ *
+ * @return The currently set alarm time.
+ *
+ * @notapi
+ */
+static inline systime_t port_timer_get_alarm(void) {
+
+  return (systime_t)MTIMECMP_LO;
+}
+
+#endif /* CHCORE_TIMER_HAZARD3_H */
+
+/** @} */

--- a/os/common/ports/RISCV-HAZARD3/compilers/GCC/chcoreasm.S
+++ b/os/common/ports/RISCV-HAZARD3/compilers/GCC/chcoreasm.S
@@ -1,0 +1,183 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/compilers/GCC/chcoreasm.S
+ * @brief   RISC-V Hazard3 port low level code.
+ *
+ * @addtogroup RISCV_HAZARD3_GCC_CORE
+ * @{
+ */
+
+#if !defined(FALSE) || defined(__DOXYGEN__)
+#define FALSE   0
+#endif
+
+#if !defined(TRUE) || defined(__DOXYGEN__)
+#define TRUE    1
+#endif
+
+#define _FROM_ASM_
+#include "chlicense.h"
+#include "chconf.h"
+#include "chcore.h"
+
+#if !defined(__DOXYGEN__)
+
+                .text
+
+/*--------------------------------------------------------------------------*
+ * Performs a context switch between two threads.
+ *
+ * void __port_switch(thread_t *ntp, thread_t *otp)
+ *
+ * Arguments:
+ *   a0 = ntp (new thread pointer)
+ *   a1 = otp (old thread pointer)
+ *--------------------------------------------------------------------------*/
+                .balign 4
+                .globl  __port_switch
+                .type   __port_switch, @function
+__port_switch:
+                /* Save callee saved registers using zcmp push.
+                   cm.push {ra, s0-s11}, -64 atomically:
+                     1. Decrements sp by 64
+                     2. Stores ra, s0-s11 at top of frame */
+                cm.push {ra, s0-s11}, -64
+
+                /* Store current sp in old thread's context */
+                sw      sp, PORT_CONTEXT_OFFSET(a1)
+
+                /* Load new thread's sp from its context */
+                lw      sp, PORT_CONTEXT_OFFSET(a0)
+
+                /* Restore callee saved registers and return using zcmp popret.
+                   cm.popret {ra, s0-s11}, 64 atomically:
+                     1. Loads ra, s0-s11 from frame
+                     2. Increments sp by 64
+                     3. Returns */
+                cm.popret {ra, s0-s11}, 64
+
+                .size   __port_switch, . - __port_switch
+
+/*--------------------------------------------------------------------------*
+ * Start a thread by invoking its work function.
+ *
+ * Threads execution starts here, the code leaves the system critical zone
+ * and then jumps into the thread function passed in register S0. The
+ * register S1 contains the thread parameter. The function chThdExit() is
+ * called on thread function return.
+ *--------------------------------------------------------------------------*/
+                .balign 4
+                .globl  __port_thread_start
+                .type   __port_thread_start, @function
+__port_thread_start:
+#if (CH_DBG_ENABLE_STACK_CHECK == TRUE) && (PORT_ENABLE_GUARD_PAGES == TRUE)
+                /* Program the new thread's guard before other C code uses
+                   its stack. */
+                call    __port_set_region
+#endif
+#if CH_DBG_SYSTEM_STATE_CHECK
+                call    __dbg_check_unlock
+#endif
+#if CH_DBG_STATISTICS
+                call    __stats_stop_measure_crit_thd
+#endif
+#if CH_CFG_SMP_MODE == TRUE
+                /* Release the configurable kernel spinlock inherited from
+                   the context switch. */
+                call    __port_spinlock_release
+#endif
+                /* Enable interrupts as we're starting with them disabled */
+                csrsi   mstatus, 0x8            /* Set MIE bit */
+
+                /* Call thread function: pf(arg) where pf=s0, arg=s1 */
+                mv      a0, s1                  /* arg */
+                jalr    s0                      /* pf(arg) */
+
+                /* Thread function returned exit thread */
+                li      a0, 0                   /* MSG_OK */
+                call    chThdExit
+
+                /* Here be dragons: should never get here */
+1:              j       1b
+
+                .size   __port_thread_start, . - __port_thread_start
+
+/*--------------------------------------------------------------------------*
+ * Post-IRQ switch code.
+ *
+ * Called from trap handler when a context switch is needed after interrupt.
+ * This function performs the actual preemption.
+ *--------------------------------------------------------------------------*/
+                .balign 4
+                .globl  __port_switch_from_isr
+                .type   __port_switch_from_isr, @function
+__port_switch_from_isr:
+                /* Save ra using zcmp push.
+                   cm.push {ra}, -16 atomically:
+                     1. Decrements sp by 16
+                     2. Stores ra at top of frame */
+                cm.push {ra}, -16
+
+#if CH_CFG_SMP_MODE == TRUE
+                /* MIE is already disabled. Hold the configurable kernel
+                   spinlock across the scheduler operation. */
+                call    __port_spinlock_take
+#endif
+
+                /* Clear before calling the scheduler because a real context
+                   switch resumes through the selected thread's saved
+                   continuation, not necessarily through the code below. */
+#if CH_CFG_SMP_MODE == TRUE
+                lui     a5, 0xD0000
+                lw      a5, 0(a5)             /* SIO->CPUID */
+                la      a4, port_preemption_pending
+                add     a5, a5, a4
+                sb      zero, 0(a5)
+#else
+                la      a5, port_preemption_pending
+                sb      zero, 0(a5)
+#endif
+
+#if CH_DBG_STATISTICS
+                call    __stats_start_measure_crit_thd
+#endif
+                /* Perform the context switch via scheduler */
+                call    __port_do_preemption
+
+#if CH_DBG_STATISTICS
+                call    __stats_stop_measure_crit_thd
+#endif
+
+#if CH_CFG_SMP_MODE == TRUE
+                call    __port_spinlock_release
+#endif
+
+                /* Restore ra and return to trap handler using zcmp popret.
+                   cm.popret {ra}, 16 atomically:
+                     1. Loads ra from frame
+                     2. Increments sp by 16
+                     3. Returns */
+                cm.popret {ra}, 16
+
+                .size   __port_switch_from_isr, . - __port_switch_from_isr
+
+#endif /* !defined(__DOXYGEN__) */
+
+/** @} */

--- a/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port.mk
+++ b/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port.mk
@@ -1,0 +1,17 @@
+# List of the ChibiOS RISC-V Hazard3 port files.
+
+# Dependencies.
+include $(CHIBIOS)/os/common/portability/GCC/ccportab.mk
+include $(CHIBIOS)/os/common/ports/RISCV-common/riscv-common.mk
+
+PORTSRC = $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/chcore.c \
+          $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/vectors_riscv.c
+
+PORTASM = $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/chcoreasm.S
+
+PORTINC = $(CHIBIOS)/os/common/ports/RISCV-HAZARD3
+
+# Shared variables
+ALLXASMSRC += $(PORTASM)
+ALLCSRC    += $(PORTSRC)
+ALLINC     += $(PORTINC)

--- a/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port_rp2.mk
+++ b/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port_rp2.mk
@@ -1,0 +1,19 @@
+# List of the ChibiOS/RT RISC-V Hazard3 RP2 SMP port files.
+
+# Dependencies.
+include $(CHIBIOS)/os/common/portability/GCC/ccportab.mk
+include $(CHIBIOS)/os/common/ports/RISCV-common/riscv-common.mk
+
+PORTSRC = $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/chcore.c \
+          $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/vectors_riscv.c \
+          $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
+
+PORTASM = $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/chcoreasm.S
+
+PORTINC = $(CHIBIOS)/os/common/ports/RISCV-HAZARD3 \
+          $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/smp/rp2
+
+# Shared variables
+ALLXASMSRC += $(PORTASM)
+ALLCSRC    += $(PORTSRC)
+ALLINC     += $(PORTINC)

--- a/os/common/ports/RISCV-HAZARD3/compilers/GCC/vectors_riscv.c
+++ b/os/common/ports/RISCV-HAZARD3/compilers/GCC/vectors_riscv.c
@@ -1,0 +1,186 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/compilers/GCC/vectors_riscv.c
+ * @brief   Software vector table and preemptive external IRQ dispatcher
+ *          for Hazard3 Xh3irq.
+ * @details 52 weak VectorXX symbols (ARM NVIC naming for HAL compatibility),
+ *          dispatch table, and _ext_irq_dispatch() implementing preemptive
+ *          nesting via MEINEXT+update with hardware mret priority pop
+ *          (MEICONTEXT save/restore in vectors_hazard3.S).
+ *
+ * @addtogroup RISCV_HAZARD3_VECTORS
+ * @{
+ */
+
+#include <stdint.h>
+
+#include "hazard3_irq.h"
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Default handler for unhandled external interrupts.
+ */
+__attribute__((weak))
+void _unhandled_irq(void) {
+
+  while (true) {
+  }
+}
+
+/*===========================================================================*/
+/* Weak VectorXX declarations.                                               */
+/* Each is aliased to _unhandled_irq so HAL drivers can override them.       */
+/*===========================================================================*/
+
+/* IRQ  0 */ void Vector40(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  1 */ void Vector44(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  2 */ void Vector48(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  3 */ void Vector4C(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  4 */ void Vector50(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  5 */ void Vector54(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  6 */ void Vector58(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  7 */ void Vector5C(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  8 */ void Vector60(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ  9 */ void Vector64(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 10 */ void Vector68(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 11 */ void Vector6C(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 12 */ void Vector70(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 13 */ void Vector74(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 14 */ void Vector78(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 15 */ void Vector7C(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 16 */ void Vector80(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 17 */ void Vector84(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 18 */ void Vector88(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 19 */ void Vector8C(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 20 */ void Vector90(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 21 */ void Vector94(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 22 */ void Vector98(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 23 */ void Vector9C(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 24 */ void VectorA0(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 25 */ void VectorA4(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 26 */ void VectorA8(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 27 */ void VectorAC(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 28 */ void VectorB0(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 29 */ void VectorB4(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 30 */ void VectorB8(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 31 */ void VectorBC(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 32 */ void VectorC0(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 33 */ void VectorC4(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 34 */ void VectorC8(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 35 */ void VectorCC(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 36 */ void VectorD0(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 37 */ void VectorD4(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 38 */ void VectorD8(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 39 */ void VectorDC(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 40 */ void VectorE0(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 41 */ void VectorE4(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 42 */ void VectorE8(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 43 */ void VectorEC(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 44 */ void VectorF0(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 45 */ void VectorF4(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 46 */ void VectorF8(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 47 */ void VectorFC(void)  __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 48 */ void Vector100(void) __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 49 */ void Vector104(void) __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 50 */ void Vector108(void) __attribute__((weak, alias("_unhandled_irq")));
+/* IRQ 51 */ void Vector10C(void) __attribute__((weak, alias("_unhandled_irq")));
+
+/*===========================================================================*/
+/* Software vector table.                                                    */
+/*===========================================================================*/
+
+/**
+ * @brief   External interrupt vector table.
+ * @details Indexed by IRQ number (0-51). Each entry points to a VectorXX
+ *          handler function. HAL drivers provide strong overrides via
+ *          OSAL_IRQ_HANDLER(VectorXX).
+ */
+void (* const _ext_vectors[RISCV_NUM_INTERRUPTS])(void) = {
+  Vector40,  Vector44,  Vector48,  Vector4C,   /*  0- 3 */
+  Vector50,  Vector54,  Vector58,  Vector5C,   /*  4- 7 */
+  Vector60,  Vector64,  Vector68,  Vector6C,   /*  8-11 */
+  Vector70,  Vector74,  Vector78,  Vector7C,   /* 12-15 */
+  Vector80,  Vector84,  Vector88,  Vector8C,   /* 16-19 */
+  Vector90,  Vector94,  Vector98,  Vector9C,   /* 20-23 */
+  VectorA0,  VectorA4,  VectorA8,  VectorAC,   /* 24-27 */
+  VectorB0,  VectorB4,  VectorB8,  VectorBC,   /* 28-31 */
+  VectorC0,  VectorC4,  VectorC8,  VectorCC,   /* 32-35 */
+  VectorD0,  VectorD4,  VectorD8,  VectorDC,   /* 36-39 */
+  VectorE0,  VectorE4,  VectorE8,  VectorEC,   /* 40-43 */
+  VectorF0,  VectorF4,  VectorF8,  VectorFC,   /* 44-47 */
+  Vector100, Vector104, Vector108, Vector10C,   /* 48-51 */
+};
+
+/*===========================================================================*/
+/* External interrupt dispatcher.                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Preemptive external interrupt dispatcher for Xh3irq.
+ * @details Called from _ext_irq_entry after MEICONTEXT is saved to the trap
+ *          frame. Assembly restores it before mret for hardware priority pop.
+ *          MIE is enabled only while a selected handler is running so a
+ *          higher-priority EIRQ can nest through the vectored table. The
+ *          assembly entry saves and disables MTIE/MSIE through
+ *          MEICONTEXT.CLEARTS before calling this function.
+ */
+void _ext_irq_dispatch(void) {
+  uint32_t irq;
+  uint32_t meinext;
+
+  /* Sample MEINEXT with MIE clear. The update ratchets the threshold
+     atomically before preemption is enabled for the selected handler.*/
+  while (true) {
+    __asm__ volatile ("csrrsi %0, " HAZARD3_CSR_STR(CSR_MEINEXT) ", 0x1"
+                      : "=r"(meinext) : : "memory");
+    if ((meinext & MEINEXT_NOIRQ) != 0U) {
+      break;
+    }
+
+    irq = (meinext >> 2) & 0x1FFU;
+
+    if (irq < RISCV_NUM_INTERRUPTS) {
+      __asm__ volatile ("csrsi mstatus, 0x8" : : : "memory");
+      _ext_vectors[irq]();
+      __asm__ volatile ("csrci mstatus, 0x8" : : : "memory");
+    }
+  }
+}
+
+/** @} */

--- a/os/common/ports/RISCV-HAZARD3/compilers/GCC/vectors_riscv.c
+++ b/os/common/ports/RISCV-HAZARD3/compilers/GCC/vectors_riscv.c
@@ -59,6 +59,7 @@
 __attribute__((weak))
 void _unhandled_irq(void) {
 
+  __asm__ volatile ("csrci mstatus, 0x8" : : : "memory");
   while (true) {
   }
 }

--- a/os/common/ports/RISCV-HAZARD3/hazard3_irq.h
+++ b/os/common/ports/RISCV-HAZARD3/hazard3_irq.h
@@ -1,0 +1,350 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/hazard3_irq.h
+ * @brief   Hazard3 Xh3irq extension support.
+ * @details Provides macros and functions for accessing the custom Xh3irq
+ *          CSRs for external interrupt control on the Hazard3 core.
+ *
+ * @note    The Xh3irq array CSRs (MEIEA, MEIPA, MEIFA, MEIPRA) use a
+ *          windowed access scheme:
+ *          - Written value: bits[4:0] = window index, bits[31:16] = data
+ *          - Read returns: {window_data[15:0], 16'h0}
+ *          - CSRRS sets bits, CSRRC clears bits (both use windowing)
+ *
+ *          MEIEA/MEIPA/MEIFA: 1 bit per IRQ, 16 IRQs per window.
+ *          MEIPRA: 4-bit priority per IRQ, 4 IRQs per window.
+ *
+ * @addtogroup RISCV_HAZARD3_IRQ
+ * @{
+ */
+
+#ifndef HAZARD3_IRQ_H
+#define HAZARD3_IRQ_H
+
+#include <stdbool.h>
+
+#include "rvparams.h"
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/* Xh3irq CSR addresses (CSR_MEIEA, CSR_MEIPA, etc.) are defined in
+   rvparams.h which is included above. */
+
+/**
+ * @name    MEINEXT register fields
+ * @{
+ */
+#define MEINEXT_NOIRQ           (1U << 31)  /**< No IRQ pending flag       */
+
+#define MEICONTEXT_NOIRQ        (1U << 15)  /**< Not in an external IRQ    */
+#define MEICONTEXT_CLEARTS      (1U << 1)   /**< Save and clear MTIE/MSIE  */
+#define MEICONTEXT_MRETEIRQ     (1U << 0)   /**< Pop priority on mret       */
+/** @} */
+
+/**
+ * @name    Interrupt priority levels
+ * @note    Hazard3 supports 4 priority levels.
+ *          Higher number = higher priority.
+ * @{
+ */
+#define HAZARD3_IRQ_PRIO_0      0U  /** Lowest priority  */
+#define HAZARD3_IRQ_PRIO_1      1U  /** Medium-low       */
+#define HAZARD3_IRQ_PRIO_2      2U  /** Medium-high      */
+#define HAZARD3_IRQ_PRIO_3      3U  /** Highest priority */
+/** @} */
+
+/**
+ * @name    RP2350 interrupt priority field conversion
+ * @details RP2350 implements four priority levels in a four-bit MEIPRA
+ *          field by hardwiring the two least-significant bits to zero.
+ *          These helpers convert between the logical raw Xh3irq level and
+ *          its register representation. Higher logical values are more
+ *          urgent; this is intentionally distinct from ChibiOS/NVIC ordering.
+ * @{
+ */
+#define HAZARD3_IRQ_PRIORITY_ENCODE(priority)                                \
+  (((uint32_t)(priority) & 0x3U) << 2)
+#define HAZARD3_IRQ_PRIORITY_DECODE(field)                                   \
+  (((uint32_t)(field) >> 2) & 0x3U)
+/** @} */
+
+#if defined(__cplusplus)
+static_assert(HAZARD3_IRQ_PRIORITY_ENCODE(HAZARD3_IRQ_PRIO_3) == 0xCU,
+              "invalid RP2350 Xh3irq priority encoding");
+#else
+_Static_assert(HAZARD3_IRQ_PRIORITY_ENCODE(HAZARD3_IRQ_PRIO_3) == 0xCU,
+               "invalid RP2350 Xh3irq priority encoding");
+#endif
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @name    Xh3irq array CSR access macros
+ * @{
+ */
+
+/* Two-level stringification so csr_num may be either a raw hex literal
+   (e.g. 0xBE0) or a macro that expands to one (e.g. CSR_MEIEA). */
+#define _HAZARD3_CSR_STR(x)     #x
+#define HAZARD3_CSR_STR(x)      _HAZARD3_CSR_STR(x)
+
+/**
+ * @brief   Set bits in an Xh3irq array CSR window.
+ * @details Uses CSRRS to atomically set bits. The written value encodes
+ *          the window index in bits[4:0] and the bit mask in bits[31:16].
+ *
+ * @param[in] csr_num   CSR number e.g. 0xBE0 for MEIEA
+ * @param[in] index     Window index IRQ/16 for 1-bit arrays
+ * @param[in] mask      Bit mask to set in upper 16 bits of window
+ */
+#define HAZARD3_IRQARRAY_SET(csr_num, index, mask) do {                \
+  uint32_t __val = ((uint32_t)(mask) << 16) | (uint32_t)(index);       \
+  __asm__ volatile ("csrrs zero, " HAZARD3_CSR_STR(csr_num) ", %0"     \
+    : : "r"(__val) : "memory");                                        \
+} while (0)
+
+/**
+ * @brief   Clear bits in an Xh3irq array CSR window.
+ * @details Uses CSRRC to atomically clear bits.
+ *
+ * @param[in] csr_num   CSR number e.g. 0xBE0 for MEIEA
+ * @param[in] index     Window index
+ * @param[in] mask      Bit mask to clear in upper 16 bits of window
+ */
+#define HAZARD3_IRQARRAY_CLEAR(csr_num, index, mask) do {              \
+  uint32_t __val = ((uint32_t)(mask) << 16) | (uint32_t)(index);       \
+  __asm__ volatile ("csrrc zero, " HAZARD3_CSR_STR(csr_num) ", %0"     \
+    : : "r"(__val) : "memory");                                        \
+} while (0)
+
+/**
+ * @brief   Read an Xh3irq array CSR window non-destructive.
+ * @details Uses CSRRS with the window index to read without modifying.
+ *
+ * @param[in] csr_num   CSR number e.g. 0xBE1 for MEIPA
+ * @param[in] index     Window index
+ * @return              The 16-bit window data
+ */
+#define HAZARD3_IRQARRAY_READ(csr_num, index) ({                       \
+  uint32_t __val = (uint32_t)(index);                                  \
+  uint32_t __result;                                                   \
+  __asm__ volatile ("csrrs %0, " HAZARD3_CSR_STR(csr_num) ", %1"       \
+    : "=r"(__result) : "r"(__val) : "memory");                         \
+  __result >> 16;                                                      \
+})
+
+/** @} */
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+/**
+ * @brief   Enable an external interrupt.
+ *
+ * @param[in] irq       IRQ number
+ */
+__STATIC_FORCEINLINE void hazard3_irq_enable(uint32_t irq) {
+  uint32_t window = irq / 16U;
+  uint32_t bit    = 1U << (irq % 16U);
+  HAZARD3_IRQARRAY_SET(CSR_MEIEA, window, bit);
+}
+
+/**
+ * @brief   Disable an external interrupt.
+ *
+ * @param[in] irq       IRQ number
+ */
+__STATIC_FORCEINLINE void hazard3_irq_disable(uint32_t irq) {
+  uint32_t window = irq / 16U;
+  uint32_t bit    = 1U << (irq % 16U);
+  HAZARD3_IRQARRAY_CLEAR(CSR_MEIEA, window, bit);
+}
+
+/**
+ * @brief   Check if an external interrupt is pending.
+ *
+ * @param[in] irq       IRQ number
+ * @return              true if the interrupt is pending
+ */
+__STATIC_FORCEINLINE bool hazard3_irq_is_pending(uint32_t irq) {
+  uint32_t window = irq / 16U;
+  uint32_t bit    = 1U << (irq % 16U);
+  return (HAZARD3_IRQARRAY_READ(CSR_MEIPA, window) & bit) != 0U;
+}
+
+/**
+ * @brief   Force an external interrupt
+ *
+ * @param[in] irq       IRQ number
+ */
+__STATIC_FORCEINLINE void hazard3_irq_force(uint32_t irq) {
+  uint32_t window = irq / 16U;
+  uint32_t bit    = 1U << (irq % 16U);
+  HAZARD3_IRQARRAY_SET(CSR_MEIFA, window, bit);
+}
+
+/**
+ * @brief   Clear a forced external interrupt.
+ *
+ * @param[in] irq       IRQ number
+ */
+__STATIC_FORCEINLINE void hazard3_irq_force_clear(uint32_t irq) {
+  uint32_t window = irq / 16U;
+  uint32_t bit    = 1U << (irq % 16U);
+  HAZARD3_IRQARRAY_CLEAR(CSR_MEIFA, window, bit);
+}
+
+/**
+ * @brief   Set the priority of an external interrupt.
+ * @details MEIPRA uses 4-bit priority fields, 4 IRQs per window.
+ *          Window index = IRQ / 4, field position = (IRQ % 4) * 4.
+ *
+ * @param[in] irq       IRQ number
+ * @param[in] priority  raw Xh3irq priority level, 0 (lowest) to 3 (highest)
+ */
+__STATIC_FORCEINLINE void hazard3_irq_set_priority(uint32_t irq, uint32_t priority) {
+  uint32_t window = irq / 4U;
+  uint32_t shift  = (irq % 4U) * 4U;
+  uint32_t mask   = 0xFU << shift;
+
+  /* Clear old priority then set new one */
+  HAZARD3_IRQARRAY_CLEAR(CSR_MEIPRA, window, mask);
+  HAZARD3_IRQARRAY_SET(CSR_MEIPRA, window,
+                       HAZARD3_IRQ_PRIORITY_ENCODE(priority) << shift);
+}
+
+/**
+ * @brief   Get the priority of an external interrupt.
+ * @details MEIPRA uses 4-bit priority fields, 4 IRQs per window.
+ *          Window index = IRQ / 4, field position = (IRQ % 4) * 4.
+ *
+ * @param[in] irq       IRQ number
+ * @return              Raw Xh3irq priority level, 0 (lowest) to 3 (highest)
+ */
+__STATIC_FORCEINLINE uint32_t hazard3_irq_get_priority(uint32_t irq) {
+  uint32_t window = irq / 4U;
+  uint32_t shift  = (irq % 4U) * 4U;
+  uint32_t field;
+
+  field = (HAZARD3_IRQARRAY_READ(CSR_MEIPRA, window) >> shift) & 0xFU;
+  return HAZARD3_IRQ_PRIORITY_DECODE(field);
+}
+
+/**
+ * @brief   Get the next pending external interrupt.
+ * @details Reads the MEINEXT CSR. The IRQ number is in bits[10:2].
+ *          Bit 31 is set if no interrupt is pending.
+ *
+ * @return  Raw MEINEXT value; check bit 31 for NOIRQ
+ */
+__STATIC_FORCEINLINE uint32_t hazard3_irq_get_next(void) {
+  uint32_t val;
+  __asm__ volatile ("csrr %0, " HAZARD3_CSR_STR(CSR_MEINEXT)
+    : "=r"(val) : : "memory");
+  return val;
+}
+
+/**
+ * @brief   Save external interrupt context and mask standard IRQ sources.
+ * @details Atomically reads MEICONTEXT while writing CLEARTS, which clears
+ *          mie.MTIE and mie.MSIE and returns their previous values in the
+ *          saved context. Interrupt selection and threshold update are a
+ *          separate MEINEXT.UPDATE operation. The returned value must be
+ *          passed to hazard3_irq_context_restore() after the handler returns.
+ *
+ * @return  Saved context value (pass to context_restore)
+ */
+__STATIC_FORCEINLINE uint32_t hazard3_irq_context_save(void) {
+  uint32_t ctx;
+
+  __asm__ volatile ("csrrsi %0, " HAZARD3_CSR_STR(CSR_MEICONTEXT) ", 0x2"
+    : "=r"(ctx) : : "memory");
+  return ctx;
+}
+
+/**
+ * @brief   Restore external interrupt context.
+ * @details Writes back a previously saved MEICONTEXT value restoring the
+ *          preemption priority to what it was before the IRQ was serviced.
+ *
+ * @param[in] ctx       Context value from hazard3_irq_context_save()
+ */
+__STATIC_FORCEINLINE void hazard3_irq_context_restore(uint32_t ctx) {
+  __asm__ volatile ("csrw " HAZARD3_CSR_STR(CSR_MEICONTEXT) ", %0"
+    : : "r"(ctx) : "memory");
+}
+
+/**
+ * @brief   Initialize the Xh3irq interrupt controller.
+ * @details Puts the controller in a known clean state by disabling all
+ *          external interrupts (MEIEA), clearing all forced-pending bits
+ *          (MEIFA), resetting all priorities to zero (MEIPRA), and restoring
+ *          MEICONTEXT to its architectural reset state.
+ * @note    Does not touch mie; the port layer (port_init) is responsible
+ *          for setting mie.MEIE and mie.MTIE.
+ */
+__STATIC_FORCEINLINE void hazard3_irq_init(void) {
+  unsigned i;
+
+  /* Clear stale threshold/priority-stack state left by a chain loader or
+     debugger restart. MIE is disabled by the caller during initialization.*/
+  __asm__ volatile ("csrw " HAZARD3_CSR_STR(CSR_MEICONTEXT) ", %0"
+                    : : "r"(MEICONTEXT_NOIRQ) : "memory");
+
+  /* Disable all external interrupts (MEIEA, 16 IRQs per window). */
+  for (i = 0U; i < ((RISCV_NUM_INTERRUPTS + 15U) / 16U); i++) {
+    HAZARD3_IRQARRAY_CLEAR(CSR_MEIEA, i, 0xFFFFU);
+  }
+
+  /* Clear all forced-pending bits (MEIFA, 16 IRQs per window). */
+  for (i = 0U; i < ((RISCV_NUM_INTERRUPTS + 15U) / 16U); i++) {
+    HAZARD3_IRQARRAY_CLEAR(CSR_MEIFA, i, 0xFFFFU);
+  }
+
+  /* Reset all priorities to zero (MEIPRA, 4 IRQs per window). */
+  for (i = 0U; i < ((RISCV_NUM_INTERRUPTS + 3U) / 4U); i++) {
+    HAZARD3_IRQARRAY_CLEAR(CSR_MEIPRA, i, 0xFFFFU);
+  }
+}
+
+#endif /* HAZARD3_IRQ_H */
+
+/** @} */

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
@@ -43,9 +43,23 @@
 /* Module local variables.                                                   */
 /*===========================================================================*/
 
+/* This shared latch is zeroed once by the primary startup. It is deliberately
+   not cleared during per-core initialization because doing so could erase a
+   panic raised while the target core is starting. */
+static uint32_t port_panic_pending[PORT_CORES_NUMBER];
+
 /*===========================================================================*/
 /* Module local functions.                                                   */
 /*===========================================================================*/
+
+static bool port_is_panic_pending(void) {
+  core_id_t core_id;
+
+  core_id = port_get_core_id();
+
+  return __atomic_load_n(&port_panic_pending[core_id],
+                         __ATOMIC_ACQUIRE) != 0U;
+}
 
 static void port_local_halt(void) {
   const char *reason = "remote panic";
@@ -76,6 +90,15 @@ CH_IRQ_HANDLER(VectorA4) {
 
   CH_IRQ_PROLOGUE();
 
+  /* A startup-time latched panic can force this local source after the ROM
+     has consumed its FIFO hint. Do not leave that forced level asserted. */
+  hazard3_irq_force_clear(SIO_IRQ_FIFOn);
+
+  /* The latch is authoritative; the FIFO message is only a wakeup hint. */
+  if (port_is_panic_pending()) {
+    port_local_halt();
+  }
+
   SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
 
   while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
@@ -101,6 +124,14 @@ CH_IRQ_HANDLER(VectorA4) {
 #endif
   }
 
+  /* Order the FIFO drain before the second latch observation. This closes the
+     race where the sender observed a full FIFO just before this core freed a
+     slot and therefore could not enqueue the panic hint. */
+  __asm__ volatile ("fence io, rw" : : : "memory");
+  if (port_is_panic_pending()) {
+    port_local_halt();
+  }
+
   __SEV();
 
   CH_IRQ_EPILOGUE();
@@ -109,6 +140,25 @@ CH_IRQ_HANDLER(VectorA4) {
 /*===========================================================================*/
 /* Module exported functions.                                                */
 /*===========================================================================*/
+
+/**
+ * @brief   Notifies the other core about a local panic.
+ * @note    The shared latch is authoritative. The FIFO write is a best-effort
+ *          wakeup and is never allowed to block the panic path.
+ */
+void __port_smp_notify_panic(void) {
+  core_id_t target;
+
+  target = port_get_core_id() ^ 1U;
+
+  /* Publish the durable indication before interacting with the FIFO. */
+  __atomic_store_n(&port_panic_pending[target], 1U, __ATOMIC_RELEASE);
+  __asm__ volatile ("fence rw, io" : : : "memory");
+
+  if ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) != 0U) {
+    SIO->FIFO_WR = PORT_FIFO_PANIC_MESSAGE;
+  }
+}
 
 /**
  * @brief   SMP-related port initialization.
@@ -126,6 +176,9 @@ void __port_smp_init(os_instance_t *oip) {
   SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
   hazard3_irq_set_priority(SIO_IRQ_FIFOn, PORT_FIFO_IRQ_PRIORITY);
   hazard3_irq_enable(SIO_IRQ_FIFOn);
+  if (port_is_panic_pending()) {
+    hazard3_irq_force(SIO_IRQ_FIFOn);
+  }
 #endif
 
   (void)oip;

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
@@ -1,0 +1,150 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/smp/rp2/chcoresmp.c
+ * @brief   RISC-V Hazard3 RP2 SMP code.
+ *
+ * @addtogroup RISCV_HAZARD3_CORE_SMP_RP2
+ * @{
+ */
+
+#include "ch.h"
+#include "hazard3_irq.h"
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+static void port_local_halt(void) {
+  const char *reason = "remote panic";
+
+  port_disable();
+
+  __trace_halt("remote panic");
+
+  currcore->dbg.panic_msg = reason;
+
+  CH_CFG_SYSTEM_HALT_HOOK(reason);
+
+  while (true) {
+  }
+}
+
+/*===========================================================================*/
+/* Module interrupt handlers.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Single FIFO interrupt handler for both cores.
+ * @note    RP2350 uses a shared SIO_IRQ_FIFO IRQ 25
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(VectorA4) {
+
+  CH_IRQ_PROLOGUE();
+
+  SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
+
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
+    uint32_t message;
+
+    message = SIO->FIFO_RD;
+
+    /* Reading frees FIFO space. Wake a peer blocked in h3.block even when
+       this message is fatal and this core does not reach the ISR epilogue.*/
+    __SEV();
+
+    /* FIFO traffic always comes from the other core, so panic handling must
+       be symmetric.*/
+    if (message == PORT_FIFO_PANIC_MESSAGE) {
+      port_local_halt();
+    }
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+    if (message != PORT_FIFO_RESCHEDULE_MESSAGE) {
+      PORT_HANDLE_FIFO_MESSAGE(port_get_core_id() ^ 1U, message);
+    }
+#else
+    (void)message;
+#endif
+  }
+
+  __SEV();
+
+  CH_IRQ_EPILOGUE();
+}
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   SMP-related port initialization.
+ *
+ * @param[in, out] oip  pointer to the @p os_instance_t structure
+ */
+void __port_smp_init(os_instance_t *oip) {
+
+#if CH_CFG_ST_TIMEDELTA > 0
+  /* Activating timer for this instance.*/
+  port_timer_enable(oip);
+#endif
+
+#if CH_CFG_SMP_MODE == TRUE
+  SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
+  hazard3_irq_set_priority(SIO_IRQ_FIFOn, PORT_FIFO_IRQ_PRIORITY);
+  hazard3_irq_enable(SIO_IRQ_FIFOn);
+#endif
+
+  (void)oip;
+}
+
+/**
+ * @brief   Takes the kernel spinlock.
+ */
+void __port_spinlock_take(void) {
+
+  port_spinlock_take();
+}
+
+/**
+ * @brief   Releases the kernel spinlock.
+ */
+void __port_spinlock_release(void) {
+
+  port_spinlock_release();
+}
+
+/** @} */

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
@@ -127,12 +127,11 @@
 
 /**
  * @brief   Panic notification.
- * @note    It is sent without polling for FIFO space because the other side
- *          could be unable to empty the FIFO after a catastrophic error.
+ * @note    The notification is durable even if the FIFO is full. It never
+ *          polls because the other side could be unable to empty the FIFO
+ *          after a catastrophic error.
  */
-#define PORT_SYSTEM_HALT_HOOK() do {                                       \
-    SIO->FIFO_WR = PORT_FIFO_PANIC_MESSAGE;                                \
-  } while (false)
+#define PORT_SYSTEM_HALT_HOOK() __port_smp_notify_panic()
 
 /**
  * @brief   SMP-related port initialization.
@@ -151,6 +150,7 @@
 extern "C" {
 #endif
   void __port_smp_init(os_instance_t *oip);
+  void __port_smp_notify_panic(void);
   void __port_spinlock_take(void);
   void __port_spinlock_release(void);
 #ifdef __cplusplus

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
@@ -1,0 +1,213 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/smp/rp2/chcoresmp.h
+ * @brief   RISC-V Hazard3 RP2 SMP macros and structures.
+ *
+ * @addtogroup RISCV_HAZARD3_CORE_SMP_RP2
+ * @{
+ */
+
+#ifndef CHCORESMP_H
+#define CHCORESMP_H
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of SMP cores.
+ */
+#define PORT_CORES_NUMBER               2
+
+/**
+ * @name    IPC FIFO messages
+ * @{
+ */
+#define PORT_FIFO_RESCHEDULE_MESSAGE    0xFFFFFFFFU
+#define PORT_FIFO_PANIC_MESSAGE         0xFFFFFFFEU
+/** @} */
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Spinlock to be used by the port layer.
+ * @details RP2350-E2 permits unrelated SIO writes to release certain
+ *          spinlocks on A2, A3, and A4 silicon. The default selects an
+ *          unconditionally safe lock number.
+ */
+#if !defined(PORT_SPINLOCK_NUMBER)
+#define PORT_SPINLOCK_NUMBER            31
+#endif
+
+/**
+ * @brief   Raw Xh3irq priority level for the SIO FIFO inter-core IRQ.
+ * @details Raw Hazard3 external interrupt priorities are 0-3 (higher = more
+ *          urgent), unlike the ChibiOS/NVIC public ordering. Setting this to
+ *          the maximum gives cross-core reschedule notifications the highest
+ *          available urgency (tied with any maximum-urgency peripheral IRQ).
+ */
+#if !defined(PORT_FIFO_IRQ_PRIORITY)
+#define PORT_FIFO_IRQ_PRIORITY          3
+#endif
+
+/**
+ * @brief   Preferential local and coherent BSS section for core zero.
+ */
+#if !defined(PORT_MEM_LOCAL_COHERENT_BSS0)
+#define PORT_MEM_LOCAL_COHERENT_BSS0    CC_SECTION(".ram4_clear.core0")
+#endif
+
+/**
+ * @brief   Preferential local and coherent BSS section for core one.
+ */
+#if !defined(PORT_MEM_LOCAL_COHERENT_BSS1)
+#define PORT_MEM_LOCAL_COHERENT_BSS1    CC_SECTION(".ram5_clear.core1")
+#endif
+
+/**
+ * @brief   Preferential local BSS section for core zero.
+ */
+#if !defined(PORT_MEM_LOCAL_BSS0)
+#define PORT_MEM_LOCAL_BSS0             CC_SECTION(".ram4_clear.core0")
+#endif
+
+/**
+ * @brief   Preferential local BSS section for core one.
+ */
+#if !defined(PORT_MEM_LOCAL_BSS1)
+#define PORT_MEM_LOCAL_BSS1             CC_SECTION(".ram5_clear.core1")
+#endif
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if (PORT_SPINLOCK_NUMBER < 0) || (PORT_SPINLOCK_NUMBER > 31)
+  #error "invalid PORT_SPINLOCK_NUMBER value"
+#endif
+
+/* RP2350-E2: only these spinlocks are immune to false releases caused by
+   unrelated SIO writes on all affected mask revisions.*/
+#if (PORT_SPINLOCK_NUMBER != 5)  && (PORT_SPINLOCK_NUMBER != 6)  &&       \
+    (PORT_SPINLOCK_NUMBER != 7)  && (PORT_SPINLOCK_NUMBER != 10) &&       \
+    (PORT_SPINLOCK_NUMBER != 11) && (PORT_SPINLOCK_NUMBER < 18)
+  #error "PORT_SPINLOCK_NUMBER is unsafe on RP2350 A2/A3/A4 (RP2350-E2)"
+#endif
+
+#if (PORT_FIFO_IRQ_PRIORITY < 0) || (PORT_FIFO_IRQ_PRIORITY > 3)
+  #error "invalid PORT_FIFO_IRQ_PRIORITY value"
+#endif
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Panic notification.
+ * @note    It is sent without polling for FIFO space because the other side
+ *          could be unable to empty the FIFO after a catastrophic error.
+ */
+#define PORT_SYSTEM_HALT_HOOK() do {                                       \
+    SIO->FIFO_WR = PORT_FIFO_PANIC_MESSAGE;                                \
+  } while (false)
+
+/**
+ * @brief   SMP-related port initialization.
+ * @note    The port checks on presence of this macro so this
+ *          must be a macro.
+ *
+ * @param[in, out] oip  pointer to the @p os_instance_t structure
+ */
+#define port_smp_init(oip) __port_smp_init(oip)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void __port_smp_init(os_instance_t *oip);
+  void __port_spinlock_take(void);
+  void __port_spinlock_release(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+/**
+ * @brief   Triggers an inter-core notification.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+static inline void port_notify_instance(os_instance_t *oip) {
+
+  (void)oip;
+
+  /* Sending a reschedule order to the other core if there is space in the FIFO. */
+  if ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) != 0U) {
+    SIO->FIFO_WR = PORT_FIFO_RESCHEDULE_MESSAGE;
+  }
+}
+
+/**
+ * @brief   Takes the kernel spinlock.
+ */
+static inline void port_spinlock_take(void) {
+
+  while (SIO->SPINLOCK[PORT_SPINLOCK_NUMBER] == 0U) {
+  }
+  __DMB();
+}
+
+/**
+ * @brief   Releases the kernel spinlock.
+ */
+static inline void port_spinlock_release(void) {
+
+  __DMB();
+  SIO->SPINLOCK[PORT_SPINLOCK_NUMBER] = (uint32_t)SIO;
+}
+
+/**
+ * @brief   Returns a core index.
+ * @return  The core identifier from 0 to @p PORT_CORES_NUMBER - 1.
+ */
+static inline core_id_t port_get_core_id(void) {
+
+  return SIO->CPUID;
+}
+
+/*===========================================================================*/
+/* Module late inclusions.                                                   */
+/*===========================================================================*/
+
+#endif /* CHCORESMP_H */
+
+/** @} */

--- a/os/common/ports/RISCV-common/include/chtypes.h
+++ b/os/common/ports/RISCV-common/include/chtypes.h
@@ -1,0 +1,151 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-common/include/chtypes.h
+ * @brief   RISC-V port system types.
+ *
+ * @addtogroup RISCV_COMMON_CORE
+ * @{
+ */
+
+#ifndef CHTYPES_H
+#define CHTYPES_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "ccportab.h"
+
+#if !defined(__riscv_xlen)
+#error "__riscv_xlen must be defined by the RISC-V compiler"
+#endif
+
+/**
+ * @name    Architecture data constraints
+ * @{
+ */
+#if __riscv_xlen == 64
+#define PORT_ARCH_SIZEOF_DATA_PTR   8
+#define PORT_ARCH_SIZEOF_CODE_PTR   8
+#define PORT_ARCH_REGISTERS_WIDTH   64
+#elif __riscv_xlen == 32
+#define PORT_ARCH_SIZEOF_DATA_PTR   4
+#define PORT_ARCH_SIZEOF_CODE_PTR   4
+#define PORT_ARCH_REGISTERS_WIDTH   32
+#else
+#error "unsupported RISC-V register width"
+#endif
+#define PORT_ARCH_REVERSE_ORDER     1
+/** @} */
+
+/**
+ * @name    Port types
+ * @{
+ */
+/**
+ * @brief   Realtime counter.
+ */
+typedef uint32_t            port_rtcnt_t;
+
+/**
+ * @brief   Realtime accumulator.
+ */
+typedef uint64_t            port_rttime_t;
+
+/**
+ * @brief   System status word.
+ */
+#if __riscv_xlen == 64
+typedef uint64_t            port_syssts_t;
+#else
+typedef uint32_t            port_syssts_t;
+#endif
+
+/**
+ * @brief   Type of stack and memory alignment enforcement.
+ * @note    RISC-V ABI requires 16-byte stack alignment for function calls.
+ *          Using 128-bit (16 bytes) alignment for stack lines.
+ */
+typedef struct CC_ALIGN_DATA(16) {
+  uint64_t                  l0;
+  uint64_t                  l1;
+} port_stkline_t;
+/** @} */
+
+/**
+ * @brief   This port does not define OS-related types.
+ */
+#define PORT_DOES_NOT_PROVIDE_TYPES
+
+/**
+ * @brief   ROM constant modifier.
+ * @note    It is set to use the "const" keyword in this port.
+ */
+#define ROMCONST            CC_ROMCONST
+
+/**
+ * @brief   Makes functions not inlineable.
+ * @note    If the compiler does not support such attribute then some
+ *          time-dependent services could be degraded.
+ */
+#define NOINLINE            CC_NO_INLINE
+
+/**
+ * @brief   Memory alignment enforcement for variables.
+ */
+#define ALIGNED_VAR(n)      CC_ALIGN_DATA(n)
+
+/**
+ * @brief   Packed variable specifier.
+ */
+#define PACKED_VAR          CC_PACK
+
+/**
+ * @brief   Size of a pointer.
+ * @note    To be used where the sizeof operator cannot be used, preprocessor
+ *          expressions for example.
+ */
+#define SIZEOF_PTR          PORT_ARCH_SIZEOF_DATA_PTR
+
+/**
+ * @brief   Marks a boolean expression as likely true.
+ *
+ * @param[in] x         a valid expression
+ */
+#if defined(CC_LIKELY) || defined(__DOXYGEN__)
+#define PORT_LIKELY(x)      CC_LIKELY(x)
+#else
+#define PORT_LIKELY(x)      x
+#endif
+
+/**
+ * @brief   Marks a boolean expression as likely false.
+ *
+ * @param[in] x         a valid expression
+ */
+#if defined(CC_UNLIKELY) || defined(__DOXYGEN__)
+#define PORT_UNLIKELY(x)    CC_UNLIKELY(x)
+#else
+#define PORT_UNLIKELY(x)    x
+#endif
+
+#endif /* CHTYPES_H */
+
+/** @} */

--- a/os/common/ports/RISCV-common/include/riscv_csr.h
+++ b/os/common/ports/RISCV-common/include/riscv_csr.h
@@ -1,0 +1,119 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-common/include/riscv_csr.h
+ * @brief   Standard RISC-V CSR definitions.
+ * @details Defines CSR addresses and bit fields from the RISC-V privileged
+ *          specification. These are identical across all RISC-V cores.
+ *
+ * @addtogroup RISCV_COMMON_CSR
+ * @{
+ */
+
+#ifndef RISCV_CSR_H
+#define RISCV_CSR_H
+
+/*===========================================================================*/
+/* Standard RISC-V CSR addresses (privileged specification).                 */
+/*===========================================================================*/
+
+/**
+ * @name    Machine-level CSR addresses
+ * @{
+ */
+#define CSR_MSTATUS                 0x300   /**< Machine status             */
+#define CSR_MISA                    0x301   /**< Machine ISA                */
+#define CSR_MIE                     0x304   /**< Machine interrupt enable   */
+#define CSR_MTVEC                   0x305   /**< Machine trap vector        */
+#define CSR_MSCRATCH                0x340   /**< Machine scratch            */
+#define CSR_MEPC                    0x341   /**< Machine exception PC       */
+#define CSR_MCAUSE                  0x342   /**< Machine trap cause         */
+#define CSR_MTVAL                   0x343   /**< Machine trap value         */
+#define CSR_MIP                     0x344   /**< Machine interrupt pending  */
+/** @} */
+
+/*===========================================================================*/
+/* MSTATUS bit definitions.                                                  */
+/*===========================================================================*/
+
+/**
+ * @name    MSTATUS register fields
+ * @{
+ */
+#define MSTATUS_MIE                 (1U << 3)   /**< Machine Interrupt Enable       */
+#define MSTATUS_MPIE                (1U << 7)   /**< Machine Prior Interrupt Enable */
+#define MSTATUS_MPP_MASK            (3U << 11)  /**< Machine Prior Privilege mask   */
+#define MSTATUS_MPP_M               (3U << 11)  /**< M-mode                         */
+/** @} */
+
+/*===========================================================================*/
+/* MIE/MIP bit definitions.                                                  */
+/*===========================================================================*/
+
+/**
+ * @name    Machine interrupt enable/pending fields
+ * @{
+ */
+#define MIE_MSIE                    (1U << 3)   /**< Machine Software Interrupt */
+#define MIE_MTIE                    (1U << 7)   /**< Machine Timer Interrupt    */
+#define MIE_MEIE                    (1U << 11)  /**< Machine External Interrupt */
+#define MIP_MSIP                    (1U << 3)   /**< Machine Software Pending   */
+#define MIP_MTIP                    (1U << 7)   /**< Machine Timer Pending      */
+#define MIP_MEIP                    (1U << 11)  /**< Machine External Pending   */
+/** @} */
+
+/*===========================================================================*/
+/* MCAUSE values.                                                            */
+/*===========================================================================*/
+
+/**
+ * @name    Machine cause register values
+ * @{
+ */
+#define MCAUSE_INTERRUPT            (1UL << (__riscv_xlen - 1))  /**< Interrupt flag in mcause */
+#define MCAUSE_M_SOFT_INT           3           /**< Machine software interrupt */
+#define MCAUSE_M_TIMER_INT          7           /**< Machine timer interrupt    */
+#define MCAUSE_M_EXT_INT            11          /**< Machine external interrupt */
+/** @} */
+
+/*===========================================================================*/
+/* PMP CSR addresses.                                                        */
+/*===========================================================================*/
+
+/**
+ * @name    Physical Memory Protection CSR addresses
+ * @{
+ */
+#define CSR_PMPCFG0                 0x3A0   /**< PMP config (entries 0-3)   */
+#define CSR_PMPCFG1                 0x3A1   /**< PMP config (entries 4-7)   */
+#define CSR_PMPCFG2                 0x3A2   /**< PMP config (entries 8-11)  */
+#define CSR_PMPCFG3                 0x3A3   /**< PMP config (entries 12-15) */
+#define CSR_PMPADDR0                0x3B0   /**< PMP address register 0    */
+#define CSR_PMPADDR1                0x3B1   /**< PMP address register 1    */
+#define CSR_PMPADDR2                0x3B2   /**< PMP address register 2    */
+#define CSR_PMPADDR3                0x3B3   /**< PMP address register 3    */
+#define CSR_PMPADDR4                0x3B4   /**< PMP address register 4    */
+#define CSR_PMPADDR5                0x3B5   /**< PMP address register 5    */
+#define CSR_PMPADDR6                0x3B6   /**< PMP address register 6    */
+#define CSR_PMPADDR7                0x3B7   /**< PMP address register 7    */
+/** @} */
+
+#endif /* RISCV_CSR_H */
+
+/** @} */

--- a/os/common/ports/RISCV-common/riscv-common.mk
+++ b/os/common/ports/RISCV-common/riscv-common.mk
@@ -1,0 +1,13 @@
+# RISCV-common subsystem build.
+
+# Required files.
+ifndef RISCVCOMMONSRC
+  RISCVCOMMONSRC =
+  ALLCSRC += $(RISCVCOMMONSRC)
+endif
+
+# Required include directories
+ifndef RISCVCOMMONINC
+  RISCVCOMMONINC = ${CHIBIOS}/os/common/ports/RISCV-common/include
+  ALLINC += $(RISCVCOMMONINC)
+endif

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/crt0_c1_hazard3.S
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/crt0_c1_hazard3.S
@@ -1,0 +1,190 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    crt0_c1_hazard3.S
+ * @brief   RISC-V Hazard3 core 1 startup file for ChibiOS SMP.
+ * @details Core 1 entry point. Core 0 has already initialized .data, .bss,
+ *          and global constructors. Core 1 only needs to set up its own
+ *          stack, global pointer, trap vector, and call c1_main().
+ *
+ * @addtogroup RISCV_HAZARD3_GCC_STARTUP
+ * @{
+ */
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+#if !defined(FALSE) || defined(__DOXYGEN__)
+#define FALSE                               0
+#endif
+
+#if !defined(TRUE) || defined(__DOXYGEN__)
+#define TRUE                                1
+#endif
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Core initialization switch.
+ */
+#if !defined(CRT0_INIT_CORE) || defined(__DOXYGEN__)
+#define CRT0_INIT_CORE                      TRUE
+#endif
+
+/**
+ * @brief   Stack initialization switch.
+ */
+#if !defined(CRT0_INIT_STACKS) || defined(__DOXYGEN__)
+#define CRT0_INIT_STACKS                    TRUE
+#endif
+
+/**
+ * @brief   Stack fill pattern.
+ */
+#if !defined(CRT0_STACKS_FILL_PATTERN) || defined(__DOXYGEN__)
+#define CRT0_STACKS_FILL_PATTERN            0x55555555
+#endif
+
+/**
+ * @brief   Number of extra cores.
+ */
+#if !defined(CRT0_EXTRA_CORES_NUMBER) || defined(__DOXYGEN__)
+#define CRT0_EXTRA_CORES_NUMBER             0
+#endif
+
+#if CRT0_EXTRA_CORES_NUMBER > 1
+#error "RP2350 supports at most one extra core"
+#endif
+
+/*===========================================================================*/
+/* Code section.                                                             */
+/*===========================================================================*/
+
+#if !defined(__DOXYGEN__) && (CRT0_EXTRA_CORES_NUMBER > 0)
+
+                .section .text, "ax", @progbits
+                .balign 4
+                .globl  _crt0_c1_entry
+                .type   _crt0_c1_entry, @function
+_crt0_c1_entry:
+                /* Disable interrupts globally */
+                csrci   mstatus, 0x8            /* Clear MIE bit */
+
+                /* Clear all interrupt enable bits */
+                csrw    mie, zero
+
+                /* Set up the global pointer gp for linker relaxation. */
+                .option push
+                .option norelax
+                la      gp, __global_pointer$
+                .option pop
+
+                /* Set up the stack pointer sp in SCRATCH_Y. */
+                la      sp, __c1_process_stack_end__
+
+                /* Set up the trap vector (vectored mode, shared with core 0). */
+                la      t0, _vectors
+                ori     t0, t0, 1               /* mode=1: vectored */
+                csrw    mtvec, t0
+
+                /* Initialize mscratch with tagged core 1 ISR stack top. */
+                la      t0, __c1_main_stack_end__
+                li      t1, 0x80000000
+                or      t0, t0, t1
+                csrw    mscratch, t0
+
+#if CRT0_INIT_CORE == TRUE
+                /* Architecture-dependent core initialization. */
+                call    __c1_cpu_init
+#endif /* CRT0_INIT_CORE == TRUE */
+
+                /* Early initialization for core 1. */
+                call    __c1_early_init
+
+#if CRT0_INIT_STACKS == TRUE
+                /* Main Stack initialization for core 1 */
+                li      t0, CRT0_STACKS_FILL_PATTERN
+                la      t1, __c1_main_stack_base__
+                la      t2, __c1_main_stack_end__
+.Lc1msloop:
+                bgeu    t1, t2, .Lc1msloop_done
+                sw      t0, 0(t1)
+                addi    t1, t1, 4
+                j       .Lc1msloop
+.Lc1msloop_done:
+
+                /* Process Stack initialization for core 1 */
+                la      t1, __c1_process_stack_base__
+                la      t2, __c1_process_stack_end__
+.Lc1psloop:
+                bgeu    t1, t2, .Lc1psloop_done
+                sw      t0, 0(t1)
+                addi    t1, t1, 4
+                j       .Lc1psloop
+.Lc1psloop_done:
+#endif /* CRT0_INIT_STACKS == TRUE */
+
+                /* Late initialization for core 1. */
+                call    __c1_late_init
+
+                /* Call core 1 main */
+                call    c1_main
+
+                /* Fall through to exit */
+                j       __c1_default_exit
+
+                .size   _crt0_c1_entry, . - _crt0_c1_entry
+
+/*===========================================================================*/
+/* Default weak handlers for core 1.                                         */
+/*===========================================================================*/
+
+                /* Default __c1_cpu_init - can be overridden by the port. */
+                .weak   __c1_cpu_init
+                .type   __c1_cpu_init, @function
+__c1_cpu_init:
+                ret
+                .size   __c1_cpu_init, . - __c1_cpu_init
+
+                /* Default __c1_early_init - can be overridden. */
+                .weak   __c1_early_init
+                .type   __c1_early_init, @function
+__c1_early_init:
+                ret
+                .size   __c1_early_init, . - __c1_early_init
+
+                /* Default __c1_late_init - can be overridden. */
+                .weak   __c1_late_init
+                .type   __c1_late_init, @function
+__c1_late_init:
+                ret
+                .size   __c1_late_init, . - __c1_late_init
+
+                /* Default exit handler for core 1 infinite WFI loop. */
+                .weak   __c1_default_exit
+                .type   __c1_default_exit, @function
+__c1_default_exit:
+                wfi
+                j       __c1_default_exit
+                .size   __c1_default_exit, . - __c1_default_exit
+
+#endif /* !defined(__DOXYGEN__) && (CRT0_EXTRA_CORES_NUMBER > 0) */
+
+/** @} */

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/crt0_hazard3.S
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/crt0_hazard3.S
@@ -1,0 +1,295 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    crt0_hazard3.S
+ * @brief   Generic RISC-V Hazard3 startup file for ChibiOS.
+ *
+ * @addtogroup RISCV_HAZARD3_GCC_STARTUP
+ * @{
+ */
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+#if !defined(FALSE) || defined(__DOXYGEN__)
+#define FALSE                               0
+#endif
+
+#if !defined(TRUE) || defined(__DOXYGEN__)
+#define TRUE                                1
+#endif
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Core initialization switch.
+ */
+#if !defined(CRT0_INIT_CORE) || defined(__DOXYGEN__)
+#define CRT0_INIT_CORE                      TRUE
+#endif
+
+/**
+ * @brief   Stack initialization switch.
+ */
+#if !defined(CRT0_INIT_STACKS) || defined(__DOXYGEN__)
+#define CRT0_INIT_STACKS                    TRUE
+#endif
+
+/**
+ * @brief   Stack fill pattern.
+ */
+#if !defined(CRT0_STACKS_FILL_PATTERN) || defined(__DOXYGEN__)
+#define CRT0_STACKS_FILL_PATTERN            0x55555555
+#endif
+
+/**
+ * @brief   DATA segment initialization switch.
+ */
+#if !defined(CRT0_INIT_DATA) || defined(__DOXYGEN__)
+#define CRT0_INIT_DATA                      TRUE
+#endif
+
+/**
+ * @brief   BSS segment initialization switch.
+ */
+#if !defined(CRT0_INIT_BSS) || defined(__DOXYGEN__)
+#define CRT0_INIT_BSS                       TRUE
+#endif
+
+/**
+ * @brief   RAM areas initialization switch.
+ */
+#if !defined(CRT0_INIT_RAM_AREAS) || defined(__DOXYGEN__)
+#define CRT0_INIT_RAM_AREAS                 TRUE
+#endif
+
+/**
+ * @brief   Constructors invocation switch.
+ */
+#if !defined(CRT0_CALL_CONSTRUCTORS) || defined(__DOXYGEN__)
+#define CRT0_CALL_CONSTRUCTORS              TRUE
+#endif
+
+/**
+ * @brief   Destructors invocation switch.
+ */
+#if !defined(CRT0_CALL_DESTRUCTORS) || defined(__DOXYGEN__)
+#define CRT0_CALL_DESTRUCTORS               TRUE
+#endif
+
+/*===========================================================================*/
+/* Code section.                                                             */
+/*===========================================================================*/
+
+#if !defined(__DOXYGEN__)
+
+                .section .init, "ax", @progbits
+                .balign 4
+                .globl  _crt0_entry
+                .type   _crt0_entry, @function
+_crt0_entry:
+                /* Disable interrupts globally */
+                csrci   mstatus, 0x8            /* Clear MIE bit */
+
+                /* Clear all interrupt enable bits */
+                csrw    mie, zero
+
+                /* Set up the global pointer gp for linker relaxation. */
+                .option push
+                .option norelax
+                la      gp, __global_pointer$
+                .option pop
+
+                /* Set up the stack pointer sp */
+                la      sp, __process_stack_end__
+
+                /* Set up the trap vector (vectored mode). */
+                la      t0, _vectors
+                ori     t0, t0, 1               /* mode=1: vectored */
+                csrw    mtvec, t0
+
+                /* Initialize mscratch with tagged ISR stack top. */
+                la      t0, __main_stack_end__
+                li      t1, 0x80000000
+                or      t0, t0, t1
+                csrw    mscratch, t0
+
+#if CRT0_INIT_CORE == TRUE
+                /* Architecture-dependent core initialization. */
+                call    __cpu_init
+#endif /* CRT0_INIT_CORE == TRUE */
+
+                /* Early initialization. */
+                call    __early_init
+
+#if CRT0_INIT_STACKS == TRUE
+                /* Main Stack initialization */
+                li      t0, CRT0_STACKS_FILL_PATTERN
+                la      t1, __main_stack_base__
+                la      t2, __main_stack_end__
+.Lmsloop:
+                bgeu    t1, t2, .Lmsloop_done
+                sw      t0, 0(t1)
+                addi    t1, t1, 4
+                j       .Lmsloop
+.Lmsloop_done:
+
+                /* Process Stack initialization. */
+                la      t1, __process_stack_base__
+                la      t2, __process_stack_end__
+.Lpsloop:
+                bgeu    t1, t2, .Lpsloop_done
+                sw      t0, 0(t1)
+                addi    t1, t1, 4
+                j       .Lpsloop
+.Lpsloop_done:
+#endif /* CRT0_INIT_STACKS == TRUE */
+
+#if CRT0_INIT_DATA == TRUE
+                /* Data segment initialization from flash to RAM.
+                   Note: Assumes size is a multiple of 4 bytes. */
+                la      t0, __textdata_base__   /* Source in flash */
+                la      t1, __data_base__       /* Destination start */
+                la      t2, __data_end__        /* Destination end */
+.Ldloop:
+                bgeu    t1, t2, .Ldloop_done
+                lw      t3, 0(t0)
+                sw      t3, 0(t1)
+                addi    t0, t0, 4
+                addi    t1, t1, 4
+                j       .Ldloop
+.Ldloop_done:
+#endif /* CRT0_INIT_DATA == TRUE */
+
+#if CRT0_INIT_BSS == TRUE
+                /* Zero fill BSS segment initialization */
+                la      t0, __bss_base__
+                la      t1, __bss_end__
+.Lbloop:
+                bgeu    t0, t1, .Lbloop_done
+                sw      zero, 0(t0)
+                addi    t0, t0, 4
+                j       .Lbloop
+.Lbloop_done:
+#endif /* CRT0_INIT_BSS == TRUE */
+
+#if CRT0_INIT_RAM_AREAS == TRUE
+                /* Additional RAM areas initialization */
+                call    __init_ram_areas
+#endif /* CRT0_INIT_RAM_AREAS == TRUE */
+
+                /* Late initialization after C runtime setup, before main. */
+                call    __late_init
+
+#if CRT0_CALL_CONSTRUCTORS == TRUE
+                la      s0, __init_array_base__
+                la      s1, __init_array_end__
+.Linitloop:
+                bgeu    s0, s1, .Linitloop_done
+                lw      t0, 0(s0)
+                jalr    t0
+                addi    s0, s0, 4
+                j       .Linitloop
+.Linitloop_done:
+#endif /* CRT0_CALL_CONSTRUCTORS == TRUE */
+
+                /* Call main program. Return value is in a0. */
+                call    main
+
+#if CRT0_CALL_DESTRUCTORS == TRUE
+                la      s0, __fini_array_base__
+                la      s1, __fini_array_end__
+.Lfiniloop:
+                bgeu    s0, s1, .Lfiniloop_done
+                lw      t0, 0(s0)
+                jalr    t0
+                addi    s0, s0, 4
+                j       .Lfiniloop
+.Lfiniloop_done:
+#endif /* CRT0_CALL_DESTRUCTORS == TRUE */
+
+                /* Exit handler */
+                j       __default_exit
+
+                .size   _crt0_entry, . - _crt0_entry
+
+/*===========================================================================*/
+/* Default weak handlers.                                                    */
+/*===========================================================================*/
+
+                .section .text, "ax", @progbits
+
+                /* Default __cpu_init - can be overridden by the port. */
+                .weak   __cpu_init
+                .type   __cpu_init, @function
+__cpu_init:
+                ret
+                .size   __cpu_init, . - __cpu_init
+
+                /* Default __early_init - can be overridden by board code. */
+                .weak   __early_init
+                .type   __early_init, @function
+__early_init:
+                ret
+                .size   __early_init, . - __early_init
+
+                /* Default __late_init - can be overridden by board code. */
+                .weak   __late_init
+                .type   __late_init, @function
+__late_init:
+                ret
+                .size   __late_init, . - __late_init
+
+                /* Default RP2350 scratch RAM initialization. The normal
+                   DATA/BSS loops above cover ram0; these two areas contain
+                   the per-core local BSS selected by the RP2 SMP port. */
+                .weak   __init_ram_areas
+                .type   __init_ram_areas, @function
+__init_ram_areas:
+                la      t0, __ram4_clear__
+                la      t1, __ram4_clear_end__
+.Lram4loop:
+                bgeu    t0, t1, .Lram5start
+                sw      zero, 0(t0)
+                addi    t0, t0, 4
+                j       .Lram4loop
+.Lram5start:
+                la      t0, __ram5_clear__
+                la      t1, __ram5_clear_end__
+.Lram5loop:
+                bgeu    t0, t1, .Lramareasdone
+                sw      zero, 0(t0)
+                addi    t0, t0, 4
+                j       .Lram5loop
+.Lramareasdone:
+                ret
+                .size   __init_ram_areas, . - __init_ram_areas
+
+                /* Default exit handler - infinite loop. */
+                .weak   __default_exit
+                .type   __default_exit, @function
+__default_exit:
+                wfi
+                j       __default_exit
+                .size   __default_exit, . - __default_exit
+
+#endif /* !defined(__DOXYGEN__) */
+
+/** @} */

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/ld/RP2350_RISCV_FLASH.ld
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/ld/RP2350_RISCV_FLASH.ld
@@ -1,0 +1,299 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 RISC-V Hazard3 memory setup for XIP
+ */
+
+/* Entry point */
+ENTRY(_crt0_entry)
+
+/* Stack sizes are provided by the compiler rules. Core 1 uses the same
+   sizes as core 0 unless the application defines explicit overrides. */
+__c1_main_stack_size__    = DEFINED(__c1_main_stack_size__)    ? __c1_main_stack_size__    : __main_stack_size__;
+__c1_process_stack_size__ = DEFINED(__c1_process_stack_size__) ? __c1_process_stack_size__ : __process_stack_size__;
+__c1_main_stack_allocation__ = DEFINED(_crt0_c1_entry) ? __c1_main_stack_size__ : 0;
+__c1_process_stack_allocation__ = DEFINED(_crt0_c1_entry) ? __c1_process_stack_size__ : 0;
+
+MEMORY
+{
+    flash0 (rx) : org = 0x00000000, len = 16k   /* ROM                  */
+    flash1 (rx) : org = 0x10000000, len = DEFINED(FLASH_LEN) ? FLASH_LEN : 4096k /* XIP */
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x20000000, len = 512k  /* SRAM                 */
+    ram1   (wx) : org = 0x00000000, len = 0
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x20080000, len = 4k    /* SCRATCH_X            */
+    ram5   (wx) : org = 0x20081000, len = 4k    /* SCRATCH_Y            */
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x00000000, len = 0
+}
+
+/* Memory region aliases */
+REGION_ALIAS("VECTORS_FLASH", flash1);
+REGION_ALIAS("VECTORS_FLASH_LMA", flash1);
+REGION_ALIAS("XTORS_FLASH", flash1);
+REGION_ALIAS("XTORS_FLASH_LMA", flash1);
+REGION_ALIAS("TEXT_FLASH", flash1);
+REGION_ALIAS("TEXT_FLASH_LMA", flash1);
+REGION_ALIAS("RODATA_FLASH", flash1);
+REGION_ALIAS("RODATA_FLASH_LMA", flash1);
+REGION_ALIAS("VARIOUS_FLASH", flash1);
+REGION_ALIAS("VARIOUS_FLASH_LMA", flash1);
+REGION_ALIAS("RAM_INIT_FLASH_LMA", flash1);
+REGION_ALIAS("MAIN_STACK_RAM", ram4);
+REGION_ALIAS("PROCESS_STACK_RAM", ram4);
+REGION_ALIAS("DATA_RAM", ram0);
+REGION_ALIAS("DATA_RAM_LMA", flash1);
+REGION_ALIAS("BSS_RAM", ram0);
+REGION_ALIAS("HEAP_RAM", ram0);
+
+SECTIONS
+{
+    /* Flash binary start marker */
+    .flash_begin : {
+        __flash_binary_start = .;
+    } > flash1
+
+    /* PICOBIN metadata block - must be within first 4KB for bootrom detection */
+    .embedded_block : ALIGN(4)
+    {
+        KEEP(*(.embedded_block))
+        __embedded_block_end__ = .;
+    } > flash1
+
+    /* Init section - contains _crt0_entry */
+    .init : ALIGN(4)
+    {
+        KEEP(*(.init))
+    } > flash1
+
+    /* Trap vectors */
+    .vectors : ALIGN(64)
+    {
+        __vectors_base__ = .;
+        KEEP(*(.vectors))
+        __vectors_end__ = .;
+    } > VECTORS_FLASH AT > VECTORS_FLASH_LMA
+
+    /* Global constructors/destructors */
+    .xtors : ALIGN(4)
+    {
+        __init_array_base__ = .;
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        __init_array_end__ = .;
+        __fini_array_base__ = .;
+        KEEP(*(.fini_array))
+        KEEP(*(SORT(.fini_array.*)))
+        __fini_array_end__ = .;
+    } > XTORS_FLASH AT > XTORS_FLASH_LMA
+
+    /* Code */
+    .text : ALIGN(4)
+    {
+        __text_base__ = .;
+        *(.text)
+        *(.text.*)
+        *(.gnu.linkonce.t.*)
+        __text_end__ = .;
+    } > TEXT_FLASH AT > TEXT_FLASH_LMA
+
+    /* Read-only data */
+    .rodata : ALIGN(4)
+    {
+        __rodata_base__ = .;
+        *(.rodata)
+        *(.rodata.*)
+        *(.gnu.linkonce.r.*)
+        *(.srodata)
+        *(.srodata.*)
+        . = ALIGN(4);
+        __rodata_end__ = .;
+    } > RODATA_FLASH AT > RODATA_FLASH_LMA
+
+    /* RISC-V exception handling (C++ exceptions) */
+    .eh_frame_hdr : ALIGN(4)
+    {
+        *(.eh_frame_hdr)
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    .eh_frame : ALIGN(4)
+    {
+        __eh_frame_base__ = .;
+        *(.eh_frame)
+        __eh_frame_end__ = .;
+    } > VARIOUS_FLASH AT > VARIOUS_FLASH_LMA
+
+    /* Small data section for linker relaxation.
+       NOTE: Data copy symbols start here so CRT0 copies both .sdata
+       and .data from flash to RAM. */
+    .sdata : ALIGN(4)
+    {
+        __global_pointer$ = . + 0x800;
+        PROVIDE(_textdata = LOADADDR(.sdata));
+        PROVIDE(_data = .);
+        __textdata_base__ = LOADADDR(.sdata);
+        __data_base__ = .;
+        *(.sdata)
+        *(.sdata.*)
+        *(.gnu.linkonce.s.*)
+    } > DATA_RAM AT > DATA_RAM_LMA
+
+    /* Initialized data (contiguous with .sdata for CRT0 copy) */
+    .data : ALIGN(4)
+    {
+        *(.data)
+        *(.data.*)
+        *(.gnu.linkonce.d.*)
+        *(.ramtext)
+        . = ALIGN(4);
+        PROVIDE(_edata = .);
+        __data_end__ = .;
+    } > DATA_RAM AT > DATA_RAM_LMA
+
+    /* Uninitialized data (BSS) — .sbss must be included so crt0 clears it */
+    .bss (NOLOAD) : ALIGN(4)
+    {
+        __bss_base__ = .;
+        *(.sbss)
+        *(.sbss.*)
+        *(.gnu.linkonce.sb.*)
+        *(.bss)
+        *(.bss.*)
+        *(.gnu.linkonce.b.*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+        PROVIDE(end = .);
+    } > BSS_RAM
+
+    /* Main stack (used for interrupts/exceptions) */
+    .mstack (NOLOAD) : ALIGN(32)
+    {
+        __main_stack_base__ = .;
+        . += __main_stack_size__;
+        . = ALIGN(32);
+        __main_stack_end__ = .;
+    } > MAIN_STACK_RAM
+
+    /* Process stack (used by main thread) */
+    .pstack (NOLOAD) : ALIGN(32)
+    {
+        __process_stack_base__ = .;
+        __main_thread_stack_base__ = .;
+        . += __process_stack_size__;
+        . = ALIGN(32);
+        __process_stack_end__ = .;
+        __main_thread_stack_end__ = .;
+    } > PROCESS_STACK_RAM
+
+    /* Per-core BSS in SCRATCH_X (core 0) */
+    .ram4_bss (NOLOAD) : ALIGN(4)
+    {
+        __ram4_clear__ = .;
+        *(.ram4_clear)
+        *(.ram4_clear.*)
+        . = ALIGN(4);
+        __ram4_clear_end__ = .;
+    } > ram4
+
+    /* Core 1 main stack (used for interrupts/exceptions) in SCRATCH_Y */
+    .c1_mstack (NOLOAD) : ALIGN(32)
+    {
+        __c1_main_stack_base__ = .;
+        . += __c1_main_stack_allocation__;
+        . = ALIGN(32);
+        __c1_main_stack_end__ = .;
+    } > ram5
+
+    /* Core 1 process stack (used by c1_main thread) in SCRATCH_Y */
+    .c1_pstack (NOLOAD) : ALIGN(32)
+    {
+        __c1_process_stack_base__ = .;
+        __c1_main_thread_stack_base__ = .;
+        . += __c1_process_stack_allocation__;
+        . = ALIGN(32);
+        __c1_process_stack_end__ = .;
+        __c1_main_thread_stack_end__ = .;
+    } > ram5
+
+    /* Per-core BSS in SCRATCH_Y (core 1) */
+    .ram5_bss (NOLOAD) : ALIGN(4)
+    {
+        __ram5_clear__ = .;
+        *(.ram5_clear)
+        *(.ram5_clear.*)
+        . = ALIGN(4);
+        __ram5_clear_end__ = .;
+    } > ram5
+
+    /* Heap - uses remaining RAM after BSS */
+    .heap (NOLOAD) : ALIGN(16)
+    {
+        __heap_base__ = .;
+        . = ORIGIN(HEAP_RAM) + LENGTH(HEAP_RAM);
+        __heap_end__ = .;
+    } > HEAP_RAM
+
+    /* Memory region symbols for runtime */
+    __ram0_base__   = ORIGIN(ram0);
+    __ram0_size__   = LENGTH(ram0);
+    __ram0_end__    = __ram0_base__ + __ram0_size__;
+    __ram4_base__   = ORIGIN(ram4);
+    __ram4_size__   = LENGTH(ram4);
+    __ram4_end__    = __ram4_base__ + __ram4_size__;
+    __ram5_base__   = ORIGIN(ram5);
+    __ram5_size__   = LENGTH(ram5);
+    __ram5_end__    = __ram5_base__ + __ram5_size__;
+    __flash1_base__ = ORIGIN(flash1);
+    __flash1_size__ = LENGTH(flash1);
+    __flash1_end__  = __flash1_base__ + __flash1_size__;
+
+    /* Flash binary end marker */
+    .flash_end : {
+        __flash_binary_end = .;
+    } > flash1
+
+    /* Discard unwanted sections */
+    /DISCARD/ :
+    {
+        *(.note.GNU-stack)
+        *(.comment)
+        *(.gnu.attributes)
+    }
+
+    ASSERT((__embedded_block_end__ - __flash_binary_start) <= 4096,
+           "embedded block must be within the first 4096 image bytes")
+    ASSERT((_vectors & 63) == 0,
+           "Hazard3 vector table must be 64-byte aligned")
+    ASSERT(_vectors == __vectors_base__,
+           "unexpected padding before the Hazard3 vector table")
+    ASSERT((__main_stack_base__ & 31) == 0,
+           "core 0 exception stack must be 32-byte aligned")
+    ASSERT((__main_thread_stack_base__ & 31) == 0,
+           "core 0 process stack must be 32-byte aligned")
+    ASSERT(!DEFINED(_crt0_c1_entry) || ((__c1_main_stack_base__ & 31) == 0),
+           "core 1 exception stack must be 32-byte aligned")
+    ASSERT(!DEFINED(_crt0_c1_entry) || ((__c1_main_thread_stack_base__ & 31) == 0),
+           "core 1 process stack must be 32-byte aligned")
+}

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/riscv-none-elf.mk
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/riscv-none-elf.mk
@@ -1,0 +1,23 @@
+##############################################################################
+# Compiler settings for RISC-V
+#
+
+TRGT = riscv-none-elf-
+CC   = $(TRGT)gcc
+CPPC = $(TRGT)g++
+# Enable loading with g++ only if you need C++ runtime support.
+# NOTE: You can use C++ even without C++ support if you are careful. C++
+#       runtime support makes code size explode.
+LD   = $(TRGT)gcc
+#LD   = $(TRGT)g++
+CP   = $(TRGT)objcopy
+AS   = $(TRGT)gcc -x assembler-with-cpp
+AR   = $(TRGT)ar
+OD   = $(TRGT)objdump
+SZ   = $(TRGT)size
+HEX  = $(CP) -O ihex
+BIN  = $(CP) -O binary
+
+#
+# Compiler settings
+##############################################################################

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/rules.mk
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/rules.mk
@@ -1,0 +1,294 @@
+# RISC-V Hazard3 common makefile scripts and rules.
+
+##############################################################################
+# Processing options coming from the upper Makefile.
+#
+
+# Compiler options
+OPT    := $(USE_OPT)
+COPT   := $(USE_COPT)
+CPPOPT := $(USE_CPPOPT)
+
+# Garbage collection
+ifeq ($(USE_LINK_GC),yes)
+  OPT   += -ffunction-sections -fdata-sections -fno-common
+  LDOPT := ,--gc-sections
+else
+  LDOPT :=
+endif
+
+# Linker extra options
+ifneq ($(USE_LDOPT),)
+  LDOPT := $(LDOPT),$(USE_LDOPT)
+endif
+
+# Link time optimizations
+ifneq ($(USE_LTO),no)
+  ifeq ($(USE_LTO),yes)
+    OPT += -flto=auto
+  else
+    OPT += -flto=$(USE_LTO)
+  endif
+endif
+
+# RISC-V Hazard3 does not have an FPU
+DDEFS  += -DRISCV_USE_FPU=FALSE
+DADEFS += -DRISCV_USE_FPU=FALSE
+
+# Process stack size
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  LDOPT := $(LDOPT),--defsym=__process_stack_size__=0x400
+else
+  LDOPT := $(LDOPT),--defsym=__process_stack_size__=$(USE_PROCESS_STACKSIZE)
+endif
+
+# Exceptions stack size
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  LDOPT := $(LDOPT),--defsym=__main_stack_size__=0x400
+else
+  LDOPT := $(LDOPT),--defsym=__main_stack_size__=$(USE_EXCEPTIONS_STACKSIZE)
+endif
+
+# Output directory and files
+ifeq ($(BUILDDIR),)
+  BUILDDIR = build
+endif
+ifeq ($(BUILDDIR),.)
+  BUILDDIR = build
+endif
+
+# Dependencies directory
+ifeq ($(DEPDIR),)
+  DEPDIR = .dep
+endif
+ifeq ($(DEPDIR),.)
+  DEPDIR = .dep
+endif
+
+OUTFILES := $(BUILDDIR)/$(PROJECT).elf \
+            $(BUILDDIR)/$(PROJECT).hex \
+            $(BUILDDIR)/$(PROJECT).bin \
+            $(BUILDDIR)/$(PROJECT).dmp \
+            $(BUILDDIR)/$(PROJECT).list
+
+ifdef SREC
+  OUTFILES += $(BUILDDIR)/$(PROJECT).srec
+endif
+
+# Additional output files, populated by makefiles included before this one.
+ADDITIONAL_OUTFILES ?=
+
+# Source files groups and paths
+SRC      := $(CSRC) $(CPPSRC)
+SRCPATHS += $(sort $(dir $(ASMXSRC)) $(dir $(ASMSRC)) $(dir $(SRC)))
+
+# Various directories
+OBJDIR    := $(BUILDDIR)/obj
+LSTDIR    := $(BUILDDIR)/lst
+
+# Object files groups
+COBJS    := $(addprefix $(OBJDIR)/, $(notdir $(CSRC:.c=.o)))
+CPPOBJS  := $(addprefix $(OBJDIR)/, $(notdir $(patsubst %.cpp, %.o, $(filter %.cpp, $(CPPSRC)))))
+CCOBJS   := $(addprefix $(OBJDIR)/, $(notdir $(patsubst %.cc, %.o, $(filter %.cc, $(CPPSRC)))))
+ASMOBJS  := $(addprefix $(OBJDIR)/, $(notdir $(ASMSRC:.s=.o)))
+ASMXOBJS := $(addprefix $(OBJDIR)/, $(notdir $(ASMXSRC:.S=.o)))
+OBJS     += $(ASMXOBJS) $(ASMOBJS) $(COBJS) $(CPPOBJS) $(CCOBJS)
+
+# Paths
+IINCDIR   := $(sort $(patsubst %,-I%,$(INCDIR) $(DINCDIR) $(UINCDIR)))
+LLIBDIR   := $(sort $(patsubst %,-L%,$(DLIBDIR) $(ULIBDIR)))
+
+# Macros
+DEFS      := $(DDEFS) $(UDEFS)
+ADEFS     := $(DADEFS) $(UADEFS)
+
+# Libs
+LIBS      := $(DLIBS) $(ULIBS)
+
+# RISC-V machine flags for Hazard3
+# MCU is set by the demo Makefile (e.g., rv32imac_zba_zbb_zbs_zbkb_zcb_zcmp).
+# zicsr and zifencei are appended here (required for CSR and fence.i
+# instructions, separated from base ISA in newer GCC versions).
+# -mabi=ilp32: 32-bit integer ABI (no floating point)
+# -msave-restore: With Zcmp in -march, GCC emits cm.push/cm.popret in
+#   function prologues/epilogues instead of individual sw/lw sequences.
+MCFLAGS   := -march=$(MCU)_zicsr_zifencei -mabi=ilp32 -msave-restore
+
+
+ODFLAGS   = -x --syms
+ASFLAGS   = $(MCFLAGS) $(OPT) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.s=.lst)) $(ADEFS)
+ASXFLAGS  = $(MCFLAGS) $(OPT) -Wa,-amhls=$(LSTDIR)/$(notdir $(<:.S=.lst)) $(ADEFS)
+ifeq ($(USE_LTO),no)
+  CFLAGS    = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.c=.lst)) $(DEFS)
+  CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) -Wa,-alms=$(LSTDIR)/$(notdir $(<:.cpp=.lst)) $(DEFS)
+else
+  CFLAGS    = $(MCFLAGS) $(OPT) $(COPT) $(CWARN) $(DEFS)
+  CPPFLAGS  = $(MCFLAGS) $(OPT) $(CPPOPT) $(CPPWARN) $(DEFS)
+endif
+LDFLAGS   = $(MCFLAGS) $(OPT) -nostartfiles -nostdlib $(LLIBDIR) -Wl,-Map=$(BUILDDIR)/$(PROJECT).map,--cref,--no-warn-mismatch,--library-path=$(STARTUPLD),--script=$(LDSCRIPT)$(LDOPT) -lc -lgcc
+
+# Generate dependency information
+ASFLAGS  += -MD -MP -MF $(DEPDIR)/$(@F).d
+ASXFLAGS += -MD -MP -MF $(DEPDIR)/$(@F).d
+CFLAGS   += -MD -MP -MF $(DEPDIR)/$(@F).d
+CPPFLAGS += -MD -MP -MF $(DEPDIR)/$(@F).d
+
+# Paths where to search for sources
+VPATH     = $(SRCPATHS)
+
+#
+# Makefile rules
+#
+
+all: PRE_MAKE_ALL_RULE_HOOK $(OBJS) $(OUTFILES) \
+     $(ADDITIONAL_OUTFILES) POST_MAKE_ALL_RULE_HOOK
+
+PRE_MAKE_ALL_RULE_HOOK:
+
+POST_MAKE_ALL_RULE_HOOK:
+
+$(OBJS): | PRE_MAKE_ALL_RULE_HOOK $(BUILDDIR) $(OBJDIR) $(LSTDIR) $(DEPDIR)
+
+$(BUILDDIR):
+ifneq ($(USE_VERBOSE_COMPILE),yes)
+	@echo Compiler Options
+	@echo $(CC) -c $(CFLAGS) -I. $(IINCDIR) main.c -o main.o
+	@echo
+endif
+	@mkdir -p $(BUILDDIR)
+
+$(OBJDIR):
+	@mkdir -p $(OBJDIR)
+
+$(LSTDIR):
+	@mkdir -p $(LSTDIR)
+
+$(DEPDIR):
+	@mkdir -p $(DEPDIR)
+
+$(CPPOBJS) : $(OBJDIR)/%.o : %.cpp $(MAKEFILE_LIST)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	$(CPPC) -c $(CPPFLAGS) -I. $(IINCDIR) $< -o $@
+else
+	@echo Compiling $(<F)
+	@$(CPPC) -c $(CPPFLAGS) -I. $(IINCDIR) $< -o $@
+endif
+
+$(CCOBJS) : $(OBJDIR)/%.o : %.cc $(MAKEFILE_LIST)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	$(CPPC) -c $(CPPFLAGS) -I. $(IINCDIR) $< -o $@
+else
+	@echo Compiling $(<F)
+	@$(CPPC) -c $(CPPFLAGS) -I. $(IINCDIR) $< -o $@
+endif
+
+$(COBJS) : $(OBJDIR)/%.o : %.c $(MAKEFILE_LIST)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	$(CC) -c $(CFLAGS) -I. $(IINCDIR) $< -o $@
+else
+	@echo Compiling $(<F)
+	@$(CC) -c $(CFLAGS) -I. $(IINCDIR) $< -o $@
+endif
+
+$(ASMOBJS) : $(OBJDIR)/%.o : %.s $(MAKEFILE_LIST)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	$(AS) -c $(ASFLAGS) -I. $(IINCDIR) $< -o $@
+else
+	@echo Compiling $(<F)
+	@$(AS) -c $(ASFLAGS) -I. $(IINCDIR) $< -o $@
+endif
+
+$(ASMXOBJS) : $(OBJDIR)/%.o : %.S $(MAKEFILE_LIST)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	$(CC) -c $(ASXFLAGS) $(TOPT) -I. $(IINCDIR) $< -o $@
+else
+	@echo Compiling $(<F)
+	@$(CC) -c $(ASXFLAGS) $(TOPT) -I. $(IINCDIR) $< -o $@
+endif
+
+$(BUILDDIR)/$(PROJECT).elf: $(OBJS) $(LDSCRIPT)
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	@echo
+	$(LD) $(OBJS) $(LDFLAGS) $(LIBS) -o $@
+else
+	@echo Linking $@
+	@$(LD) $(OBJS) $(LDFLAGS) $(LIBS) -o $@
+endif
+
+%.hex: %.elf
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(HEX) $< $@
+else
+	@echo Creating $@
+	@$(HEX) $< $@
+endif
+
+%.bin: %.elf
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(BIN) $< $@
+else
+	@echo Creating $@
+	@$(BIN) $< $@
+endif
+
+%.srec: %.elf
+ifdef SREC
+  ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(SREC) $< $@
+  else
+	@echo Creating $@
+	@$(SREC) $< $@
+  endif
+endif
+
+%.dmp: %.elf
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(OD) $(ODFLAGS) $< > $@
+	$(SZ) $<
+else
+	@echo Creating $@
+	@$(OD) $(ODFLAGS) $< > $@
+	@echo
+	@$(SZ) $<
+endif
+
+%.list: %.elf
+ifeq ($(USE_VERBOSE_COMPILE),yes)
+	$(OD) -S $< > $@
+else
+	@echo Creating $@
+	@$(OD) -S $< > $@
+	@echo
+	@echo Done
+endif
+
+lib: $(OBJS) $(BUILDDIR)/lib$(PROJECT).a
+
+$(BUILDDIR)/lib$(PROJECT).a: $(OBJS)
+	@$(AR) -r $@ $^
+	@echo
+	@echo Done
+
+clean: CLEAN_RULE_HOOK
+	@echo Cleaning
+	@echo - $(DEPDIR)
+	@-rm -fR $(DEPDIR)/* $(BUILDDIR)/* 2>/dev/null
+	@-if [ -d "$(DEPDIR)" ]; then rmdir -p --ignore-fail-on-non-empty $(subst ./,,$(DEPDIR)) 2>/dev/null; fi
+	@echo - $(BUILDDIR)
+	@-if [ -d "$(BUILDDIR)" ]; then rmdir -p --ignore-fail-on-non-empty $(subst ./,,$(BUILDDIR)) 2>/dev/null; fi
+	@echo
+	@echo Done
+
+CLEAN_RULE_HOOK:
+
+#
+# Include the dependency files, should be the last of the makefile
+#
+-include $(wildcard $(DEPDIR)/*)
+
+# *** EOF ***

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
@@ -1,0 +1,26 @@
+# List of the ChibiOS generic RP2350 RISC-V Hazard3 startup files.
+
+STARTUPSRC =
+
+STARTUPASM = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/crt0_hazard3.S \
+             $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/crt0_c1_hazard3.S \
+             $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/vectors_hazard3.S \
+             $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/devices/RP2350/rp2350_riscv_imagedef.S
+
+STARTUPINC = $(CHIBIOS)/os/common/portability/GCC \
+             $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC \
+             $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/devices/RP2350 \
+             $(CHIBIOS)/os/common/ext/RISCV \
+             $(CHIBIOS)/os/common/ports/RISCV-common/include \
+             $(CHIBIOS)/os/common/ext/RP \
+             $(CHIBIOS)/os/common/ext/RP/RP2350
+
+STARTUPLD  = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/ld
+
+USE_EXCEPTIONS_STACKSIZE ?= 0x400
+USE_PROCESS_STACKSIZE    ?= 0x800
+
+# Shared variables
+ALLXASMSRC += $(STARTUPASM)
+ALLCSRC    += $(STARTUPSRC)
+ALLINC     += $(STARTUPINC)

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/vectors_hazard3.S
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/vectors_hazard3.S
@@ -1,0 +1,606 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    vectors_hazard3.S
+ * @brief   RISC-V Hazard3 vectored trap handlers for ChibiOS.
+ * @details Vectored mtvec (mode=1) with preemptive nesting for external IRQs
+ *          via Xh3irq. ISR nesting counter controls mscratch swap (first
+ *          entry/last exit only).
+ *
+ * @addtogroup RISCV_HAZARD3_GCC_VECTORS
+ * @{
+ */
+
+#define _FROM_ASM_
+#include "chconf.h"
+#include "chcore.h"
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/* Stack frame: 16 caller-saved regs + mepc + meicontext + mstatus + pad = 20 words.
+   20 * 4 = 80 bytes (16-byte aligned). */
+#define TRAP_FRAME_SIZE             PORT_EXTCTX_SIZE
+
+/* Offsets within trap frame */
+#define TRAP_FRAME_RA               PORT_EXTCTX_RA_OFFSET
+#define TRAP_FRAME_T0               PORT_EXTCTX_T0_OFFSET
+#define TRAP_FRAME_T1               PORT_EXTCTX_T1_OFFSET
+#define TRAP_FRAME_T2               PORT_EXTCTX_T2_OFFSET
+#define TRAP_FRAME_A0               PORT_EXTCTX_A0_OFFSET
+#define TRAP_FRAME_A1               PORT_EXTCTX_A1_OFFSET
+#define TRAP_FRAME_A2               PORT_EXTCTX_A2_OFFSET
+#define TRAP_FRAME_A3               PORT_EXTCTX_A3_OFFSET
+#define TRAP_FRAME_A4               PORT_EXTCTX_A4_OFFSET
+#define TRAP_FRAME_A5               PORT_EXTCTX_A5_OFFSET
+#define TRAP_FRAME_A6               PORT_EXTCTX_A6_OFFSET
+#define TRAP_FRAME_A7               PORT_EXTCTX_A7_OFFSET
+#define TRAP_FRAME_T3               PORT_EXTCTX_T3_OFFSET
+#define TRAP_FRAME_T4               PORT_EXTCTX_T4_OFFSET
+#define TRAP_FRAME_T5               PORT_EXTCTX_T5_OFFSET
+#define TRAP_FRAME_T6               PORT_EXTCTX_T6_OFFSET
+#define TRAP_FRAME_MEPC             PORT_EXTCTX_MEPC_OFFSET
+#define TRAP_FRAME_MEICONTEXT       PORT_EXTCTX_MEICONTEXT_OFFSET
+#define TRAP_FRAME_MSTATUS          PORT_EXTCTX_MSTATUS_OFFSET
+#define TRAP_FRAME_ORIGINAL_SP      PORT_EXTCTX_PAD_OFFSET
+#define TRAP_FRAME_EXT_FLAGS        PORT_EXTCTX_PAD_OFFSET
+
+#define TRAP_FRAME_EXT_CONTEXT_POPPED  1
+
+/*===========================================================================*/
+/* Vector table (vectored mode).                                             */
+/*===========================================================================*/
+
+#if !defined(__DOXYGEN__)
+
+                .section .vectors, "ax", @progbits
+                .globl  _vectors
+                .type   _vectors, @function
+
+/*
+ * Vectored mtvec table: exceptions → BASE+0, interrupts → BASE + 4*cause.
+ * Each entry is a single 4-byte J instruction (norvc forces no compression).
+ *
+ * IMPORTANT: Hazard3 computes the vector address as mtvec | (cause << 2),
+ * using OR instead of ADD. The base must be aligned to 64 bytes so that
+ * bits [5:2] are zero, preventing OR/ADD divergence for causes 0-11.
+ */
+                .option push
+                .option norelax
+                .option norvc
+                .balign 64
+
+_vectors:
+                j       _exception_entry        /* +0:  Exceptions (cause 0)  */
+                j       _unhandled_interrupt     /* +4:  (cause 1, reserved)  */
+                j       _unhandled_interrupt     /* +8:  (cause 2, reserved)  */
+                j       _software_irq_entry      /* +12: M software IRQ (3)  */
+                j       _unhandled_interrupt     /* +16: (cause 4, reserved)  */
+                j       _unhandled_interrupt     /* +20: (cause 5, reserved)  */
+                j       _unhandled_interrupt     /* +24: (cause 6, reserved)  */
+                j       _timer_irq_entry         /* +28: M timer IRQ (7)     */
+                j       _unhandled_interrupt     /* +32: (cause 8, reserved)  */
+                j       _unhandled_interrupt     /* +36: (cause 9, reserved)  */
+                j       _unhandled_interrupt     /* +40: (cause 10, reserved) */
+                j       _ext_irq_entry           /* +44: M external IRQ (11) */
+                j       _unhandled_interrupt     /* +48: (cause 12, reserved) */
+                j       _unhandled_interrupt     /* +52: (cause 13, reserved) */
+                j       _unhandled_interrupt     /* +56: (cause 14, reserved) */
+                j       _unhandled_interrupt     /* +60: (cause 15, reserved) */
+
+                .option pop
+
+                .size   _vectors, . - _vectors
+
+/*===========================================================================*/
+/* Register save/restore macros.                                             */
+/*===========================================================================*/
+
+/*
+ * Save all caller-saved registers + mepc + mstatus to the trap frame.
+ * Assumes sp already points to the allocated frame.
+ */
+.macro SAVE_CONTEXT
+                sw      ra, TRAP_FRAME_RA(sp)
+                sw      t0, TRAP_FRAME_T0(sp)
+                sw      t1, TRAP_FRAME_T1(sp)
+                sw      t2, TRAP_FRAME_T2(sp)
+                sw      a0, TRAP_FRAME_A0(sp)
+                sw      a1, TRAP_FRAME_A1(sp)
+                sw      a2, TRAP_FRAME_A2(sp)
+                sw      a3, TRAP_FRAME_A3(sp)
+                sw      a4, TRAP_FRAME_A4(sp)
+                sw      a5, TRAP_FRAME_A5(sp)
+                sw      a6, TRAP_FRAME_A6(sp)
+                sw      a7, TRAP_FRAME_A7(sp)
+                sw      t3, TRAP_FRAME_T3(sp)
+                sw      t4, TRAP_FRAME_T4(sp)
+                sw      t5, TRAP_FRAME_T5(sp)
+                sw      t6, TRAP_FRAME_T6(sp)
+                csrr    t0, mepc
+                csrr    t1, mstatus
+                sw      t0, TRAP_FRAME_MEPC(sp)
+                sw      t1, TRAP_FRAME_MSTATUS(sp)
+.endm
+
+/*
+ * Restore all caller-saved registers + mepc + mstatus, deallocate frame, mret.
+ */
+.macro RESTORE_CONTEXT_AND_MRET
+                lw      t0, TRAP_FRAME_MSTATUS(sp)
+                csrw    mstatus, t0
+                lw      t0, TRAP_FRAME_MEPC(sp)
+                csrw    mepc, t0
+                lw      ra, TRAP_FRAME_RA(sp)
+                lw      t0, TRAP_FRAME_T0(sp)
+                lw      t1, TRAP_FRAME_T1(sp)
+                lw      t2, TRAP_FRAME_T2(sp)
+                lw      a0, TRAP_FRAME_A0(sp)
+                lw      a1, TRAP_FRAME_A1(sp)
+                lw      a2, TRAP_FRAME_A2(sp)
+                lw      a3, TRAP_FRAME_A3(sp)
+                lw      a4, TRAP_FRAME_A4(sp)
+                lw      a5, TRAP_FRAME_A5(sp)
+                lw      a6, TRAP_FRAME_A6(sp)
+                lw      a7, TRAP_FRAME_A7(sp)
+                lw      t3, TRAP_FRAME_T3(sp)
+                lw      t4, TRAP_FRAME_T4(sp)
+                lw      t5, TRAP_FRAME_T5(sp)
+                lw      t6, TRAP_FRAME_T6(sp)
+                addi    sp, sp, TRAP_FRAME_SIZE
+                mret
+.endm
+
+/*
+ * ISR nesting entry: increment counter, conditional mscratch swap.
+ * Uses a0-a4 as scratch (already saved to frame).
+ */
+.macro NESTING_ENTRY
+                lui     a0, 0xD0000
+                lw      a0, 0(a0)               /* SIO->CPUID */
+                la      a1, port_isr_nesting
+                add     a2, a0, a1              /* &nesting[cpuid] */
+                lbu     a3, 0(a2)               /* old_nesting */
+                addi    a4, a3, 1
+                sb      a4, 0(a2)               /* nesting++ */
+                bnez    a3, 1f                  /* if old > 0: already on ISR stack */
+                csrrw   sp, mscratch, sp        /* first entry: swap to ISR stack */
+                /* Thread-mode mscratch pointers carry a bit-31 tag so an
+                   exception can recognize a safe first-level stack switch. */
+                slli    sp, sp, 1
+                srli    sp, sp, 1
+1:
+#if CH_DBG_ENABLE_STACK_CHECK == TRUE
+                /* ISR stack overflow check. SP is now on the ISR stack.
+                   a0 = CPUID from above. */
+#if CH_CFG_SMP_MODE == TRUE
+                bnez    a0, 2f
+                la      a1, __main_stack_base__
+                j       3f
+2:              la      a1, __c1_main_stack_base__
+3:
+#else
+                la      a1, __main_stack_base__
+#endif
+                /* Reserve enough space for the upcoming C handler and its
+                   worst-case interrupt-call chain. On nested entry, sp
+                   already includes this trap frame. Check subtraction for
+                   underflow before comparing against the stack base. */
+                li      a4, PORT_INT_REQUIRED_STACK
+                bltu    sp, a4, _isr_stack_overflow
+                sub     a4, sp, a4
+                bltu    a4, a1, _isr_stack_overflow
+#endif
+.endm
+
+/*
+ * ISR nesting exit: ensure MIE=0, decrement counter, conditional mscratch swap.
+ * Uses a0-a3 as scratch. After macro: a3=new nesting value.
+ */
+.macro NESTING_EXIT
+                csrci   mstatus, 0x8            /* Ensure MIE=0 */
+                lui     a0, 0xD0000
+                lw      a0, 0(a0)               /* SIO->CPUID */
+                la      a1, port_isr_nesting
+                add     a2, a0, a1              /* &nesting[cpuid] */
+                lbu     a3, 0(a2)
+                addi    a3, a3, -1
+                sb      a3, 0(a2)               /* nesting-- */
+                bnez    a3, 1f                  /* if still > 0: stay on ISR stack */
+                csrrw   sp, mscratch, sp        /* outermost: swap back to thread stack */
+                li      a1, PORT_MSCRATCH_THREAD_TAG
+                csrs    mscratch, a1            /* tag exception stack pointer */
+1:
+.endm
+
+/*
+ * Outermost ISR exit: preemption check + context restore + mret.
+ * For nested returns: just restore + mret.
+ * Expects a0 = CPUID, a3 = nesting value after decrement (from NESTING_EXIT).
+ */
+.macro ISR_EXIT_WITH_PREEMPTION
+                bnez    a3, .Lnested_\@
+
+                /* Outermost exit — now on thread stack. Check preemption.
+                   a0 = CPUID from NESTING_EXIT (avoids redundant SIO read). */
+                la      a1, port_preemption_pending
+                add     a0, a0, a1
+                lbu     a0, 0(a0)
+                beqz    a0, .Lnested_\@
+
+                call    __port_switch_from_isr
+
+.Lnested_\@:
+                RESTORE_CONTEXT_AND_MRET
+.endm
+
+/*===========================================================================*/
+/* Exception entry (vector offset +0).                                       */
+/*===========================================================================*/
+
+                .section .text, "ax", @progbits
+                .balign 4
+                .type   _exception_entry, @function
+_exception_entry:
+                /* In thread context mscratch contains a bit-31-tagged ISR
+                   stack top. Switching before the first store makes PMP stack
+                   faults recoverable without recursively using the exhausted
+                   thread stack. In an ISR mscratch is an untagged thread-frame
+                   pointer and the current ISR stack is already safe. */
+                csrrw   t0, mscratch, t0
+                bgez    t0, .Lexception_from_isr
+
+                /* Clear the tag and allocate the outer exception frame on the
+                   dedicated ISR stack. Original t0 is safe in mscratch. */
+                slli    t0, t0, 1
+                srli    t0, t0, 1
+                addi    t0, t0, -TRAP_FRAME_SIZE
+
+                sw      ra, TRAP_FRAME_RA(t0)
+                sw      t1, TRAP_FRAME_T1(t0)
+                csrr    t1, mscratch
+                sw      t1, TRAP_FRAME_T0(t0)
+                sw      t2, TRAP_FRAME_T2(t0)
+                sw      a0, TRAP_FRAME_A0(t0)
+                sw      a1, TRAP_FRAME_A1(t0)
+                sw      a2, TRAP_FRAME_A2(t0)
+                sw      a3, TRAP_FRAME_A3(t0)
+                sw      a4, TRAP_FRAME_A4(t0)
+                sw      a5, TRAP_FRAME_A5(t0)
+                sw      a6, TRAP_FRAME_A6(t0)
+                sw      a7, TRAP_FRAME_A7(t0)
+                sw      t3, TRAP_FRAME_T3(t0)
+                sw      t4, TRAP_FRAME_T4(t0)
+                sw      t5, TRAP_FRAME_T5(t0)
+                sw      t6, TRAP_FRAME_T6(t0)
+                csrr    t1, mepc
+                sw      t1, TRAP_FRAME_MEPC(t0)
+                sw      zero, TRAP_FRAME_MEICONTEXT(t0)
+                csrr    t1, mstatus
+                sw      t1, TRAP_FRAME_MSTATUS(t0)
+                sw      sp, TRAP_FRAME_ORIGINAL_SP(t0)
+                mv      sp, t0
+
+                /* While the exception handler runs, mark the core as nested
+                   on the ISR stack. This also keeps any deliberately enabled
+                   interrupt from attempting another first-level stack swap. */
+                lw      t1, TRAP_FRAME_ORIGINAL_SP(sp)
+                csrw    mscratch, t1
+                lui     a0, 0xD0000
+                lw      a0, 0(a0)               /* SIO->CPUID */
+                la      a1, port_isr_nesting
+                add     a2, a0, a1
+                lbu     a3, 0(a2)
+                addi    a3, a3, 1
+                sb      a3, 0(a2)
+
+#if CH_DBG_ENABLE_STACK_CHECK == TRUE
+#if CH_CFG_SMP_MODE == TRUE
+                bnez    a0, .Lexception_core1_stack
+                la      a1, __main_stack_base__
+                j       .Lexception_check_stack
+.Lexception_core1_stack:
+                la      a1, __c1_main_stack_base__
+.Lexception_check_stack:
+#else
+                la      a1, __main_stack_base__
+#endif
+                li      a4, PORT_INT_REQUIRED_STACK
+                bltu    sp, a4, _isr_stack_overflow
+                sub     a4, sp, a4
+                bltu    a4, a1, _isr_stack_overflow
+#endif
+
+                csrr    a0, mcause
+                csrr    a1, mtval
+                mv      a2, sp                  /* trap frame pointer */
+                call    _exception_handler
+
+                /* Close the nesting window and restore thread-mode mscratch. */
+                csrci   mstatus, 0x8
+                lui     a0, 0xD0000
+                lw      a0, 0(a0)
+                la      a1, port_isr_nesting
+                add     a2, a0, a1
+                lbu     a3, 0(a2)
+                addi    a3, a3, -1
+                sb      a3, 0(a2)
+
+                addi    t0, sp, TRAP_FRAME_SIZE
+                li      t1, PORT_MSCRATCH_THREAD_TAG
+                or      t0, t0, t1
+                csrw    mscratch, t0
+
+                lw      t0, TRAP_FRAME_MSTATUS(sp)
+                csrw    mstatus, t0
+                lw      t0, TRAP_FRAME_MEPC(sp)
+                csrw    mepc, t0
+                lw      t1, TRAP_FRAME_ORIGINAL_SP(sp)
+                lw      ra, TRAP_FRAME_RA(sp)
+                lw      t2, TRAP_FRAME_T2(sp)
+                lw      a0, TRAP_FRAME_A0(sp)
+                lw      a1, TRAP_FRAME_A1(sp)
+                lw      a2, TRAP_FRAME_A2(sp)
+                lw      a3, TRAP_FRAME_A3(sp)
+                lw      a4, TRAP_FRAME_A4(sp)
+                lw      a5, TRAP_FRAME_A5(sp)
+                lw      a6, TRAP_FRAME_A6(sp)
+                lw      a7, TRAP_FRAME_A7(sp)
+                lw      t3, TRAP_FRAME_T3(sp)
+                lw      t4, TRAP_FRAME_T4(sp)
+                lw      t5, TRAP_FRAME_T5(sp)
+                lw      t6, TRAP_FRAME_T6(sp)
+                lw      t0, TRAP_FRAME_T0(sp)
+                mv      sp, t1
+                /* Recover the ISR-frame address from tagged mscratch after SP
+                   is restored, then use it to load original t1. */
+                csrr    t1, mscratch
+                slli    t1, t1, 1
+                srli    t1, t1, 1
+                addi    t1, t1, -TRAP_FRAME_SIZE
+                lw      t1, TRAP_FRAME_T1(t1)
+                mret
+
+.Lexception_from_isr:
+                /* Undo the probe swap. The current ISR stack and the outer
+                   thread-frame pointer in mscratch are both restored. */
+                csrrw   t0, mscratch, t0
+                addi    sp, sp, -TRAP_FRAME_SIZE
+                SAVE_CONTEXT
+
+                /* Already on the ISR stack, nesting state is unchanged. */
+                csrr    a0, mcause
+                csrr    a1, mtval
+                mv      a2, sp                  /* trap frame pointer */
+                call    _exception_handler
+
+                RESTORE_CONTEXT_AND_MRET
+
+                .size   _exception_entry, . - _exception_entry
+
+/*===========================================================================*/
+/* Timer IRQ entry (vector offset +28, cause 7).                             */
+/* Its source remains masked if debug hooks temporarily enable MIE.          */
+/*===========================================================================*/
+
+                .balign 4
+                .type   _timer_irq_entry, @function
+_timer_irq_entry:
+                addi    sp, sp, -TRAP_FRAME_SIZE
+                SAVE_CONTEXT
+
+                /* CH_IRQ_PROLOGUE() can temporarily enable global interrupts
+                   for debug/statistics hooks. Mask the level-sensitive timer
+                   source until its C handler has advanced MTIMECMP. */
+                li      t0, MIE_MTIE
+                csrc    mie, t0
+                NESTING_ENTRY
+
+                call    _timer_interrupt_handler
+
+                /* Restore the source with global MIE closed. */
+                csrci   mstatus, 0x8
+                li      t0, MIE_MTIE
+                csrs    mie, t0
+                NESTING_EXIT
+                ISR_EXIT_WITH_PREEMPTION
+
+                .size   _timer_irq_entry, . - _timer_irq_entry
+
+/*===========================================================================*/
+/* Software IRQ entry (vector offset +12, cause 3).                          */
+/* Its source remains masked if debug hooks temporarily enable MIE.          */
+/*===========================================================================*/
+
+                .balign 4
+                .type   _software_irq_entry, @function
+_software_irq_entry:
+                addi    sp, sp, -TRAP_FRAME_SIZE
+                SAVE_CONTEXT
+
+                /* The software interrupt is also level-sensitive. Keep it
+                   masked while debug/statistics hooks may enable MIE. */
+                li      t0, MIE_MSIE
+                csrc    mie, t0
+                NESTING_ENTRY
+
+                call    _software_interrupt_handler
+
+                csrci   mstatus, 0x8
+                li      t0, MIE_MSIE
+                csrs    mie, t0
+                NESTING_EXIT
+                ISR_EXIT_WITH_PREEMPTION
+
+                .size   _software_irq_entry, . - _software_irq_entry
+
+/*===========================================================================*/
+/* External IRQ entry (vector offset +44, cause 11).                         */
+/* Preemptive nesting via Xh3irq — MEICONTEXT saved to trap frame so the     */
+/* hardware mret pop handles priority stack restoration.                      */
+/*===========================================================================*/
+
+                .balign 4
+                .type   _ext_irq_entry, @function
+_ext_irq_entry:
+                addi    sp, sp, -TRAP_FRAME_SIZE
+                SAVE_CONTEXT
+                sw      zero, TRAP_FRAME_EXT_FLAGS(sp)
+
+                /* Prevent timer/software interrupts from preempting this
+                   external IRQ. Those trap types clear MRETEIRQ. CLEARTS
+                   returns their previous enables in the saved context, and
+                   writing the context back below restores them atomically. */
+                csrrsi  t0, CSR_MEICONTEXT, RISCV_MEICONTEXT_CLEARTS
+                sw      t0, TRAP_FRAME_MEICONTEXT(sp)
+
+                NESTING_ENTRY
+
+                call    _ext_irq_dispatch
+
+                NESTING_EXIT
+
+                /* ISR exit with MEICONTEXT restore for hardware mret pop. */
+                bnez    a3, .Lnested_ext
+
+                /* Outermost exit — now on thread stack. Check preemption.
+                   a0 = CPUID from NESTING_EXIT (avoids redundant SIO read). */
+                la      a1, port_preemption_pending
+                add     a0, a0, a1
+                lbu     a0, 0(a0)
+                beqz    a0, .Lnested_ext
+
+                /* A real scheduler switch does not return here in the newly
+                   selected thread. Complete the Xh3irq hardware return first
+                   so that the selected thread cannot inherit an active
+                   priority context or masked timer/software sources.
+
+                   The synthetic mret returns to .Lext_switch_from_isr with
+                   MIE clear. It consumes MRETEIRQ exactly once; the frame flag
+                   prevents a second MEICONTEXT restore when the interrupted
+                   thread eventually resumes this continuation. */
+                li      t0, TRAP_FRAME_EXT_CONTEXT_POPPED
+                sw      t0, TRAP_FRAME_EXT_FLAGS(sp)
+                la      t0, .Lext_switch_from_isr
+                csrw    mepc, t0
+
+                /* Restore MPP=M from the saved trap state, but clear both MIE
+                   and MPIE so the synthetic mret stays globally locked. */
+                lw      t0, TRAP_FRAME_MSTATUS(sp)
+                li      t1, MSTATUS_MIE | MSTATUS_MPIE
+                not     t1, t1
+                and     t0, t0, t1
+                csrw    mstatus, t0
+
+                lw      t0, TRAP_FRAME_MEICONTEXT(sp)
+                csrw    CSR_MEICONTEXT, t0
+                mret
+
+.Lext_switch_from_isr:
+                call    __port_switch_from_isr
+
+.Lnested_ext:
+                /* Restore MEICONTEXT (mreteirq=1) so hardware pops the
+                   priority stack on mret unless the synthetic mret above has
+                   already done so. MIE=0 prevents intervening traps. */
+                lw      t0, TRAP_FRAME_EXT_FLAGS(sp)
+                bnez    t0, .Lext_context_popped
+                lw      t0, TRAP_FRAME_MEICONTEXT(sp)
+                csrw    CSR_MEICONTEXT, t0
+.Lext_context_popped:
+                RESTORE_CONTEXT_AND_MRET
+
+                .size   _ext_irq_entry, . - _ext_irq_entry
+
+/*===========================================================================*/
+/* Default weak handlers.                                                    */
+/*===========================================================================*/
+
+                /* Reset handler, jumps to C runtime entry */
+                .globl  Reset_Handler
+                .weak   Reset_Handler
+                .type   Reset_Handler, @function
+Reset_Handler:
+                j       _crt0_entry
+                .size   Reset_Handler, . - Reset_Handler
+
+                /* Default exception handler */
+                .globl  _exception_handler
+                .weak   _exception_handler
+                .type   _exception_handler, @function
+_exception_handler:
+                /* Arguments: a0 = mcause, a1 = mtval, a2 = trap_frame */
+                j       _unhandled_exception
+                .size   _exception_handler, . - _exception_handler
+
+                /* Default timer interrupt handler */
+                .globl  _timer_interrupt_handler
+                .weak   _timer_interrupt_handler
+                .type   _timer_interrupt_handler, @function
+_timer_interrupt_handler:
+                ret
+                .size   _timer_interrupt_handler, . - _timer_interrupt_handler
+
+                /* Default external interrupt dispatch (overridden by vectors_riscv.c) */
+                .globl  _ext_irq_dispatch
+                .weak   _ext_irq_dispatch
+                .type   _ext_irq_dispatch, @function
+_ext_irq_dispatch:
+                ret
+                .size   _ext_irq_dispatch, . - _ext_irq_dispatch
+
+                /* Default software interrupt handler */
+                .globl  _software_interrupt_handler
+                .weak   _software_interrupt_handler
+                .type   _software_interrupt_handler, @function
+_software_interrupt_handler:
+                ret
+                .size   _software_interrupt_handler, . - _software_interrupt_handler
+
+                /* Default unhandled interrupt handler */
+                .globl  _unhandled_interrupt
+                .weak   _unhandled_interrupt
+                .type   _unhandled_interrupt, @function
+_unhandled_interrupt:
+                j       _unhandled_interrupt
+                .size   _unhandled_interrupt, . - _unhandled_interrupt
+
+                /* Default unhandled exception handler */
+                .globl  _unhandled_exception
+                .weak   _unhandled_exception
+                .type   _unhandled_exception, @function
+_unhandled_exception:
+                j       _unhandled_exception
+                .size   _unhandled_exception, . - _unhandled_exception
+
+#if CH_DBG_ENABLE_STACK_CHECK == TRUE
+                /* Default ISR stack overflow handler.
+                   Disables interrupts and spins. Override with a strong
+                   symbol for custom behavior (e.g. fault LED). */
+                .globl  _isr_stack_overflow
+                .weak   _isr_stack_overflow
+                .type   _isr_stack_overflow, @function
+_isr_stack_overflow:
+                csrci   mstatus, 0x8
+                j       _isr_stack_overflow
+                .size   _isr_stack_overflow, . - _isr_stack_overflow
+#endif
+
+#endif /* !defined(__DOXYGEN__) */
+
+/** @} */

--- a/os/common/startup/RISCV-HAZARD3/devices/RP2350/rp2350_riscv_imagedef.S
+++ b/os/common/startup/RISCV-HAZARD3/devices/RP2350/rp2350_riscv_imagedef.S
@@ -1,0 +1,112 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rp2350_riscv_imagedef.S
+ * @brief   RP2350 RISC-V PICOBIN boot block definitions.
+ * @note    See RP2350 Datasheet 5.1.5 Blocks and block loops
+ * @note    See RP2350 Datasheet 5.9.1 Blocks and block loops
+ * @note    See RP2350 Datasheet 5.9.5 Minimum viable image metadata
+ *
+ * @addtogroup RISCV_HAZARD3_RP2350_IMAGEDEF
+ * @{
+ */
+
+/* Block markers */
+#define PICOBIN_BLOCK_MARKER_START              0xffffded3
+#define PICOBIN_BLOCK_MARKER_END                0xab123579
+
+/* Block item type IDs */
+#define PICOBIN_BLOCK_ITEM_1BS_IMAGE_TYPE       0x42
+#define PICOBIN_BLOCK_ITEM_1BS_VECTOR_TABLE     0x03
+#define PICOBIN_BLOCK_ITEM_1BS_ENTRY_POINT      0x44
+#define PICOBIN_BLOCK_ITEM_2BS_LAST             0xff
+
+/* Image type field values */
+#define PICOBIN_IMAGE_TYPE_IMAGE_TYPE_EXE       0x0001  /* bits 0-3: type = 1 exe */
+#define PICOBIN_IMAGE_TYPE_EXE_CPU_RISCV        0x0100  /* bits 8-10: cpu = 1 RISC-V */
+#define PICOBIN_IMAGE_TYPE_EXE_CHIP_RP2350      0x1000  /* bits 12-14: chip = 1 RP2350 */
+
+/*
+ * RP2350 RISC-V Hazard3 image type.
+ * The security field is left unspecified because it only applies to Arm.
+ */
+#if !defined(RP2350_IMAGE_TYPE) || defined(__DOXYGEN__)
+#define RP2350_IMAGE_TYPE       (PICOBIN_IMAGE_TYPE_IMAGE_TYPE_EXE |    \
+                                 PICOBIN_IMAGE_TYPE_EXE_CPU_RISCV |     \
+                                 PICOBIN_IMAGE_TYPE_EXE_CHIP_RP2350)
+#endif
+
+/*===========================================================================*/
+/* Imagedef block - placed at start of flash                                 */
+/*===========================================================================*/
+
+#if !defined(__DOXYGEN__)
+
+/*
+ * PICOBIN image definition block for RISC-V.
+ * The bootrom searches for this block within the first 4KB of flash.
+ *
+ * For ChibiOS RISC-V we use the following block structure:
+ *   - MARKER_START
+ *   - IMAGE_TYPE (CPU = RISC-V)
+ *   - ENTRY_POINT (points to _crt0_entry)
+ *   - LAST
+ *   - MARKER_END
+ *
+ * Note: Unlike ARM, RISC-V uses ENTRY_POINT instead of VECTOR_TABLE
+ * because RISC-V doesn't have an ARM-style vector table at address 0.
+ */
+                .section .embedded_block, "a", @progbits
+                .balign 4
+                .globl  __embedded_block
+__embedded_block:
+                .word   PICOBIN_BLOCK_MARKER_START
+
+                /* IMAGE_TYPE item: 1 byte type + 1 byte size + 2 byte value */
+                .byte   PICOBIN_BLOCK_ITEM_1BS_IMAGE_TYPE
+                .byte   0x01
+                .hword  RP2350_IMAGE_TYPE
+
+                /* ENTRY_POINT item: type + size + pad + entry_addr + stack_ptr
+                 * Size = 3 words (12 bytes: 4 byte header + 4 byte addr + 4 byte SP)
+                 */
+                .byte   PICOBIN_BLOCK_ITEM_1BS_ENTRY_POINT
+                .byte   0x03                    /* 3 words total */
+                .byte   0x00                    /* padding */
+                .byte   0x00                    /* padding */
+                .word   _crt0_entry             /* entry point address */
+                .word   __process_stack_end__   /* initial stack pointer */
+
+                /* LAST item: marks end of block items
+                 * Size field = total size of block in words, excluding:
+                 *   - start marker (4 bytes)
+                 *   - end marker (4 bytes)
+                 *   - LAST item itself (8 bytes)
+                 * Total excluded = 16 bytes
+                 * IMAGE_TYPE (1 word) + ENTRY_POINT (3 words) = 4 words
+                 */
+                .byte   PICOBIN_BLOCK_ITEM_2BS_LAST
+                .hword  ((__embedded_block_end - __embedded_block - 16) / 4)
+                .byte   0x00
+                .word   0x00000000              /* offset to next block (0 = single block loop) */
+
+                .word   PICOBIN_BLOCK_MARKER_END
+__embedded_block_end:
+
+#endif /* !defined(__DOXYGEN__) */
+
+/** @} */

--- a/os/common/startup/RISCV-HAZARD3/devices/RP2350/rvparams.h
+++ b/os/common/startup/RISCV-HAZARD3/devices/RP2350/rvparams.h
@@ -1,0 +1,171 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rvparams.h
+ * @brief   RISC-V Hazard3 parameters for the RP2350.
+ *
+ * @defgroup RISCV_HAZARD3_RP2350 RP2350 RISC-V Hazard3 Specific Parameters
+ * @ingroup RISCV_HAZARD3_SPECIFIC
+ * @details This file contains the RISC-V Hazard3 specific parameters for the
+ *          RP2350 platform.
+ * @{
+ */
+
+#ifndef RVPARAMS_H
+#define RVPARAMS_H
+
+/* Standard RISC-V CSR definitions shared across all RISC-V ports.*/
+#include "riscv_csr.h"
+
+/**
+ * @brief   RISC-V architecture identifier.
+ * @note    Hazard3 implements RV32IMAC.
+ */
+#define RISCV_ARCH                  rv32imac
+
+/**
+ * @brief   Hazard3 core identifier.
+ */
+#define RISCV_HAZARD3               1
+
+/**
+ * @brief   Number of external interrupt sources.
+ * @note    RP2350 has 52 external interrupts (IRQ 0-51).
+ */
+#define RISCV_NUM_INTERRUPTS        52
+
+/**
+ * @brief   SIO base address for MTIME registers.
+ * @note    Hazard3 uses memory-mapped MTIME/MTIMECMP in SIO, not CSRs.
+ */
+#define RISCV_SIO_BASE              0xD0000000U
+
+/**
+ * @brief   MTIME_CTRL register offset from SIO base.
+ */
+#define RISCV_SIO_MTIME_CTRL_OFFSET 0x1A4U
+
+/**
+ * @brief   MTIME register offset from SIO base (low 32 bits).
+ */
+#define RISCV_SIO_MTIME_OFFSET      0x1B0U
+
+/**
+ * @brief   MTIMEH register offset from SIO base (high 32 bits).
+ */
+#define RISCV_SIO_MTIMEH_OFFSET     0x1B4U
+
+/**
+ * @brief   MTIMECMP register offset from SIO base (low 32 bits).
+ */
+#define RISCV_SIO_MTIMECMP_OFFSET   0x1B8U
+
+/**
+ * @brief   MTIMECMPH register offset from SIO base (high 32 bits).
+ */
+#define RISCV_SIO_MTIMECMPH_OFFSET  0x1BCU
+
+/**
+ * @brief   MTIME_CTRL bit definitions.
+ */
+#define MTIME_CTRL_EN               (1U << 0)   /* Timer enable */
+#define MTIME_CTRL_FULLSPEED        (1U << 1)   /* Run at CLK_SYS instead of 1MHz */
+#define MTIME_CTRL_DBGPAUSE_CORE0   (1U << 2)   /* Pause when core0 halted */
+#define MTIME_CTRL_DBGPAUSE_CORE1   (1U << 3)   /* Pause when core1 halted */
+
+/**
+ * @brief   System timer frequency.
+ * @note    RP2350 MTIME runs at 1 MHz by default (when FULLSPEED=0).
+ */
+#define RISCV_MTIME_FREQUENCY       1000000U
+
+/**
+ * @brief   Hazard3 uses custom Xh3irq extension for interrupts.
+ */
+#define RISCV_HAS_XH3IRQ            1
+
+/**
+ * @brief   Xh3irq custom CSR addresses.
+ * @note    These are accessed via .word directives since GCC doesn't know them.
+ */
+#define CSR_MEIEA                   0xBE0   /* External interrupt enable array */
+#define CSR_MEIPA                   0xBE1   /* External interrupt pending array */
+#define CSR_MEIFA                   0xBE2   /* External interrupt force array */
+#define CSR_MEIPRA                  0xBE3   /* External interrupt priority array */
+#define CSR_MEINEXT                 0xBE4   /* Next external interrupt to service */
+#define CSR_MEICONTEXT              0xBE5   /* External interrupt context save */
+
+/**
+ * @brief   MEICONTEXT write-one fields.
+ * @note    CLEARTS atomically clears MIE.MSIE/MTIE and returns their previous
+ *          values in MEICONTEXT.MSIESAVE/MTIESAVE.
+ */
+#define RISCV_MEICONTEXT_CLEARTS    0x2
+
+/**
+ * @brief   Hazard3 has PMP support.
+ */
+#define RISCV_PMP_PRESENT           1
+
+/**
+ * @brief   Hazard3/RP2350 custom CSR: PMPCFGM0.
+ * @details Enables PMP enforcement for M-mode without using the L (lock) bit.
+ *          Each bit corresponds to a PMP entry; setting bit N enforces entry N
+ *          on M-mode accesses.
+ */
+#define CSR_PMPCFGM0                0xBD0
+
+/**
+ * @name    PMP configuration field constants (RP2350-E6 erratum corrected).
+ * @details RP2350-E6 erratum: PMP R/W/X permission bits are reversed in
+ *          hardware. Standard encoding: R=bit0, W=bit1, X=bit2.
+ *          RP2350 hardware: X=bit0, W=bit1, R=bit2.
+ *          These constants use the hardware (erratum) encoding.
+ * @{
+ */
+#define PMP_CFG_X                   (1U << 0)   /**< Execute permission     */
+#define PMP_CFG_W                   (1U << 1)   /**< Write permission       */
+#define PMP_CFG_R                   (1U << 2)   /**< Read permission        */
+#define PMP_CFG_A_OFF               (0U << 3)   /**< Addr matching: OFF     */
+#define PMP_CFG_A_TOR               (1U << 3)   /**< Addr matching: TOR     */
+#define PMP_CFG_A_NA4               (2U << 3)   /**< Addr matching: NA4     */
+#define PMP_CFG_A_NAPOT             (3U << 3)   /**< Addr matching: NAPOT   */
+#define PMP_CFG_L                   (1U << 7)   /**< Lock                   */
+/** @} */
+
+/* Standard RISC-V CSR addresses, MSTATUS/MIE/MCAUSE bit definitions are
+   provided by riscv_csr.h (included above).*/
+
+/* If the device type is not externally defined, for example from the Makefile,
+   then a file named board.h is included. This file must contain a device
+   definition compatible with the vendor include file.*/
+#if !defined(RP2350)
+#include "board.h"
+#endif
+
+/* The following code is not processed when the file is included from an
+   asm module.*/
+#if !defined(_FROM_ASM_)
+
+/* Including the device header.*/
+#include "rp2350.h"
+
+#endif /* !defined(_FROM_ASM_) */
+
+#endif /* RVPARAMS_H */
+
+/** @} */

--- a/os/common/startup/RISCV-HAZARD3/devices/RP2350/rvparams.h
+++ b/os/common/startup/RISCV-HAZARD3/devices/RP2350/rvparams.h
@@ -135,14 +135,17 @@
  *          hardware. Standard encoding: R=bit0, W=bit1, X=bit2.
  *          RP2350 hardware: X=bit0, W=bit1, R=bit2.
  *          These constants use the hardware (erratum) encoding.
+ * @note    RP2350 effectively supports only OFF and NAPOT address matching.
+ *          Writing the unsupported TOR encoding selects OFF. The architected
+ *          NA4 field encoding is retained for register-definition parity, but
+ *          cannot describe a four-byte region with RP2350's 32-byte granule.
  * @{
  */
 #define PMP_CFG_X                   (1U << 0)   /**< Execute permission     */
 #define PMP_CFG_W                   (1U << 1)   /**< Write permission       */
 #define PMP_CFG_R                   (1U << 2)   /**< Read permission        */
 #define PMP_CFG_A_OFF               (0U << 3)   /**< Addr matching: OFF     */
-#define PMP_CFG_A_TOR               (1U << 3)   /**< Addr matching: TOR     */
-#define PMP_CFG_A_NA4               (2U << 3)   /**< Addr matching: NA4     */
+#define PMP_CFG_A_NA4               (2U << 3)   /**< NA4 field encoding     */
 #define PMP_CFG_A_NAPOT             (3U << 3)   /**< Addr matching: NAPOT   */
 #define PMP_CFG_L                   (1U << 7)   /**< Lock                   */
 /** @} */

--- a/os/hal/ports/RP/RP2350/hal_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_lld.c
@@ -128,8 +128,8 @@ void hal_lld_init(void) {
   pioInit();
 #endif
 
-  /* Bind the system timer IRQ to this core for tickless mode. */
-#if OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING
+  /* ARM TIMER0 alarm routing requires binding, Hazard3 MTIMECMP is local.*/
+#if (OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING) && !defined(__riscv)
   stBind();
 #endif
 

--- a/os/hal/ports/RP/RP2350/platform_riscv.mk
+++ b/os/hal/ports/RP/RP2350/platform_riscv.mk
@@ -1,0 +1,54 @@
+# Required platform files.
+PLATFORMSRC := $(CHIBIOS)/os/hal/ports/common/RISCV-HAZARD3/nvic.c \
+               $(CHIBIOS)/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.c \
+               $(CHIBIOS)/os/hal/ports/RP/rp_bootrom.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350/rp_clocks.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350/rp_isr.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350/rp_pll.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350/rp_xosc.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350/hal_lld.c
+
+# Required include directories.
+PLATFORMINC := $(CHIBIOS)/os/hal/ports/common/RISCV-HAZARD3 \
+               $(CHIBIOS)/os/hal/ports/RP \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350 \
+               $(CHIBIOS)/os/common/ports/RISCV-HAZARD3
+
+# Optional platform files.
+ifeq ($(USE_SMART_BUILD),yes)
+
+# Configuration files directory
+ifeq ($(HALCONFDIR),)
+  ifeq ($(CONFDIR),)
+    HALCONFDIR = .
+  else
+    HALCONFDIR := $(CONFDIR)
+  endif
+endif
+
+HALCONF := $(strip $(shell cat $(HALCONFDIR)/halconf.h | egrep -e "\#define"))
+
+ifneq ($(findstring HAL_USE_EFL TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2350/hal_efl_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2350/hal_efl_lld.c
+endif
+
+# Drivers compatible with the platform.
+include $(CHIBIOS)/os/hal/ports/RP/LLD/EFLv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/DMAv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/PIOv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/SPIv1/driver.mk
+# The Hazard3 port owns its core-local MTIME/MTIMECMP system timer.
+include $(CHIBIOS)/os/hal/ports/RP/LLD/UARTv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/WDGv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/USBv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/I2Cv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/PWMv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/ADCv1/driver.mk
+
+# Shared variables
+ALLCSRC += $(PLATFORMSRC)
+ALLINC  += $(PLATFORMINC)

--- a/os/hal/ports/common/RISCV-HAZARD3/cache.h
+++ b/os/hal/ports/common/RISCV-HAZARD3/cache.h
@@ -1,0 +1,107 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    common/RISCV-HAZARD3/cache.h
+ * @brief   RISC-V Hazard3 cache compatibility support.
+ * @note    The Hazard3 core does not have a data cache, so these macros
+ *          are no-ops that just provide memory barriers.
+ *
+ * @addtogroup COMMON_RISCV_HAZARD3_CACHE
+ * @{
+ */
+
+#ifndef CACHE_H
+#define CACHE_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Data cache line size, zero if there is no data cache.
+ * @note    Hazard3 has no data cache.
+ */
+#define CACHE_LINE_SIZE                     0U
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Aligns the specified size to a multiple of cache line size.
+ * @note    No-op on Hazard3 since there is no data cache.
+ *
+ * @param[in] t         type of the buffer element
+ * @param[in] n         number of buffer elements
+ */
+#define CACHE_SIZE_ALIGN(t, n)              (n)
+
+/**
+ * @brief   Invalidates the data cache lines overlapping a memory buffer.
+ * @note    No-op on Hazard3 since there is no data cache. Just provides
+ *          a memory barrier for consistency.
+ *
+ * @param[in] saddr     start address of the buffer
+ * @param[in] n         size of the buffer in bytes
+ */
+#define cacheBufferInvalidate(saddr, n) do {                                \
+  (void)(saddr);                                                            \
+  (void)(n);                                                                \
+  __asm__ volatile ("fence iorw, iorw" : : : "memory");                     \
+} while (false)
+
+/**
+ * @brief   Flushes the data cache lines overlapping a memory buffer.
+ * @note    No-op on Hazard3 since there is no data cache. Just provides
+ *          a memory barrier for consistency.
+ *
+ * @param[in] saddr     start address of the buffer
+ * @param[in] n         size of the buffer in bytes
+ */
+#define cacheBufferFlush(saddr, n) do {                                     \
+  (void)(saddr);                                                            \
+  (void)(n);                                                                \
+  __asm__ volatile ("fence iorw, iorw" : : : "memory");                     \
+} while (false)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CACHE_H */
+
+/** @} */

--- a/os/hal/ports/common/RISCV-HAZARD3/cache.h
+++ b/os/hal/ports/common/RISCV-HAZARD3/cache.h
@@ -74,7 +74,7 @@
   (void)(saddr);                                                            \
   (void)(n);                                                                \
   __asm__ volatile ("fence iorw, iorw" : : : "memory");                     \
-} while (false)
+} while (0)
 
 /**
  * @brief   Flushes the data cache lines overlapping a memory buffer.
@@ -88,7 +88,7 @@
   (void)(saddr);                                                            \
   (void)(n);                                                                \
   __asm__ volatile ("fence iorw, iorw" : : : "memory");                     \
-} while (false)
+} while (0)
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/common/RISCV-HAZARD3/cache.h
+++ b/os/hal/ports/common/RISCV-HAZARD3/cache.h
@@ -24,8 +24,8 @@
  * @{
  */
 
-#ifndef CACHE_H
-#define CACHE_H
+#ifndef RISCV_HAZARD3_CACHE_H
+#define RISCV_HAZARD3_CACHE_H
 
 /*===========================================================================*/
 /* Driver constants.                                                         */
@@ -102,6 +102,6 @@ extern "C" {
 }
 #endif
 
-#endif /* CACHE_H */
+#endif /* RISCV_HAZARD3_CACHE_H */
 
 /** @} */

--- a/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.c
+++ b/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.c
@@ -1,19 +1,17 @@
 /*
     ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
 
-    This file is part of ChibiOS.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-    ChibiOS is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation version 3 of the License.
+        http://www.apache.org/licenses/LICENSE-2.0
 
-    ChibiOS is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 */
 
 /**

--- a/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.c
+++ b/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.c
@@ -1,0 +1,73 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/hal_st_lld.c
+ * @brief   RISC-V Hazard3 ST Driver subsystem low level driver code.
+ * @details The kernel port owns the core-local MTIME/MTIMECMP timer. This
+ *          file supplies the HAL initialization hook for that timer.
+ *
+ * @addtogroup ST
+ * @{
+ */
+
+#include "hal.h"
+
+#if (OSAL_ST_MODE != OSAL_ST_MODE_NONE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level ST driver initialization.
+ * @note    For RISC-V Hazard3, the timer is initialized in port_init() in
+ *          chcore.c. This function is a no-op.
+ *
+ * @notapi
+ */
+void st_lld_init(void) {
+}
+
+#endif /* OSAL_ST_MODE != OSAL_ST_MODE_NONE */
+
+/** @} */

--- a/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.h
+++ b/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.h
@@ -1,19 +1,17 @@
 /*
     ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
 
-    This file is part of ChibiOS.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-    ChibiOS is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation version 3 of the License.
+        http://www.apache.org/licenses/LICENSE-2.0
 
-    ChibiOS is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 */
 
 /**

--- a/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.h
+++ b/os/hal/ports/common/RISCV-HAZARD3/hal_st_lld.h
@@ -1,0 +1,201 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    This file is part of ChibiOS.
+
+    ChibiOS is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation version 3 of the License.
+
+    ChibiOS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/**
+ * @file    RISCV-HAZARD3/hal_st_lld.h
+ * @brief   RISC-V Hazard3 ST Driver subsystem low level driver header.
+ * @details The kernel port owns the core-local MTIME/MTIMECMP timer. The ST
+ *          low level interface delegates to the same port timer primitives.
+ *
+ * @addtogroup ST
+ * @{
+ */
+
+#ifndef HAL_ST_LLD_H
+#define HAL_ST_LLD_H
+
+#include "rvparams.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of supported alarms.
+ * @note    The core-local MTIMECMP register provides one alarm.
+ */
+#define ST_LLD_NUM_ALARMS                   1
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if OSAL_ST_RESOLUTION != 32
+#error "OSAL_ST_RESOLUTION must be 32"
+#endif
+
+#if OSAL_ST_FREQUENCY == 0
+#error "OSAL_ST_FREQUENCY must be greater than zero"
+#endif
+
+#if (OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING) &&                           \
+    (OSAL_ST_FREQUENCY != RISCV_MTIME_FREQUENCY)
+#error "OSAL_ST_FREQUENCY must equal RISCV_MTIME_FREQUENCY in freerunning mode"
+#endif
+
+#if (OSAL_ST_MODE == OSAL_ST_MODE_PERIODIC) &&                              \
+    (OSAL_ST_FREQUENCY != 0) &&                                             \
+    ((RISCV_MTIME_FREQUENCY % OSAL_ST_FREQUENCY) != 0)
+#error "OSAL_ST_FREQUENCY must divide RISCV_MTIME_FREQUENCY in periodic mode"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void st_lld_init(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Driver inline functions.                                                  */
+/*===========================================================================*/
+
+/**
+ * @brief   Returns the time counter value.
+ * @note    For RISC-V Hazard3, this returns the MTIME value.
+ *
+ * @return  The counter value.
+ *
+ * @notapi
+ */
+__STATIC_INLINE systime_t st_lld_get_counter(void) {
+
+#if OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING
+  return port_timer_get_time();
+#else
+  return (systime_t)(*(volatile uint32_t *)(RISCV_SIO_BASE +
+                                            RISCV_SIO_MTIME_OFFSET));
+#endif
+}
+
+/**
+ * @brief   Starts the alarm.
+ * @note    Not used in periodic mode.
+ *
+ * @param[in] abstime   the time to be set for the first alarm
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_start_alarm(systime_t abstime) {
+
+#if OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING
+  port_timer_start_alarm(abstime);
+#else
+  (void)abstime;
+#endif
+}
+
+/**
+ * @brief   Stops the alarm interrupt.
+ * @note    Not used in periodic mode.
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_stop_alarm(void) {
+
+#if OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING
+  port_timer_stop_alarm();
+#endif
+}
+
+/**
+ * @brief   Sets the alarm time.
+ * @note    Not used in periodic mode.
+ *
+ * @param[in] abstime   the time to be set for the next alarm
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_set_alarm(systime_t abstime) {
+
+#if OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING
+  port_timer_set_alarm(abstime);
+#else
+  (void)abstime;
+#endif
+}
+
+/**
+ * @brief   Returns the current alarm time.
+ * @note    Not used in periodic mode.
+ *
+ * @return  The current alarm time.
+ *
+ * @notapi
+ */
+__STATIC_INLINE systime_t st_lld_get_alarm(void) {
+
+#if OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING
+  return port_timer_get_alarm();
+#else
+  return (systime_t)0;
+#endif
+}
+
+/**
+ * @brief   Determines if the alarm is active.
+ * @note    Not used in periodic mode.
+ *
+ * @return The alarm status.
+ * @retval false if the alarm is not active.
+ * @retval true if the alarm is active
+ *
+ * @notapi
+ */
+__STATIC_INLINE bool st_lld_is_alarm_active(void) {
+
+#if OSAL_ST_MODE == OSAL_ST_MODE_FREERUNNING
+  return (*(volatile uint32_t *)(RISCV_SIO_BASE +
+                                 RISCV_SIO_MTIMECMP_OFFSET) != UINT32_MAX) ||
+         (*(volatile uint32_t *)(RISCV_SIO_BASE +
+                                 RISCV_SIO_MTIMECMPH_OFFSET) != UINT32_MAX);
+#else
+  return false;
+#endif
+}
+
+#endif /* HAL_ST_LLD_H */
+
+/** @} */

--- a/os/hal/ports/common/RISCV-HAZARD3/nvic.c
+++ b/os/hal/ports/common/RISCV-HAZARD3/nvic.c
@@ -1,0 +1,149 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    common/RISCV-HAZARD3/nvic.c
+ * @brief   RISC-V Hazard3 interrupt controller implementation.
+ * @details Provides the NVIC-compatible interface used by RP low level
+ *          drivers on top of the Xh3irq interrupt controller.
+ *
+ * @addtogroup COMMON_RISCV_HAZARD3_IRQ
+ * @{
+ */
+
+#include "hal.h"
+#include "hazard3_irq.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Hazard3 IRQ controller initialization.
+ * @details Disables all external interrupts, clears forced-pending state,
+ *          and resets all priorities to zero.
+ */
+void nvicInit(void) {
+  hazard3_irq_init();
+}
+
+/**
+ * @brief   Enables an external interrupt with specified priority.
+ *
+ * @param[in] n         The IRQ number
+ * @param[in] prio      The priority level
+ */
+void nvicEnableVector(uint32_t n, uint32_t prio) {
+
+  osalDbgCheck((n < HAZARD3_NUM_EXTERNAL_IRQS) &&
+               (prio < HAZARD3_NUM_PRIORITY_LEVELS));
+
+  if ((n >= HAZARD3_NUM_EXTERNAL_IRQS) ||
+      (prio >= HAZARD3_NUM_PRIORITY_LEVELS)) {
+    return;
+  }
+
+  hazard3_irq_force_clear(n);
+  hazard3_irq_set_priority(n, NVIC_PRIORITY_MASK(prio));
+  hazard3_irq_enable(n);
+}
+
+/**
+ * @brief   Disables an external interrupt.
+ *
+ * @param[in] n         The IRQ number
+ */
+void nvicDisableVector(uint32_t n) {
+
+  osalDbgCheck(n < HAZARD3_NUM_EXTERNAL_IRQS);
+
+  if (n >= HAZARD3_NUM_EXTERNAL_IRQS) {
+    return;
+  }
+
+  hazard3_irq_disable(n);
+  hazard3_irq_force_clear(n);
+  hazard3_irq_set_priority(n, 0U);
+}
+
+/**
+ * @brief   Sets system handler priority.
+ * @note    This is a no-op on RISC-V Hazard3.
+ *
+ * @param[in] handler   The handler number
+ * @param[in] prio      The priority level
+ */
+void nvicSetSystemHandlerPriority(uint32_t handler, uint32_t prio) {
+
+  (void)handler;
+  (void)prio;
+}
+
+/**
+ * @brief   Clears a pending interrupt.
+ * @note    On Hazard3 clearing pending state is handled by the interrupt
+ *          source or by clearing the force bit.
+ *
+ * @param[in] n         The IRQ number
+ */
+void nvicClearPending(uint32_t n) {
+
+  osalDbgCheck(n < HAZARD3_NUM_EXTERNAL_IRQS);
+
+  if (n >= HAZARD3_NUM_EXTERNAL_IRQS) {
+    return;
+  }
+
+  hazard3_irq_force_clear(n);
+}
+
+/**
+ * @brief   Sets a pending interrupt (forces interrupt).
+ *
+ * @param[in] n         The IRQ number
+ */
+void nvicSetPending(uint32_t n) {
+
+  osalDbgCheck(n < HAZARD3_NUM_EXTERNAL_IRQS);
+
+  if (n >= HAZARD3_NUM_EXTERNAL_IRQS) {
+    return;
+  }
+
+  hazard3_irq_force(n);
+}
+
+/** @} */

--- a/os/hal/ports/common/RISCV-HAZARD3/nvic.h
+++ b/os/hal/ports/common/RISCV-HAZARD3/nvic.h
@@ -24,8 +24,8 @@
  * @{
  */
 
-#ifndef NVIC_H
-#define NVIC_H
+#ifndef RISCV_HAZARD3_NVIC_H
+#define RISCV_HAZARD3_NVIC_H
 
 /*===========================================================================*/
 /* Driver constants.                                                         */
@@ -82,6 +82,6 @@ extern "C" {
 }
 #endif
 
-#endif /* NVIC_H */
+#endif /* RISCV_HAZARD3_NVIC_H */
 
 /** @} */

--- a/os/hal/ports/common/RISCV-HAZARD3/nvic.h
+++ b/os/hal/ports/common/RISCV-HAZARD3/nvic.h
@@ -1,0 +1,87 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    common/RISCV-HAZARD3/nvic.h
+ * @brief   RISC-V Hazard3 interrupt controller support.
+ * @details Provides the NVIC-compatible interface used by RP low level
+ *          drivers on top of the Xh3irq interrupt controller.
+ *
+ * @addtogroup COMMON_RISCV_HAZARD3_IRQ
+ * @{
+ */
+
+#ifndef NVIC_H
+#define NVIC_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of external interrupts on Hazard3/RP2350.
+ * @note    Derived from RISCV_NUM_INTERRUPTS defined in rvparams.h.
+ */
+#define HAZARD3_NUM_EXTERNAL_IRQS       RISCV_NUM_INTERRUPTS
+
+/**
+ * @brief   Number of interrupt priority levels on Hazard3.
+ */
+#define HAZARD3_NUM_PRIORITY_LEVELS     4U
+
+/**
+ * @brief   ChibiOS logical priority to Xh3irq priority conversion macro.
+ * @note    ChibiOS uses zero as the most urgent logical priority while
+ *          Xh3irq uses three as the most urgent logical priority.
+ */
+#define NVIC_PRIORITY_MASK(prio)        (3U - (uint32_t)(prio))
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void nvicInit(void);
+  void nvicEnableVector(uint32_t n, uint32_t prio);
+  void nvicDisableVector(uint32_t n);
+  void nvicSetSystemHandlerPriority(uint32_t handler, uint32_t prio);
+  void nvicClearPending(uint32_t n);
+  void nvicSetPending(uint32_t n);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NVIC_H */
+
+/** @} */

--- a/os/rt/src/chsys.c
+++ b/os/rt/src/chsys.c
@@ -138,6 +138,12 @@ void chSysWaitSystemState(system_state_t state) {
 
   while (ch_system.state != state) {
   }
+
+#if defined(PORT_SYSTEM_STATE_ACQUIRE)
+  /* Pairs with the publishing core's release operation so that observing the
+     requested state also makes the preceding system initialization visible.*/
+  PORT_SYSTEM_STATE_ACQUIRE();
+#endif
 }
 
 /**
@@ -185,6 +191,10 @@ void chSysInit(void) {
   chInstanceObjectInit(&ch0, &ch_core0_cfg);
 
   /* It is alive now.*/
+#if defined(PORT_SYSTEM_STATE_RELEASE)
+  /* Publish all preceding initialization before changing the shared state.*/
+  PORT_SYSTEM_STATE_RELEASE();
+#endif
   ch_system.state = ch_sys_running;
   chSysUnlock();
 }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,10 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- NEW: Hazard3 RISC-V support for RP2350: RT/NIL ports, dual-core SMP,
+       Xh3irq interrupt handling, periodic and tickless MTIME support, PMP
+       stack guards, startup/HAL integration, demo, and hardware validation
+       target (github PR #90).
 - NEW: STM32U5 support extended: EPOD booster clock handling and a generated
        clock tree, the STM32U575ZI-Nucleo144 board and RT-STM32-MULTI demo
        configuration, and the STM32U575xx mcuconf template and updater

--- a/test/nil/testbuild/RISCV-HAZARD3.make
+++ b/test/nil/testbuild/RISCV-HAZARD3.make
@@ -1,0 +1,130 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=4
+endif
+
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+ifeq ($(USE_LTO),)
+  USE_LTO = no
+endif
+
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x400
+endif
+
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x400
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+PROJECT = ch
+
+MCU = rv32imac_zba_zbb_zbs_zbkb_zcb_zcmp
+
+CHIBIOS  := ../../..
+CONFDIR  := .
+BUILDDIR := ./build/RISCV-HAZARD3
+DEPDIR   := ./.dep/RISCV-HAZARD3
+
+include $(CHIBIOS)/os/license/license.mk
+include $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
+include $(CHIBIOS)/os/nil/nil.mk
+include $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port.mk
+include $(CHIBIOS)/tools/mk/autobuild.mk
+
+LDSCRIPT = $(STARTUPLD)/RP2350_RISCV_FLASH.ld
+
+CSRC = $(ALLCSRC) \
+       main.c
+
+CPPSRC = $(ALLCPPSRC)
+ASMSRC = $(ALLASMSRC)
+ASMXSRC = $(ALLXASMSRC)
+
+INCDIR = $(CONFDIR) $(ALLINC)
+
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+UDEFS = -DRP2350 \
+        -DCH_DBG_SYSTEM_STATE_CHECK=TRUE \
+        -DCH_DBG_ENABLE_CHECKS=TRUE \
+        -DCH_DBG_ENABLE_ASSERTS=TRUE \
+        -DCH_DBG_ENABLE_STACK_CHECK=TRUE \
+        -DPORT_ENABLE_GUARD_PAGES=TRUE
+
+UADEFS = -DRP2350 \
+         -DCH_DBG_SYSTEM_STATE_CHECK=TRUE \
+         -DCH_DBG_ENABLE_CHECKS=TRUE \
+         -DCH_DBG_ENABLE_ASSERTS=TRUE \
+         -DCH_DBG_ENABLE_STACK_CHECK=TRUE \
+         -DPORT_ENABLE_GUARD_PAGES=TRUE
+UINCDIR =
+ULIBDIR =
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk
+include $(RULESPATH)/riscv-none-elf.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/test/rt-ports/testbuild/make/RISCV-HAZARD3.make
+++ b/test/rt-ports/testbuild/make/RISCV-HAZARD3.make
@@ -1,0 +1,130 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=4
+endif
+
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+ifeq ($(USE_LTO),)
+  USE_LTO = no
+endif
+
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x400
+endif
+
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x400
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+PROJECT = ch
+
+MCU = rv32imac_zba_zbb_zbs_zbkb_zcb_zcmp
+
+CHIBIOS  := ../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build/RISCV-HAZARD3
+DEPDIR   := ./.dep/RISCV-HAZARD3
+
+include $(CHIBIOS)/os/license/license.mk
+include $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port.mk
+include $(CHIBIOS)/tools/mk/autobuild.mk
+
+LDSCRIPT = $(STARTUPLD)/RP2350_RISCV_FLASH.ld
+
+CSRC = $(ALLCSRC) \
+       main.c
+
+CPPSRC = $(ALLCPPSRC)
+ASMSRC = $(ALLASMSRC)
+ASMXSRC = $(ALLXASMSRC)
+
+INCDIR = $(CONFDIR) $(ALLINC)
+
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+UDEFS = -DRP2350 \
+        -DCH_DBG_SYSTEM_STATE_CHECK=TRUE \
+        -DCH_DBG_ENABLE_CHECKS=TRUE \
+        -DCH_DBG_ENABLE_ASSERTS=TRUE \
+        -DCH_DBG_ENABLE_STACK_CHECK=TRUE \
+        -DPORT_ENABLE_GUARD_PAGES=TRUE
+
+UADEFS = -DRP2350 \
+         -DCH_DBG_SYSTEM_STATE_CHECK=TRUE \
+         -DCH_DBG_ENABLE_CHECKS=TRUE \
+         -DCH_DBG_ENABLE_ASSERTS=TRUE \
+         -DCH_DBG_ENABLE_STACK_CHECK=TRUE \
+         -DPORT_ENABLE_GUARD_PAGES=TRUE
+UINCDIR =
+ULIBDIR =
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk
+include $(RULESPATH)/riscv-none-elf.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/Makefile
@@ -1,0 +1,182 @@
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=4
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = no
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the RISC-V process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the RISC-V main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = hazard3_validation
+
+# Target settings.
+# Hazard3 is RV32IMAC
+MCU  = rv32imac_zba_zbb_zbs_zbkb_zcb_zcmp
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform_riscv.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port_rp2.mk
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_RISCV_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c c1_main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC) validation_pmp.S
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_EXTRA_CORES_NUMBER=1 \
+        -DPORT_ENABLE_GUARD_PAGES=TRUE \
+        -DPORT_USE_GUARD_PMP_REGION=0
+
+# Define ASM defines here
+UADEFS = -DCRT0_EXTRA_CORES_NUMBER=1 \
+         -DCH_DBG_ENABLE_STACK_CHECK=TRUE \
+         -DPORT_ENABLE_GUARD_PAGES=TRUE \
+         -DPORT_USE_GUARD_PMP_REGION=0
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk
+include $(RULESPATH)/riscv-none-elf.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/c1_main.c
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/c1_main.c
@@ -1,0 +1,47 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+void c1_main(void) {
+  extern semaphore_t smp_sem;
+  extern volatile bool smp_run;
+  extern volatile bool smp_done;
+  extern volatile uint32_t smp_count;
+  unsigned i;
+
+  chSysWaitSystemState(ch_sys_running);
+  chInstanceObjectInit(&ch1, &ch_core1_cfg);
+  chSysUnlock();
+
+  while (!__atomic_load_n(&smp_run, __ATOMIC_ACQUIRE)) {
+    chThdSleepMicroseconds(100U);
+  }
+
+  for (i = 0U; i < 64U; i++) {
+    chThdSleepMicroseconds(100U);
+    __atomic_fetch_add(&smp_count, 1U, __ATOMIC_RELAXED);
+    if (i == 63U) {
+      __atomic_store_n(&smp_done, true, __ATOMIC_RELEASE);
+    }
+    chSemSignal(&smp_sem);
+  }
+
+  while (true) {
+    chThdSleepMilliseconds(1000U);
+  }
+}

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/cfg/chconf.h
@@ -1,0 +1,862 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     TRUE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kerkel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              1
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    MTIME runs at 1 MHz.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ * @note    20us minimum delta for MTIME tickless mode.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 TRUE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+/**
+ * @brief   Compile coverage for application-defined FIFO messages.
+ */
+#define PORT_HANDLE_FIFO_MESSAGE(source, message) do {                     \
+  (void)(source);                                                          \
+  (void)(message);                                                         \
+} while (false)
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/cfg/halconf.h
@@ -1,0 +1,568 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 115200
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_LINE
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,67 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * RP2350_MCUCONF drivers configuration.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      TRUE
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_TIMER0_PRIORITY              3
+#define RP_IRQ_TIMER1_PRIORITY              3
+#define RP_IRQ_UART0_PRIORITY               2
+#define RP_IRQ_UART1_PRIORITY               2
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    TRUE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+#define RP_SPI_SPI0_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_DMA_PRIORITY            1
+#define RP_SPI_SPI1_DMA_PRIORITY            1
+#define RP_SPI_DMA_ERROR_HOOK(spip)
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/main.c
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/main.c
@@ -147,13 +147,28 @@ static void test_timer_rollover_preinit(void) {
   port_timer_stop_alarm();
 }
 
-static void timer_callback(virtual_timer_t *vtp, void *arg) {
+typedef struct {
   semaphore_t *sp;
+  volatile bool early_fired;
+  volatile bool late_fired;
+} timer_reprogram_context_t;
 
-  sp = (semaphore_t *)arg;
+static void timer_reprogram_early_callback(virtual_timer_t *vtp, void *arg) {
+  timer_reprogram_context_t *ctxp;
+
+  ctxp = (timer_reprogram_context_t *)arg;
+  ctxp->early_fired = true;
   chSysLockFromISR();
-  chSemSignalI(sp);
+  chSemSignalI(ctxp->sp);
   chSysUnlockFromISR();
+  (void)vtp;
+}
+
+static void timer_reprogram_late_callback(virtual_timer_t *vtp, void *arg) {
+  timer_reprogram_context_t *ctxp;
+
+  ctxp = (timer_reprogram_context_t *)arg;
+  ctxp->late_fired = true;
   (void)vtp;
 }
 
@@ -209,27 +224,54 @@ static void test_pmp_guard(void) {
 }
 
 static void test_timer_reprogramming(void) {
-  virtual_timer_t vt;
+  virtual_timer_t early_vt;
+  virtual_timer_t late_vt;
   semaphore_t sem;
+  timer_reprogram_context_t ctx;
   msg_t msg;
   unsigned i;
+  bool early_fired;
+  bool late_fired;
   bool passed;
 
-  chVTObjectInit(&vt);
+  chVTObjectInit(&early_vt);
+  chVTObjectInit(&late_vt);
   chSemObjectInit(&sem, (cnt_t)0);
+  ctx.sp = &sem;
   passed = true;
 
   for (i = 0U; i < 200U; i++) {
-    chVTSet(&vt, TIME_US2I(200U), timer_callback, &sem);
-    chVTSet(&vt, TIME_US2I(40U + (i & 31U)), timer_callback, &sem);
+    chSysLock();
+    chSemResetI(&sem, (cnt_t)0);
+    ctx.early_fired = false;
+    ctx.late_fired = false;
+    chVTSetI(&late_vt, TIME_US2I(1000U),
+             timer_reprogram_late_callback, &ctx);
+    chVTSetI(&early_vt, TIME_US2I(40U + (i & 31U)),
+             timer_reprogram_early_callback, &ctx);
+    chSysUnlock();
+
     msg = chSemWaitTimeout(&sem, TIME_MS2I(10U));
-    if (msg != MSG_OK) {
+
+    chSysLock();
+    chVTResetI(&early_vt);
+    chVTResetI(&late_vt);
+    early_fired = ctx.early_fired;
+    late_fired = ctx.late_fired;
+    chSemResetI(&sem, (cnt_t)0);
+    chSysUnlock();
+
+    if ((msg != MSG_OK) || !early_fired || late_fired) {
       passed = false;
       break;
     }
   }
 
-  chVTReset(&vt);
+  chSysLock();
+  chVTResetI(&early_vt);
+  chVTResetI(&late_vt);
+  chSemResetI(&sem, (cnt_t)0);
+  chSysUnlock();
   report("tickless alarm reprogramming stress", passed);
 }
 

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/main.c
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/main.c
@@ -1,0 +1,476 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+#include "hazard3_irq.h"
+
+#define VALIDATION_LOW_IRQ                  46U
+#define VALIDATION_HIGH_IRQ                 47U
+#define VALIDATION_SWITCH_IRQ               48U
+#define VALIDATION_MEICONTEXT_PRIORITY_MASK  0xFF1F0000U
+#define VALIDATION_ROLLOVER_HI              0x12345678U
+#define VALIDATION_MTIME_CTRL               \
+  (*(volatile uint32_t *)(RISCV_SIO_BASE + RISCV_SIO_MTIME_CTRL_OFFSET))
+
+#define VALIDATION_STR2(x)                  #x
+#define VALIDATION_STR(x)                   VALIDATION_STR2(x)
+
+semaphore_t smp_sem;
+volatile bool smp_run;
+volatile bool smp_done;
+volatile uint32_t smp_count;
+
+static semaphore_t ext_switch_sem;
+static semaphore_t ext_switch_done_sem;
+static volatile uint8_t irq_sequence[3];
+static volatile uint8_t irq_sequence_count;
+static volatile bool breakpoint_expected;
+static volatile uint32_t breakpoint_status;
+static volatile bool ext_switch_context_ok;
+static volatile bool ext_switch_handoff_direct;
+static volatile bool ext_switch_irq_entered;
+static volatile bool ext_switch_main_resumed;
+static volatile bool ext_switch_timer_fired;
+static volatile bool ext_switch_timer_observed;
+static volatile uint32_t pmp_probe_pc;
+static volatile uint32_t pmp_probe_status;
+static bool timer_rollover_passed;
+static unsigned failures;
+
+void validation_pmp_store(volatile uint32_t *addr);
+void validation_breakpoint(void);
+bool validation_thread_breakpoint_probe(void);
+bool validation_context_switch_probe(void);
+
+__attribute__((noinline, used))
+void validation_context_switch_window(void) {
+  unsigned i;
+
+  for (i = 0U; i < 32U; i++) {
+    chThdSleepMicroseconds(100U);
+  }
+}
+
+void _exception_handler(uint32_t mcause, uint32_t mtval,
+                        struct port_extctx *frame) {
+
+  (void)mtval;
+
+  if (breakpoint_expected && (mcause == 3U)) {
+    breakpoint_expected = false;
+    breakpoint_status = 1U;
+    frame->mepc += 4U;
+    return;
+  }
+
+  if ((pmp_probe_status == 0U) &&
+      (pmp_probe_pc != 0U) &&
+      (mcause == 7U) &&
+      (frame->mepc == pmp_probe_pc)) {
+    pmp_probe_status = 1U;
+    frame->mepc += 4U;
+    return;
+  }
+
+  pmp_probe_status = 2U;
+  __asm__ volatile ("csrci mstatus, 0x8");
+  while (true) {
+    __asm__ volatile ("wfi");
+  }
+}
+
+static void write_text(const char *s) {
+  size_t n;
+
+  for (n = 0U; s[n] != '\0'; n++) {
+  }
+  chnWrite(&SIOD0, (const uint8_t *)s, n);
+}
+
+static void report(const char *name, bool passed) {
+
+  if (passed) {
+    write_text("PASS: ");
+  }
+  else {
+    write_text("FAIL: ");
+    failures++;
+  }
+  write_text(name);
+  write_text("\r\n");
+}
+
+static void test_timer_rollover_preinit(void) {
+  uint32_t mip;
+  unsigned i;
+  bool programmed;
+
+  VALIDATION_MTIME_CTRL = 0U;
+  MTIMECMP_LO = UINT32_MAX;
+  MTIMECMP_HI = UINT32_MAX;
+  MTIME_HI = VALIDATION_ROLLOVER_HI;
+  MTIME_LO = 0xFFFFFFF0U;
+
+  /* Exercise the port's 32-bit alarm extension while MTIME is stopped. The
+     requested low word is after the imminent rollover, so the compare high
+     word must be advanced exactly once.*/
+  port_timer_set_alarm((systime_t)0x20U);
+  programmed = (MTIMECMP_HI == (VALIDATION_ROLLOVER_HI + 1U)) &&
+               (MTIMECMP_LO == 0x20U);
+
+  VALIDATION_MTIME_CTRL = MTIME_CTRL_EN;
+
+  /* MTIP is observable even though mie.MTIE and global MIE are still clear.*/
+  for (i = 0U; i < 1000000U; i++) {
+    __asm__ volatile ("csrr %0, mip" : "=r"(mip));
+    if ((mip & MIP_MTIP) != 0U) {
+      break;
+    }
+  }
+
+  timer_rollover_passed = programmed && (i < 1000000U) &&
+                          (MTIME_HI == (VALIDATION_ROLLOVER_HI + 1U));
+  port_timer_stop_alarm();
+}
+
+static void timer_callback(virtual_timer_t *vtp, void *arg) {
+  semaphore_t *sp;
+
+  sp = (semaphore_t *)arg;
+  chSysLockFromISR();
+  chSemSignalI(sp);
+  chSysUnlockFromISR();
+  (void)vtp;
+}
+
+static void test_isa(void) {
+  uint32_t misa;
+  uint32_t required;
+
+  __asm__ volatile ("csrr %0, misa" : "=r"(misa));
+  required = (1U << 0) | (1U << 2) | (1U << 8) | (1U << 12);
+  report("RV32 I/M/A/C ISA", (misa & required) == required);
+}
+
+static void test_context_switch_abi(void) {
+
+  report("callee-saved registers across context switches",
+         validation_context_switch_probe());
+}
+
+static void test_thread_exception_restore(void) {
+  bool registers_ok;
+
+  breakpoint_expected = true;
+  breakpoint_status = 0U;
+  registers_ok = validation_thread_breakpoint_probe();
+  if (breakpoint_expected) {
+    breakpoint_status = 2U;
+    breakpoint_expected = false;
+  }
+
+  report("thread exception caller-register restoration",
+         registers_ok && (breakpoint_status == 1U));
+}
+
+static void test_pmp_guard(void) {
+  uint32_t pmpaddr;
+  uint32_t pmpcfg;
+  uint32_t pmpcfgm;
+  uint32_t cfg;
+  bool passed;
+
+  __asm__ volatile ("csrr %0, " VALIDATION_STR(PORT_GUARD_PMPADDR_CSR)
+                    : "=r"(pmpaddr));
+  __asm__ volatile ("csrr %0, " VALIDATION_STR(PORT_GUARD_PMPCFG_CSR)
+                    : "=r"(pmpcfg));
+  __asm__ volatile ("csrr %0, " VALIDATION_STR(CSR_PMPCFGM0)
+                    : "=r"(pmpcfgm));
+
+  cfg = (pmpcfg >> PORT_GUARD_PMPCFG_SHIFT) & 0xFFU;
+  passed = (pmpaddr != 0U) &&
+           (cfg == PMP_CFG_A_NAPOT) &&
+           ((pmpcfgm & (1U << PORT_USE_GUARD_PMP_REGION)) != 0U);
+  report("PMP stack guard configuration", passed);
+}
+
+static void test_timer_reprogramming(void) {
+  virtual_timer_t vt;
+  semaphore_t sem;
+  msg_t msg;
+  unsigned i;
+  bool passed;
+
+  chVTObjectInit(&vt);
+  chSemObjectInit(&sem, (cnt_t)0);
+  passed = true;
+
+  for (i = 0U; i < 200U; i++) {
+    chVTSet(&vt, TIME_US2I(200U), timer_callback, &sem);
+    chVTSet(&vt, TIME_US2I(40U + (i & 31U)), timer_callback, &sem);
+    msg = chSemWaitTimeout(&sem, TIME_MS2I(10U));
+    if (msg != MSG_OK) {
+      passed = false;
+      break;
+    }
+  }
+
+  chVTReset(&vt);
+  report("tickless alarm reprogramming stress", passed);
+}
+
+static void ext_switch_timer_callback(virtual_timer_t *vtp, void *arg) {
+
+  ext_switch_timer_fired = true;
+  (void)vtp;
+  (void)arg;
+}
+
+static THD_WORKING_AREA(wa_ext_switch, 512);
+static THD_FUNCTION(ext_switch_thread, arg) {
+  uint32_t meicontext;
+  uint32_t mie;
+  uint32_t start;
+
+  (void)arg;
+  chSemWait(&ext_switch_sem);
+
+  /* This thread is deliberately awakened by an external IRQ. It runs before
+     the interrupted lower-priority thread can resume its trap continuation. */
+  ext_switch_handoff_direct = ext_switch_irq_entered &&
+                              !ext_switch_main_resumed;
+  __asm__ volatile ("csrr %0, " VALIDATION_STR(CSR_MEICONTEXT)
+                    : "=r"(meicontext));
+  __asm__ volatile ("csrr %0, mie" : "=r"(mie));
+  ext_switch_context_ok =
+      ((meicontext & (MEICONTEXT_NOIRQ | MEICONTEXT_MRETEIRQ)) ==
+       MEICONTEXT_NOIRQ) &&
+      ((meicontext & VALIDATION_MEICONTEXT_PRIORITY_MASK) == 0U) &&
+      ((mie & MIE_MTIE) != 0U);
+
+  /* Keep this higher-priority thread runnable while waiting. The old thread
+     therefore cannot finish the suspended external-IRQ epilogue; the virtual
+     timer can fire only if that epilogue completed Xh3irq return before the
+     scheduler switch. MTIME itself keeps running even if MTIE is masked, so
+     the loop has a deterministic failure bound.*/
+  start = MTIME_LO;
+  while (!ext_switch_timer_fired &&
+         ((uint32_t)(MTIME_LO - start) < 20000U)) {
+  }
+  ext_switch_timer_observed = ext_switch_timer_fired;
+  chSemSignal(&ext_switch_done_sem);
+}
+
+OSAL_IRQ_HANDLER(Vector100) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  nvicClearPending(VALIDATION_SWITCH_IRQ);
+  ext_switch_irq_entered = true;
+  chSysLockFromISR();
+  chSemSignalI(&ext_switch_sem);
+  chSysUnlockFromISR();
+
+  OSAL_IRQ_EPILOGUE();
+}
+
+static void test_external_irq_preemption(void) {
+  virtual_timer_t vt;
+  msg_t msg;
+  bool passed;
+
+  chSemObjectInit(&ext_switch_sem, (cnt_t)0);
+  chSemObjectInit(&ext_switch_done_sem, (cnt_t)0);
+  chVTObjectInit(&vt);
+  ext_switch_context_ok = false;
+  ext_switch_handoff_direct = false;
+  ext_switch_irq_entered = false;
+  ext_switch_main_resumed = false;
+  ext_switch_timer_fired = false;
+  ext_switch_timer_observed = false;
+
+  (void)chThdCreateStatic(wa_ext_switch, sizeof(wa_ext_switch),
+                          NORMALPRIO + 1U, ext_switch_thread, NULL);
+  chVTSet(&vt, TIME_US2I(2000U), ext_switch_timer_callback, NULL);
+  nvicEnableVector(VALIDATION_SWITCH_IRQ, 1U);
+  nvicSetPending(VALIDATION_SWITCH_IRQ);
+
+  /* If ISR-exit preemption works, the higher-priority waiter runs before this
+     loop can complete. Waiting for the ISR marker avoids relying on the exact
+     instruction at which the core recognizes a newly forced interrupt. */
+  while (!ext_switch_irq_entered) {
+  }
+  ext_switch_main_resumed = true;
+
+  msg = chSemWaitTimeout(&ext_switch_done_sem, TIME_MS2I(50U));
+  nvicDisableVector(VALIDATION_SWITCH_IRQ);
+  chVTReset(&vt);
+
+  passed = (msg == MSG_OK) && ext_switch_handoff_direct &&
+           ext_switch_context_ok &&
+           ext_switch_timer_observed;
+  report("external IRQ preemption context handoff", passed);
+}
+
+OSAL_IRQ_HANDLER(VectorF8) {
+  uint32_t i;
+
+  OSAL_IRQ_PROLOGUE();
+
+  nvicClearPending(VALIDATION_LOW_IRQ);
+  irq_sequence[irq_sequence_count] = 1U;
+  irq_sequence_count++;
+  nvicSetPending(VALIDATION_HIGH_IRQ);
+
+  for (i = 0U; (i < 100000U) && (irq_sequence_count < 2U); i++) {
+    __asm__ volatile ("nop");
+  }
+
+  if (irq_sequence_count < 3U) {
+    irq_sequence[irq_sequence_count] = 3U;
+    irq_sequence_count++;
+  }
+
+  OSAL_IRQ_EPILOGUE();
+}
+
+OSAL_IRQ_HANDLER(VectorFC) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  nvicClearPending(VALIDATION_HIGH_IRQ);
+  breakpoint_expected = true;
+  validation_breakpoint();
+  if (breakpoint_expected) {
+    breakpoint_status = 2U;
+    breakpoint_expected = false;
+  }
+  if (irq_sequence_count < 3U) {
+    irq_sequence[irq_sequence_count] = 2U;
+    irq_sequence_count++;
+  }
+
+  OSAL_IRQ_EPILOGUE();
+}
+
+static void test_irq_nesting(void) {
+  unsigned i;
+  bool passed;
+
+  irq_sequence_count = 0U;
+  irq_sequence[0] = 0U;
+  irq_sequence[1] = 0U;
+  irq_sequence[2] = 0U;
+  breakpoint_expected = false;
+  breakpoint_status = 0U;
+
+  nvicEnableVector(VALIDATION_LOW_IRQ, 3U);
+  nvicEnableVector(VALIDATION_HIGH_IRQ, 0U);
+  nvicSetPending(VALIDATION_LOW_IRQ);
+
+  for (i = 0U; (i < 100U) && (irq_sequence_count < 3U); i++) {
+    chThdSleepMicroseconds(50U);
+  }
+
+  nvicDisableVector(VALIDATION_HIGH_IRQ);
+  nvicDisableVector(VALIDATION_LOW_IRQ);
+
+  passed = (irq_sequence_count == 3U) &&
+           (irq_sequence[0] == 1U) &&
+           (irq_sequence[1] == 2U) &&
+           (irq_sequence[2] == 3U) &&
+           (breakpoint_status == 1U);
+  report("nested Xh3irq and exception restoration", passed);
+}
+
+static void test_smp(void) {
+  msg_t msg;
+  unsigned i;
+  bool passed;
+
+  __atomic_store_n(&smp_run, true, __ATOMIC_RELEASE);
+  passed = true;
+
+  for (i = 0U; i < 64U; i++) {
+    msg = chSemWaitTimeout(&smp_sem, TIME_MS2I(20U));
+    if (msg != MSG_OK) {
+      passed = false;
+      break;
+    }
+  }
+
+  passed = passed && __atomic_load_n(&smp_done, __ATOMIC_ACQUIRE) &&
+           (__atomic_load_n(&smp_count, __ATOMIC_RELAXED) == 64U);
+  report("SMP cross-core semaphore and core-local timer", passed);
+}
+
+static void test_pmp_store_fault(void) {
+  volatile uint32_t *guardp;
+
+  guardp = (volatile uint32_t *)(void *)chThdGetSelfX()->wabase;
+  pmp_probe_pc = (uint32_t)(uintptr_t)validation_pmp_store;
+  pmp_probe_status = 0U;
+  validation_pmp_store(guardp);
+  pmp_probe_pc = 0U;
+  report("PMP guarded-stack store fault", pmp_probe_status == 1U);
+}
+
+int main(void) {
+  bool led_state;
+
+  chSemObjectInit(&smp_sem, (cnt_t)0);
+  smp_run = false;
+  smp_done = false;
+  smp_count = 0U;
+  failures = 0U;
+  test_timer_rollover_preinit();
+
+  halInit();
+  chSysInit();
+
+  palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(25U, PAL_MODE_OUTPUT_PUSHPULL | PAL_RP_PAD_DRIVE12);
+  sioStart(&SIOD0, NULL);
+
+  write_text("Hazard3/RP2350 validation\r\n");
+  test_isa();
+  test_context_switch_abi();
+  test_thread_exception_restore();
+  test_pmp_guard();
+  report("tickless alarm across MTIME low-word rollover",
+         timer_rollover_passed);
+  test_timer_reprogramming();
+  test_irq_nesting();
+  test_external_irq_preemption();
+  test_smp();
+  test_pmp_store_fault();
+
+  if (failures == 0U) {
+    write_text("RESULT: PASS\r\n");
+  }
+  else {
+    write_text("RESULT: FAIL\r\n");
+  }
+
+  led_state = false;
+  while (true) {
+    led_state = !led_state;
+    palWriteLine(25U, led_state ? PAL_HIGH : PAL_LOW);
+    chThdSleepMilliseconds(failures == 0U ? 500U : 100U);
+  }
+}

--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/validation_pmp.S
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/validation_pmp.S
@@ -1,0 +1,131 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+                .section .text, "ax", @progbits
+                .balign 4
+                .globl  validation_pmp_store
+                .type   validation_pmp_store, @function
+
+                .option push
+                .option norvc
+validation_pmp_store:
+                sw      zero, 0(a0)
+                ret
+                .option pop
+
+                .size   validation_pmp_store, . - validation_pmp_store
+
+                .balign 4
+                .globl  validation_breakpoint
+                .type   validation_breakpoint, @function
+
+                .option push
+                .option norvc
+validation_breakpoint:
+                ebreak
+                ret
+                .option pop
+
+                .size   validation_breakpoint, . - validation_breakpoint
+
+/*
+ * Exercises the tagged, thread-mode exception entry with a live t1 value.
+ * t1 is caller-saved at the C ABI boundary, so the check must surround the
+ * ebreak directly in assembly rather than relying on a C caller.
+ */
+                .balign 4
+                .globl  validation_thread_breakpoint_probe
+                .type   validation_thread_breakpoint_probe, @function
+
+                .option push
+                .option norvc
+validation_thread_breakpoint_probe:
+                li      t1, 0x51a7c3e9
+                ebreak
+                li      t0, 0x51a7c3e9
+                bne     t1, t0, .Lthread_breakpoint_failed
+                li      a0, 1
+                ret
+
+.Lthread_breakpoint_failed:
+                li      a0, 0
+                ret
+                .option pop
+
+                .size   validation_thread_breakpoint_probe, . - validation_thread_breakpoint_probe
+
+/*
+ * Loads distinct values into every callee-saved register, invokes a C window
+ * that performs repeated thread context switches, then verifies that the port
+ * restored the complete register set. The caller's original registers are
+ * preserved by the surrounding Zcmp frame.
+ */
+                .balign 4
+                .globl  validation_context_switch_probe
+                .type   validation_context_switch_probe, @function
+validation_context_switch_probe:
+                cm.push {ra, s0-s11}, -64
+
+                li      s0,  0x10203040
+                li      s1,  0x11213141
+                li      s2,  0x12223242
+                li      s3,  0x13233343
+                li      s4,  0x14243444
+                li      s5,  0x15253545
+                li      s6,  0x16263646
+                li      s7,  0x17273747
+                li      s8,  0x18283848
+                li      s9,  0x19293949
+                li      s10, 0x1a2a3a4a
+                li      s11, 0x1b2b3b4b
+
+                call    validation_context_switch_window
+
+                li      t0, 0x10203040
+                bne     s0, t0, .Lcontext_failed
+                li      t0, 0x11213141
+                bne     s1, t0, .Lcontext_failed
+                li      t0, 0x12223242
+                bne     s2, t0, .Lcontext_failed
+                li      t0, 0x13233343
+                bne     s3, t0, .Lcontext_failed
+                li      t0, 0x14243444
+                bne     s4, t0, .Lcontext_failed
+                li      t0, 0x15253545
+                bne     s5, t0, .Lcontext_failed
+                li      t0, 0x16263646
+                bne     s6, t0, .Lcontext_failed
+                li      t0, 0x17273747
+                bne     s7, t0, .Lcontext_failed
+                li      t0, 0x18283848
+                bne     s8, t0, .Lcontext_failed
+                li      t0, 0x19293949
+                bne     s9, t0, .Lcontext_failed
+                li      t0, 0x1a2a3a4a
+                bne     s10, t0, .Lcontext_failed
+                li      t0, 0x1b2b3b4b
+                bne     s11, t0, .Lcontext_failed
+
+                li      a0, 1
+                j       .Lcontext_done
+
+.Lcontext_failed:
+                li      a0, 0
+
+.Lcontext_done:
+                cm.popret {ra, s0-s11}, 64
+
+                .size   validation_context_switch_probe, . - validation_context_switch_probe


### PR DESCRIPTION
## Summary

- port the SourceForge `hazard3_dev` work to the current ChibiOS tree
- add Hazard3 startup, RT/NIL port support, Xh3irq dispatch, exception handling, tickless timing, PMP stack guards, and RP2350 SMP support
- integrate the RISC-V core with the RP2350 HAL and image metadata
- add an RP2350 Hazard3 SMP demo and a dedicated hardware validation target
- address review findings around unsupported PMP modes, unhandled IRQ state, timer queue-head reprogramming, and durable cross-core panic delivery

## Source provenance

The port was reconstructed from SourceForge `branches/hazard3_dev@18063`, based on `trunk@17838` and merged through `trunk@18062`. All 37 canonical branch changes were accounted for; the port commits retain detailed SVN provenance trailers.

## Correctness highlights

- preserves full RV32 trap context and distinguishes thread/ISR exception stacks through tagged `mscratch`
- restores Xh3irq priority state exactly once across direct ISR-exit scheduler handoff
- masks timer/software sources while debug ISR hooks may re-enable global interrupts
- provides RVWMO release/acquire publication for shared SMP system state
- safely programs MTIMECMP across low-word rollover
- uses RP2350-E2-safe hardware spinlocks
- preserves panic notification through full FIFO and startup races without blocking the catastrophic path

## Validation

Builds passed for:

- RP2350 Hazard3 demo and validation targets
- Hazard3 RT and NIL testbuilds
- x86-64 RT regression
- ARMv7-M RT regression

Connected RP2350/PicoDebug hardware validation passed:

- RV32 I/M/A/C ISA
- callee-saved and exception register restoration
- PMP configuration and guarded-stack fault
- tickless rollover and earlier-alarm reprogramming stress
- nested Xh3irq/exception restoration
- direct external-IRQ scheduler handoff
- SMP semaphore and core-local timer behavior
- periodic-tick demo operation

A destructive full-FIFO test also confirmed that the durable panic latch halts the peer before draining existing FIFO traffic, without enqueueing or dropping a panic word.

`git diff --check` passes and build artifacts were cleaned. The only diagnostics are five pre-existing GCC array-bounds warnings in `rp_bootrom.c`.
