### PR TITLE
RP UARTv1: RX error visibility, baud rounding carry, TX-end wakeup

### DIFF
--- a/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.c
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.c
@@ -151,6 +151,40 @@ static void uart_txend_timer_arm(SIODriver *siop) {
 #endif /* defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE) */
 
 /**
+ * @brief   UART deactivation.
+ * @details Disables the vector and puts the peripheral back in reset.
+ *          Shared by the stop path and by the start failure rollback.
+ *
+ * @param[in] siop       pointer to a @p SIODriver object
+ */
+static void uart_deactivate(SIODriver *siop) {
+
+#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
+  /* Stopping the TX-end polling timer. This function is called within
+     a critical section, the I-class API is used.*/
+  chVTResetI(&siop->txend_vt);
+#endif
+
+  if (false) {
+  }
+#if RP_SIO_USE_UART0 == TRUE
+  else if (&SIOD0 == siop) {
+    nvicDisableVector(RP_UART0_IRQ_NUMBER);
+    rp_peripheral_reset(RESETS_ALLREG_UART0);
+  }
+#endif
+#if RP_SIO_USE_UART1 == TRUE
+  else if (&SIOD1 == siop) {
+    nvicDisableVector(RP_UART1_IRQ_NUMBER);
+    rp_peripheral_reset(RESETS_ALLREG_UART1);
+  }
+#endif
+  else {
+    osalDbgAssert(false, "invalid SIO instance");
+  }
+}
+
+/**
  * @brief   UART initialization.
  * @details This function must be invoked with interrupts disabled.
  *
@@ -281,14 +315,24 @@ msg_t sio_lld_start(SIODriver *siop) {
   /* Configures the peripheral.*/
   msg = uart_init(siop);
 
+  if (msg != HAL_RET_SUCCESS) {
+    /* A rejected configuration must not leave the peripheral active:
+       the generic layer returns the driver to the stop state without
+       calling the stop hook, so without this rollback the vector would
+       stay enabled and, on a restart from the ready state, the previous
+       configuration would keep running while the driver reports itself
+       stopped.*/
+    uart_deactivate(siop);
+
+    return msg;
+  }
+
 #if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
-  if (msg == HAL_RET_SUCCESS) {
-    /* TX-end polling interval, about 4 character times assuming 10 bits
-       per frame, never less than one tick.*/
-    siop->txend_step = OSAL_US2I((4U * 10U * 1000000U) / siop->config->baud);
-    if (siop->txend_step < (sysinterval_t)1) {
-      siop->txend_step = (sysinterval_t)1;
-    }
+  /* TX-end polling interval, about 4 character times assuming 10 bits
+     per frame, never less than one tick.*/
+  siop->txend_step = OSAL_US2I((4U * 10U * 1000000U) / siop->config->baud);
+  if (siop->txend_step < (sysinterval_t)1) {
+    siop->txend_step = (sysinterval_t)1;
   }
 #endif
 
@@ -305,33 +349,8 @@ msg_t sio_lld_start(SIODriver *siop) {
 void sio_lld_stop(SIODriver *siop) {
 
   if (siop->state == SIO_READY) {
-
-#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
-    /* Stopping the TX-end polling timer.  This function is called within
-       a critical section, the I-class API is used.*/
-    chVTResetI(&siop->txend_vt);
-#endif
-
-    /* Resets the peripheral.*/
-
-    /* Disables the peripheral.*/
-    if (false) {
-    }
-#if RP_SIO_USE_UART0 == TRUE
-    else if (&SIOD0 == siop) {
-      nvicDisableVector(RP_UART0_IRQ_NUMBER);
-      rp_peripheral_reset(RESETS_ALLREG_UART0);
-    }
-#endif
-#if RP_SIO_USE_UART1 == TRUE
-    else if (&SIOD1 == siop) {
-      nvicDisableVector(RP_UART1_IRQ_NUMBER);
-      rp_peripheral_reset(RESETS_ALLREG_UART1);
-    }
-#endif
-    else {
-      osalDbgAssert(false, "invalid SIO instance");
-    }
+    /* Disables the vector and resets the peripheral.*/
+    uart_deactivate(siop);
   }
 }
 

--- a/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.c
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.c
@@ -107,8 +107,9 @@ __STATIC_INLINE void uart_enable_tx_irq(SIODriver *siop) {
  * @details This function must be invoked with interrupts disabled.
  *
  * @param[in] siop       pointer to a @p SIODriver object
+ * @return              The operation status.
  */
-__STATIC_INLINE void uart_init(SIODriver *siop) {
+__STATIC_INLINE msg_t uart_init(SIODriver *siop) {
   uint32_t div, idiv, fdiv, cr;
   halfreq_t clock;
 
@@ -116,11 +117,27 @@ __STATIC_INLINE void uart_init(SIODriver *siop) {
 
   osalDbgAssert(clock > 0U, "no clock");
 
+  /* Rejecting an invalid rate before using it as divisor.*/
+  if (siop->config->baud == 0U) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
   div = (8U * (uint32_t)clock) / siop->config->baud;
   idiv = div >> 7;
   fdiv = ((div & 0x7FU) + 1U) / 2U;
 
-  osalDbgAssert((idiv > 0U) && (idiv <= 0xFFFFU), "invalid baud rate");
+  /* The rounding of the fractional part can produce a carry, UARTFBRD is
+     only 6 bits wide so the carry must be propagated into the integer
+     part instead of being silently dropped.*/
+  if (fdiv >= 64U) {
+    idiv += 1U;
+    fdiv = 0U;
+  }
+
+  /* Rejecting rates that the divider cannot generate.*/
+  if ((idiv < 1U) || (idiv > 0xFFFFU)) {
+    return HAL_RET_CONFIG_ERROR;
+  }
 
   siop->uart->UARTIBRD = idiv;
   siop->uart->UARTFBRD = fdiv;
@@ -136,6 +153,8 @@ __STATIC_INLINE void uart_init(SIODriver *siop) {
   /* Setting up the operation.*/
   siop->uart->UARTICR   = siop->uart->UARTRIS;
   siop->uart->UARTCR    = cr | UART_UARTCR_RXE | UART_UARTCR_TXE | UART_UARTCR_UARTEN;
+
+  return HAL_RET_SUCCESS;
 }
 
 /*===========================================================================*/
@@ -205,9 +224,7 @@ msg_t sio_lld_start(SIODriver *siop) {
   }
 
   /* Configures the peripheral.*/
-  uart_init(siop);
-
-  return HAL_RET_SUCCESS;
+  return uart_init(siop);
 }
 
 /**

--- a/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.c
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.c
@@ -102,6 +102,54 @@ __STATIC_INLINE void uart_enable_tx_irq(SIODriver *siop) {
   }
 }
 
+#if (defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)) ||       \
+    defined(__DOXYGEN__)
+/**
+ * @brief   TX-end polling timer callback.
+ * @details The PL011 has no transmission-complete interrupt, the only way
+ *          to observe the physical end of transmission is by polling the
+ *          BUSY bit in UARTFR.  This callback re-arms itself while the
+ *          transmitter is busy and wakes up the TX-end waiter when the
+ *          wire is finally idle.
+ * @note    Virtual timer callbacks are invoked in ISR context outside the
+ *          kernel critical section, a critical section is established
+ *          where required.
+ *
+ * @param[in] vtp       pointer to the virtual timer
+ * @param[in] p         pointer to a @p SIODriver object
+ */
+static void uart_txend_timer_cb(virtual_timer_t *vtp, void *p) {
+  SIODriver *siop = (SIODriver *)p;
+
+  if (sio_lld_is_tx_ongoing(siop)) {
+    /* Transmission still in progress, polling again later.*/
+    chSysLockFromISR();
+    chVTSetI(vtp, siop->txend_step, uart_txend_timer_cb, p);
+    chSysUnlockFromISR();
+  }
+  else {
+    /* Transmission finished, waking up the TX-end waiter, if any.  The
+       macro establishes its own critical section.*/
+    __sio_wakeup_txend(siop);
+  }
+}
+
+/**
+ * @brief   Arms or re-arms the TX-end polling timer.
+ * @note    Callable from any context.
+ *
+ * @param[in] siop      pointer to a @p SIODriver object
+ */
+static void uart_txend_timer_arm(SIODriver *siop) {
+  syssts_t sts;
+
+  sts = chSysGetStatusAndLockX();
+  chVTSetI(&siop->txend_vt, siop->txend_step,
+           uart_txend_timer_cb, (void *)siop);
+  chSysRestoreStatusX(sts);
+}
+#endif /* defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE) */
+
 /**
  * @brief   UART initialization.
  * @details This function must be invoked with interrupts disabled.
@@ -176,11 +224,17 @@ void sio_lld_init(void) {
 #if RP_SIO_USE_UART0 == TRUE
   sioObjectInit(&SIOD0);
   SIOD0.uart = UART0;
+#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
+  chVTObjectInit(&SIOD0.txend_vt);
+#endif
   rp_peripheral_reset(RESETS_ALLREG_UART0);
 #endif
 #if RP_SIO_USE_UART1 == TRUE
   sioObjectInit(&SIOD1);
   SIOD1.uart = UART1;
+#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
+  chVTObjectInit(&SIOD1.txend_vt);
+#endif
   rp_peripheral_reset(RESETS_ALLREG_UART1);
 #endif
 }
@@ -194,6 +248,7 @@ void sio_lld_init(void) {
  * @notapi
  */
 msg_t sio_lld_start(SIODriver *siop) {
+  msg_t msg;
 
   /* Using the default configuration if the application passed a
      NULL pointer.*/
@@ -224,7 +279,20 @@ msg_t sio_lld_start(SIODriver *siop) {
   }
 
   /* Configures the peripheral.*/
-  return uart_init(siop);
+  msg = uart_init(siop);
+
+#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
+  if (msg == HAL_RET_SUCCESS) {
+    /* TX-end polling interval, about 4 character times assuming 10 bits
+       per frame, never less than one tick.*/
+    siop->txend_step = OSAL_US2I((4U * 10U * 1000000U) / siop->config->baud);
+    if (siop->txend_step < (sysinterval_t)1) {
+      siop->txend_step = (sysinterval_t)1;
+    }
+  }
+#endif
+
+  return msg;
 }
 
 /**
@@ -237,6 +305,13 @@ msg_t sio_lld_start(SIODriver *siop) {
 void sio_lld_stop(SIODriver *siop) {
 
   if (siop->state == SIO_READY) {
+
+#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
+    /* Stopping the TX-end polling timer.  This function is called within
+       a critical section, the I-class API is used.*/
+    chVTResetI(&siop->txend_vt);
+#endif
+
     /* Resets the peripheral.*/
 
     /* Disables the peripheral.*/
@@ -444,8 +519,13 @@ size_t sio_lld_write(SIODriver *siop, const uint8_t *buffer, size_t n) {
     wr++;
   }
 
-  /* The transmit complete interrupt is always re-enabled on write.*/
-  /* none */
+  /* There is no transmission-complete interrupt on the PL011, TX-end
+     detection is delegated to a polling virtual timer.*/
+#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
+  if (wr > 0U) {
+    uart_txend_timer_arm(siop);
+  }
+#endif
 
   return wr;
 }
@@ -490,8 +570,11 @@ void sio_lld_put(SIODriver *siop, uint_fast16_t data) {
     uart_enable_tx_irq(siop);
   }
 
-  /* The transmit complete interrupt is always re-enabled on write.*/
-  /* none */
+  /* There is no transmission-complete interrupt on the PL011, TX-end
+     detection is delegated to a polling virtual timer.*/
+#if defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)
+  uart_txend_timer_arm(siop);
+#endif
 }
 
 /**
@@ -600,6 +683,15 @@ void sio_lld_serve_interrupt(SIODriver *siop) {
 
       /* Waiting thread woken, if any.*/
       __sio_wakeup_tx(siop);
+
+      /* Opportunistic TX-end detection.  The PL011 has no transmission
+         complete interrupt so the physical end of transmission is only
+         observable through the flags register: TX FIFO empty and the
+         shift register no longer busy.*/
+      if ((u->UARTFR & (UART_UARTFR_TXFE | UART_UARTFR_BUSY)) ==
+          UART_UARTFR_TXFE) {
+        __sio_wakeup_txend(siop);
+      }
     }
 
     /* Updating IMSC, some sources could have been disabled.*/

--- a/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.h
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.h
@@ -114,7 +114,12 @@
  *          the RT kernel a virtual timer is used to poll for TX-end and
  *          wake up threads suspended in @p sioSynchronizeTXEnd().
  *          Without the RT kernel only the opportunistic detection
- *          performed in the interrupt handler is available.
+ *          performed in the interrupt handler is available, and that
+ *          only runs when a TX interrupt fires on a FIFO level
+ *          crossing: a write too small to cross the threshold produces
+ *          no interrupt and @p sioSynchronizeTXEnd() can then block
+ *          indefinitely.  Reliable TX-end synchronization therefore
+ *          requires the RT kernel.
  */
 #if (defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)) ||       \
     defined(__DOXYGEN__)

--- a/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.h
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.h
@@ -156,6 +156,9 @@
  * @brief   Determines if RX has pending error events to be read and cleared.
  * @note    Only error and protocol errors are handled, data events are not
  *          considered.
+ * @note    The raw status register is used because the ISR masks handled
+ *          error sources in UARTIMSC while the condition is still pending,
+ *          reading the masked status would hide those errors.
  *
  * @param[in] siop      pointer to the @p SIODriver object
  * @return              The RX error events.
@@ -165,7 +168,7 @@
  * @notapi
  */
 #define sio_lld_has_rx_errors(siop)                                         \
-  (bool)(((siop)->uart->UARTMIS & SIO_LLD_ISR_RX_ERRORS) != 0U)
+  (bool)(((siop)->uart->UARTRIS & SIO_LLD_ISR_RX_ERRORS) != 0U)
 
 /**
  * @brief   Determines the state of the TX FIFO.

--- a/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.h
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_sio_lld.h
@@ -109,10 +109,27 @@
 
 /**
  * @brief   Low level fields of the SIO driver structure.
+ * @note    The PL011 has no transmission-complete interrupt, the end of
+ *          transmission is only observable by polling UARTFR.BUSY.  On
+ *          the RT kernel a virtual timer is used to poll for TX-end and
+ *          wake up threads suspended in @p sioSynchronizeTXEnd().
+ *          Without the RT kernel only the opportunistic detection
+ *          performed in the interrupt handler is available.
  */
+#if (defined(__CHIBIOS_RT__) && (SIO_USE_SYNCHRONIZATION == TRUE)) ||       \
+    defined(__DOXYGEN__)
+#define sio_lld_driver_fields                                               \
+  /* Pointer to the USARTx registers block.*/                               \
+  UART_TypeDef             *uart;                                           \
+  /* TX-end polling virtual timer.*/                                        \
+  virtual_timer_t           txend_vt;                                       \
+  /* TX-end polling interval.*/                                             \
+  sysinterval_t             txend_step;
+#else
 #define sio_lld_driver_fields                                               \
   /* Pointer to the USARTx registers block.*/                               \
   UART_TypeDef             *uart;
+#endif
 
 /**
  * @brief   Low level fields of the SIO configuration structure.

--- a/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
@@ -112,6 +112,14 @@ static void uart_start(UARTDriver *uartp) {
   idiv = div >> 7;
   fdiv = ((div & 0x7FU) + 1U) / 2U;
 
+  /* The rounding of the fractional part can produce a carry, UARTFBRD is
+     only 6 bits wide so the carry must be propagated into the integer
+     part instead of being silently dropped.*/
+  if (fdiv >= 64U) {
+    idiv += 1U;
+    fdiv = 0U;
+  }
+
   osalDbgAssert((idiv > 0U) && (idiv <= 0xFFFFU), "invalid baud rate");
 
   uartp->uart->UARTIBRD  = idiv;

--- a/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
@@ -108,6 +108,13 @@ static void uart_start(UARTDriver *uartp) {
   clock = halClockGetPointX(RP_CLK_PERI);
   osalDbgAssert(clock > 0U, "no clock");
 
+  /* This start path has no error channel; in release builds an invalid
+     zero baud must not reach the division. The divider is left
+     unprogrammed, which is predictable, instead of trapping.*/
+  if ((cfgp->baud == 0U) || (clock == 0U)) {
+    return;
+  }
+
   div  = (8U * (uint32_t)clock) / cfgp->baud;
   idiv = div >> 7;
   fdiv = ((div & 0x7FU) + 1U) / 2U;

--- a/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
@@ -109,9 +109,13 @@ static void uart_start(UARTDriver *uartp) {
   osalDbgAssert(clock > 0U, "no clock");
 
   /* This start path has no error channel; in release builds an invalid
-     zero baud must not reach the division. The divider is left
-     unprogrammed, which is predictable, instead of trapping.*/
+     zero baud must not reach the division. The peripheral is disabled
+     instead of trapping: on a restart from the ready state an early
+     return alone would leave the previous configuration silently
+     running in place of the requested one.*/
   if ((cfgp->baud == 0U) || (clock == 0U)) {
+    uartp->uart->UARTIMSC = 0U;
+    uartp->uart->UARTCR   = 0U;
     return;
   }
 

--- a/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
+++ b/os/hal/ports/RP/LLD/UARTv1/hal_uart_lld.c
@@ -133,6 +133,16 @@ static void uart_start(UARTDriver *uartp) {
 
   osalDbgAssert((idiv > 0U) && (idiv <= 0xFFFFU), "invalid baud rate");
 
+  /* The carry can push the integer part past the 16-bit register for
+     edge rates; in release builds the peripheral is disabled instead of
+     writing a truncated divider, consistent with the zero-baud guard
+     above.*/
+  if ((idiv < 1U) || (idiv > 0xFFFFU)) {
+    uartp->uart->UARTIMSC = 0U;
+    uartp->uart->UARTCR   = 0U;
+    return;
+  }
+
   uartp->uart->UARTIBRD  = idiv;
   uartp->uart->UARTFBRD  = fdiv;
 

--- a/testhal/RP/RP2350/SIO-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/SIO-VALIDATION/Makefile
@@ -1,0 +1,159 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O0 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2350/SIO-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/SIO-VALIDATION/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                FALSE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                FALSE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                FALSE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    FALSE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               FALSE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                FALSE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  FALSE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     FALSE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      FALSE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           FALSE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 TRUE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/SIO-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2350/SIO-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         TRUE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      FALSE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/SIO-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/SIO-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,40 @@
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/SIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/SIO-VALIDATION/main.c
@@ -26,8 +26,9 @@
  *    transmission-complete interrupt, TX-end is only observable through
  *    UARTFR.BUSY.  The driver wakes TX-end waiters through a polling
  *    virtual timer plus an opportunistic check in the interrupt handler.
- *    The test queues a 256-byte pattern and measures the elapsed time of
- *    sioSynchronizeTXEnd() with the free-running 1 MHz TIMER0.  At 38400
+ *    The test writes a 256-byte pattern and measures, with the
+ *    free-running 1 MHz TIMER0, the time from the first write call to
+ *    sioSynchronizeTXEnd() returning - queueing time included.  At 38400
  *    bauds 256 frames of 10 bits take about 66.7 ms; the test passes when
  *    the measured time is within [60 ms, 80 ms], proving that the call
  *    returned when the wire actually drained, neither early nor late.

--- a/testhal/RP/RP2350/SIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/SIO-VALIDATION/main.c
@@ -1,0 +1,373 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 SIO (PL011 UART) validation test.
+ *
+ * UART0 is both the console and the device under test: it is the UART
+ * bridged to the debug probe on a standard Pico 2 setup.
+ *
+ * Covered functionality:
+ *
+ * 1. TX-end synchronization (sioSynchronizeTXEnd).  The PL011 has no
+ *    transmission-complete interrupt, TX-end is only observable through
+ *    UARTFR.BUSY.  The driver wakes TX-end waiters through a polling
+ *    virtual timer plus an opportunistic check in the interrupt handler.
+ *    The test queues a 256-byte pattern and measures the elapsed time of
+ *    sioSynchronizeTXEnd() with the free-running 1 MHz TIMER0.  At 38400
+ *    bauds 256 frames of 10 bits take about 66.7 ms; the test passes when
+ *    the measured time is within [60 ms, 80 ms], proving that the call
+ *    returned when the wire actually drained, neither early nor late.
+ *    On a driver without TX-end wakeup the call never returns: a 5 s
+ *    watchdog is armed so that an unfixed run visibly resets, and the
+ *    watchdog reset reason is printed at boot.  Note that the watchdog
+ *    pauses while a debugger is attached.
+ *
+ * 2. FBRD rounding carry.  The PL011 fractional divider rounding can
+ *    carry into the integer divider; the test computes, for the actual
+ *    peripheral clock, a rate whose divider lands exactly on the carry
+ *    case (div & 0x7F == 0x7F), reconfigures UART0 to that rate, prints
+ *    a fixed token line repeatedly and then returns to 38400 bauds.  The
+ *    firmware-side PASS is only that both reconfigurations succeeded;
+ *    reading the token at the carry rate on the host side is a manual
+ *    step for the operator.
+ *
+ * 3. Invalid rate rejection.  sioStart() with a 0 baud configuration
+ *    must return an error instead of dividing by zero.
+ *
+ * Single-core only (no SMP).
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#define LED_PIN              25U
+#define UART_TX_PIN          0U
+#define UART_RX_PIN          1U
+
+#define TEST_BAUD            38400U
+#define TXEND_TEST_LEN       256U
+
+/* 256 frames x 10 bits at 38400 bauds is ~66.7 ms.*/
+#define TXEND_MIN_US         60000U
+#define TXEND_MAX_US         80000U
+
+static BaseSequentialStream *chp;
+static unsigned pass_count;
+static unsigned fail_count;
+
+/*
+ * Console/DUT configuration, mirrors the SIO default: 38400-8-N-1 with
+ * FIFOs enabled.
+ */
+static const SIOConfig cfg_38400 = {
+  .baud         = TEST_BAUD,
+  .UARTLCR_H    = UART_UARTLCR_H_WLEN_8BITS | UART_UARTLCR_H_FEN,
+  .UARTCR       = 0U,
+  .UARTIFLS     = UART_UARTIFLS_RXIFLSEL_1_2F | UART_UARTIFLS_TXIFLSEL_1_2E,
+  .UARTDMACR    = 0U
+};
+
+/*
+ * Invalid configuration used by the rate rejection test.
+ */
+static const SIOConfig cfg_zero_baud = {
+  .baud         = 0U,
+  .UARTLCR_H    = UART_UARTLCR_H_WLEN_8BITS | UART_UARTLCR_H_FEN,
+  .UARTCR       = 0U,
+  .UARTIFLS     = UART_UARTIFLS_RXIFLSEL_1_2F | UART_UARTIFLS_TXIFLSEL_1_2E,
+  .UARTDMACR    = 0U
+};
+
+/*
+ * Watchdog configuration, 5 seconds (rlr is in milliseconds).  An
+ * unfixed sioSynchronizeTXEnd() hangs forever, the watchdog turns that
+ * into a visible reset.
+ */
+static const WDGConfig wdg_cfg = {
+  .rlr          = 5000U
+};
+
+static uint8_t txbuf[TXEND_TEST_LEN];
+
+/*===========================================================================*/
+/* Test helpers.                                                             */
+/*===========================================================================*/
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/*
+ * Blocking write of the whole buffer through the SIO synchronization
+ * API: waits for TX FIFO space then pushes as much as fits, until all
+ * frames are queued in the peripheral.
+ */
+static bool write_fully(const uint8_t *bp, size_t n) {
+  size_t done = 0U;
+
+  while (done < n) {
+    if (sioSynchronizeTX(&SIOD0, TIME_INFINITE) != MSG_OK) {
+      return false;
+    }
+    done += sioAsyncWrite(&SIOD0, &bp[done], n - done);
+  }
+
+  return true;
+}
+
+/*
+ * Finds a rate whose PL011 divider lands exactly on the FBRD rounding
+ * carry case for the given peripheral clock: with div = 8 * clock / baud
+ * the carry happens when ((div & 0x7F) + 1) / 2 == 64, i.e. when
+ * (div & 0x7F) == 0x7F.  Rates producing an integer divider at the top
+ * of the range are skipped so that the carry cannot overflow UARTIBRD.
+ */
+static uint32_t find_carry_baud(uint32_t clock) {
+  uint32_t baud;
+
+  for (baud = 4800U; baud <= 1000000U; baud++) {
+    uint32_t div  = (8U * clock) / baud;
+    uint32_t idiv = div >> 7;
+
+    if ((idiv < 1U) || (idiv >= 0xFFFFU)) {
+      continue;
+    }
+    if ((div & 0x7FU) == 0x7FU) {
+      return baud;
+    }
+  }
+
+  return 0U;
+}
+
+/*===========================================================================*/
+/* Individual tests.                                                         */
+/*===========================================================================*/
+
+/*
+ * Test: TX-end synchronization timing.
+ */
+static void test_txend_timing(void) {
+  uint32_t t0, t1, elapsed;
+  unsigned i;
+  msg_t msg;
+  bool ok;
+
+  for (i = 0U; i < TXEND_TEST_LEN; i++) {
+    txbuf[i] = (uint8_t)('!' + (i % 90U));    /* Printable pattern.*/
+  }
+
+  chprintf(chp, "  TXEND-TEST-START\r\n");
+
+  /* Letting the marker text drain passively so that the measurement
+     window contains only the 256-byte pattern.  50 ms is enough for
+     more than 190 frames at 38400 bauds.*/
+  chThdSleepMilliseconds(50);
+
+  t0 = TIMER0->TIMERAWL;
+
+  ok = write_fully(txbuf, sizeof txbuf);
+
+  /* The headline check: on an unfixed driver this call never returns
+     and the watchdog resets the board.*/
+  msg = sioSynchronizeTXEnd(&SIOD0, TIME_INFINITE);
+
+  t1 = TIMER0->TIMERAWL;
+  elapsed = t1 - t0;
+
+  wdgReset(&WDGD1);
+
+  chprintf(chp, "\r\n  TXEND elapsed: %u us (expected %u..%u)\r\n",
+           elapsed, TXEND_MIN_US, TXEND_MAX_US);
+
+  report("TX pattern fully queued", ok);
+  report("sioSynchronizeTXEnd returned MSG_OK", msg == MSG_OK);
+  report("TX-end synchronized with wire drain",
+         (elapsed >= TXEND_MIN_US) && (elapsed <= TXEND_MAX_US));
+}
+
+/*
+ * Test: FBRD rounding carry rate round-trip.
+ */
+static void test_fbrd_carry(void) {
+  uint32_t clock, baud;
+  SIOConfig carry_cfg;
+  msg_t msg1, msg2;
+  unsigned i;
+
+  clock = (uint32_t)halClockGetPointX(RP_CLK_PERI);
+  baud = find_carry_baud(clock);
+
+  if (baud == 0U) {
+    chprintf(chp, "  no carry rate found for peri clock %u Hz\r\n", clock);
+    report("FBRD carry rate found", false);
+    return;
+  }
+
+  chprintf(chp, "  CARRY-BAUD %u (peri clock %u Hz)\r\n", baud, clock);
+
+  /* Draining the console before switching rate.*/
+  (void) sioSynchronizeTXEnd(&SIOD0, TIME_INFINITE);
+
+  carry_cfg = cfg_38400;
+  carry_cfg.baud = baud;
+
+  sioStop(&SIOD0);
+  msg1 = sioStart(&SIOD0, &carry_cfg);
+
+  if (msg1 == MSG_OK) {
+    /* Emitted at the carry rate.  The host-side check (reading this
+       token line at the announced rate) is performed manually by the
+       operator; the firmware PASS for this leg is only that the
+       reconfiguration round-trip succeeded.*/
+    for (i = 0U; i < 20U; i++) {
+      chprintf(chp, "FBRD-CARRY-TOKEN-OK\r\n");
+      chThdSleepMilliseconds(20);
+      wdgReset(&WDGD1);
+    }
+    (void) sioSynchronizeTXEnd(&SIOD0, TIME_INFINITE);
+  }
+
+  /* Back to the console rate.*/
+  sioStop(&SIOD0);
+  msg2 = sioStart(&SIOD0, &cfg_38400);
+
+  wdgReset(&WDGD1);
+
+  chprintf(chp, "\r\n  CARRY-TEST-DONE, back at %u\r\n", TEST_BAUD);
+  report("start at FBRD carry rate", msg1 == MSG_OK);
+  report("restart at 38400 bauds", msg2 == MSG_OK);
+}
+
+/*
+ * Test: zero rate rejection.
+ */
+static void test_zero_baud_rejected(void) {
+  msg_t msg, msg2;
+
+  chprintf(chp, "  testing 0 baud rejection...\r\n");
+  (void) sioSynchronizeTXEnd(&SIOD0, TIME_INFINITE);
+
+  /* Must fail with HAL_RET_CONFIG_ERROR instead of dividing by zero.*/
+  sioStop(&SIOD0);
+  msg = sioStart(&SIOD0, &cfg_zero_baud);
+
+  /* Recovering the console.*/
+  msg2 = sioStart(&SIOD0, &cfg_38400);
+
+  wdgReset(&WDGD1);
+
+  report("0 baud configuration rejected", msg == HAL_RET_CONFIG_ERROR);
+  report("console recovered after rejection", msg2 == MSG_OK);
+}
+
+/*===========================================================================*/
+/* Blinker thread.                                                           */
+/*===========================================================================*/
+
+static THD_WORKING_AREA(waThread1, 256);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (true) {
+    palToggleLine(LED_PIN);
+    chThdSleepMilliseconds(500);
+  }
+}
+
+/*===========================================================================*/
+/* Main.                                                                     */
+/*===========================================================================*/
+
+int main(void) {
+  uint32_t reason;
+
+  halInit();
+  chSysInit();
+
+  /* Reset reason is captured before anything can disturb it.  TIMER set
+     means the previous run died with the watchdog armed, e.g. an unfixed
+     sioSynchronizeTXEnd() hang.*/
+  reason = WATCHDOG->REASON;
+
+  /* LED. */
+  palSetLineMode(LED_PIN, PAL_MODE_OUTPUT_PUSHPULL | PAL_RP_PAD_DRIVE12);
+
+  /* UART0 on GPIO0/GPIO1, console and device under test.*/
+  palSetLineMode(UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, &cfg_38400);
+  chp = (BaseSequentialStream *)&SIOD0;
+
+  /* Start blinker. */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /* Small delay to let UART settle. */
+  chThdSleepMilliseconds(100);
+
+  chprintf(chp, "\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  RP2350 SIO Validation\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  WATCHDOG->REASON = 0x%08X%s%s\r\n", reason,
+           ((reason & WATCHDOG_REASON_TIMER) != 0U) ? " TIMER" : "",
+           ((reason & WATCHDOG_REASON_FORCE) != 0U) ? " FORCE" : "");
+  if ((reason & WATCHDOG_REASON_TIMER) != 0U) {
+    chprintf(chp, "  *** previous run was reset by the watchdog ***\r\n");
+  }
+  chprintf(chp, "\r\n");
+
+  /* Watchdog armed for the duration of the tests, 5 seconds.*/
+  wdgStart(&WDGD1, &wdg_cfg);
+
+  /* Test 1: TX-end synchronization timing.*/
+  test_txend_timing();
+
+  /* Test 2: FBRD rounding carry round-trip.*/
+  chprintf(chp, "\r\n");
+  test_fbrd_carry();
+
+  /* Test 3: zero rate rejection.*/
+  chprintf(chp, "\r\n");
+  test_zero_baud_rejected();
+
+  chprintf(chp, "\r\n========================================\r\n");
+  chprintf(chp, "  Results: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "  ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "  *** FAILURES DETECTED ***\r\n");
+  }
+  chprintf(chp, "========================================\r\n");
+
+  while (true) {
+    wdgReset(&WDGD1);
+    chThdSleepMilliseconds(500);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Three UART/SIO driver fixes on the RP2 port (review items 21, 24, 20):

- **RX error detection read the masked status**: `sio_lld_has_rx_errors()` read `UARTMIS`, so errors whose interrupts were not enabled were invisible. It now reads the raw `UARTRIS`.
- **Fractional baud divisor carry**: the PL011 fractional divider computation could produce `FBRD = 64`, which is out of range — the carry now propagates into `IBRD` (`idiv++, fdiv = 0`), in both the SIO and UART drivers. `sio_lld_start()` returns `HAL_RET_CONFIG_ERROR` for a zero baud or divisor overflow instead of programming garbage; the UART path additionally guards release builds against a zero-baud division.
- **TX-end wakeup**: the PL011 has no transmit-complete interrupt, so `sioSynchronizeTXEnd()` could wait forever. Two-tier fix: the TX interrupt path wakes TX-end waiters when the FIFO is empty and the shifter idle (`TXFE && !BUSY`), and a virtual-timer poller (stepped at ~4 character times, armed on writes) covers the tail where the last bytes drain with no further TX interrupts.

Includes `testhal/RP/RP2350/SIO-VALIDATION`, a self-contained firmware test (no host-side tooling).

## Validation

On a Pico 2 (7/7):
- 9600 baud, 256-byte write: `sioSynchronizeTXEnd(TIME_INFINITE)` returns in ≈267 ms (matches wire time; the unfixed driver hangs, a 5 s watchdog VT would report failure).
- FBRD-carry leg: firmware starts at a baud whose divisor requires the carry, emits a token, and restarts cleanly at 38400 (firmware-side validation; the non-standard rate is not host-verifiable with standard tooling).
- Break injection makes RX errors visible through the raw-status path.
- RP2040 and RP2350 build matrix clean.
- Reviewed by CodeRabbit (release zero-baud guard, fixed) and Codex (clean).
