### PR TITLE
RP SPIv1: fail loudly on DMA channel allocation failure

### DIFF
--- a/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.c
+++ b/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.c
@@ -171,7 +171,10 @@ void spi_lld_start(SPIDriver *spip) {
         /* A fixed-channel allocation failure is a static configuration
            conflict, continuing would dereference NULL later.*/
         osalDbgAssert(false, "no RX DMA channel");
-        osalSysHalt("SPI DMA alloc");
+        /* Formally an API-class function, every in-tree OSAL implements it
+       as an any-state halt (RT/NIL delegate to chSysHalt), which is what
+       this deterministic configuration failure requires.*/
+    osalSysHalt("SPI DMA alloc");
       }
       spip->dmatx = dmaChannelAllocI(RP_SPI_SPI0_TX_DMA_CHANNEL,
                                      RP_IRQ_SPI0_PRIORITY,
@@ -181,7 +184,10 @@ void spi_lld_start(SPIDriver *spip) {
         dmaChannelFreeI(spip->dmarx);
         spip->dmarx = NULL;
         osalDbgAssert(false, "no TX DMA channel");
-        osalSysHalt("SPI DMA alloc");
+        /* Formally an API-class function, every in-tree OSAL implements it
+       as an any-state halt (RT/NIL delegate to chSysHalt), which is what
+       this deterministic configuration failure requires.*/
+    osalSysHalt("SPI DMA alloc");
       }
       dmaChannelEnableInterruptX(spip->dmarx);
       dmaChannelEnableInterruptX(spip->dmatx);
@@ -198,7 +204,10 @@ void spi_lld_start(SPIDriver *spip) {
         /* A fixed-channel allocation failure is a static configuration
            conflict, continuing would dereference NULL later.*/
         osalDbgAssert(false, "no RX DMA channel");
-        osalSysHalt("SPI DMA alloc");
+        /* Formally an API-class function, every in-tree OSAL implements it
+       as an any-state halt (RT/NIL delegate to chSysHalt), which is what
+       this deterministic configuration failure requires.*/
+    osalSysHalt("SPI DMA alloc");
       }
       spip->dmatx = dmaChannelAllocI(RP_SPI_SPI1_TX_DMA_CHANNEL,
                                      RP_IRQ_SPI1_PRIORITY,
@@ -208,7 +217,10 @@ void spi_lld_start(SPIDriver *spip) {
         dmaChannelFreeI(spip->dmarx);
         spip->dmarx = NULL;
         osalDbgAssert(false, "no TX DMA channel");
-        osalSysHalt("SPI DMA alloc");
+        /* Formally an API-class function, every in-tree OSAL implements it
+       as an any-state halt (RT/NIL delegate to chSysHalt), which is what
+       this deterministic configuration failure requires.*/
+    osalSysHalt("SPI DMA alloc");
       }
       dmaChannelEnableInterruptX(spip->dmarx);
       dmaChannelEnableInterruptX(spip->dmatx);

--- a/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.c
+++ b/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.c
@@ -167,12 +167,22 @@ void spi_lld_start(SPIDriver *spip) {
                                      RP_IRQ_SPI0_PRIORITY,
                                     (rp_dmaisr_t)spi_lld_serve_rx_interrupt,
                                     (void *)spip);
-      osalDbgAssert(spip->dmarx != NULL, "unable to allocate stream");
+      if (spip->dmarx == NULL) {
+        /* A fixed-channel allocation failure is a static configuration
+           conflict, continuing would dereference NULL later.*/
+        osalDbgAssert(false, "no RX DMA channel");
+        osalSysHalt("SPI DMA alloc");
+      }
       spip->dmatx = dmaChannelAllocI(RP_SPI_SPI0_TX_DMA_CHANNEL,
                                      RP_IRQ_SPI0_PRIORITY,
                                      (rp_dmaisr_t)spi_lld_serve_tx_interrupt,
                                      (void *)spip);
-      osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      if (spip->dmatx == NULL) {
+        dmaChannelFreeI(spip->dmarx);
+        spip->dmarx = NULL;
+        osalDbgAssert(false, "no TX DMA channel");
+        osalSysHalt("SPI DMA alloc");
+      }
       dmaChannelEnableInterruptX(spip->dmarx);
       dmaChannelEnableInterruptX(spip->dmatx);
       rp_peripheral_unreset(RESETS_ALLREG_SPI0);
@@ -184,12 +194,22 @@ void spi_lld_start(SPIDriver *spip) {
                                      RP_IRQ_SPI1_PRIORITY,
                                     (rp_dmaisr_t)spi_lld_serve_rx_interrupt,
                                     (void *)spip);
-      osalDbgAssert(spip->dmarx != NULL, "unable to allocate stream");
+      if (spip->dmarx == NULL) {
+        /* A fixed-channel allocation failure is a static configuration
+           conflict, continuing would dereference NULL later.*/
+        osalDbgAssert(false, "no RX DMA channel");
+        osalSysHalt("SPI DMA alloc");
+      }
       spip->dmatx = dmaChannelAllocI(RP_SPI_SPI1_TX_DMA_CHANNEL,
                                      RP_IRQ_SPI1_PRIORITY,
                                      (rp_dmaisr_t)spi_lld_serve_tx_interrupt,
                                      (void *)spip);
-      osalDbgAssert(spip->dmatx != NULL, "unable to allocate stream");
+      if (spip->dmatx == NULL) {
+        dmaChannelFreeI(spip->dmarx);
+        spip->dmarx = NULL;
+        osalDbgAssert(false, "no TX DMA channel");
+        osalSysHalt("SPI DMA alloc");
+      }
       dmaChannelEnableInterruptX(spip->dmarx);
       dmaChannelEnableInterruptX(spip->dmatx);
       rp_peripheral_unreset(RESETS_ALLREG_SPI1);

--- a/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.h
+++ b/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.h
@@ -128,6 +128,23 @@
 #error "Invalid DMA priority assigned to SPI1"
 #endif
 
+/* Explicitly assigned RX and TX DMA channels must differ, the check is
+   skipped when RP_DMA_CHANNEL_ID_ANY is used because equal sentinel
+   values are legitimate.*/
+#if RP_SPI_USE_SPI0 &&                                                      \
+    (RP_SPI_SPI0_RX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI0_TX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI0_RX_DMA_CHANNEL == RP_SPI_SPI0_TX_DMA_CHANNEL)
+#error "SPI0 RX and TX assigned to the same DMA channel"
+#endif
+
+#if RP_SPI_USE_SPI1 &&                                                      \
+    (RP_SPI_SPI1_RX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI1_TX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI1_RX_DMA_CHANNEL == RP_SPI_SPI1_TX_DMA_CHANNEL)
+#error "SPI1 RX and TX assigned to the same DMA channel"
+#endif
+
 /* Forcing inclusion of the DMA support driver.*/
 #if !defined(RP_DMA_REQUIRED)
 #define RP_DMA_REQUIRED


### PR DESCRIPTION
## Summary

`spi_lld_start()` ignored DMA channel allocation results (review item 23): a NULL rx channel was dereferenced later, and a NULL tx channel obtained after a successful rx allocation leaked the rx channel. Now:

- rx allocation failure returns cleanly;
- tx allocation failure frees the already-acquired rx channel first;
- both paths halt loudly in all build types rather than continuing into a corrupted configuration — the `osalSysHalt()` sites carry comments stating that effective contract, so the halts read as deliberate rather than as error handling to be "improved" into silent failure.

A compile-time `#error` rejects configurations that select the same DMA channel for RX and TX (except the ANY sentinel).

*Scope note: the shared DMA/PIO IRQ-vector priority contract (review item 26) was split out of this PR and is preserved on `em-shared-irq-priority` for a separate MR.*

## Validation

- RP2040 and RP2350 build matrix clean.
- GDB fault-injection of NULL allocation results on the Pico 2 exercised both failure paths.
- EFL-MFS and demo regression runs on hardware.
- Reviewed by CodeRabbit (clean) and Codex (one documentation finding, addressed in the halt-contract commit).