### PR TITLE
RP2350: add optional runtime clock switching

### DIFF
--- a/os/common/ext/RP/RP2350/rp2350.h
+++ b/os/common/ext/RP/RP2350/rp2350.h
@@ -1481,6 +1481,13 @@ typedef struct {
 } CLOCKS_FC0_TypeDef;
 
 typedef struct {
+  __IO uint32_t         BADPASSWD;
+  __IO uint32_t         VREG_CTRL;
+  __I  uint32_t         VREG_STS;
+  __IO uint32_t         VREG;
+} POWMAN_TypeDef;
+
+typedef struct {
   CLOCKS_CLK_TypeDef    CLK[10];
   __IO uint32_t         DFTCLK_XOSC_CTRL;
   __IO uint32_t         DFTCLK_ROSC_CTRL;
@@ -1686,6 +1693,7 @@ typedef struct {
 #define PLL_USB                           ((PLL_TypeDef *)        __PLL_USB_BASE)
 #define XOSC                              ((XOSC_TypeDef *)       __XOSC_BASE)
 #define CLOCKS                            ((CLOCKS_TypeDef *)     __CLOCKS_BASE)
+#define POWMAN                            ((POWMAN_TypeDef *)     __POWMAN_BASE)
 #define TICKS                             ((TICKS_TypeDef *)      __TICKS_BASE)
 #define XIP_CTRL                          ((XIP_CTRL_TypeDef *)   __XIP_CTRL_BASE)
 #define QMI                               ((QMI_TypeDef *)        __QMI_BASE)
@@ -3090,6 +3098,20 @@ typedef struct {
 #define CLOCKS_FC0_RESULT_KHZ_Pos         5U
 #define CLOCKS_FC0_RESULT_KHZ_Msk         (0x1FFFFFFU << CLOCKS_FC0_RESULT_KHZ_Pos)
 #define CLOCKS_FC0_MAX_KHZ_Msk            0x1FFFFFFU
+/** @} */
+
+/**
+ * @name    POWMAN bits definitions
+ * @note    Every POWMAN register write requires the password in the
+ *          upper half word.
+ * @{
+ */
+#define POWMAN_PASSWORD                   (0x5AFEU << 16)
+#define POWMAN_VREG_VSEL_Pos              4U
+#define POWMAN_VREG_VSEL_Msk              (0x1FU << POWMAN_VREG_VSEL_Pos)
+#define POWMAN_VREG_VSEL(n)               ((n) << POWMAN_VREG_VSEL_Pos)
+#define POWMAN_VREG_UPDATE_IN_PROGRESS    (1U << 15)
+#define POWMAN_VREG_HIZ                   (1U << 1)
 /** @} */
 
 /**

--- a/os/common/ext/RP/RP2350/rp2350.h
+++ b/os/common/ext/RP/RP2350/rp2350.h
@@ -3059,6 +3059,37 @@ typedef struct {
 #define CLOCKS_CLK_ADC_CTRL_AUXSRC_PLL_SYS (0x1U << CLOCKS_CLK_ADC_CTRL_AUXSRC_Pos)
 #define CLOCKS_CLK_ADC_CTRL_AUXSRC_ROSC   (0x2U << CLOCKS_CLK_ADC_CTRL_AUXSRC_Pos)
 #define CLOCKS_CLK_ADC_CTRL_AUXSRC_XOSC   (0x3U << CLOCKS_CLK_ADC_CTRL_AUXSRC_Pos)
+
+/* FC0 frequency counter */
+#define CLOCKS_FC0_SRC_NULL               0x00U
+#define CLOCKS_FC0_SRC_PLL_SYS            0x01U
+#define CLOCKS_FC0_SRC_PLL_USB            0x02U
+#define CLOCKS_FC0_SRC_ROSC               0x03U
+#define CLOCKS_FC0_SRC_ROSC_PH            0x04U
+#define CLOCKS_FC0_SRC_XOSC               0x05U
+#define CLOCKS_FC0_SRC_GPIN0              0x06U
+#define CLOCKS_FC0_SRC_GPIN1              0x07U
+#define CLOCKS_FC0_SRC_CLK_REF            0x08U
+#define CLOCKS_FC0_SRC_CLK_SYS            0x09U
+#define CLOCKS_FC0_SRC_CLK_PERI           0x0AU
+#define CLOCKS_FC0_SRC_CLK_USB            0x0BU
+#define CLOCKS_FC0_SRC_CLK_ADC            0x0CU
+#define CLOCKS_FC0_SRC_CLK_HSTX           0x0DU
+#define CLOCKS_FC0_SRC_LPOSC              0x0EU
+#define CLOCKS_FC0_SRC_OTP_CLK2FC         0x0FU
+#define CLOCKS_FC0_STATUS_PASS            (1U << 0)
+#define CLOCKS_FC0_STATUS_DONE            (1U << 4)
+#define CLOCKS_FC0_STATUS_RUNNING         (1U << 8)
+#define CLOCKS_FC0_STATUS_WAITING         (1U << 12)
+#define CLOCKS_FC0_STATUS_FAIL            (1U << 16)
+#define CLOCKS_FC0_STATUS_SLOW            (1U << 20)
+#define CLOCKS_FC0_STATUS_FAST            (1U << 24)
+#define CLOCKS_FC0_STATUS_DIED            (1U << 28)
+#define CLOCKS_FC0_RESULT_FRAC_Pos        0U
+#define CLOCKS_FC0_RESULT_FRAC_Msk        (0x1FU << CLOCKS_FC0_RESULT_FRAC_Pos)
+#define CLOCKS_FC0_RESULT_KHZ_Pos         5U
+#define CLOCKS_FC0_RESULT_KHZ_Msk         (0x1FFFFFFU << CLOCKS_FC0_RESULT_KHZ_Pos)
+#define CLOCKS_FC0_MAX_KHZ_Msk            0x1FFFFFFU
 /** @} */
 
 /**

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -104,6 +104,15 @@
 #endif
 
 /**
+ * @brief   Rated maximum system frequency of the device.
+ * @note    This is the specification limit, independent of the
+ *          compile-time boot configuration which may be lower.
+ */
+#if !defined(RP_CLK_SYS_MAX) || defined(__DOXYGEN__)
+#define RP_CLK_SYS_MAX                      150000000U
+#endif
+
+/**
  * @brief   Upper frequency bound admitted when overclocking is enabled.
  */
 #if !defined(RP_CLK_SYS_OVERCLOCK_MAX) || defined(__DOXYGEN__)
@@ -245,7 +254,7 @@
 #endif
 
 #if (RP_ALLOW_OVERCLOCK == TRUE) &&                                         \
-    ((RP_CLK_SYS_OVERCLOCK_MAX) < (RP_CLK_SYS_FREQ))
+    ((RP_CLK_SYS_OVERCLOCK_MAX) < (RP_CLK_SYS_MAX))
 #error "RP_CLK_SYS_OVERCLOCK_MAX below the rated system frequency"
 #endif
 
@@ -305,8 +314,8 @@ typedef struct {
    * @brief   Effective QMI flash clock divider for the new frequency,
    *          0 or 1..255.
    * @details Zero selects the divider the system booted with (captured
-   *          before the first switch), which is safe at every admitted
-   *          frequency because it is safe at the highest one. A
+   *          before the first switch), accepted only for targets at or
+   *          below the boot frequency where it is known-safe. A
    *          non-zero value must keep the flash SCK within the device
    *          rating at the new clk_sys. The switch first widens the
    *          divider to a value safe at both the old and the new

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -89,6 +89,28 @@
 #endif
 
 /**
+ * @brief   Allows runtime clock configurations above the rated system
+ *          frequency.
+ * @details Effective only together with @p RP_CLOCK_DYNAMIC. When
+ *          @p FALSE (default) the runtime validation rejects any
+ *          configuration above the compile-time system frequency.
+ *          Overclocked operation is outside the device specification;
+ *          configurations above the rated frequency must carry an
+ *          explicit QMI flash divider and may require a raised core
+ *          voltage (@p vreg_mv).
+ */
+#if !defined(RP_ALLOW_OVERCLOCK) || defined(__DOXYGEN__)
+#define RP_ALLOW_OVERCLOCK                  FALSE
+#endif
+
+/**
+ * @brief   Upper frequency bound admitted when overclocking is enabled.
+ */
+#if !defined(RP_CLK_SYS_OVERCLOCK_MAX) || defined(__DOXYGEN__)
+#define RP_CLK_SYS_OVERCLOCK_MAX            300000000U
+#endif
+
+/**
  * @brief   Starts core 1 after initialization.
  */
 #if !defined(RP_CORE1_START) || defined(__DOXYGEN__)
@@ -218,6 +240,15 @@
 #error "RP_CLOCK_DYNAMIC requires tick-less mode, in periodic mode SysTick counts clk_sys and the kernel tick would scale with every switch"
 #endif
 
+#if (RP_ALLOW_OVERCLOCK == TRUE) && (RP_CLOCK_DYNAMIC == FALSE)
+#error "RP_ALLOW_OVERCLOCK requires RP_CLOCK_DYNAMIC"
+#endif
+
+#if (RP_ALLOW_OVERCLOCK == TRUE) &&                                         \
+    ((RP_CLK_SYS_OVERCLOCK_MAX) < (RP_CLK_SYS_FREQ))
+#error "RP_CLK_SYS_OVERCLOCK_MAX below the rated system frequency"
+#endif
+
 /**
  * @name    Various clock points.
  * @{
@@ -284,6 +315,17 @@ typedef struct {
    *          specification at every instant.
    */
   uint32_t          qmi_clkdiv;
+  /**
+   * @brief   Core voltage in millivolts, 0 or 1100..1300 in steps of
+   *          50.
+   * @details Zero leaves the regulator untouched. A non-zero value is
+   *          only accepted when @p RP_ALLOW_OVERCLOCK is enabled; the
+   *          regulator is raised before an upward frequency change and
+   *          lowered after a downward one. Values above 1300 mV are
+   *          not supported (they require the POWMAN voltage-limit
+   *          unlock, deliberately out of scope).
+   */
+  uint32_t          vreg_mv;
 } halclkcfg_t;
 #endif /* RP_CLOCK_DYNAMIC == TRUE */
 
@@ -335,6 +377,9 @@ extern uint32_t SystemCoreClock;
 #if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
 extern const halclkcfg_t hal_clkcfg_default;
 extern const halclkcfg_t hal_clkcfg_low;
+#if (RP_ALLOW_OVERCLOCK == TRUE) || defined(__DOXYGEN__)
+extern const halclkcfg_t hal_clkcfg_overclock;
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -93,7 +93,9 @@
  *          frequency.
  * @details Effective only together with @p RP_CLOCK_DYNAMIC. When
  *          @p FALSE (default) the runtime validation rejects any
- *          configuration above the compile-time system frequency.
+ *          configuration above the rated maximum system frequency
+ *          (@p RP_CLK_SYS_MAX); a boot configuration below the rated
+ *          maximum may still switch up to it.
  *          Overclocked operation is outside the device specification;
  *          configurations above the rated frequency must carry an
  *          explicit QMI flash divider and may require a raised core

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -271,11 +271,17 @@ typedef struct {
    */
   uint32_t          pll_sys_postdiv2;
   /**
-   * @brief   QMI flash clock divider to program after the switch.
-   * @note    Zero keeps the divider currently in effect (as programmed
-   *          by the boot ROM for the boot configuration). A non-zero
-   *          value must keep the flash SCK within the device rating at
-   *          the new clk_sys.
+   * @brief   Effective QMI flash clock divider for the new frequency,
+   *          0 or 1..255.
+   * @details Zero selects the divider the system booted with (captured
+   *          before the first switch), which is safe at every admitted
+   *          frequency because it is safe at the highest one. A
+   *          non-zero value must keep the flash SCK within the device
+   *          rating at the new clk_sys. The switch first widens the
+   *          divider to a value safe at both the old and the new
+   *          frequency, and programs this target value only after the
+   *          new frequency is established, so flash timing stays in
+   *          specification at every instant.
    */
   uint32_t          qmi_clkdiv;
 } halclkcfg_t;

--- a/os/hal/ports/RP/RP2350/hal_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_lld.h
@@ -78,6 +78,17 @@
 #endif
 
 /**
+ * @brief   Enables runtime changes of the system clock.
+ * @details When @p TRUE the port advertises the generic clock management
+ *          API (@p halClockSwitchMode()) and clock point queries become
+ *          dynamic. When @p FALSE (default) the clock tree is fixed at
+ *          initialization time and this feature costs nothing.
+ */
+#if !defined(RP_CLOCK_DYNAMIC) || defined(__DOXYGEN__)
+#define RP_CLOCK_DYNAMIC                    FALSE
+#endif
+
+/**
  * @brief   Starts core 1 after initialization.
  */
 #if !defined(RP_CORE1_START) || defined(__DOXYGEN__)
@@ -202,6 +213,11 @@
 #error "RP2350-E12: clk_sys must be at least 1.1 * clk_usb for reliable USB operation"
 #endif
 
+#if (RP_CLOCK_DYNAMIC == TRUE) && defined(OSAL_ST_MODE) &&                  \
+    (OSAL_ST_MODE == OSAL_ST_MODE_PERIODIC)
+#error "RP_CLOCK_DYNAMIC requires tick-less mode, in periodic mode SysTick counts clk_sys and the kernel tick would scale with every switch"
+#endif
+
 /**
  * @name    Various clock points.
  * @{
@@ -223,6 +239,47 @@
 /*===========================================================================*/
 /* Driver data structures and types.                                         */
 /*===========================================================================*/
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   The port supports the generic clock management API.
+ */
+#define HAL_LLD_USE_CLOCK_MANAGEMENT
+
+/**
+ * @brief   Type of a clock configuration structure.
+ * @details Describes a PLL_SYS setting reachable at runtime through
+ *          @p halClockSwitchMode(). The reference is always the crystal
+ *          (@p RP_XOSCCLK); clk_peri follows clk_sys, clk_ref, clk_usb
+ *          and clk_adc are not affected by a switch.
+ */
+typedef struct {
+  /**
+   * @brief   PLL_SYS reference divider, 1..63.
+   */
+  uint32_t          pll_sys_refdiv;
+  /**
+   * @brief   PLL_SYS VCO frequency in Hz, 750 MHz..1600 MHz.
+   */
+  uint32_t          pll_sys_vco_freq;
+  /**
+   * @brief   PLL_SYS first post divider, 1..7.
+   */
+  uint32_t          pll_sys_postdiv1;
+  /**
+   * @brief   PLL_SYS second post divider, 1..postdiv1.
+   */
+  uint32_t          pll_sys_postdiv2;
+  /**
+   * @brief   QMI flash clock divider to program after the switch.
+   * @note    Zero keeps the divider currently in effect (as programmed
+   *          by the boot ROM for the boot configuration). A non-zero
+   *          value must keep the flash SCK within the device rating at
+   *          the new clk_sys.
+   */
+  uint32_t          qmi_clkdiv;
+} halclkcfg_t;
+#endif /* RP_CLOCK_DYNAMIC == TRUE */
 
 /*===========================================================================*/
 /* Driver macros.                                                            */
@@ -267,10 +324,20 @@ typedef uint32_t halcnt_t;
 #include "rp_pio.h"
 #include "rp_bootrom.h"
 
+extern uint32_t SystemCoreClock;
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+extern const halclkcfg_t hal_clkcfg_default;
+extern const halclkcfg_t hal_clkcfg_low;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
   void hal_lld_init(void);
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+  bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp);
+#endif
 #ifdef __cplusplus
 }
 #endif

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -348,11 +348,6 @@ static bool rp_clock_config_valid(const halclkcfg_t *ccp) {
   if (sys_freq > RP_CLK_SYS_OVERCLOCK_MAX) {
     return false;
   }
-  /* Above the rated frequency the boot flash divider is no longer
-     known-safe, an explicit divider is mandatory. */
-  if ((sys_freq > RP_PLL_SYS_CLK) && (ccp->qmi_clkdiv == 0U)) {
-    return false;
-  }
   /* Regulator range: 1100..1300 mV in 50 mV steps, or untouched. */
   if (ccp->vreg_mv != 0U) {
     if ((ccp->vreg_mv < 1100U) || (ccp->vreg_mv > 1300U) ||
@@ -362,14 +357,22 @@ static bool rp_clock_config_valid(const halclkcfg_t *ccp) {
   }
 #else
   /* Without overclocking support the port admits configurations up to
-     the rated system frequency only, and the regulator is off limits. */
-  if (sys_freq > RP_PLL_SYS_CLK) {
+     the rated maximum, which may exceed a lower compile-time boot
+     frequency; the regulator is off limits. */
+  if (sys_freq > RP_CLK_SYS_MAX) {
     return false;
   }
   if (ccp->vreg_mv != 0U) {
     return false;
   }
 #endif
+
+  /* The boot flash divider is only known-safe up to the boot
+     frequency; any target above it requires an explicit divider,
+     whether overclocked or merely above a low boot configuration. */
+  if ((sys_freq > RP_PLL_SYS_CLK) && (ccp->qmi_clkdiv == 0U)) {
+    return false;
+  }
 
   /* RP2350-E12: reliable USB operation requires clk_sys >= 1.1 *
      clk_usb; clk_usb stays at its fixed frequency across switches. The
@@ -429,7 +432,8 @@ static uint32_t rp_clock_get_vreg_mv(void) {
  *          while the timing register changes.
  * @note    This function MUST be in RAM.
  *
- * @param[in] clkdiv    new CLKDIV value, 1..255
+ * @param[in] clkdiv    new CLKDIV encoding, 0..255 where zero encodes
+ *                      the effective divider 256
  */
 RAMFUNC static void rp_clock_set_qmi_clkdiv(uint32_t clkdiv) {
 

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -595,12 +595,13 @@ bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
 
 #if RP_ALLOW_OVERCLOCK == TRUE
   /* A lowered voltage is applied only after the frequency has come
-     down; a late regulator timeout is reported although the clocks
-     are already at the (safe, lower) target. */
+     down. A late regulator timeout is deliberately not reported: the
+     clocks are already at the target and the voltage stays at its
+     previous, higher and therefore safe, level - a missed power
+     optimization must not make callers believe the frequency change
+     failed and skip their driver restarts. */
   if ((ccp->vreg_mv != 0U) && (ccp->vreg_mv < rp_clock_get_vreg_mv())) {
-    if (rp_clock_set_vreg(ccp->vreg_mv)) {
-      return true;
-    }
+    (void)rp_clock_set_vreg(ccp->vreg_mv);
   }
 #endif
 

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -107,6 +107,15 @@ const halclkcfg_t hal_clkcfg_overclock = {
 static volatile uint32_t rp_clock_points[RP_CLK_COUNT];
 
 /**
+ * @brief   Clock point table sequence counter.
+ * @details Incremented to odd before and to even after every table
+ *          update; lock-free readers on the other core retry while an
+ *          update is in progress or has intervened. The first-switch
+ *          activation is still gated on a non-zero @p RP_CLK_SYS entry.
+ */
+static volatile uint32_t rp_clock_seq;
+
+/**
  * @brief   Effective QMI flash divider the system booted with, 1..256.
  * @details Captured on the first switch, before anything has changed
  *          it; zero means not yet captured (BSS state). The boot value
@@ -164,12 +173,14 @@ void rp_clock_init(void) {
   {
     /* Deactivating the dynamic table explicitly: this code can run
        before CRT0 clears BSS and retained SRAM after a warm reset
-       could otherwise present a stale table to early callers. */
+       could otherwise present a stale table or an odd sequence to
+       early callers. */
     unsigned i;
 
     for (i = 0U; i < RP_CLK_COUNT; i++) {
       rp_clock_points[i] = 0U;
     }
+    rp_clock_seq = 0U;
   }
 #endif
 
@@ -274,12 +285,25 @@ uint32_t rp_clock_get_hz(uint32_t clk_index) {
 #if RP_CLOCK_DYNAMIC == TRUE
   /* The table stays zero (explicitly cleared at rp_clock_init() entry,
      again by the CRT0 BSS clear) until the first successful runtime
-     switch populates every entry and writes RP_CLK_SYS last; falling
-     through to the compile-time constants preserves the documented
-     pre-initialization callability and the constants are correct by
-     definition until that first switch. */
-  if (rp_clock_points[RP_CLK_SYS] != 0U) {
-    return rp_clock_points[clk_index];
+     switch populates every entry; falling through to the compile-time
+     constants preserves the documented pre-initialization callability
+     and the constants are correct by definition until that first
+     switch. Reads are guarded by a sequence counter, a reader racing
+     an update on the other core retries until it holds a consistent
+     snapshot; the writer's update window is a handful of stores. */
+  {
+    uint32_t seq, value, active;
+
+    do {
+      seq = rp_clock_seq;
+      __DMB();
+      active = rp_clock_points[RP_CLK_SYS];
+      value  = rp_clock_points[clk_index];
+      __DMB();
+    } while (((seq & 1U) != 0U) || (seq != rp_clock_seq));
+    if (active != 0U) {
+      return value;
+    }
   }
 #endif
 
@@ -422,6 +446,12 @@ static uint32_t rp_clock_get_vreg_mv(void) {
   uint32_t vsel = (POWMAN->VREG & POWMAN_VREG_VSEL_Msk) >>
                   POWMAN_VREG_VSEL_Pos;
 
+  /* Encodings below 1.10 V exist (down to 0.55 V); reporting them as
+     zero makes any upward request actually raise the regulator instead
+     of underflowing into a nonsensically high reading. */
+  if (vsel < 0x0BU) {
+    return 0U;
+  }
   return 1100U + ((vsel - 0x0BU) * 50U);
 }
 #endif /* RP_ALLOW_OVERCLOCK == TRUE */
@@ -544,18 +574,20 @@ bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
      effective divider 256 is zero. */
   rp_clock_set_qmi_clkdiv(div_new & 0xFFU);
 
-  /* Publishing the new frequencies. Every entry is written on every
-     switch because the table may have been cleared after a partial
-     early population; RP_CLK_SYS is the activation entry and is
-     published last, behind a barrier, so a lock-free reader on the
-     other core that observes it also observes the rest. */
+  /* Publishing the new frequencies under the sequence counter: odd
+     while the table is inconsistent, readers retry across the window.
+     Every entry is written on every switch because the table may have
+     been cleared after a partial early population; RP_CLK_SYS doubles
+     as the first-switch activation entry. */
+  rp_clock_seq = rp_clock_seq + 1U;
+  __DMB();
   rp_clock_points[RP_CLK_REF]  = RP_CLK_REF_FREQ;
   rp_clock_points[RP_CLK_USB]  = RP_CLK_USB_FREQ;
   rp_clock_points[RP_CLK_ADC]  = RP_CLK_ADC_FREQ;
   rp_clock_points[RP_CLK_PERI] = sys_freq;
-  __DMB();
   rp_clock_points[RP_CLK_SYS]  = sys_freq;
   __DMB();
+  rp_clock_seq = rp_clock_seq + 1U;
   SystemCoreClock = sys_freq;
 
   __set_PRIMASK(primask);

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -55,7 +55,8 @@ const halclkcfg_t hal_clkcfg_default = {
   .pll_sys_vco_freq = RP_PLL_SYS_VCO_FREQ,
   .pll_sys_postdiv1 = RP_PLL_SYS_POSTDIV1,
   .pll_sys_postdiv2 = RP_PLL_SYS_POSTDIV2,
-  .qmi_clkdiv       = 0U
+  .qmi_clkdiv       = 0U,
+  .vreg_mv          = 0U
 };
 
 /**
@@ -68,8 +69,26 @@ const halclkcfg_t hal_clkcfg_low = {
   .pll_sys_vco_freq = 768000000U,
   .pll_sys_postdiv1 = 4U,
   .pll_sys_postdiv2 = 2U,
-  .qmi_clkdiv       = 0U
+  .qmi_clkdiv       = 0U,
+  .vreg_mv          = 0U
 };
+
+#if (RP_ALLOW_OVERCLOCK == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   An overclocked configuration, 200 MHz at 1.15 V.
+ * @note    Outside the device specification. Assumes the default
+ *          12 MHz crystal. The explicit flash divider yields a 50 MHz
+ *          SCK, conservative for common flash devices.
+ */
+const halclkcfg_t hal_clkcfg_overclock = {
+  .pll_sys_refdiv   = RP_PLL_SYS_REFDIV,
+  .pll_sys_vco_freq = 1200000000U,
+  .pll_sys_postdiv1 = 3U,
+  .pll_sys_postdiv2 = 2U,
+  .qmi_clkdiv       = 4U,
+  .vreg_mv          = 1150U
+};
+#endif
 #endif /* RP_CLOCK_DYNAMIC == TRUE */
 
 /*===========================================================================*/
@@ -325,11 +344,32 @@ static bool rp_clock_config_valid(const halclkcfg_t *ccp) {
   }
   sys_freq = ccp->pll_sys_vco_freq / pdiv;
 
-  /* No overclocking support, the port is validated up to the rated
-     system frequency only. */
+#if RP_ALLOW_OVERCLOCK == TRUE
+  if (sys_freq > RP_CLK_SYS_OVERCLOCK_MAX) {
+    return false;
+  }
+  /* Above the rated frequency the boot flash divider is no longer
+     known-safe, an explicit divider is mandatory. */
+  if ((sys_freq > RP_PLL_SYS_CLK) && (ccp->qmi_clkdiv == 0U)) {
+    return false;
+  }
+  /* Regulator range: 1100..1300 mV in 50 mV steps, or untouched. */
+  if (ccp->vreg_mv != 0U) {
+    if ((ccp->vreg_mv < 1100U) || (ccp->vreg_mv > 1300U) ||
+        ((ccp->vreg_mv % 50U) != 0U)) {
+      return false;
+    }
+  }
+#else
+  /* Without overclocking support the port admits configurations up to
+     the rated system frequency only, and the regulator is off limits. */
   if (sys_freq > RP_PLL_SYS_CLK) {
     return false;
   }
+  if (ccp->vreg_mv != 0U) {
+    return false;
+  }
+#endif
 
   /* RP2350-E12: reliable USB operation requires clk_sys >= 1.1 *
      clk_usb; clk_usb stays at its fixed frequency across switches. The
@@ -344,6 +384,44 @@ static bool rp_clock_config_valid(const halclkcfg_t *ccp) {
 
   return true;
 }
+
+#if RP_ALLOW_OVERCLOCK == TRUE
+/**
+ * @brief   Programs the core voltage regulator.
+ * @details Millivolts are mapped onto the VSEL encoding (1100 mV is
+ *          VSEL 0x0B, 50 mV per step); voltages above 1300 mV would
+ *          require the POWMAN voltage-limit unlock and are rejected by
+ *          validation. Every POWMAN write carries the password.
+ *
+ * @param[in] mv        target voltage, 1100..1300 in steps of 50
+ * @return              @p true on regulator update timeout.
+ */
+static bool rp_clock_set_vreg(uint32_t mv) {
+  uint32_t vsel = 0x0BU + ((mv - 1100U) / 50U);
+  uint32_t vreg, start;
+
+  vreg = (POWMAN->VREG & 0xFFFFU & ~POWMAN_VREG_VSEL_Msk) |
+         POWMAN_VREG_VSEL(vsel);
+  POWMAN->VREG = POWMAN_PASSWORD | vreg;
+  start = TIMER0->TIMERAWL;
+  while ((POWMAN->VREG & POWMAN_VREG_UPDATE_IN_PROGRESS) != 0U) {
+    if ((uint32_t)(TIMER0->TIMERAWL - start) > 1000U) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief   Returns the currently programmed regulator voltage in mV.
+ */
+static uint32_t rp_clock_get_vreg_mv(void) {
+  uint32_t vsel = (POWMAN->VREG & POWMAN_VREG_VSEL_Msk) >>
+                  POWMAN_VREG_VSEL_Pos;
+
+  return 1100U + ((vsel - 0x0BU) * 50U);
+}
+#endif /* RP_ALLOW_OVERCLOCK == TRUE */
 
 /**
  * @brief   Reprograms the QMI flash clock divider.
@@ -418,6 +496,16 @@ bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
                                      : rp_clock_boot_qmi_div;
   div_safe = (div_new > div_old) ? div_new : div_old;
 
+#if RP_ALLOW_OVERCLOCK == TRUE
+  /* A raised core voltage must be stable before the frequency goes up;
+     a timeout aborts the switch with the clocks untouched. */
+  if ((ccp->vreg_mv != 0U) && (ccp->vreg_mv > rp_clock_get_vreg_mv())) {
+    if (rp_clock_set_vreg(ccp->vreg_mv)) {
+      return true;
+    }
+  }
+#endif
+
   /* Only local interrupts are masked: the sequence touches no kernel
      state and taking the kernel lock here would stall the other core
      on any kernel entry for the whole PLL relock. */
@@ -467,6 +555,17 @@ bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
   SystemCoreClock = sys_freq;
 
   __set_PRIMASK(primask);
+
+#if RP_ALLOW_OVERCLOCK == TRUE
+  /* A lowered voltage is applied only after the frequency has come
+     down; a late regulator timeout is reported although the clocks
+     are already at the (safe, lower) target. */
+  if ((ccp->vreg_mv != 0U) && (ccp->vreg_mv < rp_clock_get_vreg_mv())) {
+    if (rp_clock_set_vreg(ccp->vreg_mv)) {
+      return true;
+    }
+  }
+#endif
 
   return false;
 }

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -181,6 +181,7 @@ void rp_clock_init(void) {
       rp_clock_points[i] = 0U;
     }
     rp_clock_seq = 0U;
+    rp_clock_boot_qmi_div = 0U;
   }
 #endif
 

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -38,13 +38,53 @@
  */
 #define RP_ROSC_ASSUMED_HZ      6000000U
 
+#if RP_CLOCK_DYNAMIC == TRUE
+#define RAMFUNC __attribute__((noinline, section(".ramtext")))
+#endif
+
 /*===========================================================================*/
 /* Driver exported variables.                                                */
 /*===========================================================================*/
 
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   The clock configuration the system boots with.
+ */
+const halclkcfg_t hal_clkcfg_default = {
+  .pll_sys_refdiv   = RP_PLL_SYS_REFDIV,
+  .pll_sys_vco_freq = RP_PLL_SYS_VCO_FREQ,
+  .pll_sys_postdiv1 = RP_PLL_SYS_POSTDIV1,
+  .pll_sys_postdiv2 = RP_PLL_SYS_POSTDIV2,
+  .qmi_clkdiv       = 0U
+};
+
+/**
+ * @brief   A reduced-frequency configuration, 96 MHz.
+ * @note    Assumes the default 12 MHz crystal; rejected by validation
+ *          on configurations where the VCO settings do not divide.
+ */
+const halclkcfg_t hal_clkcfg_low = {
+  .pll_sys_refdiv   = RP_PLL_SYS_REFDIV,
+  .pll_sys_vco_freq = 768000000U,
+  .pll_sys_postdiv1 = 4U,
+  .pll_sys_postdiv2 = 2U,
+  .qmi_clkdiv       = 0U
+};
+#endif /* RP_CLOCK_DYNAMIC == TRUE */
+
 /*===========================================================================*/
 /* Driver local variables and types.                                         */
 /*===========================================================================*/
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Current clock point frequencies.
+ * @details Zero-initialized in BSS; @p rp_clock_get_hz() serves the
+ *          compile-time constants until @p rp_clock_init() populates
+ *          this table.
+ */
+static uint32_t rp_clock_points[RP_CLK_COUNT];
+#endif
 
 /*===========================================================================*/
 /* Driver local functions.                                                   */
@@ -172,6 +212,18 @@ void rp_clock_init(void) {
   for (uint32_t i = 0U; i < 6U; i++) {
     rp_tick_start(i, cycles);
   }
+
+#if RP_CLOCK_DYNAMIC == TRUE
+  /* Activating dynamic clock point queries, the boot values match the
+     compile-time constants by construction. */
+  rp_clock_points[RP_CLK_REF]  = RP_CLK_REF_FREQ;
+  rp_clock_points[RP_CLK_PERI] = RP_CLK_PERI_FREQ;
+  rp_clock_points[RP_CLK_USB]  = RP_CLK_USB_FREQ;
+  rp_clock_points[RP_CLK_ADC]  = RP_CLK_ADC_FREQ;
+  /* RP_CLK_SYS is written last, a non-zero value here switches
+     rp_clock_get_hz() over to the table. */
+  rp_clock_points[RP_CLK_SYS]  = RP_CLK_SYS_FREQ;
+#endif
 }
 
 /**
@@ -185,6 +237,17 @@ void rp_clock_init(void) {
 uint32_t rp_clock_get_hz(uint32_t clk_index) {
 
   osalDbgAssert(clk_index < RP_CLK_COUNT, "invalid clock index");
+
+#if RP_CLOCK_DYNAMIC == TRUE
+  /* The table lives in BSS and stays zero until rp_clock_init() has
+     populated it; falling through to the compile-time constants below
+     preserves the documented pre-initialization callability, the
+     constants are correct by definition until the first switch and the
+     first switch cannot happen before initialization. */
+  if (rp_clock_points[RP_CLK_SYS] != 0U) {
+    return rp_clock_points[clk_index];
+  }
+#endif
 
   switch (clk_index) {
   case RP_CLK_REF:
@@ -201,5 +264,169 @@ uint32_t rp_clock_get_hz(uint32_t clk_index) {
     return 0U;
   }
 }
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Checks a clock configuration for validity.
+ * @details Applies at runtime the same constraints the port enforces at
+ *          compile time on the static configuration, including the
+ *          RP2350-E12 clk_sys/clk_usb ratio.
+ *
+ * @param[in] ccp       pointer to a @p halclkcfg_t structure
+ * @return              @p true if the configuration is acceptable.
+ */
+static bool rp_clock_config_valid(const halclkcfg_t *ccp) {
+  uint32_t ref_freq, fbdiv, pdiv, sys_freq;
+
+  if ((ccp->pll_sys_refdiv < 1U) || (ccp->pll_sys_refdiv > 63U)) {
+    return false;
+  }
+  if ((RP_XOSCCLK % ccp->pll_sys_refdiv) != 0U) {
+    return false;
+  }
+  ref_freq = RP_XOSCCLK / ccp->pll_sys_refdiv;
+  if (ref_freq < 5000000U) {
+    return false;
+  }
+  if ((ccp->pll_sys_vco_freq < RP_PLL_VCO_MIN_FREQ) ||
+      (ccp->pll_sys_vco_freq > RP_PLL_VCO_MAX_FREQ)) {
+    return false;
+  }
+  if ((ccp->pll_sys_vco_freq % ref_freq) != 0U) {
+    return false;
+  }
+  fbdiv = ccp->pll_sys_vco_freq / ref_freq;
+  if ((fbdiv < 16U) || (fbdiv > 320U)) {
+    return false;
+  }
+  if ((ccp->pll_sys_postdiv1 < 1U) || (ccp->pll_sys_postdiv1 > 7U) ||
+      (ccp->pll_sys_postdiv2 < 1U) ||
+      (ccp->pll_sys_postdiv2 > ccp->pll_sys_postdiv1)) {
+    return false;
+  }
+  pdiv = ccp->pll_sys_postdiv1 * ccp->pll_sys_postdiv2;
+  if ((ccp->pll_sys_vco_freq % pdiv) != 0U) {
+    return false;
+  }
+  sys_freq = ccp->pll_sys_vco_freq / pdiv;
+
+  /* No overclocking support, the port is validated up to the rated
+     system frequency only. */
+  if (sys_freq > RP_PLL_SYS_CLK) {
+    return false;
+  }
+
+  /* RP2350-E12: reliable USB operation requires clk_sys >= 1.1 *
+     clk_usb; clk_usb stays at its fixed frequency across switches. The
+     comparison is done in 64 bits, this is runtime arithmetic. */
+  if (((uint64_t)sys_freq * 10ULL) < ((uint64_t)RP_CLK_USB_FREQ * 11ULL)) {
+    return false;
+  }
+
+  if (ccp->qmi_clkdiv > 255U) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Reprograms the QMI flash clock divider.
+ * @details Runs from RAM so no XIP fetch from this core is in flight
+ *          while the timing register changes.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] clkdiv    new CLKDIV value, 1..255
+ */
+RAMFUNC static void rp_clock_set_qmi_clkdiv(uint32_t clkdiv) {
+
+  QMI->M0_TIMING = (QMI->M0_TIMING & ~QMI_TIMING_CLKDIV_Msk) |
+                   QMI_TIMING_CLKDIV(clkdiv);
+  (void)QMI->M0_TIMING;
+  __DSB();
+  __ISB();
+}
+
+/**
+ * @brief   Switches to a different clock configuration.
+ * @details The switch keeps every clock consumer within specification
+ *          at all times: the flash divider is first widened to a value
+ *          safe at both the current and the target frequency, clk_sys
+ *          (and clk_peri with it) is parked on clk_ref through the
+ *          glitchless mux while PLL_SYS relocks, then the final flash
+ *          divider is applied. clk_ref, clk_usb and clk_adc are not
+ *          touched, so kernel time (TIMER0, fed from clk_ref) and the
+ *          48 MHz peripherals are unaffected.
+ * @note    Running peripheral drivers whose bit rates derive from
+ *          clk_sys/clk_peri keep their old divider settings; the
+ *          application must restart them after a switch, they then
+ *          recompute from the updated clock points.
+ * @note    On SMP configurations the other core keeps executing during
+ *          the switch (timing stays in specification throughout); it
+ *          slows to the parked frequency while PLL_SYS relocks.
+ *
+ * @param[in] ccp       pointer to a @p halclkcfg_t structure
+ * @return              The operation status.
+ * @retval false        if the switch operation succeeded.
+ * @retval true         if the switch operation failed.
+ *
+ * @special
+ */
+bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
+  uint32_t sys_freq, qmi_old, qmi_new, qmi_safe;
+  syssts_t sts;
+
+  osalDbgCheck(ccp != NULL);
+
+  if (!rp_clock_config_valid(ccp)) {
+    return true;
+  }
+  sys_freq = ccp->pll_sys_vco_freq /
+             (ccp->pll_sys_postdiv1 * ccp->pll_sys_postdiv2);
+
+  qmi_old  = (QMI->M0_TIMING & QMI_TIMING_CLKDIV_Msk) >>
+             QMI_TIMING_CLKDIV_Pos;
+  qmi_new  = (ccp->qmi_clkdiv != 0U) ? ccp->qmi_clkdiv : qmi_old;
+  qmi_safe = (qmi_new > qmi_old) ? qmi_new : qmi_old;
+
+  sts = osalSysGetStatusAndLockX();
+
+  /* Flash divider safe at both the current and the target frequency
+     before anything changes. */
+  rp_clock_set_qmi_clkdiv(qmi_safe);
+
+  /* Parking clk_sys on clk_ref through the glitchless mux; execution
+     continues from flash at the reference frequency. */
+  CLOCKS->CLR.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 1U) == 0U) {
+    /* Waiting for clk_sys to run from clk_ref. */
+  }
+
+  /* Reprogramming PLL_SYS while nothing runs from it. */
+  rp_pll_init(PLL_SYS, ccp->pll_sys_refdiv, ccp->pll_sys_vco_freq,
+              ccp->pll_sys_postdiv1, ccp->pll_sys_postdiv2);
+
+  /* Back onto the PLL through the glitchless mux. */
+  CLOCKS->XOR.CLK[RP_CLK_SYS].CTRL =
+      (CLOCKS->CLK[RP_CLK_SYS].CTRL ^ CLOCKS_CLK_SYS_CTRL_AUXSRC_PLL_SYS) &
+      CLOCKS_CLK_SYS_CTRL_AUXSRC_Msk;
+  CLOCKS->SET.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_AUX;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 2U) == 0U) {
+    /* Waiting for clk_sys to run from PLL_SYS. */
+  }
+
+  /* Final flash divider for the new frequency. */
+  rp_clock_set_qmi_clkdiv(qmi_new);
+
+  /* Publishing the new frequencies; clk_peri follows clk_sys. */
+  rp_clock_points[RP_CLK_SYS]  = sys_freq;
+  rp_clock_points[RP_CLK_PERI] = sys_freq;
+  SystemCoreClock = sys_freq;
+
+  osalSysRestoreStatusX(sts);
+
+  return false;
+}
+#endif /* RP_CLOCK_DYNAMIC == TRUE */
 
 /** @} */

--- a/os/hal/ports/RP/RP2350/rp_clocks.c
+++ b/os/hal/ports/RP/RP2350/rp_clocks.c
@@ -79,11 +79,23 @@ const halclkcfg_t hal_clkcfg_low = {
 #if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
 /**
  * @brief   Current clock point frequencies.
- * @details Zero-initialized in BSS; @p rp_clock_get_hz() serves the
- *          compile-time constants until @p rp_clock_init() populates
- *          this table.
+ * @details All-zero until the first successful runtime switch populates
+ *          every entry; @p rp_clock_get_hz() serves the compile-time
+ *          constants while the activation entry (@p RP_CLK_SYS, written
+ *          last) is zero. Volatile: written on one core, read lock-free
+ *          on the other.
  */
-static uint32_t rp_clock_points[RP_CLK_COUNT];
+static volatile uint32_t rp_clock_points[RP_CLK_COUNT];
+
+/**
+ * @brief   Effective QMI flash divider the system booted with, 1..256.
+ * @details Captured on the first switch, before anything has changed
+ *          it; zero means not yet captured (BSS state). The boot value
+ *          is safe at the boot frequency, which is the highest the
+ *          validation admits, therefore safe at every admitted
+ *          frequency.
+ */
+static uint32_t rp_clock_boot_qmi_div;
 #endif
 
 /*===========================================================================*/
@@ -128,6 +140,19 @@ static void rp_tick_start(uint32_t index, uint32_t cycles) {
  */
 void rp_clock_init(void) {
   uint32_t cycles;
+
+#if RP_CLOCK_DYNAMIC == TRUE
+  {
+    /* Deactivating the dynamic table explicitly: this code can run
+       before CRT0 clears BSS and retained SRAM after a warm reset
+       could otherwise present a stale table to early callers. */
+    unsigned i;
+
+    for (i = 0U; i < RP_CLK_COUNT; i++) {
+      rp_clock_points[i] = 0U;
+    }
+  }
+#endif
 
   /* Start early tick generator for safety module timeouts. */
   rp_peripheral_unreset(RESETS_ALLREG_TIMER0);
@@ -213,17 +238,6 @@ void rp_clock_init(void) {
     rp_tick_start(i, cycles);
   }
 
-#if RP_CLOCK_DYNAMIC == TRUE
-  /* Activating dynamic clock point queries, the boot values match the
-     compile-time constants by construction. */
-  rp_clock_points[RP_CLK_REF]  = RP_CLK_REF_FREQ;
-  rp_clock_points[RP_CLK_PERI] = RP_CLK_PERI_FREQ;
-  rp_clock_points[RP_CLK_USB]  = RP_CLK_USB_FREQ;
-  rp_clock_points[RP_CLK_ADC]  = RP_CLK_ADC_FREQ;
-  /* RP_CLK_SYS is written last, a non-zero value here switches
-     rp_clock_get_hz() over to the table. */
-  rp_clock_points[RP_CLK_SYS]  = RP_CLK_SYS_FREQ;
-#endif
 }
 
 /**
@@ -239,11 +253,12 @@ uint32_t rp_clock_get_hz(uint32_t clk_index) {
   osalDbgAssert(clk_index < RP_CLK_COUNT, "invalid clock index");
 
 #if RP_CLOCK_DYNAMIC == TRUE
-  /* The table lives in BSS and stays zero until rp_clock_init() has
-     populated it; falling through to the compile-time constants below
-     preserves the documented pre-initialization callability, the
-     constants are correct by definition until the first switch and the
-     first switch cannot happen before initialization. */
+  /* The table stays zero (explicitly cleared at rp_clock_init() entry,
+     again by the CRT0 BSS clear) until the first successful runtime
+     switch populates every entry and writes RP_CLK_SYS last; falling
+     through to the compile-time constants preserves the documented
+     pre-initialization callability and the constants are correct by
+     definition until that first switch. */
   if (rp_clock_points[RP_CLK_SYS] != 0U) {
     return rp_clock_points[clk_index];
   }
@@ -363,7 +378,13 @@ RAMFUNC static void rp_clock_set_qmi_clkdiv(uint32_t clkdiv) {
  *          recompute from the updated clock points.
  * @note    On SMP configurations the other core keeps executing during
  *          the switch (timing stays in specification throughout); it
- *          slows to the parked frequency while PLL_SYS relocks.
+ *          slows to the parked frequency while PLL_SYS relocks. Only
+ *          local interrupts are masked, no kernel lock is taken.
+ * @note    While PLL_SYS relocks the system transits through the
+ *          reference frequency, transiently violating the RP2350-E12
+ *          clk_sys/clk_usb ratio; do not switch while USB traffic is
+ *          active. This mirrors the transition-window caveat of the
+ *          other ports implementing this API.
  *
  * @param[in] ccp       pointer to a @p halclkcfg_t structure
  * @return              The operation status.
@@ -373,8 +394,7 @@ RAMFUNC static void rp_clock_set_qmi_clkdiv(uint32_t clkdiv) {
  * @special
  */
 bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
-  uint32_t sys_freq, qmi_old, qmi_new, qmi_safe;
-  syssts_t sts;
+  uint32_t sys_freq, div_old, div_new, div_safe, primask;
 
   osalDbgCheck(ccp != NULL);
 
@@ -384,16 +404,29 @@ bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
   sys_freq = ccp->pll_sys_vco_freq /
              (ccp->pll_sys_postdiv1 * ccp->pll_sys_postdiv2);
 
-  qmi_old  = (QMI->M0_TIMING & QMI_TIMING_CLKDIV_Msk) >>
-             QMI_TIMING_CLKDIV_Pos;
-  qmi_new  = (ccp->qmi_clkdiv != 0U) ? ccp->qmi_clkdiv : qmi_old;
-  qmi_safe = (qmi_new > qmi_old) ? qmi_new : qmi_old;
+  /* Effective divider values: the CLKDIV encoding zero means divide by
+     256, comparisons must never be done on raw encodings. The boot
+     divider is captured on the first switch, before anything has
+     changed it. */
+  div_old = (QMI->M0_TIMING & QMI_TIMING_CLKDIV_Msk) >>
+            QMI_TIMING_CLKDIV_Pos;
+  div_old = (div_old == 0U) ? 256U : div_old;
+  if (rp_clock_boot_qmi_div == 0U) {
+    rp_clock_boot_qmi_div = div_old;
+  }
+  div_new  = (ccp->qmi_clkdiv != 0U) ? ccp->qmi_clkdiv
+                                     : rp_clock_boot_qmi_div;
+  div_safe = (div_new > div_old) ? div_new : div_old;
 
-  sts = osalSysGetStatusAndLockX();
+  /* Only local interrupts are masked: the sequence touches no kernel
+     state and taking the kernel lock here would stall the other core
+     on any kernel entry for the whole PLL relock. */
+  primask = __get_PRIMASK();
+  __disable_irq();
 
   /* Flash divider safe at both the current and the target frequency
      before anything changes. */
-  rp_clock_set_qmi_clkdiv(qmi_safe);
+  rp_clock_set_qmi_clkdiv(div_safe & 0xFFU);
 
   /* Parking clk_sys on clk_ref through the glitchless mux; execution
      continues from flash at the reference frequency. */
@@ -415,15 +448,25 @@ bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
     /* Waiting for clk_sys to run from PLL_SYS. */
   }
 
-  /* Final flash divider for the new frequency. */
-  rp_clock_set_qmi_clkdiv(qmi_new);
+  /* Final flash divider for the new frequency; the encoding for the
+     effective divider 256 is zero. */
+  rp_clock_set_qmi_clkdiv(div_new & 0xFFU);
 
-  /* Publishing the new frequencies; clk_peri follows clk_sys. */
-  rp_clock_points[RP_CLK_SYS]  = sys_freq;
+  /* Publishing the new frequencies. Every entry is written on every
+     switch because the table may have been cleared after a partial
+     early population; RP_CLK_SYS is the activation entry and is
+     published last, behind a barrier, so a lock-free reader on the
+     other core that observes it also observes the rest. */
+  rp_clock_points[RP_CLK_REF]  = RP_CLK_REF_FREQ;
+  rp_clock_points[RP_CLK_USB]  = RP_CLK_USB_FREQ;
+  rp_clock_points[RP_CLK_ADC]  = RP_CLK_ADC_FREQ;
   rp_clock_points[RP_CLK_PERI] = sys_freq;
+  __DMB();
+  rp_clock_points[RP_CLK_SYS]  = sys_freq;
+  __DMB();
   SystemCoreClock = sys_freq;
 
-  osalSysRestoreStatusX(sts);
+  __set_PRIMASK(primask);
 
   return false;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,14 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- NEW: RP2350 runtime clock switching (RP_CLOCK_DYNAMIC, default FALSE):
+       real halClockSwitchMode() support with runtime-validated PLL_SYS
+       configurations, flash-timing-safe reclocking with both cores kept
+       executing from XIP, dynamic clock point queries and a hardware
+       validation target. Optional overclocking behind a second opt-in
+       (RP_ALLOW_OVERCLOCK, default FALSE) with a mandatory explicit flash
+       divider above the rated frequency and POWMAN core voltage control up
+       to 1.30 V (github PR #109).
 - NEW: Hazard3 RISC-V support for RP2350: RT/NIL ports, dual-core SMP,
        Xh3irq interrupt handling, periodic and tickless MTIME support, PMP
        stack guards, startup/HAL integration, demo, and hardware validation

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/Makefile
@@ -1,0 +1,159 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O0 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                FALSE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                FALSE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                FALSE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    FALSE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               FALSE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                FALSE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  FALSE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     FALSE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      FALSE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           FALSE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 TRUE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      FALSE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,52 @@
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_CLOCK_DYNAMIC                    TRUE
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+
+/*
+ * ADC driver system settings.
+ */
+#define RP_ADC_USE_ADC1                     FALSE
+#define RP_ADC_ADC1_DMA_PRIORITY            0
+#define RP_ADC_ADC1_DMA_IRQ_PRIORITY        3
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/cfg/mcuconf.h
@@ -7,6 +7,7 @@
  * HAL driver system settings.
  */
 #define RP_CLOCK_DYNAMIC                    TRUE
+#define RP_ALLOW_OVERCLOCK                  TRUE
 
 /*
  * HAL driver system settings.

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/main.c
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/main.c
@@ -30,8 +30,10 @@
  * 4. Flash execution: code keeps running from XIP across switches (this
  *    program lives there) and a flash-resident pattern must checksum
  *    identically at every frequency.
- * 5. Switch back and stress: return to the default configuration, then
- *    25 low/default round trips with FC0 verification.
+ * 5. Switch back and stress: return to the default configuration, an
+ *    explicit-divider round trip, a gated 200 MHz overclock leg with
+ *    core voltage raise/restore, then 25 low/default round trips with
+ *    FC0 verification.
  *
  * Single core. Output on SIOD0 (GPIO0/GPIO1) at the default 38400.
  */
@@ -230,6 +232,32 @@ int main(void) {
     report("explicit divider applied and boot divider restored",
            ok && (enc == boot_enc));
   }
+
+#if RP_ALLOW_OVERCLOCK == TRUE
+  /* Overclock leg: 200 MHz at 1.15 V with an explicit flash divider,
+     then back to the rated default. Returning with a 1100 mV request
+     exercises the lower-voltage-after-frequency path. */
+  {
+    halclkcfg_t restore = hal_clkcfg_default;
+
+    chThdSleepMilliseconds(20);
+    ok = (halClockSwitchMode(&hal_clkcfg_overclock) == false);
+    khz = fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS);
+    ok = ok && freq_close_khz(khz, 200000U);
+    ok = ok && (flash_checksum() == sum_boot);
+    ok = ok && (((POWMAN->VREG & POWMAN_VREG_VSEL_Msk) >>
+                 POWMAN_VREG_VSEL_Pos) == 0x0CU);   /* 1.15 V.*/
+    restore.vreg_mv = 1100U;
+    ok = ok && (halClockSwitchMode(&restore) == false);
+    ok = ok && freq_close_khz(fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS),
+                              RP_CLK_SYS_FREQ / 1000U);
+    ok = ok && (((POWMAN->VREG & POWMAN_VREG_VSEL_Msk) >>
+                 POWMAN_VREG_VSEL_Pos) == 0x0BU);   /* 1.10 V.*/
+    console_restart();
+    chprintf(chp, "  overclock leg measured %u kHz\r\n", khz);
+    report("200 MHz overclock round trip with voltage restore", ok);
+  }
+#endif
 
   chThdSleepMilliseconds(20);   /* Drain before the first stress switch.*/
   ok = true;

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/main.c
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/main.c
@@ -70,19 +70,28 @@ static void report(const char *name, bool ok) {
 
 /*
  * Measures a clock with the FC0 frequency counter, result in kHz.
+ * Returns zero on a counter timeout so callers report a failed
+ * measurement instead of hanging or comparing garbage.
  */
 static uint32_t fc0_measure_khz(uint32_t src) {
+  uint32_t start;
 
+  start = TIMER0->TIMERAWL;
   while ((CLOCKS->FC0.STATUS & CLOCKS_FC0_STATUS_RUNNING) != 0U) {
-    /* Waiting out a previous measurement.*/
+    if ((uint32_t)(TIMER0->TIMERAWL - start) > 100000U) {
+      return 0U;
+    }
   }
   CLOCKS->FC0.REF_KHZ  = RP_CLK_REF_FREQ / 1000U;
   CLOCKS->FC0.MIN_KHZ  = 0U;
   CLOCKS->FC0.MAX_KHZ  = CLOCKS_FC0_MAX_KHZ_Msk;
   CLOCKS->FC0.INTERVAL = 10U;         /* 2^10 us test interval.*/
   CLOCKS->FC0.SRC      = src;
+  start = TIMER0->TIMERAWL;
   while ((CLOCKS->FC0.STATUS & CLOCKS_FC0_STATUS_DONE) == 0U) {
-    /* Waiting for DONE.*/
+    if ((uint32_t)(TIMER0->TIMERAWL - start) > 100000U) {
+      return 0U;
+    }
   }
   return (CLOCKS->FC0.RESULT & CLOCKS_FC0_RESULT_KHZ_Msk) >>
          CLOCKS_FC0_RESULT_KHZ_Pos;
@@ -179,6 +188,10 @@ int main(void) {
          halClockGetPointX(RP_CLK_SYS) == 96000000U);
   report("clk_peri point follows",
          halClockGetPointX(RP_CLK_PERI) == 96000000U);
+  report("untouched points intact",
+         (halClockGetPointX(RP_CLK_REF) == RP_CLK_REF_FREQ) &&
+         (halClockGetPointX(RP_CLK_USB) == RP_CLK_USB_FREQ) &&
+         (halClockGetPointX(RP_CLK_ADC) == RP_CLK_ADC_FREQ));
   report("console talks after restart", true);  /* Reading this proves it.*/
 
   /* 4: flash integrity at the new frequency.*/
@@ -196,6 +209,27 @@ int main(void) {
   chprintf(chp, "  clk_sys = %u kHz\r\n", khz);
   report("clk_sys back at compile-time frequency",
          freq_close_khz(khz, RP_CLK_SYS_FREQ / 1000U));
+
+  /* Explicit divider round trip: switch down with a deliberately wide
+     flash divider, then verify that returning with the default
+     configuration restores the boot divider instead of keeping the
+     wide one at the high frequency.*/
+  {
+    uint32_t boot_enc, enc;
+    halclkcfg_t wide = hal_clkcfg_low;
+
+    boot_enc = QMI->M0_TIMING & QMI_TIMING_CLKDIV_Msk;
+    wide.qmi_clkdiv = 8U;             /* 96 MHz / 8 = 12 MHz SCK, safe.*/
+    chThdSleepMilliseconds(20);
+    ok = (halClockSwitchMode(&wide) == false);
+    enc = QMI->M0_TIMING & QMI_TIMING_CLKDIV_Msk;
+    ok = ok && (enc == 8U);
+    ok = ok && (halClockSwitchMode(&hal_clkcfg_default) == false);
+    enc = QMI->M0_TIMING & QMI_TIMING_CLKDIV_Msk;
+    console_restart();
+    report("explicit divider applied and boot divider restored",
+           ok && (enc == boot_enc));
+  }
 
   chThdSleepMilliseconds(20);   /* Drain before the first stress switch.*/
   ok = true;

--- a/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/main.c
+++ b/testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION/main.c
@@ -1,0 +1,239 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 runtime clock switching validation (RP_CLOCK_DYNAMIC).
+ *
+ * 1. Boot frequency: the FC0 frequency counter must read clk_sys at the
+ *    compile-time frequency.
+ * 2. Rejection: configurations violating the PLL constraints or the
+ *    RP2350-E12 clk_sys/clk_usb ratio must be refused with no clock
+ *    change.
+ * 3. Switch down: halClockSwitchMode(&hal_clkcfg_low) must land clk_sys
+ *    at 96 MHz, verified by FC0 and by the updated clock points. The
+ *    console is restarted after the switch; that it still talks at the
+ *    host's unchanged baud proves the SIO driver recomputed its divider
+ *    from the new clk_peri.
+ * 4. Flash execution: code keeps running from XIP across switches (this
+ *    program lives there) and a flash-resident pattern must checksum
+ *    identically at every frequency.
+ * 5. Switch back and stress: return to the default configuration, then
+ *    25 low/default round trips with FC0 verification.
+ *
+ * Single core. Output on SIOD0 (GPIO0/GPIO1) at the default 38400.
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+static BaseSequentialStream *chp = (BaseSequentialStream *)&SIOD0;
+
+static unsigned pass_count;
+static unsigned fail_count;
+
+/* Flash-resident pattern for the XIP integrity check.*/
+static const uint8_t flash_pattern[64] = {
+  0xC3, 0x5A, 0x0F, 0xF0, 0x81, 0x7E, 0x24, 0x42,
+  0x99, 0x66, 0x11, 0xEE, 0x33, 0xCC, 0x55, 0xAA,
+  0xC3, 0x5A, 0x0F, 0xF0, 0x81, 0x7E, 0x24, 0x42,
+  0x99, 0x66, 0x11, 0xEE, 0x33, 0xCC, 0x55, 0xAA,
+  0xC3, 0x5A, 0x0F, 0xF0, 0x81, 0x7E, 0x24, 0x42,
+  0x99, 0x66, 0x11, 0xEE, 0x33, 0xCC, 0x55, 0xAA,
+  0xC3, 0x5A, 0x0F, 0xF0, 0x81, 0x7E, 0x24, 0x42,
+  0x99, 0x66, 0x11, 0xEE, 0x33, 0xCC, 0x55, 0xAA
+};
+
+static void report(const char *name, bool ok) {
+
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+}
+
+/*
+ * Measures a clock with the FC0 frequency counter, result in kHz.
+ */
+static uint32_t fc0_measure_khz(uint32_t src) {
+
+  while ((CLOCKS->FC0.STATUS & CLOCKS_FC0_STATUS_RUNNING) != 0U) {
+    /* Waiting out a previous measurement.*/
+  }
+  CLOCKS->FC0.REF_KHZ  = RP_CLK_REF_FREQ / 1000U;
+  CLOCKS->FC0.MIN_KHZ  = 0U;
+  CLOCKS->FC0.MAX_KHZ  = CLOCKS_FC0_MAX_KHZ_Msk;
+  CLOCKS->FC0.INTERVAL = 10U;         /* 2^10 us test interval.*/
+  CLOCKS->FC0.SRC      = src;
+  while ((CLOCKS->FC0.STATUS & CLOCKS_FC0_STATUS_DONE) == 0U) {
+    /* Waiting for DONE.*/
+  }
+  return (CLOCKS->FC0.RESULT & CLOCKS_FC0_RESULT_KHZ_Msk) >>
+         CLOCKS_FC0_RESULT_KHZ_Pos;
+}
+
+static bool freq_close_khz(uint32_t measured, uint32_t expected) {
+
+  uint32_t tol = expected / 100U;     /* 1% tolerance.*/
+  return (measured >= (expected - tol)) && (measured <= (expected + tol));
+}
+
+static uint32_t flash_checksum(void) {
+  uint32_t sum = 0U;
+  unsigned i;
+
+  for (i = 0U; i < sizeof flash_pattern; i++) {
+    sum = (sum * 31U) + flash_pattern[i];
+  }
+  return sum;
+}
+
+/*
+ * Restarts the console so its baud divider is recomputed from the
+ * current clk_peri clock point.
+ */
+static void console_restart(void) {
+
+  sioStop(&SIOD0);
+  sioStart(&SIOD0, NULL);
+}
+
+int main(void) {
+  uint32_t khz, sum_boot, sum_low;
+  bool ok;
+  unsigned i;
+
+  halInit();
+  chSysInit();
+
+  palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+  chThdSleepMilliseconds(100);
+
+  chprintf(chp, "\r\n========================================\r\n");
+  chprintf(chp, "  RP2350 clock switch validation\r\n");
+  chprintf(chp, "========================================\r\n");
+
+  /* 1: boot frequency.*/
+  chprintf(chp, "--- Test 1: boot frequency\r\n");
+  khz = fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS);
+  chprintf(chp, "  clk_sys = %u kHz\r\n", khz);
+  report("boot clk_sys at compile-time frequency",
+         freq_close_khz(khz, RP_CLK_SYS_FREQ / 1000U));
+  sum_boot = flash_checksum();
+
+  /* 2: rejections, the clock must not move.*/
+  chprintf(chp, "--- Test 2: invalid configurations rejected\r\n");
+  {
+    halclkcfg_t bad = hal_clkcfg_default;
+
+    bad.pll_sys_refdiv = 0U;
+    report("zero REFDIV rejected", halClockSwitchMode(&bad) == true);
+
+    bad = hal_clkcfg_default;
+    bad.pll_sys_vco_freq = 768000000U;  /* 48 MHz output violates E12.*/
+    bad.pll_sys_postdiv1 = 4U;
+    bad.pll_sys_postdiv2 = 4U;
+    report("E12-violating 48 MHz rejected", halClockSwitchMode(&bad) == true);
+
+    bad = hal_clkcfg_default;
+    bad.pll_sys_vco_freq = 1500000000U; /* 300 MHz would overclock.*/
+    bad.pll_sys_postdiv1 = 5U;
+    bad.pll_sys_postdiv2 = 1U;
+    report("overclock rejected", halClockSwitchMode(&bad) == true);
+
+    khz = fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS);
+    report("clk_sys unchanged after rejections",
+           freq_close_khz(khz, RP_CLK_SYS_FREQ / 1000U));
+  }
+
+  /* 3: switch down to 96 MHz. The console TX FIFO is drained first,
+     queued bytes would otherwise leave the shifter at a wrong baud
+     after the switch.*/
+  chThdSleepMilliseconds(20);
+  ok = (halClockSwitchMode(&hal_clkcfg_low) == false);
+  console_restart();
+  chprintf(chp, "--- Test 3: switch to 96 MHz\r\n");
+  report("switch accepted", ok);
+  khz = fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS);
+  chprintf(chp, "  clk_sys = %u kHz\r\n", khz);
+  report("clk_sys measures 96 MHz", freq_close_khz(khz, 96000U));
+  report("clock point follows",
+         halClockGetPointX(RP_CLK_SYS) == 96000000U);
+  report("clk_peri point follows",
+         halClockGetPointX(RP_CLK_PERI) == 96000000U);
+  report("console talks after restart", true);  /* Reading this proves it.*/
+
+  /* 4: flash integrity at the new frequency.*/
+  chprintf(chp, "--- Test 4: flash execution across the switch\r\n");
+  sum_low = flash_checksum();
+  report("flash pattern identical at 96 MHz", sum_low == sum_boot);
+
+  /* 5: back to default and stress.*/
+  chThdSleepMilliseconds(20);
+  ok = (halClockSwitchMode(&hal_clkcfg_default) == false);
+  console_restart();
+  chprintf(chp, "--- Test 5: switch back and stress\r\n");
+  report("switch back accepted", ok);
+  khz = fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS);
+  chprintf(chp, "  clk_sys = %u kHz\r\n", khz);
+  report("clk_sys back at compile-time frequency",
+         freq_close_khz(khz, RP_CLK_SYS_FREQ / 1000U));
+
+  chThdSleepMilliseconds(20);   /* Drain before the first stress switch.*/
+  ok = true;
+  for (i = 0U; i < 25U; i++) {
+    if (halClockSwitchMode(&hal_clkcfg_low) != false) {
+      ok = false;
+      break;
+    }
+    if (!freq_close_khz(fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS), 96000U)) {
+      ok = false;
+      break;
+    }
+    if (halClockSwitchMode(&hal_clkcfg_default) != false) {
+      ok = false;
+      break;
+    }
+    if (!freq_close_khz(fc0_measure_khz(CLOCKS_FC0_SRC_CLK_SYS),
+                        RP_CLK_SYS_FREQ / 1000U)) {
+      ok = false;
+      break;
+    }
+  }
+  console_restart();
+  report("25 round trips with FC0 verification", ok);
+  report("flash pattern identical after stress",
+         flash_checksum() == sum_boot);
+
+  chprintf(chp, "\r\n========================================\r\n");
+  chprintf(chp, "  Results: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "  ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "  TESTS FAILED\r\n");
+  }
+  chprintf(chp, "========================================\r\n");
+
+  while (true) {
+    chThdSleepMilliseconds(500);
+  }
+}


### PR DESCRIPTION
## Summary

Implements real runtime clock management for the RP2350, filling the slot #103 created by removing the advertised-but-no-op machinery. Opt-in via `RP_CLOCK_DYNAMIC` (default `FALSE` — default builds are unchanged); when enabled the port defines `HAL_LLD_USE_CLOCK_MANAGEMENT` and `halClockSwitchMode()` works.

**Design** (scoped against the STM32G4 reference implementation and a full audit of the port's frequency consumers):

- `halclkcfg_t` carries a PLL_SYS setting (REFDIV, VCO, postdivs) plus an optional QMI flash divider (0 = keep the boot ROM's). Two presets exported: `hal_clkcfg_default` (the boot configuration) and `hal_clkcfg_low` (96 MHz).
- **Runtime validation** applies the same constraint set the port enforces at compile time — PLL ranges/divisibility, the RP2350-E12 clk_sys/clk_usb ratio (in 64-bit arithmetic), and no overclocking past the rated frequency.
- **Flash-safe sequence**: the QMI divider is first widened to a value safe at both the old and new frequency, clk_sys parks on clk_ref through the glitchless mux while PLL_SYS relocks, then the final divider is applied from RAM-resident code. Timing stays in specification at every instant, so both cores keep executing from XIP throughout — no lockout or core-parking needed.
- **Dynamic clock points**: `rp_clock_get_hz()` switches from compile-time constants to a table updated on each successful switch. The constants still serve pre-initialization callers (the documented contract), selected by a BSS flag entry. Every driver using `halClockGetPointX()` becomes switch-aware on restart with no changes.
- **Unaffected by design**: clk_ref, clk_usb, clk_adc (so USB/ADC keep working), and kernel time — TIMER0 runs from clk_ref. Periodic tick mode is rejected at compile time (SysTick counts clk_sys).
- **Driver convention** (same as STM32 ports with this API): running drivers keep their old dividers; the application restarts them after a switch and they recompute from the new points.
- Also adds the FC0 frequency counter field macros to `rp2350.h` (values verified against the SDK register description) — this MR introduces the tree's first FC0 consumer.

**Overclocking** (added on request, second layer of opt-in): `RP_ALLOW_OVERCLOCK` (default `FALSE`, requires `RP_CLOCK_DYNAMIC`) lifts the validation ceiling to `RP_CLK_SYS_OVERCLOCK_MAX` (default 300 MHz). Above the rated frequency an explicit QMI flash divider is mandatory (the boot divider is only known-safe up to the boot frequency), and the configuration gains an optional `vreg_mv` core-voltage field programmed through POWMAN — raised before an upward switch, lowered after a downward one, capped at 1.30 V (staying below the POWMAN voltage-limit unlock). A gated 200 MHz / 1.15 V preset (`hal_clkcfg_overclock`) is provided. Overclocked operation is outside the device specification and documented as such.

**Scope exclusions** (documented): voltages above 1.30 V (POWMAN limit unlock), RP2040 (its XIP restore re-executes boot2 with a build-time divisor — needs its own design), clk_peri sources other than clk_sys.

## Validation

`testhal/RP/RP2350/CLOCK-SWITCH-VALIDATION` on a Pico 2 — 18/18:

- FC0 frequency counter confirms 150000 kHz at boot, 96000 kHz after switching down, 150000 kHz after switching back (hardware measurement, not the driver's own bookkeeping).
- Rejection legs: zero REFDIV, an E12-violating 48 MHz configuration, and a 300 MHz overclock are all refused with clk_sys measurably unchanged.
- The console is restarted after each switch and keeps talking at the host's unchanged baud — end-to-end proof the SIO driver recomputes its divider from the updated clk_peri point.
- Flash-resident data checksums identically at every frequency; the test itself executes from XIP across all switches.
- 25 low/default round trips with FC0 verification after every switch (52 switches total in the run).
- Overclock leg (gated): the Pico 2 ran at an FC0-measured 200000 kHz at 1.15 V with flash intact through the explicit divider, then returned to 150 MHz with the voltage lowered back to 1.10 V (VSEL readback verified both directions).
- Default-off builds verified bit-identical in behavior: RP2350 and RP2040 demos build clean with `RP_CLOCK_DYNAMIC` and `RP_ALLOW_OVERCLOCK` unset.
