### PR TITLE
RP TIMERv1: verify and retry system tick alarms set in the past

### DIFF
--- a/os/hal/ports/RP/LLD/TIMERv1/hal_st_lld.h
+++ b/os/hal/ports/RP/LLD/TIMERv1/hal_st_lld.h
@@ -220,11 +220,22 @@ __STATIC_INLINE void st_lld_set_alarm(systime_t abstime) {
      the check and the store (an interrupt or bus stall in the window
      recreates the ~71 min wrap wait), so the deadline is re-armed until
      either it is provably in the future or the compare has genuinely
-     fired (ARMED bit cleared by hardware) - a fired alarm must not be
-     re-armed into a duplicate event. */
-  while (((TIMER0->ARMED & 1U) != 0U) &&
-         ((int32_t)(target - TIMER0->TIMERAWL) <= 0)) {
-    target = TIMER0->TIMERAWL + 2U;
+     fired (ARMED bit cleared by hardware). ARMED is sampled immediately
+     before deciding to re-arm so a firing that lands mid-check is seen
+     in the narrowest possible window; the residual race, firing between
+     that read and the store, can at worst produce one spurious alarm
+     interrupt which the ST layer tolerates - the opposite failure, not
+     re-arming a missed deadline, is the one that must not happen. */
+  while (true) {
+    uint32_t now = TIMER0->TIMERAWL;
+
+    if ((int32_t)(target - now) > 0) {
+      break;
+    }
+    if ((TIMER0->ARMED & 1U) == 0U) {
+      break;
+    }
+    target = now + 2U;
     TIMER0->ALARM[0] = target;
   }
 }
@@ -308,9 +319,16 @@ __STATIC_INLINE void st_lld_set_alarm_n(unsigned alarm, systime_t abstime) {
 
   TIMER0->ALARM[alarm] = target;
   /* Verify-and-retry, see st_lld_set_alarm(). */
-  while (((TIMER0->ARMED & (1U << alarm)) != 0U) &&
-         ((int32_t)(target - TIMER0->TIMERAWL) <= 0)) {
-    target = TIMER0->TIMERAWL + 2U;
+  while (true) {
+    uint32_t now = TIMER0->TIMERAWL;
+
+    if ((int32_t)(target - now) > 0) {
+      break;
+    }
+    if ((TIMER0->ARMED & (1U << alarm)) == 0U) {
+      break;
+    }
+    target = now + 2U;
     TIMER0->ALARM[alarm] = target;
   }
 }

--- a/os/hal/ports/RP/LLD/TIMERv1/hal_st_lld.h
+++ b/os/hal/ports/RP/LLD/TIMERv1/hal_st_lld.h
@@ -215,6 +215,10 @@ __STATIC_INLINE void st_lld_stop_alarm(void) {
 __STATIC_INLINE void st_lld_set_alarm(systime_t abstime) {
 
   TIMER0->ALARM[0]       = (uint32_t)abstime;
+  /* Re-arm if abstime already past to avoid ~71 min wait for counter wrap. */
+  if ((int32_t)(abstime - TIMER0->TIMERAWL) <= 0) {
+    TIMER0->ALARM[0]     = TIMER0->TIMERAWL + 2U;
+  }
 }
 
 /**
@@ -294,6 +298,10 @@ __STATIC_INLINE void st_lld_stop_alarm_n(unsigned alarm) {
 __STATIC_INLINE void st_lld_set_alarm_n(unsigned alarm, systime_t abstime) {
 
   TIMER0->ALARM[alarm]   = (uint32_t)abstime;
+  /* Re-arm if abstime already past to avoid ~71 min wait for counter wrap. */
+  if ((int32_t)(abstime - TIMER0->TIMERAWL) <= 0) {
+    TIMER0->ALARM[alarm] = TIMER0->TIMERAWL + 2U;
+  }
 }
 
 /**

--- a/os/hal/ports/RP/LLD/TIMERv1/hal_st_lld.h
+++ b/os/hal/ports/RP/LLD/TIMERv1/hal_st_lld.h
@@ -213,11 +213,19 @@ __STATIC_INLINE void st_lld_stop_alarm(void) {
  * @notapi
  */
 __STATIC_INLINE void st_lld_set_alarm(systime_t abstime) {
+  uint32_t target = (uint32_t)abstime;
 
-  TIMER0->ALARM[0]       = (uint32_t)abstime;
-  /* Re-arm if abstime already past to avoid ~71 min wait for counter wrap. */
-  if ((int32_t)(abstime - TIMER0->TIMERAWL) <= 0) {
-    TIMER0->ALARM[0]     = TIMER0->TIMERAWL + 2U;
+  TIMER0->ALARM[0] = target;
+  /* Verify-and-retry: the counter can pass the programmed value between
+     the check and the store (an interrupt or bus stall in the window
+     recreates the ~71 min wrap wait), so the deadline is re-armed until
+     either it is provably in the future or the compare has genuinely
+     fired (ARMED bit cleared by hardware) - a fired alarm must not be
+     re-armed into a duplicate event. */
+  while (((TIMER0->ARMED & 1U) != 0U) &&
+         ((int32_t)(target - TIMER0->TIMERAWL) <= 0)) {
+    target = TIMER0->TIMERAWL + 2U;
+    TIMER0->ALARM[0] = target;
   }
 }
 
@@ -296,11 +304,14 @@ __STATIC_INLINE void st_lld_stop_alarm_n(unsigned alarm) {
  * @notapi
  */
 __STATIC_INLINE void st_lld_set_alarm_n(unsigned alarm, systime_t abstime) {
+  uint32_t target = (uint32_t)abstime;
 
-  TIMER0->ALARM[alarm]   = (uint32_t)abstime;
-  /* Re-arm if abstime already past to avoid ~71 min wait for counter wrap. */
-  if ((int32_t)(abstime - TIMER0->TIMERAWL) <= 0) {
-    TIMER0->ALARM[alarm] = TIMER0->TIMERAWL + 2U;
+  TIMER0->ALARM[alarm] = target;
+  /* Verify-and-retry, see st_lld_set_alarm(). */
+  while (((TIMER0->ARMED & (1U << alarm)) != 0U) &&
+         ((int32_t)(target - TIMER0->TIMERAWL) <= 0)) {
+    target = TIMER0->TIMERAWL + 2U;
+    TIMER0->ALARM[alarm] = target;
   }
 }
 

--- a/testhal/RP/RP2350/ST-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/ST-VALIDATION/Makefile
@@ -1,0 +1,159 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O0 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2350/ST-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/ST-VALIDATION/cfg/chconf.h
@@ -1,0 +1,85 @@
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+#define CH_CFG_SMP_MODE                     FALSE
+
+#define CH_CFG_HARDENING_LEVEL              0
+#define CH_CFG_ST_RESOLUTION                32
+#define CH_CFG_ST_FREQUENCY                 1000000
+#define CH_CFG_INTERVALS_SIZE               32
+#define CH_CFG_TIME_TYPES_SIZE              32
+#define CH_CFG_ST_TIMEDELTA                 20
+
+#define CH_CFG_TIME_QUANTUM                 0
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+
+#define CH_CFG_USE_TM                       TRUE
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#define CH_CFG_USE_REGISTRY                 TRUE
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#define CH_CFG_USE_MUTEXES                  TRUE
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#define CH_CFG_USE_CONDVARS                 FALSE
+#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#define CH_CFG_USE_EVENTS                   TRUE
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#define CH_CFG_USE_MESSAGES                 TRUE
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#define CH_CFG_USE_DYNAMIC                  FALSE
+
+#define CH_CFG_USE_MAILBOXES                FALSE
+#define CH_CFG_USE_MEMCHECKS                FALSE
+#define CH_CFG_USE_MEMCORE                  TRUE
+#define CH_CFG_MEMCORE_SIZE                 0
+#define CH_CFG_USE_HEAP                     TRUE
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+#define CH_CFG_USE_OBJ_FIFOS                FALSE
+#define CH_CFG_USE_PIPES                    FALSE
+#define CH_CFG_USE_OBJ_CACHES               FALSE
+#define CH_CFG_USE_DELEGATES                FALSE
+#define CH_CFG_USE_JOBS                     FALSE
+#define CH_CFG_USE_FACTORY                  FALSE
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     FALSE
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      FALSE
+#define CH_CFG_FACTORY_SEMAPHORES           FALSE
+#define CH_CFG_FACTORY_MAILBOXES            FALSE
+#define CH_CFG_FACTORY_OBJ_FIFOS            FALSE
+#define CH_CFG_FACTORY_PIPES                FALSE
+
+#define CH_DBG_STATISTICS                   FALSE
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#define CH_DBG_FILL_THREADS                 TRUE
+#define CH_DBG_THREADS_PROFILING            FALSE
+
+#define CH_CFG_SYSTEM_EXTRA_FIELDS
+#define CH_CFG_SYSTEM_INIT_HOOK() do { } while (false)
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do { (void)(oip); } while (false)
+#define CH_CFG_THREAD_EXTRA_FIELDS
+#define CH_CFG_THREAD_INIT_HOOK(tp) do { (void)(tp); } while (false)
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do { (void)(tp); } while (false)
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do { (void)(ntp); (void)(otp); } while (false)
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do { } while (false)
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do { } while (false)
+#define CH_CFG_IDLE_ENTER_HOOK() do { } while (false)
+#define CH_CFG_IDLE_LEAVE_HOOK() do { } while (false)
+#define CH_CFG_IDLE_LOOP_HOOK() do { } while (false)
+#define CH_CFG_SYSTEM_TICK_HOOK() do { } while (false)
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do { (void)(reason); } while (false)
+#define CH_CFG_TRACE_HOOK(tep) do { (void)(tep); } while (false)
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do { (void)(mask); } while (false)
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do { chSysHalt(f); } while (false)
+
+#endif /* CHCONF_H */

--- a/testhal/RP/RP2350/ST-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/ST-VALIDATION/cfg/chconf.h
@@ -1,3 +1,19 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
 #ifndef CHCONF_H
 #define CHCONF_H
 

--- a/testhal/RP/RP2350/ST-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2350/ST-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         TRUE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      FALSE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/ST-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/ST-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,40 @@
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/ST-VALIDATION/main.c
+++ b/testhal/RP/RP2350/ST-VALIDATION/main.c
@@ -162,8 +162,10 @@ static bool test_set_alarm_n_future(void) {
   TIMER0->ARMED = (1U << SCRATCH_ALARM);
   TIMER0->INTR  = (1U << SCRATCH_ALARM);
 
-  /* The alarm must fire, and not before the requested deadline.*/
-  return fired && (elapsed >= 150U);
+  /* The alarm must fire, and not before the requested deadline (the
+     elapsed measurement starts before the set call, so overhead can
+     only lengthen it).*/
+  return fired && (elapsed >= 200U);
 }
 
 /*
@@ -340,6 +342,11 @@ int main(void) {
   chprintf(chp, "  Iterations:  %u (D1 %uus, D2 %uus)\r\n",
            TEST_ITERATIONS, D1_DELAY_US, D2_DELAY_US);
   chprintf(chp, "\r\n");
+
+  /* A watchdog reset means the previous run stalled - that is a test
+     failure, not a fresh start.*/
+  report("no watchdog reset from previous run",
+         (reason & WATCHDOG_REASON_TIMER) == 0U);
 
   /* Watchdog backstop, fed once per test iteration.*/
   wdgStart(&WDGD1, &wdgcfg);

--- a/testhal/RP/RP2350/ST-VALIDATION/main.c
+++ b/testhal/RP/RP2350/ST-VALIDATION/main.c
@@ -1,0 +1,409 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 system timer (ST) alarm guard validation test.
+ *
+ * The RP TIMER alarms fire on an exact 32-bit compare match, an ALARM
+ * value that is already behind TIMERAWL when written is not matched
+ * again until the counter wraps, ~71.6 minutes later at 1MHz.  The
+ * st_lld_set_alarm()/st_lld_set_alarm_n() guard must therefore re-arm
+ * the alarm a few ticks ahead whenever the requested absolute time is
+ * already in the past.
+ *
+ * Phase 1 exercises the guard directly at register level: a deadline
+ * in the past is written through the LLD and the alarm ARMED bit is
+ * polled, without the guard the alarm never fires within the window.
+ *
+ * Phase 2 is a virtual-timers alarm-miss generator: two one-shot
+ * timers D1/D2 are armed, then the system time is pushed past both
+ * deadlines by busy-waiting inside a critical zone with a random
+ * overshoot.  On unlock the pending alarm interrupt services the
+ * timers late and re-arms the alarm close to (or behind) the current
+ * time, exercising the deadline-skip paths in the ST/VT machinery.
+ *
+ * A watchdog acts as a backstop: a fully stalled ST (alarm waiting
+ * for the counter wrap) blocks all timeouts, the WDG then resets the
+ * board and the reset reason is printed in the banner on next boot.
+ *
+ * Single-core only (no SMP), tickless mode (CH_CFG_ST_TIMEDELTA 20).
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#define LED_PIN              25U
+#define UART_TX_PIN          0U
+#define UART_RX_PIN          1U
+
+#define SCRATCH_ALARM        1U
+
+#define TEST_ITERATIONS      10000U
+#define REPORT_INTERVAL      1000U
+#define D1_DELAY_US          300U
+#define D2_DELAY_US          600U
+
+static BaseSequentialStream *chp;
+static unsigned pass_count;
+static unsigned fail_count;
+
+static virtual_timer_t vt1, vt2;
+static volatile bool d1_fired;
+static volatile bool d2_fired;
+static volatile uint32_t d2_fire_rawl;
+static semaphore_t d2_sem;
+
+/* Watchdog configuration, ~5 seconds timeout.*/
+static const WDGConfig wdgcfg = {
+  5000U
+};
+
+/*===========================================================================*/
+/* Test helpers.                                                             */
+/*===========================================================================*/
+
+static uint32_t lcg_state = 0x12345678U;
+
+/* Simple LCG PRNG (Numerical Recipes constants).*/
+static uint32_t lcg_next(void) {
+
+  lcg_state = (lcg_state * 1664525U) + 1013904223U;
+
+  return lcg_state;
+}
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/*===========================================================================*/
+/* Phase 1: direct LLD register-level tests.                                 */
+/*===========================================================================*/
+
+/*
+ * Test: st_lld_set_alarm_n() with an already-passed absolute time.
+ *
+ * Uses the unused scratch alarm channel, its interrupt is neither
+ * bound nor enabled so only the ARMED bit is observed.  The guard
+ * must convert the past deadline into a near-immediate alarm, without
+ * it the channel stays armed until the ~71.6 minutes counter wrap.
+ */
+static bool test_set_alarm_n_past(void) {
+  uint32_t start;
+  bool fired = false;
+
+  chSysLock();
+  st_lld_set_alarm_n(SCRATCH_ALARM,
+                     (systime_t)(TIMER0->TIMERAWL - 100U));
+  chSysUnlock();
+
+  /* Polling the ARMED bit for up to 1ms, the guard re-arms the alarm
+     2 ticks ahead so it must fire almost immediately.*/
+  start = TIMER0->TIMERAWL;
+  while ((int32_t)(TIMER0->TIMERAWL - start) < 1000) {
+    if ((TIMER0->ARMED & (1U << SCRATCH_ALARM)) == 0U) {
+      fired = true;
+      break;
+    }
+  }
+
+  /* Disarming and clearing the raw interrupt status.*/
+  TIMER0->ARMED = (1U << SCRATCH_ALARM);
+  TIMER0->INTR  = (1U << SCRATCH_ALARM);
+
+  return fired;
+}
+
+/*
+ * Test: st_lld_set_alarm_n() with a valid future absolute time.
+ *
+ * The guard must not distort deadlines that are still ahead, the
+ * alarm has to fire at the requested time and not earlier.
+ */
+static bool test_set_alarm_n_future(void) {
+  uint32_t start, elapsed = 0U;
+  bool fired = false;
+
+  chSysLock();
+  start = TIMER0->TIMERAWL;
+  st_lld_set_alarm_n(SCRATCH_ALARM, (systime_t)(start + 200U));
+  chSysUnlock();
+
+  while ((int32_t)(TIMER0->TIMERAWL - start) < 1000) {
+    if ((TIMER0->ARMED & (1U << SCRATCH_ALARM)) == 0U) {
+      elapsed = TIMER0->TIMERAWL - start;
+      fired = true;
+      break;
+    }
+  }
+
+  /* Disarming and clearing the raw interrupt status.*/
+  TIMER0->ARMED = (1U << SCRATCH_ALARM);
+  TIMER0->INTR  = (1U << SCRATCH_ALARM);
+
+  /* The alarm must fire, and not before the requested deadline.*/
+  return fired && (elapsed >= 150U);
+}
+
+/*
+ * Test: st_lld_set_alarm() with an already-passed absolute time.
+ *
+ * Operates on the kernel alarm 0 inside a critical zone: the current
+ * alarm value is saved, a past deadline is written and the ARMED bit
+ * is polled, then the previous value is restored.  A spurious early
+ * alarm interrupt is harmless in tickless mode, the tick handler
+ * simply re-arms the alarm for the next virtual timer deadline.
+ */
+static bool test_set_alarm_past(void) {
+  systime_t saved;
+  uint32_t start;
+  bool fired = false;
+
+  chSysLock();
+
+  saved = st_lld_get_alarm();
+  st_lld_set_alarm((systime_t)(TIMER0->TIMERAWL - 100U));
+
+  /* Polling the ARMED bit for up to 200us with interrupts masked.*/
+  start = TIMER0->TIMERAWL;
+  while ((int32_t)(TIMER0->TIMERAWL - start) < 200) {
+    if ((TIMER0->ARMED & (1U << 0)) == 0U) {
+      fired = true;
+      break;
+    }
+  }
+
+  /* Restoring the kernel alarm, any interrupt made pending by the
+     test is serviced on unlock as a spurious tick.*/
+  st_lld_set_alarm(saved);
+
+  chSysUnlock();
+
+  return fired;
+}
+
+/*===========================================================================*/
+/* Phase 2: virtual-timers alarm-miss generator.                             */
+/*===========================================================================*/
+
+static void d1_cb(virtual_timer_t *vtp, void *arg) {
+
+  (void)vtp;
+  (void)arg;
+
+  d1_fired = true;
+}
+
+static void d2_cb(virtual_timer_t *vtp, void *arg) {
+
+  (void)vtp;
+  (void)arg;
+
+  d2_fired = true;
+  d2_fire_rawl = TIMER0->TIMERAWL;
+
+  chSysLockFromISR();
+  chSemSignalI(&d2_sem);
+  chSysUnlockFromISR();
+}
+
+/*
+ * Runs a single alarm-miss iteration, returns the D2 latency past the
+ * busy-wait target through "latp" when successful.
+ */
+static bool vt_iteration(unsigned i, uint32_t *latp) {
+  uint32_t start, target, overshoot;
+  msg_t msg;
+
+  /* Random overshoot past the D2 deadline, 2..250us.*/
+  overshoot = 2U + ((lcg_next() >> 16) % 249U);
+
+  d1_fired = false;
+  d2_fired = false;
+
+  /* Draining any stale semaphore signal.*/
+  while (chSemWaitTimeout(&d2_sem, TIME_IMMEDIATE) == MSG_OK) {
+  }
+
+  chSysLock();
+
+  /* Arming both one-shot timers.*/
+  start = (uint32_t)chVTGetSystemTimeX();
+  chVTSetI(&vt1, TIME_US2I(D1_DELAY_US), d1_cb, NULL);
+  chVTSetI(&vt2, TIME_US2I(D2_DELAY_US), d2_cb, NULL);
+
+  /* Busy-waiting past the D2 absolute deadline with interrupts
+     masked, the D1 alarm interrupt becomes and stays pending while
+     the system time skips past both deadlines.*/
+  target = start + D2_DELAY_US + overshoot;
+  while ((int32_t)(TIMER0->TIMERAWL - target) < 0) {
+  }
+
+  chSysUnlock();
+
+  /* The pending alarm interrupt must have serviced both timers, D2
+     signals the semaphore from its callback.  Without the alarm
+     guard a missed deadline leaves the ST stalled, this timeout (and
+     every other timeout) then never fires and the watchdog resets
+     the board.*/
+  msg = chSemWaitTimeout(&d2_sem, TIME_MS2I(10));
+  if ((msg != MSG_OK) || !d1_fired || !d2_fired) {
+    chprintf(chp, "    iteration %u: miss (d1=%u d2=%u start=%u overshoot=%u)\r\n",
+             i, d1_fired ? 1U : 0U, d2_fired ? 1U : 0U, start, overshoot);
+    chVTReset(&vt1);
+    chVTReset(&vt2);
+    return false;
+  }
+
+  *latp = d2_fire_rawl - target;
+
+  return true;
+}
+
+/*===========================================================================*/
+/* Blinker thread.                                                          */
+/*===========================================================================*/
+
+static THD_WORKING_AREA(waThread1, 256);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (true) {
+    palToggleLine(LED_PIN);
+    chThdSleepMilliseconds(500);
+  }
+}
+
+/*===========================================================================*/
+/* Main.                                                                     */
+/*===========================================================================*/
+
+int main(void) {
+  uint32_t reason;
+  unsigned i, batch_fail = 0U, total_miss = 0U;
+  uint32_t batch_maxlat = 0U;
+  bool ok;
+
+  halInit();
+  chSysInit();
+
+  /* LED. */
+  palSetLineMode(LED_PIN, PAL_MODE_OUTPUT_PUSHPULL | PAL_RP_PAD_DRIVE12);
+
+  /* UART on GPIO0/GPIO1. */
+  palSetLineMode(UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+  chp = (BaseSequentialStream *)&SIOD0;
+
+  chSemObjectInit(&d2_sem, 0);
+  chVTObjectInit(&vt1);
+  chVTObjectInit(&vt2);
+
+  /* Start blinker. */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /* Small delay to let UART settle. */
+  chThdSleepMilliseconds(100);
+
+  reason = WATCHDOG->REASON;
+
+  chprintf(chp, "\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  RP2350 ST Alarm Guard Validation\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  WDG REASON:  0x%08X%s\r\n", reason,
+           ((reason & WATCHDOG_REASON_TIMER) != 0U) ?
+           "  *** WATCHDOG RESET ***" : "");
+  chprintf(chp, "  Iterations:  %u (D1 %uus, D2 %uus)\r\n",
+           TEST_ITERATIONS, D1_DELAY_US, D2_DELAY_US);
+  chprintf(chp, "\r\n");
+
+  /* Watchdog backstop, fed once per test iteration.*/
+  wdgStart(&WDGD1, &wdgcfg);
+
+  /* Phase 1: direct LLD checks.*/
+  ok = test_set_alarm_n_past();
+  report("st_lld_set_alarm_n re-arms past deadline", ok);
+
+  ok = test_set_alarm_n_future();
+  report("st_lld_set_alarm_n keeps future deadline", ok);
+
+  ok = test_set_alarm_past();
+  report("st_lld_set_alarm re-arms past deadline", ok);
+
+  /* Phase 2: alarm-miss generator.*/
+  chprintf(chp, "\r\n  Alarm-miss generator (%u iterations)...\r\n",
+           TEST_ITERATIONS);
+  for (i = 0U; i < TEST_ITERATIONS; i++) {
+    uint32_t lat = 0U;
+
+    wdgReset(&WDGD1);
+
+    if (!vt_iteration(i, &lat)) {
+      batch_fail++;
+      total_miss++;
+    }
+    else if (lat > batch_maxlat) {
+      batch_maxlat = lat;
+    }
+
+    if (((i + 1U) % REPORT_INTERVAL) == 0U) {
+      if (batch_fail == 0U) {
+        pass_count++;
+        chprintf(chp, "  [PASS] st alarm guard (%u/%u, max latency %uus)\r\n",
+                 i + 1U, TEST_ITERATIONS, batch_maxlat);
+      }
+      else {
+        fail_count++;
+        chprintf(chp, "  [FAIL] st alarm guard (%u/%u, %u missed)\r\n",
+                 i + 1U, TEST_ITERATIONS, batch_fail);
+      }
+      batch_fail = 0U;
+      batch_maxlat = 0U;
+    }
+  }
+
+  if (total_miss != 0U) {
+    chprintf(chp, "\r\n  Total missed deadlines: %u\r\n", total_miss);
+  }
+
+  chprintf(chp, "\r\n========================================\r\n");
+  chprintf(chp, "  Results: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "  ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "  *** FAILURES DETECTED ***\r\n");
+  }
+  chprintf(chp, "========================================\r\n");
+
+  while (true) {
+    wdgReset(&WDGD1);
+    chThdSleepMilliseconds(1000);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

The tickless system timer's `st_lld_set_alarm()` (review item 12) wrote the ALARM register and returned; if the target time had already passed by the time the write landed — interrupt-latency windows, debugger stalls, long critical sections — the alarm was missed entirely and the next timer event waited for a full 32-bit TIMERAWL wrap (~71 minutes) with the scheduler's virtual timers stalled.

The set-alarm path (and its `_n` variant) now verifies after arming: while the alarm is still ARMED and the target already lies in the past, it re-arms at `TIMERAWL + 2`. The ARMED check distinguishes "alarm already fired" (nothing to do) from "alarm armed for a time that will never come" (retry), which a naive time-comparison alone gets wrong on the fired-just-now edge.

## Validation

`testhal/RP/RP2350/ST-VALIDATION` on a Pico 2, 14/14:

- Two virtual timers with one deadline forced into the past by a busy-wait under `chSysLock`: the late timer fires within bounds (max observed latency 15 µs) instead of stalling.
- 10,000 randomized iterations of deadline-vs-latency races; a hardware watchdog backstops the run and watchdog resets are counted as failures (a stalled tickless timer would otherwise reset silently and restart the test).
- RP2040 and RP2350 build matrix clean (TIMER0 alias exists on both).
- Reviewed by CodeRabbit (2 test findings fixed) and Codex (ARMED-aware verify-and-retry replaced the original racy single re-arm), hardware re-validated after each round.