### PR TITLE
ARMv8-M-ML-ALT: gate RP2 SMP port source on CH_CFG_SMP_MODE

### DIFF
--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -26,6 +26,8 @@
 
 #include "ch.h"
 
+#if (CH_CFG_SMP_MODE == TRUE) || defined(__DOXYGEN__)
+
 /*===========================================================================*/
 /* Module local definitions.                                                 */
 /*===========================================================================*/
@@ -114,12 +116,10 @@ void __port_smp_init(os_instance_t *oip) {
   port_timer_enable(oip);
 #endif
 
-#if CH_CFG_SMP_MODE == TRUE
   /* FIFO handler for this core. RP2350 uses a single shared IRQ 25.*/
   SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
   NVIC_SetPriority(SIO_IRQ_FIFOn, CORTEX_MINIMUM_PRIORITY);
   NVIC_EnableIRQ(SIO_IRQ_FIFOn);
-#endif
 
   (void)oip;
 }
@@ -139,5 +139,7 @@ void __port_spinlock_release(void) {
 
   port_spinlock_release();
 }
+
+#endif /* CH_CFG_SMP_MODE == TRUE */
 
 /** @} */


### PR DESCRIPTION
## Summary

`port_rp2.mk` unconditionally compiles `chcoresmp.c`, but its definitions reference panic, core-ID, timer and spinlock symbols that only exist when `CH_CFG_SMP_MODE` is `TRUE` — so any non-SMP configuration using the RP2 port failed to build. The makefile cannot see `chconf.h`, so the source is made self-gating instead: the file body is wrapped in `#if (CH_CFG_SMP_MODE == TRUE) || defined(__DOXYGEN__)`, matching how the port headers are already selected. An inner `CH_CFG_SMP_MODE` guard in `__port_smp_init()` becomes redundant under the file-level gate and is dropped.

## Validation

- The SMP demo builds and boots both cores unchanged on a Pico 2 (exercised extensively by the EFL-SMP-LOCKOUT validation runs, which start core 1 and depend on the FIFO handler this file provides).
- A single-core configuration rebuilt against `port_rp2.mk` now links where it previously produced undefined-symbol errors.
- Reviewed by CodeRabbit and Codex (both clean; Codex confirmed non-SMP builds lose nothing through the gate).