### PR TITLE
RP2040: correct linker script memory regions and boot2 assertion

### DIFF
--- a/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_FLASH.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_FLASH.ld
@@ -31,7 +31,12 @@ MEMORY
     flash6 (rx) : org = 0x00000000, len = 0
     flash7 (rx) : org = 0x00000000, len = 0
     ram0   (wx) : org = 0x20000000, len = 256k  /* SRAM0 striped        */
-    ram1   (wx) : org = 0x00000000, len = 256k  /* SRAM0 non striped    */
+    /* The non-striped SRAM0..SRAM3 alias window starts at 0x21000000 and
+       maps the same physical memory as the striped ram0 window, which
+       always holds data, BSS and heap. Any allocation through the alias
+       therefore collides with striped allocations, so the region is kept
+       at zero length; resize both regions consciously to use it.*/
+    ram1   (wx) : org = 0x21000000, len = 0     /* SRAM0 non striped    */
     ram2   (wx) : org = 0x00000000, len = 0
     ram3   (wx) : org = 0x00000000, len = 0
     ram4   (wx) : org = 0x20040000, len = 4k    /* SRAM4                */
@@ -104,8 +109,8 @@ SECTIONS
       __boot2_end__ = .;
    } > flash1
 
-   ASSERT(__boot2_end__ - __boot2_start__ <= 256,
-      "ERROR: The Pico second stage bootloader must be 256 bytes in size")
+   ASSERT(__boot2_end__ - __boot2_start__ == 256,
+      "ERROR: The Pico second stage bootloader must be exactly 256 bytes in size")
 }
 
 /* Generic rules inclusion.*/

--- a/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_RAM.ld
+++ b/os/common/startup/ARMCMx/compilers/GCC/ld/RP2040_RAM.ld
@@ -28,13 +28,22 @@ MEMORY
     flash6 (rx) : org = 0x00000000, len = 0
     flash7 (rx) : org = 0x00000000, len = 0
     ram0   (wx) : org = 0x20000000, len = 256k  /* SRAM0 striped        */
-    ram1   (wx) : org = 0x00000000, len = 256k  /* SRAM0 non striped    */
+    /* The non-striped SRAM0..SRAM3 alias window starts at 0x21000000 and
+       maps the same physical memory as the striped ram0 window, which
+       always holds data, BSS and heap. Any allocation through the alias
+       therefore collides with striped allocations, so the region is kept
+       at zero length; resize both regions consciously to use it.*/
+    ram1   (wx) : org = 0x21000000, len = 0     /* SRAM0 non striped    */
     ram2   (wx) : org = 0x00000000, len = 0
     ram3   (wx) : org = 0x00000000, len = 0
     ram4   (wx) : org = 0x20040000, len = 4k    /* SRAM4                */
     ram5   (wx) : org = 0x20041000, len = 4k    /* SRAM5                */
     ram6   (wx) : org = 0x00000000, len = 0
-    ram7   (wx) : org = 0x20041f00, len = 256   /* SRAM5 boot           */
+    /* The former ram7 region covered the last 256 bytes of SRAM5, fully
+       inside ram5, which hosts the core-1 stacks and .ram5 allocations.
+       The linker does not detect allocations made through overlapping
+       MEMORY regions, so the region is removed.*/
+    ram7   (wx) : org = 0x00000000, len = 0
 }
 
 /* For each data/text section two region are defined, a virtual region


### PR DESCRIPTION
Fixes items 18, 19 and 20 of the RP2040 implementation review.

- **ram1 (non-striped SRAM0 alias)** was described at `0x00000000`, so any `.ram1` object linked over the boot-ROM address. The alias window actually starts at `0x21000000`. Since the striped `ram0` window maps the same physical memory word-interleaved and always holds data/BSS/heap, no nonzero `ram1` length is collision-safe; the region now has the correct origin with zero length (mirroring the RP2350 scripts' modeling of unused aliases), turning misplaced `.ram1` objects into hard link errors.
- **RP2040_RAM.ld ram7** covered the last 256 bytes of SRAM5, fully inside `ram5` (core-1 stacks, `.ram5` allocations). GNU ld does not detect overlaps between MEMORY regions; the region is removed.
- **boot2 assertion** now requires exactly 256 bytes (was `<=`), matching the ROM contract and the official SDK assertion; a short custom boot2 previously linked and failed to boot.

Validation:
- Stub-link matrix old vs new: 16-byte boot2 linked silently before, fails the assert now; `.ram1` probe linked at VMA 0x0 before (objdump), hard error now; `.ram7` probe linked at 0x20041f00 before, hard error now.
- Zero-length regions are startup-safe (rules_memory.ld emits symbols; crt1 loops degenerate to no accesses). No in-tree project references RP2040_RAM.ld.
- All five RP2040 build targets relink unchanged; RT-RP2040-PICO SMP demo boots from flash on the bench Pico with a working core-1 shell.
- CodeRabbit: 0 findings (both revisions). Codex cross-check confirmed the alias base, the startup safety of zero-length regions, and the ==256 contract; its correction to the ram7 rationale (default 1 KiB stacks did not reach ram7; the hazard is .ram5 objects/larger stacks) is incorporated.