### PR TITLE
RP2040: correct four register bitfield definitions

### DIFF
--- a/os/common/ext/RP/RP2040/rp2040.h
+++ b/os/common/ext/RP/RP2040/rp2040.h
@@ -2144,7 +2144,7 @@ typedef struct {
 #define UART_UARTLCR_H_SPS_Msk            (1U << UART_UARTLCR_H_SPS_Pos)
 #define UART_UARTLCR_H_SPS                UART_UARTLCR_H_SPS_Msk
 #define UART_UARTLCR_H_WLEN_Pos           5U
-#define UART_UARTLCR_H_WLEN_Msk           (1U << UART_UARTLCR_H_WLEN_Pos)
+#define UART_UARTLCR_H_WLEN_Msk           (3U << UART_UARTLCR_H_WLEN_Pos)
 #define UART_UARTLCR_H_WLEN(n)            ((n) << UART_UARTLCR_H_WLEN_Pos)
 #define UART_UARTLCR_H_WLEN_5BITS         UART_UARTLCR_H_WLEN(0U)
 #define UART_UARTLCR_H_WLEN_6BITS         UART_UARTLCR_H_WLEN(1U)
@@ -2549,7 +2549,7 @@ typedef struct {
 #define WATCHDOG_REASON_TIMER             WATCHDOG_REASON_TIMER_Msk
 
 #define WATCHDOG_TICK_COUNT_Pos           11U
-#define WATCHDOG_TICK_COUNT_Msk           (0xFF800U << WATCHDOG_TICK_COUNT_Pos)
+#define WATCHDOG_TICK_COUNT_Msk           (0x1FFU << WATCHDOG_TICK_COUNT_Pos)
 #define WATCHDOG_TICK_COUNT               WATCHDOG_TICK_COUNT_Msk
 #define WATCHDOG_TICK_RUNNING_Pos         10U
 #define WATCHDOG_TICK_RUNNING_Msk         (1U << WATCHDOG_TICK_RUNNING_Pos)
@@ -2857,7 +2857,7 @@ typedef struct {
 #define I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Msk               (0xFFU << I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Pos)
 #define I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD                   I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Msk
 #define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos               0U
-#define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk               (0xFFU << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos)
+#define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk               (0xFFFFU << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos)
 #define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD                   I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk
 
 #define I2C_IC_TX_ABRT_SOURCE_TX_FLUSH_CNT_Pos           23U
@@ -2955,7 +2955,7 @@ typedef struct {
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Pos          16U
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Msk          (0xFFU << I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Pos)
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH              I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Msk
-#define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos          0U
+#define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos          8U
 #define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Msk          (0xFFU << I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos)
 #define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH              I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Msk
 


### PR DESCRIPTION
Fixes item 21 of the RP2040 implementation review (four field definitions that do not match the hardware, found by comparison against Raspberry Pi's generated header):

- UART `UARTLCR_H.WLEN` is a two-bit field at bits 6:5; the mask covered only bit 5. The `WLEN_nBITS` value macros were already correct.
- WATCHDOG `TICK.COUNT` applied the position shift to an already-positioned mask; the field is nine bits at 19:11 (`0x000ff800`).
- I2C `IC_SDA_HOLD.IC_SDA_TX_HOLD` is sixteen bits, not eight. Used as a write mask by the I2C driver; supported clocks keep the count below 256, so the old mask was wrong but not practically observable.
- I2C `IC_COMP_PARAM_1.RX_BUFFER_DEPTH` sits at bits 15:8, not 7:0.

Validation:
- Datasheet cross-check of all four fields (tables 432, 550, 481, 492); definitions now match the official generated header and the in-tree RP2350 equivalents.
- No in-tree code relied on the old values (`WLEN_8BITS` derives from the value macro, not the mask; TICK_COUNT and RX_BUFFER_DEPTH are unused).
- Clean builds: UART-VALIDATION, XIP-VALIDATION, PAL (rp2040_pico), EFL-MFS (rp2040_pico), RT-RP2040-PICO.
- Hardware (Pico via Debug Probe): UART-VALIDATION streams correctly at 115200; WATCHDOG.TICK readback decodes COUNT as a live 0–11 counter with the new mask (the old mask always extracted zero), ENABLE/RUNNING set, CYCLES=12.
- CodeRabbit: 0 findings. Codex cross-check: all four fields confirmed correct.