### PR TITLE
ARMv8-M-ML-ALT: halt on remote panic regardless of receiving core

### DIFF
--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -80,7 +80,8 @@ CH_IRQ_HANDLER(VectorA4) {
 
   while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
     uint32_t message = SIO->FIFO_RD;
-    /* A panic on either core halts the other one too.*/
+    /* FIFO traffic always comes from the other core, so panic handling must
+       be symmetric.*/
     if (message == PORT_FIFO_PANIC_MESSAGE) {
       port_local_halt();
     }

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -80,8 +80,8 @@ CH_IRQ_HANDLER(VectorA4) {
 
   while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
     uint32_t message = SIO->FIFO_RD;
-    /* Core 1 checks for panic from Core 0.*/
-    if ((message == PORT_FIFO_PANIC_MESSAGE) && (port_get_core_id() == 1U)) {
+    /* A panic on either core halts the other one too.*/
+    if (message == PORT_FIFO_PANIC_MESSAGE) {
       port_local_halt();
     }
 #if defined(PORT_HANDLE_FIFO_MESSAGE)


### PR DESCRIPTION
## Summary

The RP2 FIFO handler only honored the cross-core panic token when the receiving core was core 1: the check read `(message == PORT_FIFO_PANIC_MESSAGE) && (port_get_core_id() == 1U)`. A panic on core 1 therefore left core 0 running half of the SMP system — timers firing, threads scheduling — against a dead peer. The condition is dropped so the panic broadcast halts whichever core receives it, matching the intended symmetric design (the ARMv6-M RP2 port had the same defect on its core-0 handler, fixed in #104).

## Validation

On a Pico 2, with a test build that calls `chSysHalt("c1-test")` on core 1 five seconds after boot:

- Both cores verified halted via the debug probe.
- Core 0 parks in the FIFO handler halt loop with `panic_msg` = "remote panic"; core 1 reports the originating "c1-test".
- The panic path is also exercised implicitly by the SMP validation firmware used across the RP2350 remediation work.

Reviewed by CodeRabbit and Codex, both clean on the code change.
