### PR TITLE
ARMv6-M: halt on remote panic regardless of receiving core

### DIFF
--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -78,6 +78,10 @@ CH_IRQ_HANDLER(Vector7C) {
 
   while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
     uint32_t message = SIO->FIFO_RD;
+    /* A panic on either core halts the other one too.*/
+    if (message == PORT_FIFO_PANIC_MESSAGE) {
+      port_local_halt();
+    }
 #if defined(PORT_HANDLE_FIFO_MESSAGE)
     if (message != PORT_FIFO_RESCHEDULE_MESSAGE) {
       PORT_HANDLE_FIFO_MESSAGE(1U, message);


### PR DESCRIPTION
## Summary

Follow-up to #94, prompted by its review: the automated reviewer pointed out that the ARMv6-M RP2 port was not actually symmetric — and inspection confirmed the RP2040 core-0 FIFO handler (`Vector7C`) never checks for the panic token at all. A panic on core 1 therefore left core 0 running half of the SMP system, and additionally forwarded the panic token to `PORT_HANDLE_FIFO_MESSAGE` as if it were an application message. Core 0 now halts on the token exactly like core 1 (`Vector80`), making both ARM RP2 ports behave identically to the fix merged in #94.

## Validation (RP2040 hardware)

Panic-injection test on a Raspberry Pi Pico via Debug Probe — scratch build of the SMP RT-RP2040-PICO demo with core 1 calling `chSysHalt("c1-test")` 5 s after boot:

**With this fix:**
- Core 0 halted with PC in `port_local_halt` (`ARMv6-M/smp/rp2/chcoresmp.c`), `ch0.dbg.panic_msg` = "remote panic"
- Core 1 halted in `chSysHalt`, `ch1.dbg.panic_msg` = "c1-test"

**Negative control (unfixed master, same injection):**
- 4 s after core 1's panic, core 0 was still scheduling — halted PC resolves to `__idle_thread`, `ch0.dbg.panic_msg` = NULL — confirming the defect and that the test discriminates.

RT-RP2040-PICO demo builds clean; the injection was a scratch build only, nothing test-related is committed.