### PR TITLE
RP2350: fix XOSC, doorbell and PIO GPIOBASE register definitions

### DIFF
--- a/os/common/ext/RP/RP2350/rp2350.h
+++ b/os/common/ext/RP/RP2350/rp2350.h
@@ -459,8 +459,8 @@ typedef struct {
   __IO uint32_t         SPINLOCK[32];
   __IO uint32_t         DOORBELL_OUT_SET;
   __IO uint32_t         DOORBELL_OUT_CLR;
-  __I  uint32_t         DOORBELL_IN_SET;
-  __I  uint32_t         DOORBELL_IN_CLR;
+  __IO uint32_t         DOORBELL_IN_SET;
+  __IO uint32_t         DOORBELL_IN_CLR;
   __IO uint32_t         PERI_NONSEC;
   __I  uint32_t         resvd194[3];
   __IO uint32_t         RISCV_SOFTIRQ;
@@ -1235,7 +1235,7 @@ typedef struct {
     __IO uint32_t       PINCTRL;
   } SM[4];
   __IO uint32_t         RXF_PUTGET[4][4];
-  __I  uint32_t         GPIOBASE;
+  __IO uint32_t         GPIOBASE;
   __IO uint32_t         INTR;
   __IO uint32_t         IRQ0_INTE;
   __IO uint32_t         IRQ0_INTF;
@@ -1267,7 +1267,7 @@ typedef struct {
       __IO uint32_t     PINCTRL;
     } SM[4];
     __IO uint32_t       RXF_PUTGET[4][4];
-    __I  uint32_t       GPIOBASE;
+    __IO uint32_t       GPIOBASE;
     __IO uint32_t       INTR;
     __IO uint32_t       IRQ0_INTE;
     __IO uint32_t       IRQ0_INTF;
@@ -1300,7 +1300,7 @@ typedef struct {
       __IO uint32_t     PINCTRL;
     } SM[4];
     __IO uint32_t       RXF_PUTGET[4][4];
-    __I  uint32_t       GPIOBASE;
+    __IO uint32_t       GPIOBASE;
     __IO uint32_t       INTR;
     __IO uint32_t       IRQ0_INTE;
     __IO uint32_t       IRQ0_INTF;
@@ -1333,7 +1333,7 @@ typedef struct {
       __IO uint32_t     PINCTRL;
     } SM[4];
     __IO uint32_t       RXF_PUTGET[4][4];
-    __I  uint32_t       GPIOBASE;
+    __IO uint32_t       GPIOBASE;
     __IO uint32_t       INTR;
     __IO uint32_t       IRQ0_INTE;
     __IO uint32_t       IRQ0_INTF;
@@ -1347,38 +1347,34 @@ typedef struct {
 
 typedef struct {
   __IO uint32_t         CTRL;
-  __I  uint32_t         STATUS;
+  __IO uint32_t         STATUS;
   __IO uint32_t         DORMANT;
   __IO uint32_t         STARTUP;
-  __I  uint32_t         resvd10[3];
   __IO uint32_t         COUNT;
-  __I  uint32_t         resvd20[1016];
+  __I  uint32_t         resvd14[1019];
   struct {
     __IO uint32_t       CTRL;
-    __I  uint32_t       STATUS;
+    __IO uint32_t       STATUS;
     __IO uint32_t       DORMANT;
     __IO uint32_t       STARTUP;
-    __I  uint32_t       resvd10[3];
     __IO uint32_t       COUNT;
-    __I  uint32_t       resvd20[1016];
+    __I  uint32_t       resvd14[1019];
   } XOR;
   struct {
     __IO uint32_t       CTRL;
-    __I  uint32_t       STATUS;
+    __IO uint32_t       STATUS;
     __IO uint32_t       DORMANT;
     __IO uint32_t       STARTUP;
-    __I  uint32_t       resvd10[3];
     __IO uint32_t       COUNT;
-    __I  uint32_t       resvd20[1016];
+    __I  uint32_t       resvd14[1019];
   } SET;
   struct {
     __IO uint32_t       CTRL;
-    __I  uint32_t       STATUS;
+    __IO uint32_t       STATUS;
     __IO uint32_t       DORMANT;
     __IO uint32_t       STARTUP;
-    __I  uint32_t       resvd10[3];
     __IO uint32_t       COUNT;
-    __I  uint32_t       resvd20[1016];
+    __I  uint32_t       resvd14[1019];
   } CLR;
 } XOSC_TypeDef;
 
@@ -1665,6 +1661,11 @@ typedef struct {
  * @note    See RP2350 Datasheet 12.6.10 DMA List of Registers
  * @{
  */
+#define DMA_TRANS_COUNT_MODE_Pos          28U
+#define DMA_TRANS_COUNT_MODE_Msk          (0xFU << DMA_TRANS_COUNT_MODE_Pos)
+#define DMA_TRANS_COUNT_MODE_NORMAL       (0x0U << DMA_TRANS_COUNT_MODE_Pos)
+#define DMA_TRANS_COUNT_MODE_TRIGGER_SELF (0x1U << DMA_TRANS_COUNT_MODE_Pos)
+#define DMA_TRANS_COUNT_MODE_ENDLESS      (0xFU << DMA_TRANS_COUNT_MODE_Pos)
 #define DMA_CTRL_TRIG_AHB_ERROR           (1U << 31)
 #define DMA_CTRL_TRIG_READ_ERROR          (1U << 30)
 #define DMA_CTRL_TRIG_WRITE_ERROR         (1U << 29)
@@ -2379,6 +2380,17 @@ typedef struct {
 #define QMI_DIRECT_TX_IWIDTH_S            0U
 #define QMI_DIRECT_TX_IWIDTH_D            1U
 #define QMI_DIRECT_TX_IWIDTH_Q            2U
+/** @} */
+
+/**
+ * @name    QMI ATRANSx bits definitions
+ * @note    BASE and SIZE are expressed in 4 KiB units.
+ * @{
+ */
+#define QMI_ATRANS_BASE_Pos               0U
+#define QMI_ATRANS_BASE_Msk               (0xFFFU << QMI_ATRANS_BASE_Pos)
+#define QMI_ATRANS_SIZE_Pos               16U
+#define QMI_ATRANS_SIZE_Msk               (0x7FFU << QMI_ATRANS_SIZE_Pos)
 /** @} */
 
 

--- a/os/hal/ports/RP/RP2350/hal_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_lld.c
@@ -31,27 +31,6 @@
 /* Driver local definitions.                                                 */
 /*===========================================================================*/
 
-/* Layout probes for hand-maintained register structures, offsets taken from
-   the RP2350 datasheet register maps.*/
-_Static_assert(offsetof(XOSC_TypeDef, COUNT) == 0x10U,
-               "XOSC COUNT offset mismatch");
-_Static_assert(offsetof(XOSC_TypeDef, XOR.CTRL) == 0x1000U,
-               "XOSC alias block size mismatch");
-_Static_assert(offsetof(SIO_TypeDef, FIFO_ST) == 0x50U,
-               "SIO FIFO_ST offset mismatch");
-_Static_assert(offsetof(SIO_TypeDef, DOORBELL_IN_SET) == 0x188U,
-               "SIO DOORBELL_IN_SET offset mismatch");
-_Static_assert(offsetof(SIO_TypeDef, DOORBELL_IN_CLR) == 0x18CU,
-               "SIO DOORBELL_IN_CLR offset mismatch");
-_Static_assert(offsetof(PIO_TypeDef, GPIOBASE) == 0x168U,
-               "PIO GPIOBASE offset mismatch");
-_Static_assert(offsetof(PIO_TypeDef, XOR.CTRL) == 0x1000U,
-               "PIO alias block size mismatch");
-_Static_assert(offsetof(QMI_TypeDef, ATRANS[0]) == 0x34U,
-               "QMI ATRANS offset mismatch");
-_Static_assert(offsetof(TICKS_TypeDef, TICK[1].CTRL) == 0x0CU,
-               "TICKS entry stride mismatch");
-
 /*===========================================================================*/
 /* Driver exported variables.                                                */
 /*===========================================================================*/

--- a/os/hal/ports/RP/RP2350/hal_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_lld.c
@@ -31,6 +31,27 @@
 /* Driver local definitions.                                                 */
 /*===========================================================================*/
 
+/* Layout probes for hand-maintained register structures, offsets taken from
+   the RP2350 datasheet register maps.*/
+_Static_assert(offsetof(XOSC_TypeDef, COUNT) == 0x10U,
+               "XOSC COUNT offset mismatch");
+_Static_assert(offsetof(XOSC_TypeDef, XOR.CTRL) == 0x1000U,
+               "XOSC alias block size mismatch");
+_Static_assert(offsetof(SIO_TypeDef, FIFO_ST) == 0x50U,
+               "SIO FIFO_ST offset mismatch");
+_Static_assert(offsetof(SIO_TypeDef, DOORBELL_IN_SET) == 0x188U,
+               "SIO DOORBELL_IN_SET offset mismatch");
+_Static_assert(offsetof(SIO_TypeDef, DOORBELL_IN_CLR) == 0x18CU,
+               "SIO DOORBELL_IN_CLR offset mismatch");
+_Static_assert(offsetof(PIO_TypeDef, GPIOBASE) == 0x168U,
+               "PIO GPIOBASE offset mismatch");
+_Static_assert(offsetof(PIO_TypeDef, XOR.CTRL) == 0x1000U,
+               "PIO alias block size mismatch");
+_Static_assert(offsetof(QMI_TypeDef, ATRANS[0]) == 0x34U,
+               "QMI ATRANS offset mismatch");
+_Static_assert(offsetof(TICKS_TypeDef, TICK[1].CTRL) == 0x0CU,
+               "TICKS entry stride mismatch");
+
 /*===========================================================================*/
 /* Driver exported variables.                                                */
 /*===========================================================================*/

--- a/os/hal/ports/RP/RP2350/rp_xosc.c
+++ b/os/hal/ports/RP/RP2350/rp_xosc.c
@@ -70,7 +70,7 @@ void rp_xosc_init(void) {
   XOSC->SET.CTRL = XOSC_CTRL_ENABLE_ENABLE;
 
   /* Wait for XOSC to be stable with timeout protection. */
-  if (halRegWaitAnySet32X((volatile uint32_t *)&XOSC->STATUS, XOSC_STATUS_STABLE,
+  if (halRegWaitAnySet32X(&XOSC->STATUS, XOSC_STATUS_STABLE,
                           RP_XOSC_STABLE_TIMEOUT_US, NULL)) {
     halSftFail("XOSC stable timeout");
   }


### PR DESCRIPTION
## Summary

Corrects several register definitions in `os/common/ext/RP/RP2350/rp2350.h` that did not match RP2350 silicon, and removes a workaround that existed only because of one of them:

- **XOSC**: `STATUS` is read/write (`BADWRITE` is write-1-to-clear), and the `COUNT` register sits at offset 0x10 — the previous layout padded it out to 0x1C. The stale `resvd10[3]` padding is gone and the alias block is re-padded to keep the struct size at 0x1000.
- **SIO**: `DOORBELL_IN_SET`/`DOORBELL_IN_CLR` are read/write, not read-only.
- **PIO**: `GPIOBASE` is read/write in all four alias blocks.
- **QMI**: adds `ATRANS` `BASE`/`SIZE` field macros.
- **DMA**: adds `TRANS_COUNT` mode-field macros (`MODE_NORMAL`/`TRIGGER_SELF`/`ENDLESS`).
- Drops the const-cast workaround in `rp_xosc.c` that papered over the read-only `STATUS` declaration.

## Validation

- Register offsets verified against the RP2350 datasheet and probed on silicon (Pico 2 via Debug Probe): a write to XOSC `COUNT` at 0x40048010 decrements as documented while the old 0x4004801C offset does not count; PIO `GPIOBASE` at 0x50200168 accepts writes.
- RP2350 and RP2040 demo/testhal builds clean.
- Downstream branches build on these definitions (QMI ATRANS translation, DMA mode discriminators, PIO GPIOBASE support).