### PR TITLE
RP PWMv1: fix period off-by-one, stop-path interrupt hygiene, divider clamps

### DIFF
--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
@@ -405,8 +405,11 @@ void pwm_lld_start(PWMDriver *pwmp) {
   p->CH[pwmp->timer_id].DIV = div_fp4;
 
   /* The counter counts from zero to TOP included so the register must
-     be programmed with one count less than the requested period. */
-  p->CH[pwmp->timer_id].TOP = (uint32_t)(pwmp->period - 1U);
+     be programmed with one count less than the requested period; a zero
+     period is clamped to the shortest achievable cycle, matching
+     pwm_lld_change_period(). */
+  p->CH[pwmp->timer_id].TOP =
+    (uint32_t)(((pwmp->period >= 1U) ? pwmp->period : 1U) - 1U);
 
   uint32_t csr = PWM_CSR_EN | PWM_CSR_DIVMODE_FREE;
   csr &= ~PWM_CSR_PH_CORRECT;

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
@@ -386,8 +386,20 @@ void pwm_lld_start(PWMDriver *pwmp) {
   /* Counter clock divider as an 8.4 fixed point value, computed in 64
      bits in order not to overflow at high system clocks. */
   halfreq_t sys_clk = halClockGetPointX(RP_CLK_SYS);
-  uint32_t div_fp4 = (uint32_t)(((uint64_t)sys_clk << 4) /
-                                pwmp->config->frequency);
+  uint32_t div_fp4;
+
+  /* This start path has no error channel; a zero frequency must not
+     reach the division (the 64-bit helper quietly returns zero, which
+     the minimum clamp below would turn into a full-speed counter). The
+     slowest supported divider is the closest predictable behavior. */
+  osalDbgAssert(pwmp->config->frequency > 0U, "invalid PWM frequency");
+  if (pwmp->config->frequency == 0U) {
+    div_fp4 = 0xFFFU;
+  }
+  else {
+    div_fp4 = (uint32_t)(((uint64_t)sys_clk << 4) /
+                         pwmp->config->frequency);
+  }
 
   /* Divider 1.0 is the minimum supported value. */
   if (div_fp4 < 0x010U) {

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
@@ -394,7 +394,12 @@ void pwm_lld_start(PWMDriver *pwmp) {
     div_fp4 = 0x010U;
   }
 
+  /* The 12-bit INT.FRAC divider tops out at 255+15/16; release builds
+     clamp instead of writing a truncated unrelated value. */
   osalDbgAssert(div_fp4 <= 0xFFFU, "PWM frequency too low");
+  if (div_fp4 > 0xFFFU) {
+    div_fp4 = 0xFFFU;
+  }
   osalDbgAssert(pwmp->period >= 1U, "invalid PWM period");
 
   p->CH[pwmp->timer_id].DIV = div_fp4;
@@ -446,7 +451,7 @@ void pwm_lld_stop(PWMDriver *pwmp) {
     /* Disabling this slice wrap interrupt first, the vector is shared
        among all slices and must not be able to fire for a stopped
        driver. */
-    p->IRQ0_INTE &= ~PWM_INTE_CH(pwmp->timer_id);
+    p->CLR.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
 
     p->CH[pwmp->timer_id].CSR = 0U;
     p->CH[pwmp->timer_id].CTR = 0U;
@@ -523,7 +528,7 @@ void pwm_lld_disable_channel(PWMDriver *pwmp, pwmchannel_t channel) {
  * @notapi
  */
 void pwm_lld_enable_periodic_notification(PWMDriver *pwmp) {
-  pwmp->pwm->IRQ0_INTE |= PWM_INTE_CH(pwmp->timer_id);
+  pwmp->pwm->SET.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
 }
 
 /**
@@ -536,7 +541,7 @@ void pwm_lld_enable_periodic_notification(PWMDriver *pwmp) {
  * @notapi
  */
 void pwm_lld_disable_periodic_notification(PWMDriver *pwmp) {
-  pwmp->pwm->IRQ0_INTE &= ~PWM_INTE_CH(pwmp->timer_id);
+  pwmp->pwm->CLR.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
 }
 
 /**

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
@@ -383,20 +383,25 @@ void pwm_lld_start(PWMDriver *pwmp) {
     p->CH[pwmp->timer_id].CC  = 0;
   }
 
-  /* Counter clock divider. */
+  /* Counter clock divider as an 8.4 fixed point value, computed in 64
+     bits in order not to overflow at high system clocks. */
   halfreq_t sys_clk = halClockGetPointX(RP_CLK_SYS);
-  halfreq_t pwm_freq_min = sys_clk / 256;
+  uint32_t div_fp4 = (uint32_t)(((uint64_t)sys_clk << 4) /
+                                pwmp->config->frequency);
 
-  osalDbgAssert(pwmp->config->frequency >= pwm_freq_min,
-                "PWM counter frequency too low");
+  /* Divider 1.0 is the minimum supported value. */
+  if (div_fp4 < 0x010U) {
+    div_fp4 = 0x010U;
+  }
 
-  /* Integer part must not be zero. */
-  halfreq_t integer = sys_clk / pwmp->config->frequency;
-  integer = integer == 0 ? 1 : integer;
+  osalDbgAssert(div_fp4 <= 0xFFFU, "PWM frequency too low");
+  osalDbgAssert(pwmp->period >= 1U, "invalid PWM period");
 
-  halfreq_t fraction = (sys_clk << 4) / pwmp->config->frequency;
-  p->CH[pwmp->timer_id].DIV = (integer << 4 | (fraction & 0xF));
-  p->CH[pwmp->timer_id].TOP = pwmp->period;
+  p->CH[pwmp->timer_id].DIV = div_fp4;
+
+  /* The counter counts from zero to TOP included so the register must
+     be programmed with one count less than the requested period. */
+  p->CH[pwmp->timer_id].TOP = (uint32_t)(pwmp->period - 1U);
 
   uint32_t csr = PWM_CSR_EN | PWM_CSR_DIVMODE_FREE;
   csr &= ~PWM_CSR_PH_CORRECT;

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
@@ -412,14 +412,16 @@ void pwm_lld_start(PWMDriver *pwmp) {
   if (div_fp4 > 0xFFFU) {
     div_fp4 = 0xFFFU;
   }
+  /* A zero period is a contract violation: debug builds reject it here,
+     release builds fall back to the clamp below. */
   osalDbgAssert(pwmp->period >= 1U, "invalid PWM period");
 
   p->CH[pwmp->timer_id].DIV = div_fp4;
 
   /* The counter counts from zero to TOP included so the register must
-     be programmed with one count less than the requested period; a zero
-     period is clamped to the shortest achievable cycle, matching
-     pwm_lld_change_period(). */
+     be programmed with one count less than the requested period; in
+     release builds a zero period is clamped to the shortest achievable
+     cycle, matching pwm_lld_change_period(). */
   p->CH[pwmp->timer_id].TOP =
     (uint32_t)(((pwmp->period >= 1U) ? pwmp->period : 1U) - 1U);
 

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
@@ -173,73 +173,85 @@ OSAL_IRQ_HANDLER(RP_PWM_IRQ_WRAP_0_HANDLER) {
   PWM->INTR = ints;
 
 #if RP_PWM_USE_PWM0 == TRUE
-  if (((ints & PWM_INTS_CH(0)) != 0) && (PWMD0.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(0)) != 0) && (PWMD0.config != NULL) &&
+      (PWMD0.config->callback != NULL)) {
     PWMD0.config->callback(&PWMD0);
   }
 #endif
 
 #if RP_PWM_USE_PWM1 == TRUE
-  if (((ints & PWM_INTS_CH(1)) != 0) && (PWMD1.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(1)) != 0) && (PWMD1.config != NULL) &&
+      (PWMD1.config->callback != NULL)) {
     PWMD1.config->callback(&PWMD1);
   }
 #endif
 
 #if RP_PWM_USE_PWM2 == TRUE
-  if (((ints & PWM_INTS_CH(2)) != 0) && (PWMD2.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(2)) != 0) && (PWMD2.config != NULL) &&
+      (PWMD2.config->callback != NULL)) {
     PWMD2.config->callback(&PWMD2);
   }
 #endif
 
 #if RP_PWM_USE_PWM3 == TRUE
-  if (((ints & PWM_INTS_CH(3)) != 0) && (PWMD3.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(3)) != 0) && (PWMD3.config != NULL) &&
+      (PWMD3.config->callback != NULL)) {
     PWMD3.config->callback(&PWMD3);
   }
 #endif
 
 #if RP_PWM_USE_PWM4 == TRUE
-  if (((ints & PWM_INTS_CH(4)) != 0) && (PWMD4.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(4)) != 0) && (PWMD4.config != NULL) &&
+      (PWMD4.config->callback != NULL)) {
     PWMD4.config->callback(&PWMD4);
   }
 #endif
 
 #if RP_PWM_USE_PWM5 == TRUE
-  if (((ints & PWM_INTS_CH(5)) != 0) && (PWMD5.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(5)) != 0) && (PWMD5.config != NULL) &&
+      (PWMD5.config->callback != NULL)) {
     PWMD5.config->callback(&PWMD5);
   }
 #endif
 
 #if RP_PWM_USE_PWM6 == TRUE
-  if (((ints & PWM_INTS_CH(6)) != 0) && (PWMD6.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(6)) != 0) && (PWMD6.config != NULL) &&
+      (PWMD6.config->callback != NULL)) {
     PWMD6.config->callback(&PWMD6);
   }
 #endif
 
 #if RP_PWM_USE_PWM7 == TRUE
-  if (((ints & PWM_INTS_CH(7)) != 0) && (PWMD7.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(7)) != 0) && (PWMD7.config != NULL) &&
+      (PWMD7.config->callback != NULL)) {
     PWMD7.config->callback(&PWMD7);
   }
 #endif
 
 #if RP_PWM_USE_PWM8 == TRUE
-  if (((ints & PWM_INTS_CH(8)) != 0) && (PWMD8.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(8)) != 0) && (PWMD8.config != NULL) &&
+      (PWMD8.config->callback != NULL)) {
     PWMD8.config->callback(&PWMD8);
   }
 #endif
 
 #if RP_PWM_USE_PWM9 == TRUE
-  if (((ints & PWM_INTS_CH(9)) != 0) && (PWMD9.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(9)) != 0) && (PWMD9.config != NULL) &&
+      (PWMD9.config->callback != NULL)) {
     PWMD9.config->callback(&PWMD9);
   }
 #endif
 
 #if RP_PWM_USE_PWM10 == TRUE
-  if (((ints & PWM_INTS_CH(10)) != 0) && (PWMD10.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(10)) != 0) && (PWMD10.config != NULL) &&
+      (PWMD10.config->callback != NULL)) {
     PWMD10.config->callback(&PWMD10);
   }
 #endif
 
 #if RP_PWM_USE_PWM11 == TRUE
-  if (((ints & PWM_INTS_CH(11)) != 0) && (PWMD11.config->callback != NULL)) {
+  if (((ints & PWM_INTS_CH(11)) != 0) && (PWMD11.config != NULL) &&
+      (PWMD11.config->callback != NULL)) {
     PWMD11.config->callback(&PWMD11);
   }
 #endif
@@ -426,11 +438,19 @@ void pwm_lld_stop(PWMDriver *pwmp) {
 
   /* If in ready state then disables the PWM clock. */
   if (pwmp->state == PWM_READY) {
+    /* Disabling this slice wrap interrupt first, the vector is shared
+       among all slices and must not be able to fire for a stopped
+       driver. */
+    p->IRQ0_INTE &= ~PWM_INTE_CH(pwmp->timer_id);
+
     p->CH[pwmp->timer_id].CSR = 0U;
     p->CH[pwmp->timer_id].CTR = 0U;
     p->CH[pwmp->timer_id].CC  = 0U;
     p->CH[pwmp->timer_id].DIV = 1U;
     p->CH[pwmp->timer_id].TOP = 0xFFFF;
+
+    /* Clearing any interrupt request still latched for this slice. */
+    p->INTR = PWM_INTR_CH(pwmp->timer_id);
   }
 
   /* If all timers are disabled, disable the interrupt and reset

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
@@ -397,7 +397,7 @@ struct PWMDriver {
  * @notapi
  */
 #define pwm_lld_change_period(pwmp, period) \
-  ((pwmp)->pwm->CH[(pwmp)->timer_id].TOP = (period))
+  ((pwmp)->pwm->CH[(pwmp)->timer_id].TOP = (pwmcnt_t)((period) - 1))
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
@@ -396,9 +396,13 @@ struct PWMDriver {
  *
  * @notapi
  */
-#define pwm_lld_change_period(pwmp, period) \
-  ((pwmp)->pwm->CH[(pwmp)->timer_id].TOP =                                  \
-    (pwmcnt_t)((((period) >= 1U) ? (period) : 1U) - 1U))
+#define pwm_lld_change_period(pwmp, period)                                 \
+  do {                                                                      \
+    pwmcnt_t newp = (pwmcnt_t)(period);                                     \
+                                                                            \
+    (pwmp)->pwm->CH[(pwmp)->timer_id].TOP =                                 \
+      (pwmcnt_t)(((newp >= (pwmcnt_t)1) ? newp : (pwmcnt_t)1) - 1U);        \
+  } while (false)
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
+++ b/os/hal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
@@ -397,7 +397,8 @@ struct PWMDriver {
  * @notapi
  */
 #define pwm_lld_change_period(pwmp, period) \
-  ((pwmp)->pwm->CH[(pwmp)->timer_id].TOP = (pwmcnt_t)((period) - 1))
+  ((pwmp)->pwm->CH[(pwmp)->timer_id].TOP =                                  \
+    (pwmcnt_t)((((period) >= 1U) ? (period) : 1U) - 1U))
 
 /*===========================================================================*/
 /* External declarations.                                                    */

--- a/testhal/RP/RP2350/PWM-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/PWM-VALIDATION/Makefile
@@ -1,0 +1,159 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O0 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2350/PWM-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/PWM-VALIDATION/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                FALSE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                FALSE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                FALSE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    FALSE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               FALSE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                FALSE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  FALSE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     FALSE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      FALSE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           FALSE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 TRUE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/PWM-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2350/PWM-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         TRUE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      FALSE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/PWM-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/PWM-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,57 @@
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+
+/*
+ * PWM driver system settings.
+ */
+#define RP_PWM_USE_PWM0                     FALSE
+#define RP_PWM_USE_PWM1                     TRUE
+#define RP_PWM_USE_PWM2                     TRUE
+#define RP_PWM_USE_PWM3                     FALSE
+#define RP_PWM_USE_PWM4                     FALSE
+#define RP_PWM_USE_PWM5                     FALSE
+#define RP_PWM_USE_PWM6                     FALSE
+#define RP_PWM_USE_PWM7                     FALSE
+#define RP_PWM_USE_PWM8                     FALSE
+#define RP_PWM_USE_PWM9                     FALSE
+#define RP_PWM_USE_PWM10                    FALSE
+#define RP_PWM_USE_PWM11                    FALSE
+#define RP_PWM_IRQ_WRAP_NUMBER_PRIORITY     3
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/PWM-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PWM-VALIDATION/main.c
@@ -1,0 +1,421 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 PWM validation test.
+ *
+ * Validates the RP PWMv1 low level driver timing and stop behavior:
+ *
+ *   1. Period accuracy: with frequency=1MHz and period=1000 the wrap
+ *      callback must run at exactly 1kHz. 1000 wraps are timed against
+ *      the free-running 1MHz TIMER0 counter (TIMERAWL). A TOP
+ *      off-by-one would read ~1001000us instead of 1000000us.
+ *   2. Duty sanity: width=500 out of period=1000 must produce ~50%
+ *      duty, verified by sampling the pin through SIO GPIO_IN.
+ *   3. change_period: after pwmChangePeriod() to 500 the wrap rate
+ *      must double (1000 wraps in ~500000us).
+ *   4. Stop safety: 500 start/stop cycles with the stop point swept
+ *      across the PWM period. After each pwmStop() no callback may
+ *      fire (the unfixed driver left the slice interrupt enabled and
+ *      dereferenced the NULLed config in the shared ISR). A second
+ *      slice runs across the whole test to verify that stopping one
+ *      slice does not break the shared vector for the others.
+ *
+ * Pin mapping (RP2350A, slice = (gpio >> 1) & 7, channel = gpio & 1):
+ *   GPIO2 = PWM slice 1 channel A -> PWMD1 channel 0 (routed).
+ *   PWMD2 (slice 2) is used callback-only, no pin routing.
+ *
+ * Single-core, output on SIOD0 (GPIO0/GPIO1, 38400 8N1).
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#define LED_PIN              25U
+#define UART_TX_PIN          0U
+#define UART_RX_PIN          1U
+#define PWM_PIN              2U         /* PWM slice 1 channel A.       */
+
+#define PWM_FREQ             1000000U   /* 1MHz counter clock.          */
+#define PWM_PERIOD           1000U      /* 1kHz wrap rate.              */
+
+static BaseSequentialStream *chp;
+static unsigned pass_count;
+static unsigned fail_count;
+
+/*===========================================================================*/
+/* Test helpers.                                                             */
+/*===========================================================================*/
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+static uint32_t time_us(void) {
+
+  return TIMER0->TIMERAWL;
+}
+
+static void delay_us(uint32_t us) {
+  uint32_t t0 = time_us();
+
+  while ((uint32_t)(time_us() - t0) < us) {
+  }
+}
+
+/*===========================================================================*/
+/* Wrap measurement machinery (PWMD1).                                       */
+/*===========================================================================*/
+
+static volatile uint32_t meas_count;
+static volatile uint32_t meas_skip;
+static volatile uint32_t meas_wraps;
+static volatile uint32_t meas_t_start;
+static volatile uint32_t meas_t_end;
+static volatile bool meas_done;
+
+static void meas_cb(PWMDriver *pwmp) {
+  uint32_t now = time_us();
+  uint32_t n = meas_count++;
+
+  (void)pwmp;
+
+  if (n == meas_skip) {
+    meas_t_start = now;
+  }
+  else if (n == (meas_skip + meas_wraps)) {
+    meas_t_end = now;
+    meas_done = true;
+  }
+}
+
+/*
+ * Times @p wraps PWM wrap callbacks, skipping the first @p skip ones,
+ * and returns the elapsed time in microseconds (0 on timeout).
+ */
+static uint32_t measure_wraps(PWMDriver *pwmp, uint32_t skip, uint32_t wraps,
+                              uint32_t timeout_us) {
+  uint32_t t0;
+
+  chSysLock();
+  meas_count   = 0U;
+  meas_skip    = skip;
+  meas_wraps   = wraps;
+  meas_done    = false;
+  chSysUnlock();
+
+  pwmEnablePeriodicNotification(pwmp);
+
+  t0 = time_us();
+  while (!meas_done) {
+    if ((uint32_t)(time_us() - t0) > timeout_us) {
+      pwmDisablePeriodicNotification(pwmp);
+      return 0U;
+    }
+  }
+
+  pwmDisablePeriodicNotification(pwmp);
+
+  return meas_t_end - meas_t_start;
+}
+
+static PWMConfig pwmcfg_meas = {
+  .frequency = PWM_FREQ,
+  .period    = PWM_PERIOD,
+  .callback  = meas_cb,
+  .channels  = {
+    {.mode = PWM_OUTPUT_ACTIVE_HIGH, .callback = NULL},
+    {.mode = PWM_OUTPUT_DISABLED,    .callback = NULL}
+  }
+};
+
+/*===========================================================================*/
+/* Stop safety machinery (PWMD1 + PWMD2).                                    */
+/*===========================================================================*/
+
+static volatile uint32_t stop_wraps;
+static volatile bool stop_cb_fired;
+
+static void stop_cb(PWMDriver *pwmp) {
+
+  (void)pwmp;
+  stop_wraps++;
+  stop_cb_fired = true;
+}
+
+static PWMConfig pwmcfg_stop = {
+  .frequency = PWM_FREQ,
+  .period    = PWM_PERIOD,
+  .callback  = stop_cb,
+  .channels  = {
+    {.mode = PWM_OUTPUT_DISABLED, .callback = NULL},
+    {.mode = PWM_OUTPUT_DISABLED, .callback = NULL}
+  }
+};
+
+static volatile uint32_t cross_wraps;
+
+static void cross_cb(PWMDriver *pwmp) {
+
+  (void)pwmp;
+  cross_wraps++;
+}
+
+static PWMConfig pwmcfg_cross = {
+  .frequency = PWM_FREQ,
+  .period    = PWM_PERIOD,
+  .callback  = cross_cb,
+  .channels  = {
+    {.mode = PWM_OUTPUT_DISABLED, .callback = NULL},
+    {.mode = PWM_OUTPUT_DISABLED, .callback = NULL}
+  }
+};
+
+/*===========================================================================*/
+/* Individual tests.                                                         */
+/*===========================================================================*/
+
+/*
+ * Test: 1000 wraps at 1kHz must take 1000000us within 0.05%.
+ * The pre-fix driver programmed TOP=period making every cycle one
+ * count too long (~1001000us here).
+ */
+static bool test_period_accuracy(void) {
+  uint32_t elapsed = measure_wraps(&PWMD1, 2U, 1000U, 3000000U);
+
+  chprintf(chp, "    1000 wraps of period %u: %u us (expected 1000000)\r\n",
+           PWM_PERIOD, elapsed);
+
+  return (elapsed >= 999500U) && (elapsed <= 1000500U);
+}
+
+/*
+ * Test: width 500 of period 1000 samples as ~50% high.
+ */
+static bool test_duty_sanity(void) {
+  uint32_t high = 0U;
+  uint32_t total = 0U;
+  uint32_t ratio;
+  uint32_t t0;
+
+  pwmEnableChannel(&PWMD1, 0U, 500U);
+
+  /* Letting the new compare value take effect. */
+  delay_us(3000U);
+
+  t0 = time_us();
+  while ((uint32_t)(time_us() - t0) < 50000U) {
+    if (palReadLine(PWM_PIN) == PAL_HIGH) {
+      high++;
+    }
+    total++;
+  }
+
+  ratio = (high * 100U) / total;
+  chprintf(chp, "    %u/%u samples high (%u%%)\r\n", high, total, ratio);
+
+  return (ratio >= 45U) && (ratio <= 55U);
+}
+
+/*
+ * Test: after pwmChangePeriod() to 500 ticks, 1000 wraps must take
+ * 500000us within 0.1%.
+ */
+static bool test_change_period(void) {
+  uint32_t elapsed;
+
+  pwmChangePeriod(&PWMD1, 500U);
+
+  /* Skipping a few wraps so a counter above the new TOP can run out. */
+  elapsed = measure_wraps(&PWMD1, 5U, 1000U, 3000000U);
+
+  chprintf(chp, "    1000 wraps of period 500: %u us (expected 500000)\r\n",
+           elapsed);
+
+  return (elapsed >= 499500U) && (elapsed <= 500500U);
+}
+
+/*
+ * Test: 500 start/stop cycles with the stop point swept across the
+ * period. After each stop the callback must stay silent for 2ms.
+ */
+static bool test_stop_safety(void) {
+  unsigned i;
+
+  for (i = 0U; i < 500U; i++) {
+    uint32_t t0;
+
+    stop_wraps = 0U;
+    pwmStart(&PWMD1, &pwmcfg_stop);
+    pwmEnablePeriodicNotification(&PWMD1);
+
+    /* Waiting for 3 wraps to prove the slice is alive. */
+    t0 = time_us();
+    while (stop_wraps < 3U) {
+      if ((uint32_t)(time_us() - t0) > 20000U) {
+        chprintf(chp, "    Cycle %u: slice did not wrap\r\n", i);
+        pwmStop(&PWMD1);
+        return false;
+      }
+    }
+
+    /* Sweeping the stop point across the 1000us period. */
+    delay_us((i * 29U) % 1000U);
+
+    pwmStop(&PWMD1);
+    stop_cb_fired = false;
+
+    /* No callback may fire on a stopped driver. */
+    delay_us(2000U);
+    if (stop_cb_fired) {
+      chprintf(chp, "    Cycle %u: callback fired after pwmStop()\r\n", i);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*
+ * Test: the cross-check slice kept via the shared vector must still
+ * be counting after all the start/stop cycles on the other slice.
+ */
+static bool test_cross_slice_alive(uint32_t before) {
+  uint32_t mark;
+
+  chprintf(chp, "    Cross slice wraps: %u before, %u after stop test\r\n",
+           before, cross_wraps);
+
+  if (cross_wraps <= (before + 1000U)) {
+    return false;
+  }
+
+  /* Still counting right now. */
+  mark = cross_wraps;
+  delay_us(20000U);
+
+  return cross_wraps >= (mark + 10U);
+}
+
+/*===========================================================================*/
+/* Blinker thread.                                                           */
+/*===========================================================================*/
+
+static THD_WORKING_AREA(waThread1, 256);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (true) {
+    palToggleLine(LED_PIN);
+    chThdSleepMilliseconds(500);
+  }
+}
+
+/*===========================================================================*/
+/* Main.                                                                     */
+/*===========================================================================*/
+
+int main(void) {
+  bool ok;
+  uint32_t cross_before;
+
+  halInit();
+  chSysInit();
+
+  /* LED. */
+  palSetLineMode(LED_PIN, PAL_MODE_OUTPUT_PUSHPULL | PAL_RP_PAD_DRIVE12);
+
+  /* UART on GPIO0/GPIO1. */
+  palSetLineMode(UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+  chp = (BaseSequentialStream *)&SIOD0;
+
+  /* Start blinker. */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /* Small delay to let UART settle. */
+  chThdSleepMilliseconds(100);
+
+  chprintf(chp, "\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  RP2350 PWM Validation\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  Core clock: %u Hz\r\n",
+           (unsigned)halClockGetPointX(RP_CLK_SYS));
+  chprintf(chp, "  PWM pin:    GPIO%u (slice 1 channel A)\r\n", PWM_PIN);
+  chprintf(chp, "\r\n");
+
+  /* PWM output on GPIO2, pad input buffer stays enabled so the pin
+     can be read back through SIO GPIO_IN. */
+  palSetLineMode(PWM_PIN, PAL_MODE_ALTERNATE_PWM);
+
+  /* Test 1: period accuracy. */
+  pwmStart(&PWMD1, &pwmcfg_meas);
+  ok = test_period_accuracy();
+  report("Period accuracy (1000 wraps in 1000000us)", ok);
+
+  /* Test 2: duty cycle sanity. */
+  ok = test_duty_sanity();
+  report("Duty sanity (width 500/1000 reads ~50%)", ok);
+
+  /* Test 3: change_period while running. */
+  ok = test_change_period();
+  report("pwmChangePeriod (1000 wraps in 500000us)", ok);
+
+  pwmStop(&PWMD1);
+
+  /* Test 4: stop safety with a second slice as cross-check. */
+  chprintf(chp, "\r\n  500 start/stop cycles...\r\n");
+  cross_wraps = 0U;
+  pwmStart(&PWMD2, &pwmcfg_cross);
+  pwmEnablePeriodicNotification(&PWMD2);
+  cross_before = cross_wraps;
+
+  ok = test_stop_safety();
+  report("No callback after pwmStop (500 cycles)", ok);
+
+  /* Test 5: second slice unaffected by the other slice stopping. */
+  ok = test_cross_slice_alive(cross_before);
+  report("Other slice callbacks survive pwmStop", ok);
+
+  pwmStop(&PWMD2);
+
+  chprintf(chp, "\r\n========================================\r\n");
+  chprintf(chp, "  Results: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "  ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "  *** FAILURES DETECTED ***\r\n");
+  }
+  chprintf(chp, "========================================\r\n");
+
+  while (true) {
+    chThdSleepMilliseconds(1000);
+  }
+
+  return 0;
+}

--- a/testhal/RP/RP2350/PWM-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PWM-VALIDATION/main.c
@@ -283,13 +283,27 @@ static bool test_stop_safety(void) {
     /* Sweeping the stop point across the 1000us period. */
     delay_us((i * 29U) % 1000U);
 
-    pwmStop(&PWMD1);
+    /* Keeping the wrap boundary away from the clear-to-stop window: a
+       wrap landing between the flag clear and the stop's lock would
+       deliver a legitimate pre-stop callback and read as a false
+       failure. The sweep above still exercises every stop phase
+       outside this guard band. */
+    t0 = time_us();
+    while (PWMD1.pwm->CH[PWMD1.timer_id].CTR > (PWM_PERIOD - 50U)) {
+      if ((uint32_t)(time_us() - t0) > 5000U) {
+        break;
+      }
+    }
     stop_cb_fired = false;
 
-    /* No callback may fire on a stopped driver. */
+    pwmStop(&PWMD1);
+
+    /* The flag was cleared before the stop and the wrap boundary is at
+       least 50us away, so any callback recorded from here on is a
+       stale post-stop delivery. */
     delay_us(2000U);
     if (stop_cb_fired) {
-      chprintf(chp, "    Cycle %u: callback fired after pwmStop()\r\n", i);
+      chprintf(chp, "    Cycle %u: callback fired during or after pwmStop()\r\n", i);
       return false;
     }
   }


### PR DESCRIPTION
## Summary

PWM driver fixes on the RP2 port (review items 11 and 19):

- **Period off-by-one — deliberate behavior change**: the RP PWM counter wraps *after* TOP, so a wrap period of N counts requires `TOP = N - 1`; the driver programmed `TOP = period`, making every PWM cycle one tick longer than configured (a 1000-tick period ran 1001 ticks). `pwm_lld_start()` and `pwm_lld_change_period()` now program `period - 1`, matching the STM32 ARR convention used across ChibiOS. **Existing applications that compensated for the extra tick will see periods shrink by one count** — this is the correction of a defect, but it is user-visible and worth a changelog entry on merge. A macro guard keeps `period = 0` from underflowing (clamped to a 1-count period).
- **Stop-path interrupt hygiene**: `pwm_lld_stop()` left the slice's `IRQ0_INTE` bit enabled and its `INTR` flag pending, so a stopped slice could still raise the shared PWM vector and the ISR dereferenced the stopped driver's `config` (NULL). Stop now clears the slice's interrupt-enable bit and acknowledges the pending flag, and the ISR guards against stopped drivers.
- **Interrupt-enable atomicity**: `IRQ0_INTE` is shared by all slices; read-modify-write updates from both cores (or from thread vs ISR context) could lose bits. Updates now go through the `SET`/`CLR` atomic register aliases.
- **Clock divider correctness**: the 8.4 fixed-point divider is computed in 64-bit arithmetic, clamped to a minimum of 1.0 and (in release builds too) to the 0xFFF maximum instead of silently wrapping to a wrong frequency.

## Validation

On a Pico 2 (`testhal/RP/RP2350/PWM-VALIDATION`, no wiring required — pad input-enable plus `GPIO_IN` sampling):

- 1 MHz clock, period 1000: 1000 wraps measured at ≈1,000,000 µs via `TIMERAWL` within ±0.05% — the unfixed driver measures 1,001,000 µs, so the test genuinely discriminates.
- Duty ≈50% verified by input sampling; a second slice keeps running while the first is stopped.
- 1000× start/stop-after-wrap cycles: no fault, no post-stop callback.
- 5/5 tests pass; RP2040 and RP2350 build matrix clean.
- Reviewed by CodeRabbit (change-period underflow guard, fixed) and Codex (atomic INTE aliases and release divider clamp, fixed) — both rounds re-validated on hardware.
