### PR TITLE
RP SPIv1: reject the unimplemented LLD slave-select mode at compile time

### DIFF
--- a/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.c
+++ b/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.c
@@ -297,32 +297,8 @@ void spi_lld_stop(SPIDriver *spip) {
   }
 }
 
-#if (SPI_SELECT_MODE == SPI_SELECT_MODE_LLD) || defined(__DOXYGEN__)
-/**
- * @brief   Asserts the slave select signal and prepares for transfers.
- *
- * @param[in] spip      pointer to the @p SPIDriver object
- *
- * @notapi
- */
-void spi_lld_select(SPIDriver *spip) {
-
-  /* No implementation on RP.*/
-}
-
-/**
- * @brief   Deasserts the slave select signal.
- * @details The previously selected peripheral is unselected.
- *
- * @param[in] spip      pointer to the @p SPIDriver object
- *
- * @notapi
- */
-void spi_lld_unselect(SPIDriver *spip) {
-
-  /* No implementation on RP.*/
-}
-#endif
+/* SPI_SELECT_MODE_LLD is rejected at compile time in hal_spi_lld.h, so
+   no spi_lld_select()/spi_lld_unselect() implementations exist here.*/
 
 /**
  * @brief   Ignores data on the SPI bus.

--- a/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.h
+++ b/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.h
@@ -94,6 +94,13 @@
 #error "RP_SPI_SPI1_DMA_PRIORITY not defined in mcuconf.h"
 #endif
 
+/* The driver does not implement a low-level slave-select method; without
+   this check the mode would compile into silent no-ops and a caller could
+   believe chip select was asserted while no pin changed.*/
+#if SPI_SELECT_MODE == SPI_SELECT_MODE_LLD
+#error "SPI_SELECT_MODE_LLD is not implemented by the RP SPI driver, use SPI_SELECT_MODE_LINE, _PORT, _PAD or _NONE"
+#endif
+
 /* Device selection checks.*/
 #if RP_SPI_USE_SPI0 && !RP_HAS_SPI0
 #error "SPI0 not present in the selected device"
@@ -200,10 +207,6 @@ extern "C" {
   void spi_lld_init(void);
   void spi_lld_start(SPIDriver *spip);
   void spi_lld_stop(SPIDriver *spip);
-#if (SPI_SELECT_MODE == SPI_SELECT_MODE_LLD) || defined(__DOXYGEN__)
-  void spi_lld_select(SPIDriver *spip);
-  void spi_lld_unselect(SPIDriver *spip);
-#endif
   void spi_lld_ignore(SPIDriver *spip, size_t n);
   void spi_lld_exchange(SPIDriver *spip, size_t n,
                         const void *txbuf, void *rxbuf);


### PR DESCRIPTION
Fixes item 32 of the RP2040 implementation review.

With `SPI_SELECT_MODE_LLD` the driver compiled `spi_lld_select()` and `spi_lld_unselect()` as empty functions, so a caller could believe chip select was asserted while no pin changed. The driver has no low-level select implementation; the mode is now rejected with an explicit configuration error naming the supported modes (matching how the ADUCM and STM32 SPIv1 drivers treat it), and the dead stubs are removed.

Validation:
- SPI-enabled RP2040 build with the default select mode compiles; forcing `SPI_SELECT_MODE_LLD` fails with the explicit diagnostic.
- Shared driver: RP2350 DMA-VALIDATION still builds.
- CodeRabbit: 0 findings. Codex: no blocking findings; confirmed the generic HAL references these symbols only in LLD mode and the check placement sees `SPI_SELECT_MODE` correctly.