### PR TITLE
ARMv6-M RP2: compile SMP support source out of non-SMP builds

### DIFF
--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -26,6 +26,11 @@
 
 #include "ch.h"
 
+/* This translation unit is always listed by port_rp2.mk, but its contents
+   depend on definitions made available only when the kernel is configured
+   for SMP; it compiles to nothing in a non-SMP configuration.*/
+#if (CH_CFG_SMP_MODE == TRUE) || defined(__DOXYGEN__)
+
 /*===========================================================================*/
 /* Module local definitions.                                                 */
 /*===========================================================================*/
@@ -172,5 +177,7 @@ void __port_spinlock_release(void) {
 
   port_spinlock_release();
 }
+
+#endif /* CH_CFG_SMP_MODE == TRUE */
 
 /** @} */


### PR DESCRIPTION
Fixes the residual of item 13 of the RP2040 implementation review.

`port_rp2.mk` unconditionally lists `chcoresmp.c`, but its dependencies (`PORT_FIFO_PANIC_MESSAGE`, the spinlock and SMP timer helpers) exist only when the kernel is configured for SMP, so an explicitly non-SMP build of the RP2 port failed to compile (MR #93 had guarded only the NVIC init). The whole translation unit is now guarded by `CH_CFG_SMP_MODE` — matching the ARMv8-M-ML-ALT RP2 port's existing pattern — and compiles to nothing in a non-SMP configuration. `chcore.c` only calls `port_smp_init()` when the macro exists, so nothing references the compiled-out symbols.

Validation:
- UART-VALIDATION rebuilt against `port_rp2.mk` with its non-SMP configuration now compiles, links, and runs on the bench Pico (UART output verified).
- The SMP demo rebuilds unchanged and boots with a working core-1 shell.
- CodeRabbit: 0 findings. Codex: no blocking findings; confirmed no non-SMP consumer of the weak FIFO vectors and that source-guarding is preferable to make-level gating.