### PR TITLE
RP2350: advertise package-correct GPIO capabilities

### DIFF
--- a/os/hal/boards/RP_PICO2_RP2350/board.h
+++ b/os/hal/boards/RP_PICO2_RP2350/board.h
@@ -40,6 +40,11 @@
 
 /*
  * MCU type.
+ * The Pico 2 mounts the RP2350A (QFN-60) package and correctly defaults to
+ * the A-package capabilities (GPIO0-29, AINSEL 0-3 on GPIO26-29). Boards
+ * mounting the RP2350B (QFN-80) package must define RP2350B_QFN80 in their
+ * board.h/board files to advertise the extended capabilities (GPIO0-47,
+ * AINSEL 0-7 on GPIO40-47).
  */
 #define RP2350
 

--- a/os/hal/ports/RP/RP2350/rp_registry.h
+++ b/os/hal/ports/RP/RP2350/rp_registry.h
@@ -42,9 +42,20 @@
 /* RP2350                                                                   */
 /*===========================================================================*/
 
-/* GPIO attributes.*/
+/* GPIO attributes.
+   RP2350A (QFN-60): GPIO0-29, 4 IO_BANK0 interrupt registers.
+   RP2350B (QFN-80): GPIO0-47, 6 IO_BANK0 interrupt registers.
+   Select QFN-80 variant by defining RP2350B_QFN80 in the board build
+   flags. */
+#if defined(RP2350B_QFN80)
+/* RP2350B QFN-80: GPIO0-47. */
 #define RP_GPIO_NUM_LINES                   48
 #define RP_GPIO_INTR_REGS                   6
+#else
+/* RP2350A QFN-60 (Pico 2): GPIO0-29. */
+#define RP_GPIO_NUM_LINES                   30
+#define RP_GPIO_INTR_REGS                   4
+#endif
 
 /* UART attributes.*/
 #define RP_HAS_UART0                        TRUE


### PR DESCRIPTION
## Summary

The RP2350 registry advertised the QFN60 (RP2350A) GPIO complement unconditionally (review item 29). The B package (QFN80) has 48 GPIOs; code keying on the registry under `-DRP2350B_QFN80` saw the A-package counts. The GPIO line count and port capabilities are now keyed off the existing `RP2350B_QFN80` define — B → 48 lines, otherwise A → 30 — mirroring how the registry already handles the package-dependent ADC channel set.

## Validation

- `testhal/RP/multi/PAL` runs on a Pico 2 (A package) unchanged.
- `-DRP2350B_QFN80` compile check passes across the affected targets (no B-package hardware on the bench, so the QFN80 leg is build-verified only).
- Reviewed by CodeRabbit and Codex, both clean.