### PR TITLE
RP2350: clock tree validation, E12 guard, safe tick-generator setup

### DIFF
--- a/os/hal/ports/RP/RP2040/hal_lld.h
+++ b/os/hal/ports/RP/RP2040/hal_lld.h
@@ -62,11 +62,6 @@
 #define RP_GPIO_IOCTRL_OUTOVER_Pos          8
 /** @} */
 
-/**
- * @brief   Dynamic clock supported.
- */
-#define HAL_LLD_USE_CLOCK_MANAGEMENT
-
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -205,15 +200,6 @@
 /* Driver data structures and types.                                         */
 /*===========================================================================*/
 
-#if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
-/**
- * @brief   Type of a clock configuration structure.
- */
-typedef struct {
-  uint32_t          dummy;
-} halclkcfg_t;
-#endif /* defined(HAL_LLD_USE_CLOCK_MANAGEMENT) */
-
 /*===========================================================================*/
 /* Driver macros.                                                            */
 /*===========================================================================*/
@@ -282,24 +268,6 @@ __STATIC_INLINE void rp_peripheral_unreset(uint32_t mask) {
   }
 }
 
-#if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
-/**
- * @brief   Switches to a different clock configuration
- *
- * @param[in] ccp       pointer to clock a @p halclkcfg_t structure
- * @return              The clock switch result.
- * @retval false        if the clock switch succeeded
- * @retval true         if the clock switch failed
- *
- * @notapi
- */
-__STATIC_INLINE bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
-
-  (void)ccp;
-
-  return false;
-}
-
 /**
  * @brief   Returns the frequency of a clock point in Hz.
  *
@@ -315,7 +283,6 @@ __STATIC_INLINE halfreq_t hal_lld_get_clock_point(halclkpt_t clkpt) {
 
   return rp_clock_get_hz(clkpt);
 }
-#endif /* defined(HAL_LLD_USE_CLOCK_MANAGEMENT) */
 
 #endif /* HAL_LLD_H */
 

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -133,6 +133,10 @@
 #error "RP_XOSCCLK out of valid range (1-15 MHz)"
 #endif
 
+#if (RP_XOSCCLK % 1000000U) != 0
+#error "RP_XOSCCLK must be an integer number of MHz (1us tick granularity)"
+#endif
+
 /*
  * PLL_SYS configuration checks.
  */

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -62,11 +62,6 @@
 #define RP_GPIO_IOCTRL_OUTOVER_Pos          12
 /** @} */
 
-/**
- * @brief   Dynamic clock supported.
- */
-#define HAL_LLD_USE_CLOCK_MANAGEMENT
-
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -242,6 +237,8 @@
 #define RP_REF_CLK              hal_lld_get_clock_point(RP_CLK_REF)
 #define RP_CORE_CLK             hal_lld_get_clock_point(RP_CLK_SYS)
 #define RP_PERI_CLK             hal_lld_get_clock_point(RP_CLK_PERI)
+/* Note: the HSTX clock is reported as a clock point but it is not
+   configured by this HAL.*/
 #define RP_HSTX_CLK             hal_lld_get_clock_point(RP_CLK_HSTX)
 #define RP_USB_CLK              hal_lld_get_clock_point(RP_CLK_USB)
 #define RP_ADC_CLK              hal_lld_get_clock_point(RP_CLK_ADC)
@@ -250,15 +247,6 @@
 /*===========================================================================*/
 /* Driver data structures and types.                                         */
 /*===========================================================================*/
-
-#if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
-/**
- * @brief   Type of a clock configuration structure.
- */
-typedef struct {
-  uint32_t          dummy;
-} halclkcfg_t;
-#endif /* defined(HAL_LLD_USE_CLOCK_MANAGEMENT) */
 
 /*===========================================================================*/
 /* Driver macros.                                                            */
@@ -328,24 +316,6 @@ __STATIC_INLINE void rp_peripheral_unreset(uint32_t mask) {
   }
 }
 
-#if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
-/**
- * @brief   Switches to a different clock configuration
- *
- * @param[in] ccp       pointer to clock a @p halclkcfg_t structure
- * @return              The clock switch result.
- * @retval false        if the clock switch succeeded
- * @retval true         if the clock switch failed
- *
- * @notapi
- */
-__STATIC_INLINE bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
-
-  (void)ccp;
-
-  return false;
-}
-
 /**
  * @brief   Returns the frequency of a clock point in Hz.
  *
@@ -361,7 +331,6 @@ __STATIC_INLINE halfreq_t hal_lld_get_clock_point(halclkpt_t clkpt) {
 
   return rp_clock_get_hz(clkpt);
 }
-#endif /* defined(HAL_LLD_USE_CLOCK_MANAGEMENT) */
 
 #endif /* HAL_LLD_H */
 

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -226,6 +226,14 @@
 #error "RP_PLL_USB_CLK must be 48 MHz for USB to work"
 #endif
 
+/*
+ * RP2350-E12 erratum check: reliable USB operation requires
+ * clk_sys >= 1.1 * clk_usb.
+ */
+#if ((RP_CLK_SYS_FREQ) * 10U) < ((RP_CLK_USB_FREQ) * 11U)
+#error "RP2350-E12: clk_sys must be at least 1.1 * clk_usb for reliable USB operation"
+#endif
+
 /**
  * @name    Various clock points.
  * @{

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -157,6 +157,27 @@
 #error "RP_PLL_SYS_POSTDIV1 must be >= RP_PLL_SYS_POSTDIV2"
 #endif
 
+#if (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_SYS_REFDIV"
+#endif
+
+#if (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
+#error "PLL_SYS reference frequency below 5 MHz minimum"
+#endif
+
+#if (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not an integer multiple of the PLL_SYS reference frequency"
+#endif
+
+#if ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||      \
+    ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
+#error "PLL_SYS FBDIV out of valid range (16-320)"
+#endif
+
+#if (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not divisible by RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2"
+#endif
+
 /*
  * PLL_USB configuration checks.
  */
@@ -179,6 +200,27 @@
 
 #if RP_PLL_USB_POSTDIV1 < RP_PLL_USB_POSTDIV2
 #error "RP_PLL_USB_POSTDIV1 must be >= RP_PLL_USB_POSTDIV2"
+#endif
+
+#if (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_USB_REFDIV"
+#endif
+
+#if (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
+#error "PLL_USB reference frequency below 5 MHz minimum"
+#endif
+
+#if (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not an integer multiple of the PLL_USB reference frequency"
+#endif
+
+#if ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||      \
+    ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
+#error "PLL_USB FBDIV out of valid range (16-320)"
+#endif
+
+#if (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not divisible by RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2"
 #endif
 
 #if RP_PLL_USB_CLK != 48000000

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -156,7 +156,9 @@
 #error "RP_PLL_SYS_POSTDIV1 must be >= RP_PLL_SYS_POSTDIV2"
 #endif
 
-#if (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
+#if (RP_PLL_SYS_REFDIV) < 1
+#error "RP_PLL_SYS_REFDIV must be at least 1"
+#elif (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
 #error "RP_XOSCCLK is not divisible by RP_PLL_SYS_REFDIV"
 #endif
 
@@ -201,7 +203,9 @@
 #error "RP_PLL_USB_POSTDIV1 must be >= RP_PLL_USB_POSTDIV2"
 #endif
 
-#if (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
+#if (RP_PLL_USB_REFDIV) < 1
+#error "RP_PLL_USB_REFDIV must be at least 1"
+#elif (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
 #error "RP_XOSCCLK is not divisible by RP_PLL_USB_REFDIV"
 #endif
 

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -133,96 +133,60 @@
 #endif
 
 /*
- * PLL_SYS configuration checks.
+ * PLL_SYS configuration checks. The checks form a single chain so that
+ * a derived check dividing by a parameter is never evaluated while that
+ * parameter is out of range: a stray "division by zero in #if"
+ * diagnostic would bury the intended message.
  */
 #if (RP_PLL_SYS_REFDIV < 1) || (RP_PLL_SYS_REFDIV > 63)
 #error "RP_PLL_SYS_REFDIV out of valid range (1-63)"
-#endif
-
-#if (RP_PLL_SYS_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                          \
-    (RP_PLL_SYS_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#elif (RP_PLL_SYS_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_SYS_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
 #error "RP_PLL_SYS_VCO_FREQ out of valid range (750-1600 MHz)"
-#endif
-
-#if (RP_PLL_SYS_POSTDIV1 < 1) || (RP_PLL_SYS_POSTDIV1 > 7)
+#elif (RP_PLL_SYS_POSTDIV1 < 1) || (RP_PLL_SYS_POSTDIV1 > 7)
 #error "RP_PLL_SYS_POSTDIV1 out of valid range (1-7)"
-#endif
-
-#if (RP_PLL_SYS_POSTDIV2 < 1) || (RP_PLL_SYS_POSTDIV2 > 7)
+#elif (RP_PLL_SYS_POSTDIV2 < 1) || (RP_PLL_SYS_POSTDIV2 > 7)
 #error "RP_PLL_SYS_POSTDIV2 out of valid range (1-7)"
-#endif
-
-#if RP_PLL_SYS_POSTDIV1 < RP_PLL_SYS_POSTDIV2
+#elif RP_PLL_SYS_POSTDIV1 < RP_PLL_SYS_POSTDIV2
 #error "RP_PLL_SYS_POSTDIV1 must be >= RP_PLL_SYS_POSTDIV2"
-#endif
-
-#if (RP_PLL_SYS_REFDIV) < 1
-#error "RP_PLL_SYS_REFDIV must be at least 1"
 #elif (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
 #error "RP_XOSCCLK is not divisible by RP_PLL_SYS_REFDIV"
-#endif
-
-#if (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
+#elif (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
 #error "PLL_SYS reference frequency below 5 MHz minimum"
-#endif
-
-#if (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
 #error "RP_PLL_SYS_VCO_FREQ is not an integer multiple of the PLL_SYS reference frequency"
-#endif
-
-#if ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||      \
-    ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
+#elif ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||    \
+      ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
 #error "PLL_SYS FBDIV out of valid range (16-320)"
-#endif
-
-#if (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
 #error "RP_PLL_SYS_VCO_FREQ is not divisible by RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2"
 #endif
 
 /*
- * PLL_USB configuration checks.
+ * PLL_USB configuration checks, chained for the same reason as the
+ * PLL_SYS checks above.
  */
 #if (RP_PLL_USB_REFDIV < 1) || (RP_PLL_USB_REFDIV > 63)
 #error "RP_PLL_USB_REFDIV out of valid range (1-63)"
-#endif
-
-#if (RP_PLL_USB_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                          \
-    (RP_PLL_USB_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#elif (RP_PLL_USB_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_USB_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
 #error "RP_PLL_USB_VCO_FREQ out of valid range (750-1600 MHz)"
-#endif
-
-#if (RP_PLL_USB_POSTDIV1 < 1) || (RP_PLL_USB_POSTDIV1 > 7)
+#elif (RP_PLL_USB_POSTDIV1 < 1) || (RP_PLL_USB_POSTDIV1 > 7)
 #error "RP_PLL_USB_POSTDIV1 out of valid range (1-7)"
-#endif
-
-#if (RP_PLL_USB_POSTDIV2 < 1) || (RP_PLL_USB_POSTDIV2 > 7)
+#elif (RP_PLL_USB_POSTDIV2 < 1) || (RP_PLL_USB_POSTDIV2 > 7)
 #error "RP_PLL_USB_POSTDIV2 out of valid range (1-7)"
-#endif
-
-#if RP_PLL_USB_POSTDIV1 < RP_PLL_USB_POSTDIV2
+#elif RP_PLL_USB_POSTDIV1 < RP_PLL_USB_POSTDIV2
 #error "RP_PLL_USB_POSTDIV1 must be >= RP_PLL_USB_POSTDIV2"
-#endif
-
-#if (RP_PLL_USB_REFDIV) < 1
-#error "RP_PLL_USB_REFDIV must be at least 1"
 #elif (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
 #error "RP_XOSCCLK is not divisible by RP_PLL_USB_REFDIV"
-#endif
-
-#if (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
+#elif (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
 #error "PLL_USB reference frequency below 5 MHz minimum"
-#endif
-
-#if (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
+#elif (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
 #error "RP_PLL_USB_VCO_FREQ is not an integer multiple of the PLL_USB reference frequency"
-#endif
-
-#if ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||      \
-    ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
+#elif ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||    \
+      ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
 #error "PLL_USB FBDIV out of valid range (16-320)"
-#endif
-
-#if (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
+#elif (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
 #error "RP_PLL_USB_VCO_FREQ is not divisible by RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2"
 #endif
 

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -85,6 +85,7 @@ static void rp_tick_start(uint32_t index, uint32_t cycles) {
  * @note    See RP2350 Datasheet 8.1.3.1 Clock Instances (Table 541)
  */
 void rp_clock_init(void) {
+  uint32_t cycles;
 
   /* Start early tick generator for safety module timeouts. */
   rp_peripheral_unreset(RESETS_ALLREG_TIMER0);
@@ -163,7 +164,7 @@ void rp_clock_init(void) {
 
   /* Calculate cycles for 1us tick based on clk_ref frequency, RP_XOSCCLK
      is checked at compile time to be an integer number of MHz. */
-  uint32_t cycles = RP_XOSCCLK / 1000000U;
+  cycles = RP_XOSCCLK / 1000000U;
 
   /* Start tick generators */
   for (uint32_t i = 0U; i < 6U; i++) {

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -63,6 +63,8 @@
  */
 static void rp_tick_start(uint32_t index, uint32_t cycles) {
 
+  osalDbgAssert(index <= TICKS_RISCV, "invalid tick generator index");
+
   TICKS->TICK[index].CTRL = 0U;
   while ((TICKS->TICK[index].CTRL & TICKS_CTRL_RUNNING) != 0U) {
     /* Waiting for the tick generator to stop */

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -50,6 +50,27 @@
 /* Driver local functions.                                                   */
 /*===========================================================================*/
 
+/**
+ * @brief   Safely programs and starts a tick generator.
+ * @note    The CYCLES register must not be rewritten while the generator
+ *          is running, the counter is only reloaded when it reaches zero
+ *          so a live rewrite can produce one wrong-length tick period.
+ *          Disable the generator and wait until it reports not running
+ *          before reprogramming it.
+ *
+ * @param[in] index     tick generator index (TICKS_xxx)
+ * @param[in] cycles    clk_ref cycles per tick
+ */
+static void rp_tick_start(uint32_t index, uint32_t cycles) {
+
+  TICKS->TICK[index].CTRL = 0U;
+  while ((TICKS->TICK[index].CTRL & TICKS_CTRL_RUNNING) != 0U) {
+    /* Waiting for the tick generator to stop */
+  }
+  TICKS->TICK[index].CYCLES = cycles;
+  TICKS->TICK[index].CTRL = TICKS_CTRL_ENABLE;
+}
+
 /*===========================================================================*/
 /* Driver exported functions.                                                */
 /*===========================================================================*/
@@ -69,8 +90,7 @@ void rp_clock_init(void) {
   rp_peripheral_unreset(RESETS_ALLREG_TIMER0);
 
   /* Configure tick generator for ~1 us ticks. */
-  TICKS->TICK[TICKS_TIMER0].CYCLES = RP_ROSC_ASSUMED_HZ / 1000000U;
-  TICKS->TICK[TICKS_TIMER0].CTRL = TICKS_CTRL_ENABLE;
+  rp_tick_start(TICKS_TIMER0, RP_ROSC_ASSUMED_HZ / 1000000U);
 
   /* Clear clock resus that may be in an unknown state */
   CLOCKS->RESUS.CTRL = 0U;
@@ -141,13 +161,13 @@ void rp_clock_init(void) {
   CLOCKS->CLK[RP_CLK_PERI].DIV = 1U << 16;
   CLOCKS->SET.CLK[RP_CLK_PERI].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
 
-  /* Calculate cycles for 1us tick based on clk_ref frequency. */
+  /* Calculate cycles for 1us tick based on clk_ref frequency, RP_XOSCCLK
+     is checked at compile time to be an integer number of MHz. */
   uint32_t cycles = RP_XOSCCLK / 1000000U;
 
   /* Start tick generators */
   for (uint32_t i = 0U; i < 6U; i++) {
-    TICKS->TICK[i].CYCLES = cycles;
-    TICKS->TICK[i].CTRL = TICKS_CTRL_ENABLE;
+    rp_tick_start(i, cycles);
   }
 }
 

--- a/os/hal/ports/RP/RP2350/rp_pll.c
+++ b/os/hal/ports/RP/RP2350/rp_pll.c
@@ -76,7 +76,11 @@ void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
   osalDbgAssert(vco_freq >= RP_PLL_VCO_MIN_FREQ &&
                 vco_freq <= RP_PLL_VCO_MAX_FREQ,
                 "VCO frequency out of range");
+  osalDbgAssert((RP_XOSCCLK % refdiv) == 0U, "XOSC not divisible by REFDIV");
+  osalDbgAssert(ref_freq >= 5000000U, "reference frequency below 5 MHz");
   osalDbgAssert(fbdiv >= 16U && fbdiv <= 320U, "FBDIV out of range");
+  osalDbgAssert((ref_freq * fbdiv) == vco_freq,
+                "VCO not an integer multiple of reference");
   osalDbgAssert(postdiv1 >= 1U && postdiv1 <= 7U, "POSTDIV1 out of range");
   osalDbgAssert(postdiv2 >= 1U && postdiv2 <= 7U, "POSTDIV2 out of range");
   osalDbgAssert(ref_freq <= (vco_freq / 16U), "Reference frequency too high");

--- a/os/hal/ports/RP/RP2350/rp_pll.c
+++ b/os/hal/ports/RP/RP2350/rp_pll.c
@@ -69,9 +69,17 @@
 void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
                  uint32_t postdiv1, uint32_t postdiv2) {
 
-  uint32_t ref_freq = RP_XOSCCLK / refdiv;
-  uint32_t fbdiv = vco_freq / ref_freq;
-  uint32_t pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
+  uint32_t ref_freq;
+  uint32_t fbdiv;
+  uint32_t pdiv;
+
+  /* Denominators must be validated before any division uses them. */
+  osalDbgAssert((refdiv >= 1U) && (refdiv <= 63U), "invalid REFDIV");
+
+  ref_freq = RP_XOSCCLK / refdiv;
+  osalDbgAssert(ref_freq != 0U, "reference frequency is zero");
+  fbdiv = vco_freq / ref_freq;
+  pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
 
   osalDbgAssert(vco_freq >= RP_PLL_VCO_MIN_FREQ &&
                 vco_freq <= RP_PLL_VCO_MAX_FREQ,

--- a/os/hal/ports/RP/RP2350/rp_xosc.h
+++ b/os/hal/ports/RP/RP2350/rp_xosc.h
@@ -31,10 +31,13 @@
 
 /**
  * @brief   XOSC startup delay multiplier.
- * @note    Default value of 1 for 12MHz crystal.
+ * @note    The base delay is ~1 ms of crystal periods. The default
+ *          multiplier of 6 gives a conservative ~6 ms startup delay
+ *          which accommodates slow-starting crystals. It can be
+ *          overridden from the board file.
  */
 #if !defined(RP_XOSC_STARTUP_DELAY_MULTIPLIER)
-#define RP_XOSC_STARTUP_DELAY_MULTIPLIER    1U
+#define RP_XOSC_STARTUP_DELAY_MULTIPLIER    6U
 #endif
 
 /*===========================================================================*/
@@ -48,10 +51,14 @@
 /**
  * @brief   XOSC startup delay value.
  * @note    Delay is in multiples of 256 crystal periods
- *          For 12MHz, each count is ~21.3us. Default gives 1ms startup.
+ *          For 12MHz, each count is ~21.3us. Default gives 6ms startup.
  */
 #define RP_XOSC_STARTUP_DELAY               \
     ((((RP_XOSCCLK / 1000U) + 128U) / 256U) * RP_XOSC_STARTUP_DELAY_MULTIPLIER)
+
+#if RP_XOSC_STARTUP_DELAY > 0x3FFF
+#error "RP_XOSC_STARTUP_DELAY exceeds the 14-bit STARTUP.DELAY register field"
+#endif
 
 /*===========================================================================*/
 /* Driver data structures and types.                                         */


### PR DESCRIPTION
## Summary

Clock-tree correctness work on the RP2350 (review items 17, 34, 35 plus errata hardening), six commits:

- **PLL settings validated at compile time**: the configured XOSC/REFDIV/FBDIV/postdiv combination is checked on *achieved* values — reference divisibility, reference ≥ 5 MHz, FBDIV in 16–320, VCO consistency, and exact divisibility down to the target frequency — so an unachievable clock request is a `#error`, not a silently wrong frequency. Matching runtime asserts in `rp_pll.c` validate denominators before any division (review-round fix: validation ordered ahead of use).
- **RP2350-E12 guard**: `#error` unless clk_sys×10 ≥ clk_usb×11, per the erratum's required ratio.
- **XOSC startup**: conservative startup-delay default (×6) and a range check on the computed `STARTUP` value.
- **Integer-MHz XOSC required + safe tick-generator sequence**: the TICKS generators are reprogrammed as disable → wait `!RUNNING` → write `CYCLES` → enable, instead of changing `CYCLES` under a running generator; non-integer-MHz crystals are rejected at compile time since the tick generators assume a 1 µs base.
- **Dropped dummy clock management**: `HAL_LLD_USE_CLOCK_MANAGEMENT` advertised a no-op `halclkcfg_t`/switch machinery; removed on both RP2040 and RP2350, while keeping `hal_lld_get_clock_point()` (called unconditionally by the generic HAL).

## Validation

On a Pico 2:
- FC0 frequency counter reads clk_sys at exactly 150000 kHz after init; TICKS `CYCLES` readback matches the crystal (12).
- Negative compile matrix: 13 MHz and 12.288 MHz crystal configurations fail with the intended `#error`s.
- Demo and EFL-MFS regression runs clean; RP2040 and RP2350 build matrix clean.
- Reviewed by CodeRabbit (clean) and Codex (denominator validation ordering, fixed and re-verified).