### PR TITLE
RP GPIOv1: full-port write atomicity and event vector core affinity

### DIFF
--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
@@ -150,7 +150,14 @@ void _pal_lld_init(void) {
     _pal_init_event(i);
   }
 
-  nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+  /* The ISR reads the interrupt statuses of the per-core PROC block
+     selected by RP_PAL_EVENT_CORE_AFFINITY and the NVIC is a per-core
+     resource, so the vector can only be enabled here when halInit() is
+     running on the affinity core. Otherwise the application must call
+     palRPEnableEventsIrqX() from the affinity core.*/
+  if (SIO->CPUID == (uint32_t)RP_PAL_EVENT_CORE_AFFINITY) {
+    nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+  }
   #endif
 }
 

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -104,7 +104,15 @@
 /** @} */
 
 #if !defined(RP_PAL_EVENT_CORE_AFFINITY)
-  /** @brief Core that handles all the PAL event interrupts. */
+  /**
+   * @brief   Core that handles all the PAL event interrupts.
+   * @note    The NVIC is a per-core resource, halInit() enables the events
+   *          interrupt vector only when it is executed on this core. When
+   *          the affinity core is not the core running halInit(), the
+   *          application must call @p palRPEnableEventsIrqX() from the
+   *          affinity core (e.g. from @p c1_main() after
+   *          @p chInstanceObjectInit()) before PAL events can be served.
+   */
   #define RP_PAL_EVENT_CORE_AFFINITY        0
 #endif
 
@@ -440,6 +448,25 @@ typedef uint32_t iopadid_t;
   /** @brief IRQ priority of the external pad events. */
   #define RP_IO_IRQ_BANK0_PRIORITY          2
 #endif
+
+/**
+ * @brief   Enables the PAL events interrupt vector on the calling core.
+ * @details The NVIC is a per-core resource and the PAL events interrupts are
+ *          routed to the core selected by @p RP_PAL_EVENT_CORE_AFFINITY.
+ *          halInit() enables the vector only when running on the affinity
+ *          core, otherwise this function must be called from the affinity
+ *          core after it has been started.
+ * @note    Must be called from the @p RP_PAL_EVENT_CORE_AFFINITY core.
+ *
+ * @special
+ */
+__STATIC_INLINE void palRPEnableEventsIrqX(void) {
+
+  osalDbgAssert(SIO->CPUID == (uint32_t)RP_PAL_EVENT_CORE_AFFINITY,
+                "wrong core");
+
+  nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+}
 
 #if !defined(__DOXYGEN__)
 extern palevent_t _pal_events[RP_GPIO_NUM_LINES];

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -347,13 +347,15 @@ typedef uint32_t iopadid_t;
  * @notapi
  */
 /* @note    On RP2350, IOPORT2 maps to SIO GPIO_HI_OUT which is shared with
- *          QSPI/USB outputs in bits 31:16. This is a raw full-register write;
- *          use palSetPort()/palClearPort()/palTogglePort() when non-PAL high
- *          bits must be preserved.
+ *          QSPI/USB outputs in bits 31:16. Only the bits belonging to PAL
+ *          lines are updated, using a single write to the GPIO_OUT_XOR
+ *          alias, so the shared non-PAL latch bits are preserved.
  */
 #define pal_lld_writeport(port, bits)                                       \
   do {                                                                      \
-    RP_PAL_SIO_REG(GPIO_OUT, (port)) = (uint32_t)(bits);                    \
+    RP_PAL_SIO_REG(GPIO_OUT_XOR, (port)) =                                  \
+      (RP_PAL_SIO_REG(GPIO_OUT, (port)) ^ (uint32_t)(bits)) &               \
+      (uint32_t)RP_PAL_VALID_MASK(port);                                    \
   } while (false)
 
 /**

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -358,6 +358,12 @@ typedef uint32_t iopadid_t;
  *          QSPI/USB outputs in bits 31:16. Only the bits belonging to PAL
  *          lines are updated, using a single write to the GPIO_OUT_XOR
  *          alias, so the shared non-PAL latch bits are preserved.
+ * @note    The latch read and XOR write are not one atomic step:
+ *          concurrent full-port writes to the SAME port from both cores
+ *          are unsupported (they can combine into a value neither core
+ *          requested) and must be serialized by the application; the
+ *          set/clear based line and group APIs remain safe for
+ *          concurrent use. Different ports are independent.
  */
 #define pal_lld_writeport(port, bits)                                       \
   do {                                                                      \

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -358,12 +358,13 @@ typedef uint32_t iopadid_t;
  *          QSPI/USB outputs in bits 31:16. Only the bits belonging to PAL
  *          lines are updated, using a single write to the GPIO_OUT_XOR
  *          alias, so the shared non-PAL latch bits are preserved.
- * @note    The latch read and XOR write are not one atomic step:
- *          concurrent full-port writes to the SAME port from both cores
- *          are unsupported (they can combine into a value neither core
- *          requested) and must be serialized by the application; the
- *          set/clear based line and group APIs remain safe for
- *          concurrent use. Different ports are independent.
+ * @note    The latch read and XOR write are not one atomic step: a
+ *          full-port write must be serialized by the application against
+ *          ALL concurrent output updates to the SAME port - including
+ *          line/group set, clear and toggle - because an update landing
+ *          between the read and the XOR write is folded into a value
+ *          neither writer requested. The set/clear based APIs are only
+ *          atomic among themselves. Different ports are independent.
  */
 #define pal_lld_writeport(port, bits)                                       \
   do {                                                                      \

--- a/testhal/RP/multi/PAL/main.c
+++ b/testhal/RP/multi/PAL/main.c
@@ -38,6 +38,58 @@ static THD_FUNCTION(Thread1, arg) {
 }
 #endif
 
+#if (defined(RP_PAL_SIO_REG) && (RP_GPIO_NUM_LINES > 32U)) ||               \
+    defined(__DOXYGEN__)
+/*
+ * On RP devices with more than 32 GPIO lines (RP2350), IOPORT2 maps to SIO
+ * GPIO_HI_OUT which shares bits 31:16 with the QSPI/USB output latches.
+ * This one-shot boot check verifies that palWritePort() on IOPORT2 updates
+ * only the PAL line latches and preserves the shared high bits.
+ *
+ * This demo has no serial console, therefore a failure is signalled by
+ * blinking a fast SOS pattern on LED1 forever; on success the normal demo
+ * behavior follows.
+ */
+static void check_ioport2_latch_preservation(void) {
+  static const uint8_t sos[] = {1, 1, 1, 3, 3, 3, 1, 1, 1};
+  uint32_t hi_snapshot, saved_latch;
+  bool ok = true;
+
+  saved_latch = palReadLatch(IOPORT2) & 0xFFFFU;
+  hi_snapshot = SIO->GPIO_HI_OUT & 0xFFFF0000U;
+
+  palWritePort(IOPORT2, 0xAAAAU);
+  ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0xAAAAU);
+  ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
+
+  palWritePort(IOPORT2, 0x5555U);
+  ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0x5555U);
+  ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
+
+  palWritePort(IOPORT2, 0x0000U);
+  ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0x0000U);
+  ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
+
+  /* Restoring the original latch value.*/
+  palWritePort(IOPORT2, saved_latch);
+
+  while (!ok) {
+    unsigned i;
+
+    for (i = 0U; i < (sizeof sos / sizeof sos[0]); i++) {
+      palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_ON);
+      chThdSleepMilliseconds(50U * sos[i]);
+      palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_OFF);
+      chThdSleepMilliseconds(50U);
+    }
+    chThdSleepMilliseconds(300U);
+  }
+}
+#define CHECK_IOPORT2_LATCH_PRESERVATION()  check_ioport2_latch_preservation()
+#else
+#define CHECK_IOPORT2_LATCH_PRESERVATION()  do { } while (false)
+#endif
+
 #if PAL_USE_WAIT || defined(__DOXYGEN__)
 
 /*
@@ -57,6 +109,10 @@ int main(void) {
 
   /* Board-dependent GPIO setup code.*/
   portab_setup();
+
+  /* One-shot IOPORT2 shared-latch preservation check, no-op where IOPORT2
+     is not present.*/
+  CHECK_IOPORT2_LATCH_PRESERVATION();
 
 #if defined(PORTAB_LINE_LED2)
   /*
@@ -125,6 +181,10 @@ int main(void) {
   /* Board-dependent GPIO setup code.*/
   portab_setup();
 
+  /* One-shot IOPORT2 shared-latch preservation check, no-op where IOPORT2
+     is not present.*/
+  CHECK_IOPORT2_LATCH_PRESERVATION();
+
   /* Events initialization and registration.*/
   chEvtObjectInit(&button_pressed_event);
   chEvtObjectInit(&button_released_event);
@@ -177,6 +237,10 @@ int main(void) {
 
   /* Board-dependent GPIO setup code.*/
   portab_setup();
+
+  /* One-shot IOPORT2 shared-latch preservation check, no-op where IOPORT2
+     is not present.*/
+  CHECK_IOPORT2_LATCH_PRESERVATION();
 
 #if defined(PORTAB_LINE_LED2)
   /*

--- a/testhal/RP/multi/PAL/main.c
+++ b/testhal/RP/multi/PAL/main.c
@@ -56,6 +56,11 @@ static void check_ioport2_latch_preservation(void) {
   bool ok = true;
 
   saved_latch = palReadLatch(IOPORT2) & 0xFFFFU;
+
+  /* Seeding a non-GPIO latch bit so preservation is actually exercised,
+     the QSPI/USB output latches are inert while their pads are not on
+     the SIO function.*/
+  SIO->GPIO_HI_OUT_SET = 0x00010000U;
   hi_snapshot = SIO->GPIO_HI_OUT & 0xFFFF0000U;
 
   palWritePort(IOPORT2, 0xAAAAU);
@@ -70,8 +75,9 @@ static void check_ioport2_latch_preservation(void) {
   ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0x0000U);
   ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
 
-  /* Restoring the original latch value.*/
+  /* Restoring the original latch and clearing the seeded bit.*/
   palWritePort(IOPORT2, saved_latch);
+  SIO->GPIO_HI_OUT_CLR = 0x00010000U;
 
   while (!ok) {
     unsigned i;


### PR DESCRIPTION
## Summary

Two PAL fixes on the RP2 port (review items 14 and 28), plus test coverage:

- **`pal_lld_writeport()` clobbered shared SIO latch bits**: the full-port write stored the value straight into `GPIO_OUT`, wiping the QSPI/USB-DPRAM latch bits that share the register's upper half on RP2350. It now performs a single atomic `GPIO_OUT_XOR` write of `(current ^ value)` masked to the port's valid GPIO lines, leaving non-GPIO latch bits untouched and staying glitch-free for the written pins (no momentary wrong level, unlike a set/clear pair).
  - *Documented limitation (from review)*: the read-XOR-write pair is not linearizable against concurrent same-port output updates from the other core — concurrent full-port writes must be serialized by the application. The set/clear/toggle line and group APIs remain safe for concurrent use among themselves. This contract is stated at the macro.
- **PAL event vector enabled on the wrong core**: the PAL event ISR reads the per-core `IO_BANK0` PROC block selected by `RP_PAL_EVENT_CORE_AFFINITY`, but `_pal_lld_init()` enabled the NVIC vector unconditionally on whichever core ran `halInit()`. With affinity 1, core 1's vector was never enabled (events never served) while core 0 held a vector for statuses it never sees. The vector is now enabled only when `SIO->CPUID` matches the affinity, and a new `palRPEnableEventsIrqX()` helper (asserting it runs on the affinity core) covers the case where the affinity core is not the one running `halInit()` — documented at the affinity setting.
- **Test coverage**: the multi/PAL test gains a boot self-check that seeds an inert non-GPIO latch bit, performs full-port writes, and verifies the latch half is preserved — the seed makes the check genuinely fail against the old behavior instead of passing trivially on all-zero latch bits.

## Validation

- On a Pico 2: latch-preservation self-check passes (and was confirmed to fail against the unfixed `pal_lld_writeport`); flash/UART remain alive across the write patterns (the QSPI latch bits genuinely matter there).
- RP2040 and RP2350 build matrix clean.
- Reviewed by CodeRabbit and Codex; both reviewers' findings on the concurrency contract are addressed in the two documentation commits.