### PR TITLE
RP PIOv1: GPIOBASE support for GPIOs above 31

### DIFF
--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
@@ -668,10 +668,15 @@ void pioProgramUnload(const rp_pio_block_t *block,
  * @post    The block is taken out of reset and intentionally left out of
  *          reset so the setting persists across the following
  *          @p pioSmAllocI() calls (whose internal unreset is idempotent).
- * @note    Releasing the last state machine of the block puts the block
- *          back in reset which clears GPIOBASE to zero, the window must be
- *          configured again before the next allocation cycle if a
- *          non-default base is required.
+ * @note    The block is put back in reset (clearing GPIOBASE to zero)
+ *          only when it becomes fully idle: no state machines allocated
+ *          AND no program loaded. After such a full release the window
+ *          must be configured again before the next allocation cycle if
+ *          a non-default base is required.
+ * @note    Not serialized against concurrent allocations: the base must
+ *          be selected during single-threaded initialization, before any
+ *          state machine of the block is allocated. Callers cannot
+ *          atomically pair this call with a following allocation.
  * @note    This function only exists on devices with the
  *          @p RP_PIO_HAS_GPIOBASE capability; on RP2040 all pads are
  *          directly accessible and no window selection is available.

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
@@ -653,6 +653,65 @@ void pioProgramUnload(const rp_pio_block_t *block,
   osalSysUnlock();
 }
 
+#if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Selects the GPIO window of a PIO block.
+ * @details On devices with more than 32 GPIO lines (RP2350) each PIO block
+ *          accesses a 32-pin window of the pads. With @p base set to 0 the
+ *          block drives GPIO0..31, with @p base set to 16 it drives
+ *          GPIO16..47 (RP2350B). The 5-bit pin fields written into the
+ *          PINCTRL and EXECCTRL registers are relative to this window,
+ *          see @p pioGpioToRel().
+ * @pre     The block must be completely idle: no state machines allocated
+ *          on either core and no program loaded. Moving the pin window
+ *          under running state machines is invalid.
+ * @post    The block is taken out of reset and intentionally left out of
+ *          reset so the setting persists across the following
+ *          @p pioSmAllocI() calls (whose internal unreset is idempotent).
+ * @note    Releasing the last state machine of the block puts the block
+ *          back in reset which clears GPIOBASE to zero, the window must be
+ *          configured again before the next allocation cycle if a
+ *          non-default base is required.
+ * @note    This function only exists on devices with the
+ *          @p RP_PIO_HAS_GPIOBASE capability; on RP2040 all pads are
+ *          directly accessible and no window selection is available.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] base      first GPIO accessible by the block, must be 0 or 16
+ *
+ * @api
+ */
+void pioSetGpioBase(const rp_pio_block_t *block, uint32_t base) {
+  uint32_t b;
+
+  osalDbgCheck(block != NULL);
+  osalDbgCheck((base == 0U) || (base == 16U));
+
+  b = block->pioidx;
+
+  osalSysLock();
+
+  /* The pin window can only be moved while the block is completely
+     idle.*/
+  osalDbgAssert((pio.blocks[b].c0_allocated_mask |
+                 pio.blocks[b].c1_allocated_mask) == 0U,
+                "state machines allocated");
+  osalDbgAssert(pio.blocks[b].imem_allocated == 0U, "program loaded");
+
+  /* An idle block is held in reset, it must be released for the GPIOBASE
+     write to take effect. Resetting it back would clear the register so
+     the block is left out of reset.*/
+  rp_peripheral_unreset(block->resets_mask);
+
+  block->pio->GPIOBASE = base;
+
+  /* Read-back check, catches read-only register definitions.*/
+  osalDbgAssert(block->pio->GPIOBASE == base, "GPIOBASE not written");
+
+  osalSysUnlock();
+}
+#endif /* RP_PIO_HAS_GPIOBASE == TRUE */
+
 #endif /* RP_PIO_REQUIRED */
 
 /** @} */

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -267,6 +267,9 @@ extern "C" {
                           const rp_pio_program_t *program);
   void pioProgramUnload(const rp_pio_block_t *block,
                          int32_t offset, uint32_t length);
+#if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
+  void pioSetGpioBase(const rp_pio_block_t *block, uint32_t base);
+#endif
 #ifdef __cplusplus
 }
 #endif
@@ -594,9 +597,14 @@ __STATIC_INLINE uint32_t pioSmGet(const rp_pio_sm_t *smp) {
  * @brief   Routes a GPIO pin to the PIO block that owns this state machine.
  * @details Sets IO_BANK0 FUNCSEL for the given pin to PIO0, PIO1, or PIO2
  *          based on the block index of the state machine.
+ * @note    The @p gpio parameter is an absolute GPIO number. On devices
+ *          with the @p RP_PIO_HAS_GPIOBASE capability (RP2350) the pin
+ *          fields written into PINCTRL/EXECCTRL are instead relative to
+ *          the window selected with @p pioSetGpioBase(), see
+ *          @p pioGpioToRel().
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
- * @param[in] gpio      GPIO pin number
+ * @param[in] gpio      absolute GPIO pin number
  *
  * @special
  */
@@ -610,7 +618,44 @@ __STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
 #endif
   };
 
+  osalDbgCheck(gpio < RP_GPIO_NUM_LINES);
+
   IO_BANK0->GPIO[gpio].CTRL = funcsel[smp->block->pioidx];
+}
+
+/**
+ * @brief   Converts an absolute GPIO number to a block-relative pin number.
+ * @details The 5-bit pin fields in the PINCTRL and EXECCTRL registers are
+ *          relative to the GPIO window selected with @p pioSetGpioBase()
+ *          on devices with the @p RP_PIO_HAS_GPIOBASE capability (RP2350).
+ *          On devices without the capability (RP2040) pin numbers are
+ *          absolute and this function is an identity mapping.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] gpio      absolute GPIO pin number, must fall within the
+ *                      currently selected 32-pin window of the block
+ * @return              The window-relative pin number to be used in the
+ *                      PINCTRL/EXECCTRL pin fields.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioGpioToRel(const rp_pio_block_t *block,
+                                       uint32_t gpio) {
+#if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
+  uint32_t base = block->pio->GPIOBASE;
+
+  /* The result must fit the 5-bit pin fields, i.e. the GPIO must be in
+     the [base, base + 31] window.*/
+  osalDbgCheck((gpio >= base) && ((gpio - base) < 32U));
+
+  return gpio - base;
+#else
+  (void)block;
+
+  osalDbgCheck(gpio < RP_GPIO_NUM_LINES);
+
+  return gpio;
+#endif
 }
 
 /**

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -648,6 +648,12 @@ __STATIC_INLINE uint32_t pioGpioToRel(const rp_pio_block_t *block,
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
   uint32_t base = block->pio->GPIOBASE;
 
+  /* The hardware only implements windows at 0 and 16; any other value
+     read back would mean a misprogrammed or misdeclared register and
+     the arithmetic below would produce a plausible-looking but wrong
+     relative pin.*/
+  osalDbgCheck((base == 0U) || (base == 16U));
+
   /* The line must exist on the package and the result must fit the
      5-bit pin fields, i.e. the GPIO must be in the [base, base + 31]
      window.*/

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -630,6 +630,10 @@ __STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
  *          on devices with the @p RP_PIO_HAS_GPIOBASE capability (RP2350).
  *          On devices without the capability (RP2040) pin numbers are
  *          absolute and this function is an identity mapping.
+ * @note    The window also applies to absolute GPIO operands encoded in
+ *          PIO instructions themselves, notably WAIT GPIO: a high-window
+ *          program must encode such operands window-relative too (e.g.
+ *          GPIO42 becomes 26 with base 16).
  *
  * @param[in] block     pointer to the PIO block descriptor
  * @param[in] gpio      absolute GPIO pin number, must fall within the
@@ -644,9 +648,11 @@ __STATIC_INLINE uint32_t pioGpioToRel(const rp_pio_block_t *block,
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
   uint32_t base = block->pio->GPIOBASE;
 
-  /* The result must fit the 5-bit pin fields, i.e. the GPIO must be in
-     the [base, base + 31] window.*/
-  osalDbgCheck((gpio >= base) && ((gpio - base) < 32U));
+  /* The line must exist on the package and the result must fit the
+     5-bit pin fields, i.e. the GPIO must be in the [base, base + 31]
+     window.*/
+  osalDbgCheck((gpio < RP_GPIO_NUM_LINES) &&
+               (gpio >= base) && ((gpio - base) < 32U));
 
   return gpio - base;
 #else

--- a/os/hal/ports/RP/RP2040/rp_registry.h
+++ b/os/hal/ports/RP/RP2040/rp_registry.h
@@ -55,6 +55,7 @@
 #define RP_HAS_PIO1                         TRUE
 #define RP_HAS_PIO2                         FALSE
 #define RP_PIO_NUM_BLOCKS                   2
+#define RP_PIO_HAS_GPIOBASE                 FALSE
 
 /* TIMER attributes.*/
 #define RP_HAS_TIMER0                       TRUE

--- a/os/hal/ports/RP/RP2350/rp_registry.h
+++ b/os/hal/ports/RP/RP2350/rp_registry.h
@@ -55,6 +55,7 @@
 #define RP_HAS_PIO1                         TRUE
 #define RP_HAS_PIO2                         TRUE
 #define RP_PIO_NUM_BLOCKS                   3
+#define RP_PIO_HAS_GPIOBASE                 TRUE
 
 /* TIMER attributes.*/
 #define RP_HAS_TIMER0                       TRUE


### PR DESCRIPTION
## Summary

Stacked on #107's base branch (`em-pio-fixes`) — this PR shows only the GPIOBASE commits and retargets to master automatically when that merges.

RP2350 PIO blocks address at most 32 GPIOs at a time; the `GPIOBASE` register (fixed as read-write in the register map by #92) selects whether a block sees GPIO0-31 or GPIO16-47 — required for the upper pins on RP2350B/QFN80 packages (review item 30):

- New registry capability `RP_PIO_HAS_GPIOBASE` (RP2350 TRUE, RP2040 FALSE).
- `pioSetGpioBase()` accepts 0 or 16, asserted against the capability and against changing the window while any state machine is allocated (the window shifts pin semantics under running programs).
- Pin-facing APIs gain `gpio < RP_GPIO_NUM_LINES` bounds checks; the `pioGpioToRel()` helper converts an absolute GPIO to the block-relative index, and the WAIT-instruction GPIO operand semantics (absolute vs relative) are documented.

## Validation

On a Pico 2 (RP2350A — the base window covers all its pins, so the high-window leg uses the LED):

- `GPIOBASE = 16` on PIO2, SET-pin program on relative pin 9 drives GPIO25 (LED), verified by `GPIO_IN` readback; raw register write to 0x50200168 silicon-probed during the register-map work.
- Full PIO-VALIDATION suite passes 17/17 with the GPIOBASE legs added; legs whose prerequisites are absent on this package are gated with explicit skips.
- Reviewed by CodeRabbit (1 fixed / 1 deferred to the package-registry PR, since merged as #102) and Codex (4 fixed including lifetime alignment with the base branch), hardware re-validated after each round.