### PR TITLE
RP2: correct ROM region size and enable core-local BSS annotations

### DIFF
--- a/demos/RP/RT-RP2350-RISCV-BLINK/Makefile
+++ b/demos/RP/RT-RP2350-RISCV-BLINK/Makefile
@@ -54,7 +54,7 @@ endif
 # Stack size to be allocated to the RISC-V process stack. This stack is
 # the stack used by the main() thread.
 ifeq ($(USE_PROCESS_STACKSIZE),)
-  USE_PROCESS_STACKSIZE = 0x800
+  USE_PROCESS_STACKSIZE = 0x400
 endif
 
 # Stack size to the allocated to the RISC-V main/exceptions stack. This

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
@@ -60,6 +60,18 @@
 #define PORT_SPINLOCK_NUMBER            31
 #endif
 
+/* Note: the ram4/ram5 scratch banks used by the following sections also
+   hold the per-core default stacks, annotated data competes with stack
+   space and an overflow surfaces as a link-time region error.*/
+
+/**
+ * @brief   Marker enabling suffixed @p PORT_MEM_LOCAL_COHERENT_BSSn
+ *          selection in chmem.h.
+ */
+#if !defined(PORT_MEM_LOCAL_COHERENT_BSS)
+#define PORT_MEM_LOCAL_COHERENT_BSS     /* Enables suffixed PORT_MEM_LOCAL_COHERENT_BSSn selection in chmem.h.*/
+#endif
+
 /**
  * @brief   Preferential local and coherent BSS section for core zero.
  */
@@ -72,6 +84,14 @@
  */
 #if !defined(PORT_MEM_LOCAL_COHERENT_BSS1)
 #define PORT_MEM_LOCAL_COHERENT_BSS1    CC_SECTION(".ram5_clear.core1")
+#endif
+
+/**
+ * @brief   Marker enabling suffixed @p PORT_MEM_LOCAL_BSSn selection
+ *          in chmem.h.
+ */
+#if !defined(PORT_MEM_LOCAL_BSS)
+#define PORT_MEM_LOCAL_BSS              /* Enables suffixed PORT_MEM_LOCAL_BSSn selection in chmem.h.*/
 #endif
 
 /**

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
@@ -60,6 +60,18 @@
 #define PORT_SPINLOCK_NUMBER            31
 #endif
 
+/* Note: the ram4/ram5 scratch banks used by the following sections also
+   hold the per-core default stacks, annotated data competes with stack
+   space and an overflow surfaces as a link-time region error.*/
+
+/**
+ * @brief   Marker enabling suffixed @p PORT_MEM_LOCAL_COHERENT_BSSn
+ *          selection in chmem.h.
+ */
+#if !defined(PORT_MEM_LOCAL_COHERENT_BSS)
+#define PORT_MEM_LOCAL_COHERENT_BSS     /* Enables suffixed PORT_MEM_LOCAL_COHERENT_BSSn selection in chmem.h.*/
+#endif
+
 /**
  * @brief   Preferential local and coherent BSS section for core zero.
  */
@@ -72,6 +84,14 @@
  */
 #if !defined(PORT_MEM_LOCAL_COHERENT_BSS1)
 #define PORT_MEM_LOCAL_COHERENT_BSS1    CC_SECTION(".ram5_clear.core1")
+#endif
+
+/**
+ * @brief   Marker enabling suffixed @p PORT_MEM_LOCAL_BSSn selection
+ *          in chmem.h.
+ */
+#if !defined(PORT_MEM_LOCAL_BSS)
+#define PORT_MEM_LOCAL_BSS              /* Enables suffixed PORT_MEM_LOCAL_BSSn selection in chmem.h.*/
 #endif
 
 /**

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
@@ -69,6 +69,18 @@
 #define PORT_FIFO_IRQ_PRIORITY          3
 #endif
 
+/* Note: the ram4/ram5 scratch banks used by the following sections also
+   hold the per-core default stacks, annotated data competes with stack
+   space and an overflow surfaces as a link-time region error.*/
+
+/**
+ * @brief   Marker enabling suffixed @p PORT_MEM_LOCAL_COHERENT_BSSn
+ *          selection in chmem.h.
+ */
+#if !defined(PORT_MEM_LOCAL_COHERENT_BSS)
+#define PORT_MEM_LOCAL_COHERENT_BSS     /* Enables suffixed PORT_MEM_LOCAL_COHERENT_BSSn selection in chmem.h.*/
+#endif
+
 /**
  * @brief   Preferential local and coherent BSS section for core zero.
  */
@@ -81,6 +93,14 @@
  */
 #if !defined(PORT_MEM_LOCAL_COHERENT_BSS1)
 #define PORT_MEM_LOCAL_COHERENT_BSS1    CC_SECTION(".ram5_clear.core1")
+#endif
+
+/**
+ * @brief   Marker enabling suffixed @p PORT_MEM_LOCAL_BSSn selection
+ *          in chmem.h.
+ */
+#if !defined(PORT_MEM_LOCAL_BSS)
+#define PORT_MEM_LOCAL_BSS              /* Enables suffixed PORT_MEM_LOCAL_BSSn selection in chmem.h.*/
 #endif
 
 /**

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/RP2350_FLASH.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/RP2350_FLASH.ld
@@ -20,7 +20,7 @@
 
 MEMORY
 {
-    flash0 (rx) : org = 0x00000000, len = 16k   /* ROM                  */
+    flash0 (rx) : org = 0x00000000, len = 32k   /* ROM                  */
     flash1 (rx) : org = 0x10000000, len = DEFINED(FLASH_LEN) ? FLASH_LEN : 4096k /* XIP */
     flash2 (rx) : org = 0x00000000, len = 0
     flash3 (rx) : org = 0x00000000, len = 0

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/RP2350_RAM.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/RP2350_RAM.ld
@@ -20,7 +20,7 @@
 
 MEMORY
 {
-    flash0 (rx) : org = 0x00000000, len = 16k   /* ROM                  */
+    flash0 (rx) : org = 0x00000000, len = 32k   /* ROM                  */
     flash1 (rx) : org = 0x10000000, len = DEFINED(FLASH_LEN) ? FLASH_LEN : 4096k /* XIP */
     flash2 (rx) : org = 0x00000000, len = 0
     flash3 (rx) : org = 0x00000000, len = 0

--- a/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+++ b/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
@@ -17,8 +17,11 @@ STARTUPINC = $(CHIBIOS)/os/common/portability/GCC \
 
 STARTUPLD  = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/ld
 
-USE_EXCEPTIONS_STACKSIZE ?= 0x800
-USE_PROCESS_STACKSIZE    ?= 0x800
+# Note: the per-core stacks live in the 4KiB scratch banks (ram4/ram5)
+# together with CH_MEM_LOCAL_BSS()/CH_MEM_LOCAL_COHERENT_BSS() annotated
+# data, 0x400+0x400 leaves half of each bank for annotated data.
+USE_EXCEPTIONS_STACKSIZE ?= 0x400
+USE_PROCESS_STACKSIZE    ?= 0x400
 
 # Shared variables
 ALLXASMSRC += $(STARTUPASM)

--- a/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+++ b/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
@@ -14,8 +14,11 @@ STARTUPINC = $(CHIBIOS)/os/common/portability/GCC \
 
 STARTUPLD  = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/ld
 
-USE_EXCEPTIONS_STACKSIZE ?= 0x800
-USE_PROCESS_STACKSIZE    ?= 0x800
+# Note: the per-core stacks live in the 4KiB scratch banks (ram4/ram5)
+# together with CH_MEM_LOCAL_BSS()/CH_MEM_LOCAL_COHERENT_BSS() annotated
+# data, 0x400+0x400 leaves half of each bank for annotated data.
+USE_EXCEPTIONS_STACKSIZE ?= 0x400
+USE_PROCESS_STACKSIZE    ?= 0x400
 
 # Shared variables
 ALLXASMSRC += $(STARTUPASM)

--- a/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
+++ b/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
@@ -17,8 +17,11 @@ STARTUPINC = $(CHIBIOS)/os/common/portability/GCC \
 
 STARTUPLD  = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/ld
 
+# Note: the per-core stacks live in the 4KiB scratch banks (ram4/ram5)
+# together with CH_MEM_LOCAL_BSS()/CH_MEM_LOCAL_COHERENT_BSS() annotated
+# data, 0x400+0x400 leaves half of each bank for annotated data.
 USE_EXCEPTIONS_STACKSIZE ?= 0x400
-USE_PROCESS_STACKSIZE    ?= 0x800
+USE_PROCESS_STACKSIZE    ?= 0x400
 
 # Shared variables
 ALLXASMSRC += $(STARTUPASM)


### PR DESCRIPTION
## Summary

Related fixes to the RP2 memory setup (review item 37):

- **ROM region size**: the `flash0` region in `RP2350_FLASH.ld`/`RP2350_RAM.ld` claimed 16k; the RP2350 boot ROM is 32k. Descriptive only — nothing is placed there — but the annotation was wrong.
- **Core-local BSS enablement**: `chmem.h` only activates the per-core `CH_MEM_LOCAL_BSS(n)`/`CH_MEM_LOCAL_COHERENT_BSS(n)` machinery when the *unsuffixed* `PORT_MEM_LOCAL_BSS`/`PORT_MEM_LOCAL_COHERENT_BSS` names are defined (it pastes the core suffix before expansion). All three RP2 SMP port headers (ARMv6-M, ARMv8-M-ML-ALT, and RISCV-HAZARD3) defined only the suffixed `...BSS0`/`...BSS1` variants, leaving the whole feature silently dead. Empty unsuffixed marker macros now switch it on; annotated variables land in `.ram4_clear.core0`/`.ram5_clear.core1`. The RT kernel immediately uses this for its per-core instance data (~1.8 KiB per core), which is the point of the feature — and what forces the next item.
- **Default stack sizes** (deliberate behavior change): `USE_EXCEPTIONS_STACKSIZE`/`USE_PROCESS_STACKSIZE` defaults become 0x400+0x400 in the RP2040, RP2350 and RP2350-RISCV startup makefiles (previously 0x800+0x800 on ARM, 0x400+0x800 on Hazard3; the RISCV-BLINK demo's own override is aligned too). The linker scripts place the per-core stacks in the 4 KiB scratch banks (ram4/SCRATCH_X for core 0, ram5/SCRATCH_Y for core 1); the old defaults left too little room for the newly-enabled core-local data — the ARM banks were completely full, and Hazard3's 1 KiB of headroom overflowed by 752 bytes the moment the feature came alive. 0x400+0x400 leaves half of each bank for annotated data and matches the common ChibiOS default on other ports.

**Impact note**: projects setting their own stack sizes are unaffected (`?=` defaults). A project silently relying on more than 1 KiB of default IRQ or main-thread stack now overflows at runtime instead of fitting; debug builds with stack checking catch this. Documented in the port headers: annotated data competes with stack space, and an overflow of annotated data surfaces as a link-time region error.

## Validation

- Map-file probe: `CH_MEM_LOCAL_BSS(0)`/`(1)` and coherent variants placed in ram4/ram5 as expected on RP2040 and RP2350 ARM builds.
- Hazard3: RISCV-BLINK links with each bank holding 0x400+0x400 stacks plus 0x6F0 of core-local kernel instance data (272 bytes spare); flashed to a Pico 2 in RISC-V mode and observed running (timer advancing, kernel scheduling) before restoring ARM firmware.
- Demo smoke runs on Pico 2 hardware with the new defaults; the full RP2350 remediation integration build (19 RP targets) also ran on hardware with these values.
- Reviewed by CodeRabbit and Codex, both clean; the automated PR review's should-fix (Hazard3 coverage) is addressed in d81018df66.