### PR TITLE
RP EFL: built-in SMP flash lockout for RP2040 and RP2350

### DIFF
--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -35,6 +35,13 @@
 /* Module local definitions.                                                 */
 /*===========================================================================*/
 
+/**
+ * @brief   FIFO interrupt number of the current core.
+ * @note    RP2040 routes the SIO FIFO through separate per-core IRQs,
+ *          15 for core 0 and 16 for core 1.
+ */
+#define SIO_FIFO_IRQn ((IRQn_Type)(15 + (int)SIO->CPUID))
+
 /*===========================================================================*/
 /* Module exported variables.                                                */
 /*===========================================================================*/
@@ -46,6 +53,51 @@
 /*===========================================================================*/
 /* Module local variables.                                                   */
 /*===========================================================================*/
+
+/**
+ * @brief   Cores which completed SMP initialization.
+ * @note    A core which never started must not be waited for in the
+ *          lockout handshake.
+ */
+static volatile bool port_lockout_ready[PORT_CORES_NUMBER];
+
+/**
+ * @brief   Per-core lockout-in-progress flags.
+ * @details Published with interrupts masked BEFORE acquiring the lockout
+ *          spinlock and cleared, also with interrupts masked, together
+ *          with its release. A same-core caller finding its flag already
+ *          set would otherwise spin on the hardware lock above the
+ *          holder's priority forever; that is a design error (concurrent
+ *          same-core lockouts must be serialized at a higher layer) and
+ *          fails loudly instead.
+ */
+static volatile bool port_lockout_wanted[PORT_CORES_NUMBER];
+
+/**
+ * @brief   True when the current lockout actually parked the other core.
+ * @note    Written only while the lockout spinlock is held; the unlock
+ *          path must consume the decision made at lockout time, the
+ *          ready flag may change in between.
+ */
+static volatile bool port_lockout_parked;
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE) || defined(__DOXYGEN__)
+/**
+ * @brief   Per-core application messages captured while the FIFO is being
+ *          drained outside the FIFO handler.
+ * @details While a core is parked its FIFO drain cannot run flash-resident
+ *          handlers, and a core draining the FIFO during a lockout
+ *          handshake is in thread context which the handler is not
+ *          entitled to; messages below the reserved range are buffered
+ *          here and delivered from the FIFO handler afterwards. Excess
+ *          messages beyond the buffer depth are dropped. Each core only
+ *          touches its own row, no cross-core synchronization is needed.
+ */
+#define PORT_LOCKOUT_MSG_BUFFER_DEPTH   8U
+static volatile uint32_t port_lockout_msg_buffer[PORT_CORES_NUMBER]
+                                                [PORT_LOCKOUT_MSG_BUFFER_DEPTH];
+static volatile uint32_t port_lockout_msg_count[PORT_CORES_NUMBER];
+#endif
 
 /*===========================================================================*/
 /* Module local functions.                                                   */
@@ -66,6 +118,187 @@ static void port_local_halt(void) {
   }
 }
 
+/**
+ * @brief   Parks the core while the other core has flash unavailable.
+ * @details Called from the FIFO handler on reception of the lockout token.
+ *          The whole wait executes from RAM with interrupts masked because
+ *          the requesting core is about to disable XIP; any flash fetch on
+ *          this core would fault or return garbage.
+ */
+CC_NO_INLINE CC_SECTION(".ramtext")
+static void port_fifo_lockout_wait(void) {
+  uint32_t primask = __get_PRIMASK();
+
+  __disable_irq();
+
+  /* Acknowledging the lockout, the requester waits for this before
+     touching XIP.*/
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) == 0U) {
+  }
+  SIO->FIFO_WR = PORT_FIFO_LOCKOUT_ACK_MESSAGE;
+  __SEV();
+
+  /* Spinning on SIO registers only until released.*/
+  while (true) {
+    uint32_t message;
+
+    while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) == 0U) {
+    }
+    message = SIO->FIFO_RD;
+    if (message == PORT_FIFO_UNLOCK_MESSAGE) {
+      break;
+    }
+    if (message == PORT_FIFO_PANIC_MESSAGE) {
+      /* Cannot reach the flash-resident halt path, parking here, the
+         other core is halting anyway.*/
+      while (true) {
+      }
+    }
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+    /* Application messages cannot be delivered while flash handlers are
+       unreachable, buffering for delivery after unparking. Reschedule
+       tokens are dropped, the ISR epilogue reschedules on return.*/
+    if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
+      /* SIO->CPUID is read directly: port_get_core_id() is a static
+         inline whose out-of-line copy would live in flash, which is
+         unreachable here.*/
+      uint32_t core = SIO->CPUID;
+
+      if (port_lockout_msg_count[core] < PORT_LOCKOUT_MSG_BUFFER_DEPTH) {
+        port_lockout_msg_buffer[core][port_lockout_msg_count[core]++] = message;
+      }
+    }
+#else
+    /* Anything else (reschedule tokens) is stale, the ISR epilogue
+       reschedules on return anyway.*/
+#endif
+  }
+
+  /* Acknowledging the unlock, XIP is available again at this point.*/
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) == 0U) {
+  }
+  SIO->FIFO_WR = PORT_FIFO_LOCKOUT_ACK_MESSAGE;
+  __SEV();
+
+  __set_PRIMASK(primask);
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+  /* Back on flash, delivering the messages buffered during the park in
+     arrival order; still in the FIFO ISR context.*/
+  {
+    core_id_t core = port_get_core_id();
+    uint32_t i;
+
+    for (i = 0U; i < port_lockout_msg_count[core]; i++) {
+      PORT_HANDLE_FIFO_MESSAGE(core ^ 1U,
+                               port_lockout_msg_buffer[core][i]);
+    }
+    port_lockout_msg_count[core] = 0U;
+  }
+#endif
+}
+
+/**
+ * @brief   Sends a token to the other core and waits for its acknowledge.
+ * @details The FIFO RX side is drained directly because this core's FIFO
+ *          interrupt is masked during the handshake.
+ *
+ * @param[in] token     token to be sent
+ * @return              @p true on acknowledge, @p false on timeout.
+ */
+static bool port_lockout_handshake(uint32_t token) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) == 0U) {
+    if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+      return false;
+    }
+  }
+  SIO->FIFO_WR = token;
+  __SEV();
+
+  while (true) {
+    if ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
+      uint32_t message = SIO->FIFO_RD;
+
+      if (message == PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
+        return true;
+      }
+      if (message == PORT_FIFO_PANIC_MESSAGE) {
+        port_local_halt();
+      }
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+      /* Application messages cannot be delivered here: this is thread
+         context with interrupts masked, not the ISR context the handler
+         is entitled to (state checking, epilogue reschedule). Buffering
+         for delivery from the FIFO handler pended after the handshake.*/
+      if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
+        core_id_t core = port_get_core_id();
+
+        if (port_lockout_msg_count[core] < PORT_LOCKOUT_MSG_BUFFER_DEPTH) {
+          port_lockout_msg_buffer[core][port_lockout_msg_count[core]++] =
+            message;
+        }
+      }
+#endif
+      /* Reschedule tokens are dropped here, a reschedule round is forced
+         after the handshake.*/
+    }
+    if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+      return false;
+    }
+  }
+}
+
+/**
+ * @brief   Common FIFO service routine for both per-core handlers.
+ * @note    Runs on the receiving core; messages always come from the
+ *          other core.
+ */
+static void port_fifo_serve(void) {
+
+  SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+  /* Messages buffered by a lockout handshake on this core are delivered
+     first, they arrived before anything still in the FIFO. The producer
+     runs in thread context with interrupts masked, it cannot race this
+     handler.*/
+  {
+    core_id_t core = port_get_core_id();
+    uint32_t i;
+
+    for (i = 0U; i < port_lockout_msg_count[core]; i++) {
+      PORT_HANDLE_FIFO_MESSAGE(core ^ 1U, port_lockout_msg_buffer[core][i]);
+    }
+    port_lockout_msg_count[core] = 0U;
+  }
+#endif
+
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
+    uint32_t message = SIO->FIFO_RD;
+
+    /* A panic on either core halts the other one too.*/
+    if (message == PORT_FIFO_PANIC_MESSAGE) {
+      port_local_halt();
+    }
+    /* The other core needs this core off flash, parking until released.*/
+    if (message == PORT_FIFO_LOCKOUT_MESSAGE) {
+      port_fifo_lockout_wait();
+      continue;
+    }
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+    if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
+      PORT_HANDLE_FIFO_MESSAGE(port_get_core_id() ^ 1U, message);
+    }
+#else
+    (void)message;
+#endif
+  }
+
+  __SEV();
+}
+
 /*===========================================================================*/
 /* Module interrupt handlers.                                                */
 /*===========================================================================*/
@@ -79,24 +312,7 @@ CH_IRQ_HANDLER(Vector7C) {
 
   CH_IRQ_PROLOGUE();
 
-  SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
-
-  while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
-    uint32_t message = SIO->FIFO_RD;
-    /* A panic on either core halts the other one too.*/
-    if (message == PORT_FIFO_PANIC_MESSAGE) {
-      port_local_halt();
-    }
-#if defined(PORT_HANDLE_FIFO_MESSAGE)
-    if (message != PORT_FIFO_RESCHEDULE_MESSAGE) {
-      PORT_HANDLE_FIFO_MESSAGE(1U, message);
-    }
-#else
-    (void)message;
-#endif
-  }
-
-  __SEV();
+  port_fifo_serve();
 
   CH_IRQ_EPILOGUE();
 }
@@ -110,21 +326,7 @@ CH_IRQ_HANDLER(Vector80) {
 
   CH_IRQ_PROLOGUE();
 
-  SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
-
-  while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
-    uint32_t message = SIO->FIFO_RD;
-    if (message == PORT_FIFO_PANIC_MESSAGE) {
-      port_local_halt();
-    }
-#if defined(PORT_HANDLE_FIFO_MESSAGE)
-    if (message != PORT_FIFO_RESCHEDULE_MESSAGE) {
-      PORT_HANDLE_FIFO_MESSAGE(0U, message);
-    }
-#endif
-  }
-
-  __SEV();
+  port_fifo_serve();
 
   CH_IRQ_EPILOGUE();
 }
@@ -145,7 +347,6 @@ void __port_smp_init(os_instance_t *oip) {
   port_timer_enable(oip);
 #endif
 
-#if CH_CFG_SMP_MODE == TRUE
   /* FIFO handlers for each core.*/
   SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
   if (oip->core_id == 0U) {
@@ -159,7 +360,141 @@ void __port_smp_init(os_instance_t *oip) {
   else {
     chDbgAssert(false, "unexpected core id");
   }
+
+  /* This core can now be parked by the other one.*/
+  port_lockout_ready[port_get_core_id()] = true;
+}
+
+/**
+ * @brief   Parks the other core outside flash for a flash operation.
+ * @details On return the other core is spinning in RAM with interrupts
+ *          disabled and stays there until @p __port_flash_unlockout() is
+ *          called. Requests from both cores are serialized on a dedicated
+ *          hardware spinlock which is spun with interrupts enabled so that
+ *          a crossing request from the other core can park this core
+ *          first instead of deadlocking.
+ * @note    Must be called from thread context outside any critical
+ *          section.
+ */
+void __port_flash_lockout(void) {
+
+  chDbgAssert(!port_is_isr_context() &&
+              __port_irq_enabled(__port_get_irq_status()) &&
+              ((__get_PRIMASK() & 1U) == 0U),
+              "not in thread context");
+
+  /* Publishing the lockout intent atomically before contending for the
+     hardware lock. A same-core caller finding the flag set would spin
+     on the spinlock above the holder's priority forever with no
+     timeout; concurrent same-core lockouts must be serialized at a
+     higher layer (the EFL state machine already does), so this is a
+     design error and fails loudly even in release builds.*/
+  __disable_irq();
+  if (port_lockout_wanted[port_get_core_id()]) {
+    __enable_irq();
+    chSysHalt("lockout re-entered");
+  }
+  port_lockout_wanted[port_get_core_id()] = true;
+  __enable_irq();
+
+  /* Serializing requesters, interrupts stay enabled while spinning so a
+     crossing request from the other core can park this core first.
+     While the lockout is held the owning thread remains preemptible;
+     this is deliberate (interrupt windows between flash pages keep
+     watchdog feeding and IRQ latency alive on this core) at the
+     documented cost of extending the other core's park time.*/
+  while (SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] == 0U) {
+  }
+  __DMB();
+
+  /* A core which never initialized cannot acknowledge and does not need
+     parking. The decision is recorded for the unlock side, the flag may
+     rise in the meantime.*/
+  if (!port_lockout_ready[port_get_core_id() ^ 1U]) {
+    port_lockout_parked = false;
+    return;
+  }
+  port_lockout_parked = true;
+
+  /* Masking local interrupts so that the FIFO handler cannot steal the
+     acknowledge token; no lockout traffic can be in flight here because
+     the spinlock is held.*/
+  __disable_irq();
+
+  if (!port_lockout_handshake(PORT_FIFO_LOCKOUT_MESSAGE)) {
+    chSysHalt("lockout timeout");
+  }
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+  /* Messages captured during the handshake are delivered by the FIFO
+     handler in its normal ISR context, pending it while still masked so
+     delivery happens right at the enable below.*/
+  if (port_lockout_msg_count[port_get_core_id()] > 0U) {
+    NVIC_SetPendingIRQ(SIO_FIFO_IRQn);
+  }
 #endif
+
+  __enable_irq();
+}
+
+/**
+ * @brief   Releases the core parked by @p __port_flash_lockout().
+ */
+void __port_flash_unlockout(void) {
+
+  chDbgAssert((SIO->SPINLOCK_ST &
+               (1UL << PORT_LOCKOUT_SPINLOCK_NUMBER)) != 0U,
+              "lockout not active");
+
+  /* Unlocking only if the matching lockout parked the other core, the
+     ready flag alone could have risen since then.*/
+  if (port_lockout_parked) {
+    port_lockout_parked = false;
+    __disable_irq();
+
+    if (!port_lockout_handshake(PORT_FIFO_UNLOCK_MESSAGE)) {
+      chSysHalt("unlock timeout");
+    }
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+    /* Messages captured during the handshake are delivered by the FIFO
+       handler in its normal ISR context, pending it while still masked
+       so delivery happens right at the enable below.*/
+    if (port_lockout_msg_count[port_get_core_id()] > 0U) {
+      NVIC_SetPendingIRQ(SIO_FIFO_IRQn);
+    }
+#endif
+
+    __enable_irq();
+  }
+
+  /* Releasing the hardware lock and withdrawing the intent flag as one
+     unit so a preempting same-core caller never observes them apart.*/
+  __disable_irq();
+  __DMB();
+  SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] = (uint32_t)SIO;
+  port_lockout_wanted[port_get_core_id()] = false;
+  __enable_irq();
+
+  /* A reschedule token could have been consumed during the handshakes,
+     forcing a reschedule round.*/
+  chSysLock();
+  chSchRescheduleS();
+  chSysUnlock();
+}
+
+/**
+ * @brief   Tells whether the other core completed SMP initialization.
+ * @details Until this returns @p true the other core may be executing
+ *          startup code from flash without being parkable; callers which
+ *          know the core was started must wait for readiness before the
+ *          first lockout.
+ *
+ * @return              @p true if the other core can be parked.
+ */
+bool __port_lockout_other_ready(void) {
+
+  return port_lockout_ready[port_get_core_id() ^ 1U];
 }
 
 /**

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -26,6 +26,11 @@
 
 #include "ch.h"
 
+/* This translation unit is always listed by port_rp2.mk, but its contents
+   depend on definitions made available only when the kernel is configured
+   for SMP; it compiles to nothing in a non-SMP configuration.*/
+#if (CH_CFG_SMP_MODE == TRUE) || defined(__DOXYGEN__)
+
 /*===========================================================================*/
 /* Module local definitions.                                                 */
 /*===========================================================================*/
@@ -172,5 +177,7 @@ void __port_spinlock_release(void) {
 
   port_spinlock_release();
 }
+
+#endif /* CH_CFG_SMP_MODE == TRUE */
 
 /** @} */

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
@@ -43,10 +43,16 @@
 
 /**
  * @name    IPC FIFO messages
+ * @note    Values from @p PORT_FIFO_LOCKOUT_ACK_MESSAGE upwards are reserved
+ *          for the port layer, @p PORT_HANDLE_FIFO_MESSAGE only receives
+ *          values below it.
  * @{
  */
 #define PORT_FIFO_RESCHEDULE_MESSAGE    0xFFFFFFFFU
 #define PORT_FIFO_PANIC_MESSAGE         0xFFFFFFFEU
+#define PORT_FIFO_LOCKOUT_MESSAGE       0xFFFFFFFDU
+#define PORT_FIFO_UNLOCK_MESSAGE        0xFFFFFFFCU
+#define PORT_FIFO_LOCKOUT_ACK_MESSAGE   0xFFFFFFFBU
 /** @} */
 
 /*===========================================================================*/
@@ -58,6 +64,22 @@
  */
 #if !defined(PORT_SPINLOCK_NUMBER)
 #define PORT_SPINLOCK_NUMBER            31
+#endif
+
+/**
+ * @brief   Spinlock serializing core-lockout requesters.
+ */
+#if !defined(PORT_LOCKOUT_SPINLOCK_NUMBER)
+#define PORT_LOCKOUT_SPINLOCK_NUMBER    30
+#endif
+
+/**
+ * @brief   Timeout on the lockout handshake in microseconds.
+ * @note    A core which does not acknowledge within this time is assumed
+ *          dead and the system is halted.
+ */
+#if !defined(PORT_LOCKOUT_TIMEOUT_US)
+#define PORT_LOCKOUT_TIMEOUT_US         100000U
 #endif
 
 /* Note: the ram4/ram5 scratch banks used by the following sections also
@@ -116,6 +138,14 @@
   #error "invalid PORT_SPINLOCK_NUMBER value"
 #endif
 
+#if (PORT_LOCKOUT_SPINLOCK_NUMBER < 0) || (PORT_LOCKOUT_SPINLOCK_NUMBER > 31)
+  #error "invalid PORT_LOCKOUT_SPINLOCK_NUMBER value"
+#endif
+
+#if PORT_LOCKOUT_SPINLOCK_NUMBER == PORT_SPINLOCK_NUMBER
+  #error "PORT_LOCKOUT_SPINLOCK_NUMBER conflicts with PORT_SPINLOCK_NUMBER"
+#endif
+
 /*===========================================================================*/
 /* Module data structures and types.                                         */
 /*===========================================================================*/
@@ -152,6 +182,9 @@ extern "C" {
   void __port_smp_init(os_instance_t *oip);
   void __port_spinlock_take(void);
   void __port_spinlock_release(void);
+  void __port_flash_lockout(void);
+  void __port_flash_unlockout(void);
+  bool __port_lockout_other_ready(void);
 #ifdef __cplusplus
 }
 #endif

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -73,15 +73,20 @@ static volatile bool port_lockout_parked;
 
 #if defined(PORT_HANDLE_FIFO_MESSAGE) || defined(__DOXYGEN__)
 /**
- * @brief   Application messages captured while parked.
+ * @brief   Per-core application messages captured while the FIFO is being
+ *          drained outside the FIFO handler.
  * @details While a core is parked its FIFO drain cannot run flash-resident
- *          handlers; messages below the reserved range are buffered here
- *          and delivered right after unparking. Excess messages beyond the
- *          buffer depth are dropped.
+ *          handlers, and a core draining the FIFO during a lockout
+ *          handshake is in thread context which the handler is not
+ *          entitled to; messages below the reserved range are buffered
+ *          here and delivered from the FIFO handler afterwards. Excess
+ *          messages beyond the buffer depth are dropped. Each core only
+ *          touches its own row, no cross-core synchronization is needed.
  */
 #define PORT_LOCKOUT_MSG_BUFFER_DEPTH   8U
-static volatile uint32_t port_lockout_msg_buffer[PORT_LOCKOUT_MSG_BUFFER_DEPTH];
-static volatile uint32_t port_lockout_msg_count;
+static volatile uint32_t port_lockout_msg_buffer[PORT_CORES_NUMBER]
+                                                [PORT_LOCKOUT_MSG_BUFFER_DEPTH];
+static volatile uint32_t port_lockout_msg_count[PORT_CORES_NUMBER];
 #endif
 
 /*===========================================================================*/
@@ -144,8 +149,13 @@ static void port_fifo_lockout_wait(void) {
        unreachable, buffering for delivery after unparking. Reschedule
        tokens are dropped, the ISR epilogue reschedules on return.*/
     if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
-      if (port_lockout_msg_count < PORT_LOCKOUT_MSG_BUFFER_DEPTH) {
-        port_lockout_msg_buffer[port_lockout_msg_count++] = message;
+      /* SIO->CPUID is read directly: port_get_core_id() is a static
+         inline whose out-of-line copy would live in flash, which is
+         unreachable here.*/
+      uint32_t core = SIO->CPUID;
+
+      if (port_lockout_msg_count[core] < PORT_LOCKOUT_MSG_BUFFER_DEPTH) {
+        port_lockout_msg_buffer[core][port_lockout_msg_count[core]++] = message;
       }
     }
 #else
@@ -163,12 +173,17 @@ static void port_fifo_lockout_wait(void) {
   __set_PRIMASK(primask);
 
 #if defined(PORT_HANDLE_FIFO_MESSAGE)
-  /* Back on flash, delivering the messages buffered during the park;
-     still in the FIFO ISR context.*/
-  while (port_lockout_msg_count > 0U) {
-    port_lockout_msg_count--;
-    PORT_HANDLE_FIFO_MESSAGE(port_get_core_id() ^ 1U,
-                             port_lockout_msg_buffer[port_lockout_msg_count]);
+  /* Back on flash, delivering the messages buffered during the park in
+     arrival order; still in the FIFO ISR context.*/
+  {
+    core_id_t core = port_get_core_id();
+    uint32_t i;
+
+    for (i = 0U; i < port_lockout_msg_count[core]; i++) {
+      PORT_HANDLE_FIFO_MESSAGE(core ^ 1U,
+                               port_lockout_msg_buffer[core][i]);
+    }
+    port_lockout_msg_count[core] = 0U;
   }
 #endif
 }
@@ -203,12 +218,17 @@ static bool port_lockout_handshake(uint32_t token) {
         port_local_halt();
       }
 #if defined(PORT_HANDLE_FIFO_MESSAGE)
-      /* Application messages are delivered inline, XIP is still on at
-         handshake time; the context is a thread with interrupts
-         masked, equivalent to the locked ISR context the handler
-         normally sees.*/
+      /* Application messages cannot be delivered here: this is thread
+         context with interrupts masked, not the ISR context the handler
+         is entitled to (state checking, epilogue reschedule). Buffering
+         for delivery from the FIFO handler pended after the handshake.*/
       if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
-        PORT_HANDLE_FIFO_MESSAGE(port_get_core_id() ^ 1U, message);
+        core_id_t core = port_get_core_id();
+
+        if (port_lockout_msg_count[core] < PORT_LOCKOUT_MSG_BUFFER_DEPTH) {
+          port_lockout_msg_buffer[core][port_lockout_msg_count[core]++] =
+            message;
+        }
       }
 #endif
       /* Reschedule tokens are dropped here, a reschedule round is forced
@@ -236,6 +256,22 @@ CH_IRQ_HANDLER(VectorA4) {
   CH_IRQ_PROLOGUE();
 
   SIO->FIFO_ST = SIO_FIFO_ST_ROE | SIO_FIFO_ST_WOF;
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+  /* Messages buffered by a lockout handshake on this core are delivered
+     first, they arrived before anything still in the FIFO. The producer
+     runs in thread context with interrupts masked, it cannot race this
+     handler.*/
+  {
+    core_id_t core = port_get_core_id();
+    uint32_t i;
+
+    for (i = 0U; i < port_lockout_msg_count[core]; i++) {
+      PORT_HANDLE_FIFO_MESSAGE(core ^ 1U, port_lockout_msg_buffer[core][i]);
+    }
+    port_lockout_msg_count[core] = 0U;
+  }
+#endif
 
   while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
     uint32_t message = SIO->FIFO_RD;
@@ -350,6 +386,15 @@ void __port_flash_lockout(void) {
     chSysHalt("lockout timeout");
   }
 
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+  /* Messages captured during the handshake are delivered by the FIFO
+     handler in its normal ISR context, pending it while still masked so
+     delivery happens right at the enable below.*/
+  if (port_lockout_msg_count[port_get_core_id()] > 0U) {
+    NVIC_SetPendingIRQ(SIO_IRQ_FIFOn);
+  }
+#endif
+
   __enable_irq();
 }
 
@@ -371,6 +416,15 @@ void __port_flash_unlockout(void) {
     if (!port_lockout_handshake(PORT_FIFO_UNLOCK_MESSAGE)) {
       chSysHalt("unlock timeout");
     }
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+    /* Messages captured during the handshake are delivered by the FIFO
+       handler in its normal ISR context, pending it while still masked
+       so delivery happens right at the enable below.*/
+    if (port_lockout_msg_count[port_get_core_id()] > 0U) {
+      NVIC_SetPendingIRQ(SIO_IRQ_FIFOn);
+    }
+#endif
 
     __enable_irq();
   }

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -52,10 +52,16 @@
 static volatile bool port_lockout_ready[PORT_CORES_NUMBER];
 
 /**
- * @brief   Core currently owning the lockout spinlock, -1 when idle.
- * @note    Written only while the lockout spinlock is held.
+ * @brief   Per-core lockout-in-progress flags.
+ * @details Published with interrupts masked BEFORE acquiring the lockout
+ *          spinlock and cleared, also with interrupts masked, together
+ *          with its release. A same-core caller finding its flag already
+ *          set would otherwise spin on the hardware lock above the
+ *          holder's priority forever; that is a design error (concurrent
+ *          same-core lockouts must be serialized at a higher layer) and
+ *          fails loudly instead.
  */
-static volatile int port_lockout_owner = -1;
+static volatile bool port_lockout_wanted[PORT_CORES_NUMBER];
 
 /**
  * @brief   True when the current lockout actually parked the other core.
@@ -64,6 +70,19 @@ static volatile int port_lockout_owner = -1;
  *          ready flag may change in between.
  */
 static volatile bool port_lockout_parked;
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE) || defined(__DOXYGEN__)
+/**
+ * @brief   Application messages captured while parked.
+ * @details While a core is parked its FIFO drain cannot run flash-resident
+ *          handlers; messages below the reserved range are buffered here
+ *          and delivered right after unparking. Excess messages beyond the
+ *          buffer depth are dropped.
+ */
+#define PORT_LOCKOUT_MSG_BUFFER_DEPTH   8U
+static volatile uint32_t port_lockout_msg_buffer[PORT_LOCKOUT_MSG_BUFFER_DEPTH];
+static volatile uint32_t port_lockout_msg_count;
+#endif
 
 /*===========================================================================*/
 /* Module local functions.                                                   */
@@ -120,8 +139,19 @@ static void port_fifo_lockout_wait(void) {
       while (true) {
       }
     }
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+    /* Application messages cannot be delivered while flash handlers are
+       unreachable, buffering for delivery after unparking. Reschedule
+       tokens are dropped, the ISR epilogue reschedules on return.*/
+    if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
+      if (port_lockout_msg_count < PORT_LOCKOUT_MSG_BUFFER_DEPTH) {
+        port_lockout_msg_buffer[port_lockout_msg_count++] = message;
+      }
+    }
+#else
     /* Anything else (reschedule tokens) is stale, the ISR epilogue
        reschedules on return anyway.*/
+#endif
   }
 
   /* Acknowledging the unlock, XIP is available again at this point.*/
@@ -131,6 +161,16 @@ static void port_fifo_lockout_wait(void) {
   __SEV();
 
   __set_PRIMASK(primask);
+
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+  /* Back on flash, delivering the messages buffered during the park;
+     still in the FIFO ISR context.*/
+  while (port_lockout_msg_count > 0U) {
+    port_lockout_msg_count--;
+    PORT_HANDLE_FIFO_MESSAGE(port_get_core_id() ^ 1U,
+                             port_lockout_msg_buffer[port_lockout_msg_count]);
+  }
+#endif
 }
 
 /**
@@ -162,6 +202,15 @@ static bool port_lockout_handshake(uint32_t token) {
       if (message == PORT_FIFO_PANIC_MESSAGE) {
         port_local_halt();
       }
+#if defined(PORT_HANDLE_FIFO_MESSAGE)
+      /* Application messages are delivered inline, XIP is still on at
+         handshake time; the context is a thread with interrupts
+         masked, equivalent to the locked ISR context the handler
+         normally sees.*/
+      if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
+        PORT_HANDLE_FIFO_MESSAGE(port_get_core_id() ^ 1U, message);
+      }
+#endif
       /* Reschedule tokens are dropped here, a reschedule round is forced
          after the handshake.*/
     }
@@ -259,10 +308,19 @@ void __port_flash_lockout(void) {
               ((__get_PRIMASK() & 1U) == 0U),
               "not in thread context");
 
-  /* Same-core re-entry would spin on the lockout spinlock forever,
-     failing loudly instead.*/
-  chDbgAssert(port_lockout_owner != (int)port_get_core_id(),
-              "lockout re-entered");
+  /* Publishing the lockout intent atomically before contending for the
+     hardware lock. A same-core caller finding the flag set would spin
+     on the spinlock above the holder's priority forever with no
+     timeout; concurrent same-core lockouts must be serialized at a
+     higher layer (the EFL state machine already does), so this is a
+     design error and fails loudly even in release builds.*/
+  __disable_irq();
+  if (port_lockout_wanted[port_get_core_id()]) {
+    __enable_irq();
+    chSysHalt("lockout re-entered");
+  }
+  port_lockout_wanted[port_get_core_id()] = true;
+  __enable_irq();
 
   /* Serializing requesters, interrupts stay enabled while spinning so a
      crossing request from the other core can park this core first.
@@ -273,7 +331,6 @@ void __port_flash_lockout(void) {
   while (SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] == 0U) {
   }
   __DMB();
-  port_lockout_owner = (int)port_get_core_id();
 
   /* A core which never initialized cannot acknowledge and does not need
      parking. The decision is recorded for the unlock side, the flag may
@@ -318,9 +375,13 @@ void __port_flash_unlockout(void) {
     __enable_irq();
   }
 
-  port_lockout_owner = -1;
+  /* Releasing the hardware lock and withdrawing the intent flag as one
+     unit so a preempting same-core caller never observes them apart.*/
+  __disable_irq();
   __DMB();
   SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] = (uint32_t)SIO;
+  port_lockout_wanted[port_get_core_id()] = false;
+  __enable_irq();
 
   /* A reschedule token could have been consumed during the handshakes,
      forcing a reschedule round.*/

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -131,6 +131,9 @@ static bool port_lockout_handshake(uint32_t token) {
   uint32_t start = TIMER0->TIMERAWL;
 
   while ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) == 0U) {
+    if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+      return false;
+    }
   }
   SIO->FIFO_WR = token;
   __SEV();

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -51,6 +51,20 @@
  */
 static volatile bool port_lockout_ready[PORT_CORES_NUMBER];
 
+/**
+ * @brief   Core currently owning the lockout spinlock, -1 when idle.
+ * @note    Written only while the lockout spinlock is held.
+ */
+static volatile int port_lockout_owner = -1;
+
+/**
+ * @brief   True when the current lockout actually parked the other core.
+ * @note    Written only while the lockout spinlock is held; the unlock
+ *          path must consume the decision made at lockout time, the
+ *          ready flag may change in between.
+ */
+static volatile bool port_lockout_parked;
+
 /*===========================================================================*/
 /* Module local functions.                                                   */
 /*===========================================================================*/
@@ -241,19 +255,34 @@ void __port_smp_init(os_instance_t *oip) {
 void __port_flash_lockout(void) {
 
   chDbgAssert(!port_is_isr_context() &&
-              __port_irq_enabled(__port_get_irq_status()),
+              __port_irq_enabled(__port_get_irq_status()) &&
+              ((__get_PRIMASK() & 1U) == 0U),
               "not in thread context");
 
-  /* Serializing requesters, interrupts stay enabled while spinning.*/
+  /* Same-core re-entry would spin on the lockout spinlock forever,
+     failing loudly instead.*/
+  chDbgAssert(port_lockout_owner != (int)port_get_core_id(),
+              "lockout re-entered");
+
+  /* Serializing requesters, interrupts stay enabled while spinning so a
+     crossing request from the other core can park this core first.
+     While the lockout is held the owning thread remains preemptible;
+     this is deliberate (interrupt windows between flash pages keep
+     watchdog feeding and IRQ latency alive on this core) at the
+     documented cost of extending the other core's park time.*/
   while (SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] == 0U) {
   }
   __DMB();
+  port_lockout_owner = (int)port_get_core_id();
 
   /* A core which never initialized cannot acknowledge and does not need
-     parking.*/
+     parking. The decision is recorded for the unlock side, the flag may
+     rise in the meantime.*/
   if (!port_lockout_ready[port_get_core_id() ^ 1U]) {
+    port_lockout_parked = false;
     return;
   }
+  port_lockout_parked = true;
 
   /* Masking local interrupts so that the FIFO handler cannot steal the
      acknowledge token; no lockout traffic can be in flight here because
@@ -276,7 +305,10 @@ void __port_flash_unlockout(void) {
                (1UL << PORT_LOCKOUT_SPINLOCK_NUMBER)) != 0U,
               "lockout not active");
 
-  if (port_lockout_ready[port_get_core_id() ^ 1U]) {
+  /* Unlocking only if the matching lockout parked the other core, the
+     ready flag alone could have risen since then.*/
+  if (port_lockout_parked) {
+    port_lockout_parked = false;
     __disable_irq();
 
     if (!port_lockout_handshake(PORT_FIFO_UNLOCK_MESSAGE)) {
@@ -286,6 +318,7 @@ void __port_flash_unlockout(void) {
     __enable_irq();
   }
 
+  port_lockout_owner = -1;
   __DMB();
   SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] = (uint32_t)SIO;
 
@@ -294,6 +327,20 @@ void __port_flash_unlockout(void) {
   chSysLock();
   chSchRescheduleS();
   chSysUnlock();
+}
+
+/**
+ * @brief   Tells whether the other core completed SMP initialization.
+ * @details Until this returns @p true the other core may be executing
+ *          startup code from flash without being parkable; callers which
+ *          know the core was started must wait for readiness before the
+ *          first lockout.
+ *
+ * @return              @p true if the other core can be parked.
+ */
+bool __port_lockout_other_ready(void) {
+
+  return port_lockout_ready[port_get_core_id() ^ 1U];
 }
 
 /**

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -44,6 +44,13 @@
 /* Module local variables.                                                   */
 /*===========================================================================*/
 
+/**
+ * @brief   Cores which completed SMP initialization.
+ * @note    A core which never started must not be waited for in the
+ *          lockout handshake.
+ */
+static volatile bool port_lockout_ready[PORT_CORES_NUMBER];
+
 /*===========================================================================*/
 /* Module local functions.                                                   */
 /*===========================================================================*/
@@ -60,6 +67,90 @@ static void port_local_halt(void) {
   CH_CFG_SYSTEM_HALT_HOOK(reason);
 
   while (true) {
+  }
+}
+
+/**
+ * @brief   Parks the core while the other core has flash unavailable.
+ * @details Called from the FIFO handler on reception of the lockout token.
+ *          The whole wait executes from RAM with interrupts masked because
+ *          the requesting core is about to disable XIP; any flash fetch on
+ *          this core would fault or return garbage.
+ */
+CC_NO_INLINE CC_SECTION(".ramtext")
+static void port_fifo_lockout_wait(void) {
+  uint32_t primask = __get_PRIMASK();
+
+  __disable_irq();
+
+  /* Acknowledging the lockout, the requester waits for this before
+     touching XIP.*/
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) == 0U) {
+  }
+  SIO->FIFO_WR = PORT_FIFO_LOCKOUT_ACK_MESSAGE;
+  __SEV();
+
+  /* Spinning on SIO registers only until released.*/
+  while (true) {
+    uint32_t message;
+
+    while ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) == 0U) {
+    }
+    message = SIO->FIFO_RD;
+    if (message == PORT_FIFO_UNLOCK_MESSAGE) {
+      break;
+    }
+    if (message == PORT_FIFO_PANIC_MESSAGE) {
+      /* Cannot reach the flash-resident halt path, parking here, the
+         other core is halting anyway.*/
+      while (true) {
+      }
+    }
+    /* Anything else (reschedule tokens) is stale, the ISR epilogue
+       reschedules on return anyway.*/
+  }
+
+  /* Acknowledging the unlock, XIP is available again at this point.*/
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) == 0U) {
+  }
+  SIO->FIFO_WR = PORT_FIFO_LOCKOUT_ACK_MESSAGE;
+  __SEV();
+
+  __set_PRIMASK(primask);
+}
+
+/**
+ * @brief   Sends a token to the other core and waits for its acknowledge.
+ * @details The FIFO RX side is drained directly because this core's FIFO
+ *          interrupt is masked during the handshake.
+ *
+ * @param[in] token     token to be sent
+ * @return              @p true on acknowledge, @p false on timeout.
+ */
+static bool port_lockout_handshake(uint32_t token) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((SIO->FIFO_ST & SIO_FIFO_ST_RDY) == 0U) {
+  }
+  SIO->FIFO_WR = token;
+  __SEV();
+
+  while (true) {
+    if ((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U) {
+      uint32_t message = SIO->FIFO_RD;
+
+      if (message == PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
+        return true;
+      }
+      if (message == PORT_FIFO_PANIC_MESSAGE) {
+        port_local_halt();
+      }
+      /* Reschedule tokens are dropped here, a reschedule round is forced
+         after the handshake.*/
+    }
+    if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+      return false;
+    }
   }
 }
 
@@ -86,8 +177,13 @@ CH_IRQ_HANDLER(VectorA4) {
     if (message == PORT_FIFO_PANIC_MESSAGE) {
       port_local_halt();
     }
+    /* The other core needs this core off flash, parking until released.*/
+    if (message == PORT_FIFO_LOCKOUT_MESSAGE) {
+      port_fifo_lockout_wait();
+      continue;
+    }
 #if defined(PORT_HANDLE_FIFO_MESSAGE)
-    if (message != PORT_FIFO_RESCHEDULE_MESSAGE) {
+    if (message < PORT_FIFO_LOCKOUT_ACK_MESSAGE) {
       PORT_HANDLE_FIFO_MESSAGE(port_get_core_id() ^ 1U, message);
     }
 #else
@@ -121,7 +217,80 @@ void __port_smp_init(os_instance_t *oip) {
   NVIC_SetPriority(SIO_IRQ_FIFOn, CORTEX_MINIMUM_PRIORITY);
   NVIC_EnableIRQ(SIO_IRQ_FIFOn);
 
+  /* This core can now be parked by the other one.*/
+  port_lockout_ready[port_get_core_id()] = true;
+
   (void)oip;
+}
+
+/**
+ * @brief   Parks the other core outside flash and masks local interrupts
+ *          sourced from it.
+ * @details On return the other core is spinning in RAM with interrupts
+ *          disabled and stays there until @p __port_flash_unlockout() is
+ *          called. Requests from both cores are serialized on a dedicated
+ *          hardware spinlock which is spun with interrupts enabled so that
+ *          a crossing request from the other core can park this core
+ *          first instead of deadlocking.
+ * @note    Must be called from thread context outside any critical
+ *          section.
+ */
+void __port_flash_lockout(void) {
+
+  chDbgAssert(!port_is_isr_context() &&
+              __port_irq_enabled(__port_get_irq_status()),
+              "not in thread context");
+
+  /* Serializing requesters, interrupts stay enabled while spinning.*/
+  while (SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] == 0U) {
+  }
+  __DMB();
+
+  /* A core which never initialized cannot acknowledge and does not need
+     parking.*/
+  if (!port_lockout_ready[port_get_core_id() ^ 1U]) {
+    return;
+  }
+
+  /* Masking local interrupts so that the FIFO handler cannot steal the
+     acknowledge token; no lockout traffic can be in flight here because
+     the spinlock is held.*/
+  __disable_irq();
+
+  if (!port_lockout_handshake(PORT_FIFO_LOCKOUT_MESSAGE)) {
+    chSysHalt("lockout timeout");
+  }
+
+  __enable_irq();
+}
+
+/**
+ * @brief   Releases the core parked by @p __port_flash_lockout().
+ */
+void __port_flash_unlockout(void) {
+
+  chDbgAssert((SIO->SPINLOCK_ST &
+               (1UL << PORT_LOCKOUT_SPINLOCK_NUMBER)) != 0U,
+              "lockout not active");
+
+  if (port_lockout_ready[port_get_core_id() ^ 1U]) {
+    __disable_irq();
+
+    if (!port_lockout_handshake(PORT_FIFO_UNLOCK_MESSAGE)) {
+      chSysHalt("unlock timeout");
+    }
+
+    __enable_irq();
+  }
+
+  __DMB();
+  SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] = (uint32_t)SIO;
+
+  /* A reschedule token could have been consumed during the handshakes,
+     forcing a reschedule round.*/
+  chSysLock();
+  chSchRescheduleS();
+  chSysUnlock();
 }
 
 /**

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
@@ -43,10 +43,16 @@
 
 /**
  * @name    IPC FIFO messages
+ * @note    Values from @p PORT_FIFO_LOCKOUT_ACK_MESSAGE upwards are reserved
+ *          for the port layer, @p PORT_HANDLE_FIFO_MESSAGE only receives
+ *          values below it.
  * @{
  */
 #define PORT_FIFO_RESCHEDULE_MESSAGE    0xFFFFFFFFU
 #define PORT_FIFO_PANIC_MESSAGE         0xFFFFFFFEU
+#define PORT_FIFO_LOCKOUT_MESSAGE       0xFFFFFFFDU
+#define PORT_FIFO_UNLOCK_MESSAGE        0xFFFFFFFCU
+#define PORT_FIFO_LOCKOUT_ACK_MESSAGE   0xFFFFFFFBU
 /** @} */
 
 /*===========================================================================*/
@@ -58,6 +64,22 @@
  */
 #if !defined(PORT_SPINLOCK_NUMBER)
 #define PORT_SPINLOCK_NUMBER            31
+#endif
+
+/**
+ * @brief   Spinlock serializing core-lockout requesters.
+ */
+#if !defined(PORT_LOCKOUT_SPINLOCK_NUMBER)
+#define PORT_LOCKOUT_SPINLOCK_NUMBER    30
+#endif
+
+/**
+ * @brief   Timeout on the lockout handshake in microseconds.
+ * @note    A core which does not acknowledge within this time is assumed
+ *          dead and the system is halted.
+ */
+#if !defined(PORT_LOCKOUT_TIMEOUT_US)
+#define PORT_LOCKOUT_TIMEOUT_US         100000U
 #endif
 
 /**
@@ -96,6 +118,14 @@
   #error "invalid PORT_SPINLOCK_NUMBER value"
 #endif
 
+#if (PORT_LOCKOUT_SPINLOCK_NUMBER < 0) || (PORT_LOCKOUT_SPINLOCK_NUMBER > 31)
+  #error "invalid PORT_LOCKOUT_SPINLOCK_NUMBER value"
+#endif
+
+#if PORT_LOCKOUT_SPINLOCK_NUMBER == PORT_SPINLOCK_NUMBER
+  #error "PORT_LOCKOUT_SPINLOCK_NUMBER conflicts with PORT_SPINLOCK_NUMBER"
+#endif
+
 /*===========================================================================*/
 /* Module data structures and types.                                         */
 /*===========================================================================*/
@@ -132,6 +162,8 @@ extern "C" {
   void __port_smp_init(os_instance_t *oip);
   void __port_spinlock_take(void);
   void __port_spinlock_release(void);
+  void __port_flash_lockout(void);
+  void __port_flash_unlockout(void);
 #ifdef __cplusplus
 }
 #endif

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
@@ -164,6 +164,7 @@ extern "C" {
   void __port_spinlock_release(void);
   void __port_flash_lockout(void);
   void __port_flash_unlockout(void);
+  bool __port_lockout_other_ready(void);
 #ifdef __cplusplus
 }
 #endif

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -488,6 +488,10 @@ RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
  */
 RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
                                         uint32_t offset) {
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  __disable_irq();
 
   /* Connect SSI to flash and exit XIP mode. */
   rp_flash_connect_internal();
@@ -501,6 +505,8 @@ RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
 
   /* Re-enter XIP mode. */
   rp_flash_enter_xip(eflp);
+
+  __set_PRIMASK(primask);
 }
 
 /**
@@ -518,6 +524,10 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
                                                uint32_t offset,
                                                const uint8_t *data,
                                                size_t len) {
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  __disable_irq();
 
   /* Connect SSI to flash and exit XIP mode. */
   rp_flash_connect_internal();
@@ -528,6 +538,8 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
 
   /* Re-enter XIP mode. */
   rp_flash_enter_xip(eflp);
+
+  __set_PRIMASK(primask);
 }
 
 /**
@@ -542,6 +554,10 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
  */
 RAMFUNC static void rp_flash_read_uid_full(EFlashDriver *eflp,
                                            uint8_t *rx, size_t count) {
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  __disable_irq();
 
   /* Connect SSI to flash and exit XIP mode. */
   rp_flash_connect_internal();
@@ -552,6 +568,8 @@ RAMFUNC static void rp_flash_read_uid_full(EFlashDriver *eflp,
 
   /* Re-enter XIP mode. */
   rp_flash_enter_xip(eflp);
+
+  __set_PRIMASK(primask);
 }
 
 /*===========================================================================*/

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.h
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.h
@@ -86,6 +86,27 @@
  */
 #define RP_FLASH_UNIQUE_ID_SIZE             8U
 
+/**
+ * @name    XIP safety strategies
+ * @{
+ */
+/**
+ * @brief   Flash safety left to the application.
+ * @details The application is responsible for providing @p
+ *          rpEflBeforeXipOff() / @p rpEflAfterXipOn() implementations
+ *          which keep the other core and DMA away from XIP while flash
+ *          operations are in progress.
+ */
+#define RP_EFL_XIP_SAFETY_NONE              0
+/**
+ * @brief   Built-in SMP lockout.
+ * @details The port parks the other core in RAM with interrupts masked
+ *          for the duration of each flash operation. DMA reading from the
+ *          XIP window remains an application responsibility.
+ */
+#define RP_EFL_XIP_SAFETY_LOCKOUT           1
+/** @} */
+
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -102,6 +123,26 @@
  */
 #if !defined(RP_FLASH_SIZE) || defined(__DOXYGEN__)
 #define RP_FLASH_SIZE                       (2U * 1024U * 1024U)
+#endif
+
+/**
+ * @brief   XIP safety strategy used while flash operations run.
+ * @details One of @p RP_EFL_XIP_SAFETY_NONE (application-provided hooks)
+ *          or @p RP_EFL_XIP_SAFETY_LOCKOUT (built-in SMP core lockout).
+ * @note    SMP configurations must select a strategy explicitly in
+ *          mcuconf.h, flash operations are not SMP-safe otherwise.
+ */
+#if !defined(RP_EFL_XIP_SAFETY) || defined(__DOXYGEN__)
+#if defined(CH_CFG_SMP_MODE) && (CH_CFG_SMP_MODE == TRUE)
+#error "SMP EFL requires RP_EFL_XIP_SAFETY in mcuconf.h: select RP_EFL_XIP_SAFETY_LOCKOUT or RP_EFL_XIP_SAFETY_NONE with application hooks"
+#else
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_NONE
+#endif
+#endif
+
+#if (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_NONE) &&                        \
+    (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_LOCKOUT)
+#error "invalid RP_EFL_XIP_SAFETY value"
 #endif
 
 /**

--- a/os/hal/ports/RP/RP2040/platform.mk
+++ b/os/hal/ports/RP/RP2040/platform.mk
@@ -27,10 +27,12 @@ endif
 HALCONF := $(strip $(shell cat $(HALCONFDIR)/halconf.h | egrep -e "\#define"))
 
 ifneq ($(findstring HAL_USE_EFL TRUE,$(HALCONF)),)
-PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2040/hal_efl_lld.c
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2040/hal_efl_lld.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2040/rp_flash_safety.c
 endif
 else
-PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2040/hal_efl_lld.c
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2040/hal_efl_lld.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2040/rp_flash_safety.c
 endif
 
 # Drivers compatible with the platform.

--- a/os/hal/ports/RP/RP2040/rp_flash_safety.c
+++ b/os/hal/ports/RP/RP2040/rp_flash_safety.c
@@ -1,0 +1,72 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_flash_safety.c
+ * @brief   Built-in SMP flash safety hooks.
+ * @details Strong implementations of the EFL XIP hooks which park the
+ *          other core in RAM for the duration of flash operations, using
+ *          the RP2 SMP port lockout services.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_EFL == TRUE) && (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT)
+
+#if !defined(CH_CFG_SMP_MODE) || (CH_CFG_SMP_MODE != TRUE)
+#error "RP_EFL_XIP_SAFETY_LOCKOUT requires the RT SMP kernel (CH_CFG_SMP_MODE == TRUE)"
+#endif
+
+/**
+ * @brief   Parks the other core before XIP becomes unavailable.
+ * @note    When the HAL itself started core 1, its readiness is awaited
+ *          before the first lockout: until then the core may be running
+ *          startup code from flash without being parkable yet. A core
+ *          started by other means is the application's responsibility
+ *          (do not perform flash operations before it is ready).
+ */
+void rpEflBeforeXipOff(void) {
+
+#if RP_CORE1_START == TRUE
+  if (!__port_lockout_other_ready()) {
+    uint32_t start = TIMER0->TIMERAWL;
+
+    while (!__port_lockout_other_ready()) {
+      if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+        osalSysHalt("core 1 never became parkable");
+      }
+    }
+  }
+#endif
+
+  __port_flash_lockout();
+}
+
+/**
+ * @brief   Releases the other core once XIP is available again.
+ */
+void rpEflAfterXipOn(void) {
+
+  __port_flash_unlockout();
+}
+
+#endif /* (HAL_USE_EFL == TRUE) &&
+          (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT) */
+
+/** @} */

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -496,6 +496,10 @@ RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
  */
 RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
                                          uint32_t offset) {
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  __disable_irq();
 
   /* Exit XIP mode. */
   rp_flash_exit_xip(eflp);
@@ -508,6 +512,8 @@ RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
 
   /* Re-enter XIP mode. */
   rp_flash_enter_xip(eflp);
+
+  __set_PRIMASK(primask);
 }
 
 /**
@@ -525,6 +531,10 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
                                                uint32_t offset,
                                                const uint8_t *data,
                                                size_t len) {
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  __disable_irq();
 
   /* Exit XIP mode. */
   rp_flash_exit_xip(eflp);
@@ -534,6 +544,8 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
 
   /* Re-enter XIP mode. */
   rp_flash_enter_xip(eflp);
+
+  __set_PRIMASK(primask);
 }
 
 /**
@@ -548,6 +560,10 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
  */
 RAMFUNC static void rp_flash_read_uid_full(EFlashDriver *eflp,
                                             uint8_t *rx, size_t count) {
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  __disable_irq();
 
   /* Exit XIP mode. */
   rp_flash_exit_xip(eflp);
@@ -557,6 +573,8 @@ RAMFUNC static void rp_flash_read_uid_full(EFlashDriver *eflp,
 
   /* Re-enter XIP mode. */
   rp_flash_enter_xip(eflp);
+
+  __set_PRIMASK(primask);
 }
 
 /*===========================================================================*/

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.h
@@ -140,6 +140,11 @@
 #endif
 #endif
 
+#if (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_NONE) &&                        \
+    (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_LOCKOUT)
+#error "invalid RP_EFL_XIP_SAFETY value"
+#endif
+
 /**
  * @brief   Suggested wait time during erase operations polling.
  */

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.h
@@ -86,6 +86,27 @@
  */
 #define RP_FLASH_UNIQUE_ID_SIZE             8U
 
+/**
+ * @name    XIP safety strategies
+ * @{
+ */
+/**
+ * @brief   Flash safety left to the application.
+ * @details The application is responsible for providing @p
+ *          rpEflBeforeXipOff() / @p rpEflAfterXipOn() implementations
+ *          which keep the other core, fast interrupts and DMA away from
+ *          XIP while flash operations are in progress.
+ */
+#define RP_EFL_XIP_SAFETY_NONE              0
+/**
+ * @brief   Built-in SMP lockout.
+ * @details The port parks the other core in RAM with interrupts masked
+ *          for the duration of each flash operation. DMA reading from the
+ *          XIP window remains an application responsibility.
+ */
+#define RP_EFL_XIP_SAFETY_LOCKOUT           1
+/** @} */
+
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -102,6 +123,21 @@
  */
 #if !defined(RP_FLASH_SIZE) || defined(__DOXYGEN__)
 #define RP_FLASH_SIZE                       (4U * 1024U * 1024U)
+#endif
+
+/**
+ * @brief   XIP safety strategy used while flash operations run.
+ * @details One of @p RP_EFL_XIP_SAFETY_NONE (application-provided hooks)
+ *          or @p RP_EFL_XIP_SAFETY_LOCKOUT (built-in SMP core lockout).
+ * @note    SMP configurations must select a strategy explicitly in
+ *          mcuconf.h, flash operations are not SMP-safe otherwise.
+ */
+#if !defined(RP_EFL_XIP_SAFETY) || defined(__DOXYGEN__)
+#if defined(CH_CFG_SMP_MODE) && (CH_CFG_SMP_MODE == TRUE)
+#error "SMP EFL requires RP_EFL_XIP_SAFETY in mcuconf.h: select RP_EFL_XIP_SAFETY_LOCKOUT or RP_EFL_XIP_SAFETY_NONE with application hooks"
+#else
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_NONE
+#endif
 #endif
 
 /**

--- a/os/hal/ports/RP/RP2350/platform.mk
+++ b/os/hal/ports/RP/RP2350/platform.mk
@@ -27,10 +27,12 @@ endif
 HALCONF := $(strip $(shell cat $(HALCONFDIR)/halconf.h | egrep -e "\#define"))
 
 ifneq ($(findstring HAL_USE_EFL TRUE,$(HALCONF)),)
-PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2350/hal_efl_lld.c
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2350/hal_efl_lld.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350/rp_flash_safety.c
 endif
 else
-PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2350/hal_efl_lld.c
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/RP2350/hal_efl_lld.c \
+               $(CHIBIOS)/os/hal/ports/RP/RP2350/rp_flash_safety.c
 endif
 
 # Drivers compatible with the platform.

--- a/os/hal/ports/RP/RP2350/rp_flash_safety.c
+++ b/os/hal/ports/RP/RP2350/rp_flash_safety.c
@@ -35,8 +35,25 @@
 
 /**
  * @brief   Parks the other core before XIP becomes unavailable.
+ * @note    When the HAL itself started core 1, its readiness is awaited
+ *          before the first lockout: until then the core may be running
+ *          startup code from flash without being parkable yet. A core
+ *          started by other means is the application's responsibility
+ *          (do not perform flash operations before it is ready).
  */
 void rpEflBeforeXipOff(void) {
+
+#if RP_CORE1_START == TRUE
+  if (!__port_lockout_other_ready()) {
+    uint32_t start = TIMER0->TIMERAWL;
+
+    while (!__port_lockout_other_ready()) {
+      if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+        osalSysHalt("core 1 never became parkable");
+      }
+    }
+  }
+#endif
 
   __port_flash_lockout();
 }

--- a/os/hal/ports/RP/RP2350/rp_flash_safety.c
+++ b/os/hal/ports/RP/RP2350/rp_flash_safety.c
@@ -1,0 +1,55 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_flash_safety.c
+ * @brief   Built-in SMP flash safety hooks.
+ * @details Strong implementations of the EFL XIP hooks which park the
+ *          other core in RAM for the duration of flash operations, using
+ *          the RP2 SMP port lockout services.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_EFL == TRUE) && (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT)
+
+#if !defined(CH_CFG_SMP_MODE) || (CH_CFG_SMP_MODE != TRUE)
+#error "RP_EFL_XIP_SAFETY_LOCKOUT requires the RT SMP kernel (CH_CFG_SMP_MODE == TRUE)"
+#endif
+
+/**
+ * @brief   Parks the other core before XIP becomes unavailable.
+ */
+void rpEflBeforeXipOff(void) {
+
+  __port_flash_lockout();
+}
+
+/**
+ * @brief   Releases the other core once XIP is available again.
+ */
+void rpEflAfterXipOn(void) {
+
+  __port_flash_unlockout();
+}
+
+#endif /* (HAL_USE_EFL == TRUE) &&
+          (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT) */
+
+/** @} */

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/Makefile
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/Makefile
@@ -1,0 +1,180 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT = 
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT = 
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+# FPU-related options.
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv4-sp-d16
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m0plus
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv6-M/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here 
+LDSCRIPT= $(STARTUPLD)/RP2040_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c c1_main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC) $(TESTINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1 -DCRT0_EXTRA_CORES_NUMBER=1 -DNDEBUG
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1 -DCRT0_EXTRA_CORES_NUMBER=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/c1_main.c
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/c1_main.c
@@ -1,0 +1,56 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+#include "efl_smp_lockout.h"
+
+/**
+ * Core 1 entry point.
+ */
+void c1_main(void) {
+  unsigned i;
+
+  /*
+   * Starting a new OS instance running on this core, we need to wait for
+   * system initialization on the other side.
+   */
+  chSysWaitSystemState(ch_sys_running);
+  chInstanceObjectInit(&ch1, &ch_core1_cfg);
+
+  /* It is alive now.*/
+  chSysUnlock();
+
+  chSemSignal(&c1_ready_sem);
+
+  /* Phase A: this core performs the flash work while core 0 keeps
+     executing from flash.*/
+  while (c1_go == 0U) {
+    c1_heartbeat++;
+  }
+
+  for (i = 0U; i < C1_FLASH_CYCLES; i++) {
+    c1_errors += flash_cycle((uint8_t)(0x10U + i));
+    c1_cycles++;
+  }
+  c1_done = 1U;
+
+  /* Phase B: plain flash-resident heartbeat while core 0 flashes.*/
+  while (true) {
+    c1_heartbeat++;
+  }
+}

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/chconf.h
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     TRUE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/halconf.h
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 115200
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_LINE
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/mcuconf.h
@@ -1,0 +1,98 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * RP2040_MCUCONF drivers configuration.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#define RP2040_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      TRUE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * EFL driver system settings.
+ */
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_LOCKOUT
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+#define RP_IRQ_I2C0_PRIORITY                2
+#define RP_IRQ_I2C1_PRIORITY                2
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    TRUE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+#define RP_SPI_SPI0_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_DMA_PRIORITY            1
+#define RP_SPI_SPI1_DMA_PRIORITY            1
+#define RP_SPI_DMA_ERROR_HOOK(spip)
+
+/*
+ * I2C driver system settings.
+ */
+#define RP_I2C_USE_I2C0                     FALSE
+#define RP_I2C_USE_I2C1                     FALSE
+
+/*
+ * PWM driver system settings.
+ */
+#define RP_PWM_USE_PWM0                     FALSE
+#define RP_PWM_USE_PWM1                     FALSE
+#define RP_PWM_USE_PWM2                     FALSE
+#define RP_PWM_USE_PWM3                     FALSE
+#define RP_PWM_USE_PWM4                     FALSE
+#define RP_PWM_USE_PWM5                     FALSE
+#define RP_PWM_USE_PWM6                     FALSE
+#define RP_PWM_USE_PWM7                     FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/efl_smp_lockout.h
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/efl_smp_lockout.h
@@ -1,0 +1,39 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * Shared state between the two cores of the EFL SMP lockout validation.
+ */
+
+#ifndef EFL_SMP_LOCKOUT_H
+#define EFL_SMP_LOCKOUT_H
+
+#define C1_FLASH_CYCLES     40U
+#define C0_FLASH_CYCLES     15U
+
+extern volatile uint32_t c0_heartbeat;
+extern volatile uint32_t c1_heartbeat;
+extern volatile uint32_t c1_cycles;
+extern volatile uint32_t c1_errors;
+extern volatile uint32_t c1_go;
+extern volatile uint32_t c1_done;
+extern volatile uint32_t fastirq_count;
+
+extern semaphore_t c1_ready_sem;
+
+uint32_t flash_cycle(uint8_t pattern);
+
+#endif /* EFL_SMP_LOCKOUT_H */

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
@@ -174,8 +174,17 @@ int main(void) {
   chThdCreateStatic(waHeartbeat, sizeof(waHeartbeat),
                     NORMALPRIO - 1, HeartbeatThread, NULL);
 
-  /* Waiting for core 1 to come alive.*/
-  chSemWait(&c1_ready_sem);
+  /* Waiting for core 1 to come alive; a core that never starts must
+     produce a report rather than an eternal hang.*/
+  if (chSemWaitTimeout(&c1_ready_sem, TIME_S2I(5)) != MSG_OK) {
+    report("core 1 became ready", false);
+    chprintf(chp, "\r\nResults: %u pass, %u fail\r\n", pass_count, fail_count);
+    chprintf(chp, "*** FAILURES DETECTED ***\r\n");
+    while (true) {
+      palToggleLine(25U);
+      chThdSleepMilliseconds(100);
+    }
+  }
 
   /*
    * Phase A: core 1 flashes, core 0 executes from flash throughout.

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
@@ -193,6 +193,11 @@ int main(void) {
          (c1_errors == 0U) && (c1_cycles == C1_FLASH_CYCLES));
   report("core 0 heartbeat advanced", c0_heartbeat != hb_before);
 
+  /* Liveness now, not just at some point during the phase.*/
+  hb_before = c0_heartbeat;
+  chThdSleepMilliseconds(10);
+  report("core 0 alive after phase A", c0_heartbeat != hb_before);
+
   /*
    * Phase B: mirrored, core 0 flashes while core 1 executes from flash.
    * Skipped if phase A never completed, core 1 could still be inside
@@ -208,6 +213,12 @@ int main(void) {
 
     report("core 0 flash cycles clean", my_errors == 0U);
     report("core 1 heartbeat advanced", c1_heartbeat != c1hb_before);
+
+    /* The peer must still be running after the last flash operation; a
+       core that faulted mid-phase would have stopped incrementing.*/
+    c1hb_before = c1_heartbeat;
+    chThdSleepMilliseconds(10);
+    report("core 1 alive after flashing", c1_heartbeat != c1hb_before);
   }
   else {
     report("phase B skipped, phase A incomplete", false);

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
@@ -1,0 +1,229 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * EFL SMP lockout validation.
+ *
+ * Exercises the built-in RP_EFL_XIP_SAFETY_LOCKOUT strategy: one core
+ * performs erase/program/verify cycles on the last flash sector while the
+ * other core keeps executing flash-resident code. Without the lockout the
+ * flash-resident core would fault or read garbage as soon as XIP is
+ * disabled. ARMv6-M has no above-kernel interrupt tier, so unlike the
+ * RP2350 variant there is no fast-interrupt leg.
+ *
+ * Report is emitted on UART0 (GPIO0/GPIO1) at the SIO default bitrate.
+ */
+
+#include <string.h>
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#include "efl_smp_lockout.h"
+
+/*===========================================================================*/
+/* Shared state, plain SRAM is coherent between the RP2040 cores.            */
+/*===========================================================================*/
+
+volatile uint32_t c0_heartbeat;
+volatile uint32_t c1_heartbeat;
+volatile uint32_t c1_cycles;
+volatile uint32_t c1_errors;
+volatile uint32_t c1_go;
+volatile uint32_t c1_done;
+
+/* Statically initialized: core 1 can signal it before core 0's main()
+   runs any code after chSysInit().*/
+SEMAPHORE_DECL(c1_ready_sem, 0);
+
+/*===========================================================================*/
+/* Report helpers.                                                           */
+/*===========================================================================*/
+
+static BaseSequentialStream *chp = (BaseSequentialStream *)&SIOD0;
+
+static unsigned pass_count;
+static unsigned fail_count;
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/*===========================================================================*/
+/* Flash exercise, shared by both cores.                                     */
+/*===========================================================================*/
+
+#define TEST_SECTOR         (RP_FLASH_SECTORS_COUNT - 1U)
+#define TEST_OFFSET         ((flash_offset_t)TEST_SECTOR * RP_FLASH_SECTOR_SIZE)
+#define TEST_PAGES          (RP_FLASH_SECTOR_SIZE / RP_FLASH_PAGE_SIZE)
+
+uint32_t flash_cycle(uint8_t pattern) {
+  static uint8_t buf[RP_FLASH_PAGE_SIZE];
+  BaseFlash *bfp = (BaseFlash *)&EFLD1;
+  uint32_t errors = 0U;
+  flash_error_t err;
+  unsigned page;
+
+  err = flashStartEraseSector(bfp, TEST_SECTOR);
+  if (err != FLASH_NO_ERROR) {
+    return 1U;
+  }
+  {
+    uint32_t polls = 0U;
+
+    while ((err = flashQueryErase(bfp, NULL)) == FLASH_BUSY_ERASING) {
+      if (++polls > 5000000U) {
+        return 1U;
+      }
+    }
+    if (err != FLASH_NO_ERROR) {
+      return 1U;
+    }
+  }
+
+  for (page = 0U; page < TEST_PAGES; page++) {
+    memset(buf, (int)(uint8_t)(pattern + page), sizeof buf);
+    err = flashProgram(bfp, TEST_OFFSET + (page * RP_FLASH_PAGE_SIZE),
+                       RP_FLASH_PAGE_SIZE, buf);
+    if (err != FLASH_NO_ERROR) {
+      errors++;
+    }
+  }
+
+  for (page = 0U; page < TEST_PAGES; page++) {
+    uint8_t expected = (uint8_t)(pattern + page);
+    unsigned i;
+
+    err = flashRead(bfp, TEST_OFFSET + (page * RP_FLASH_PAGE_SIZE),
+                    RP_FLASH_PAGE_SIZE, buf);
+    if (err != FLASH_NO_ERROR) {
+      errors++;
+      continue;
+    }
+    for (i = 0U; i < RP_FLASH_PAGE_SIZE; i++) {
+      if (buf[i] != expected) {
+        errors++;
+        break;
+      }
+    }
+  }
+
+  return errors;
+}
+
+/*===========================================================================*/
+/* Core 0 heartbeat thread, flash-resident tight loop.                       */
+/*===========================================================================*/
+
+static volatile bool hb_stop;
+
+static CH_MEM_PRIVATE_BSS(0) THD_WORKING_AREA(waHeartbeat, 256);
+static THD_FUNCTION(HeartbeatThread, arg) {
+
+  (void)arg;
+  chRegSetThreadName("heartbeat");
+  while (!hb_stop) {
+    c0_heartbeat++;
+  }
+}
+
+/*
+ * Application entry point, core 0.
+ */
+int main(void) {
+  uint32_t hb_before, c1hb_before;
+  uint32_t my_errors;
+  unsigned i;
+
+  halInit();
+  chSysInit();
+
+  /* UART0 console on GPIO0/GPIO1.*/
+  palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+
+  palSetLineMode(25U, PAL_MODE_OUTPUT_PUSHPULL);
+
+  chprintf(chp, "\r\n*** EFL SMP lockout validation\r\n");
+  chprintf(chp, "*** Flash sector under test: %u\r\n", TEST_SECTOR);
+
+  eflStart(&EFLD1, NULL);
+
+  chThdCreateStatic(waHeartbeat, sizeof(waHeartbeat),
+                    NORMALPRIO - 1, HeartbeatThread, NULL);
+
+  /* Waiting for core 1 to come alive.*/
+  chSemWait(&c1_ready_sem);
+
+  /*
+   * Phase A: core 1 flashes, core 0 executes from flash throughout.
+   */
+  chprintf(chp, "--- Phase A: core 1 flashing, core 0 on flash\r\n");
+  hb_before = c0_heartbeat;
+  c1_go = 1U;
+
+  for (i = 0U; (c1_done == 0U) && (i < 1200U); i++) {
+    chThdSleepMilliseconds(100);
+  }
+
+  report("phase A completed", c1_done != 0U);
+  report("core 1 flash cycles clean",
+         (c1_errors == 0U) && (c1_cycles == C1_FLASH_CYCLES));
+  report("core 0 heartbeat advanced", c0_heartbeat != hb_before);
+
+  /*
+   * Phase B: mirrored, core 0 flashes while core 1 executes from flash.
+   * Skipped if phase A never completed, core 1 could still be inside
+   * flash_cycle().
+   */
+  if (c1_done != 0U) {
+    chprintf(chp, "--- Phase B: core 0 flashing, core 1 on flash\r\n");
+    c1hb_before = c1_heartbeat;
+    my_errors = 0U;
+    for (i = 0U; i < C0_FLASH_CYCLES; i++) {
+      my_errors += flash_cycle((uint8_t)(0xA0U + i));
+    }
+
+    report("core 0 flash cycles clean", my_errors == 0U);
+    report("core 1 heartbeat advanced", c1_heartbeat != c1hb_before);
+  }
+  else {
+    report("phase B skipped, phase A incomplete", false);
+  }
+
+  chprintf(chp, "\r\nResults: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "*** FAILURES DETECTED ***\r\n");
+  }
+
+  hb_stop = true;
+  while (true) {
+    palToggleLine(25U);
+    chThdSleepMilliseconds(500);
+  }
+}

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/Makefile
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/Makefile
@@ -1,0 +1,176 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = softfp
+endif
+
+# FPU-related options.
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-sp-d16
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       \
+       main.c c1_main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1 -DCRT0_EXTRA_CORES_NUMBER=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1 -DCRT0_EXTRA_CORES_NUMBER=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+
+#
+# Custom rules
+##############################################################################

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/c1_main.c
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/c1_main.c
@@ -1,0 +1,56 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+#include "efl_smp_lockout.h"
+
+/**
+ * Core 1 entry point.
+ */
+void c1_main(void) {
+  unsigned i;
+
+  /*
+   * Starting a new OS instance running on this core, we need to wait for
+   * system initialization on the other side.
+   */
+  chSysWaitSystemState(ch_sys_running);
+  chInstanceObjectInit(&ch1, &ch_core1_cfg);
+
+  /* It is alive now.*/
+  chSysUnlock();
+
+  chSemSignal(&c1_ready_sem);
+
+  /* Phase A: this core performs the flash work while core 0 keeps
+     executing from flash.*/
+  while (c1_go == 0U) {
+    c1_heartbeat++;
+  }
+
+  for (i = 0U; i < C1_FLASH_CYCLES; i++) {
+    c1_errors += flash_cycle((uint8_t)(0x10U + i));
+    c1_cycles++;
+  }
+  c1_done = 1U;
+
+  /* Phase B: plain flash-resident heartbeat while core 0 flashes.*/
+  while (true) {
+    c1_heartbeat++;
+  }
+}

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/chconf.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     TRUE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/chconf.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/chconf.h
@@ -117,6 +117,17 @@
  *          The value one is not valid, timeouts are rounded up to
  *          this value.
  */
+/**
+ * @brief   Fast interrupt priority levels.
+ * @details Reserves NVIC priorities 0..1 as above-kernel "fast" levels so
+ *          the test's TIMER1 interrupt is genuinely unmasked by kernel
+ *          critical sections; only PRIMASK (the lockout / RAM flash
+ *          sequences) defers it.
+ */
+#if !defined(PORT_FAST_PRIORITIES)
+#define PORT_FAST_PRIORITIES                2
+#endif
+
 #if !defined(CH_CFG_ST_TIMEDELTA)
 #define CH_CFG_ST_TIMEDELTA                 20
 #endif

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/halconf.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 115200
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_LINE
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/mcuconf.h
@@ -1,0 +1,78 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * RP2350_MCUCONF drivers configuration.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest (4 bits on Cortex-M33).
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      TRUE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * EFL driver settings.
+ */
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_LOCKOUT
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    TRUE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+#define RP_SPI_SPI0_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_DMA_PRIORITY            1
+#define RP_SPI_SPI1_DMA_PRIORITY            1
+#define RP_SPI_DMA_ERROR_HOOK(spip)
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/efl_smp_lockout.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/efl_smp_lockout.h
@@ -1,0 +1,39 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * Shared state between the two cores of the EFL SMP lockout validation.
+ */
+
+#ifndef EFL_SMP_LOCKOUT_H
+#define EFL_SMP_LOCKOUT_H
+
+#define C1_FLASH_CYCLES     40U
+#define C0_FLASH_CYCLES     15U
+
+extern volatile uint32_t c0_heartbeat;
+extern volatile uint32_t c1_heartbeat;
+extern volatile uint32_t c1_cycles;
+extern volatile uint32_t c1_errors;
+extern volatile uint32_t c1_go;
+extern volatile uint32_t c1_done;
+extern volatile uint32_t fastirq_count;
+
+extern semaphore_t c1_ready_sem;
+
+uint32_t flash_cycle(uint8_t pattern);
+
+#endif /* EFL_SMP_LOCKOUT_H */

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
@@ -1,0 +1,243 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * EFL SMP lockout validation.
+ *
+ * Exercises the built-in RP_EFL_XIP_SAFETY_LOCKOUT strategy: one core
+ * performs erase/program/verify cycles on the last flash sector while the
+ * other core keeps executing flash-resident code, and a fast (above
+ * kernel priority) interrupt with a flash-resident handler runs
+ * throughout. Without the lockout the flash-resident core would fault or
+ * read garbage as soon as XIP is disabled.
+ *
+ * Report is emitted on UART0 (GPIO0/GPIO1) at the SIO default bitrate.
+ */
+
+#include <string.h>
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#include "efl_smp_lockout.h"
+
+/*===========================================================================*/
+/* Shared state, plain SRAM is coherent between the RP2350 cores.            */
+/*===========================================================================*/
+
+volatile uint32_t c0_heartbeat;
+volatile uint32_t c1_heartbeat;
+volatile uint32_t c1_cycles;
+volatile uint32_t c1_errors;
+volatile uint32_t c1_go;
+volatile uint32_t c1_done;
+volatile uint32_t fastirq_count;
+
+semaphore_t c1_ready_sem;
+
+/*===========================================================================*/
+/* Report helpers.                                                           */
+/*===========================================================================*/
+
+static BaseSequentialStream *chp = (BaseSequentialStream *)&SIOD0;
+
+static unsigned pass_count;
+static unsigned fail_count;
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/*===========================================================================*/
+/* Fast interrupt, priority above the kernel, handler in flash.              */
+/*===========================================================================*/
+
+/**
+ * @brief   TIMER1 alarm 0 handler.
+ * @note    Runs above the kernel priority ceiling so it is not masked by
+ *          critical sections; the lockout must defer it with PRIMASK
+ *          while XIP is off because this code executes from flash.
+ */
+void RP_TIMER1_IRQ0_HANDLER(void) {
+
+  TIMER1->INTR = 1U;
+  fastirq_count++;
+  TIMER1->ALARM[0] = TIMER1->TIMERAWL + 1000U;
+}
+
+static void fastirq_start(void) {
+
+  rp_peripheral_unreset(RESETS_ALLREG_TIMER1);
+  TIMER1->INTE = 1U;
+  nvicEnableVector(RP_TIMER1_IRQ0_NUMBER, 1U);
+  TIMER1->ALARM[0] = TIMER1->TIMERAWL + 1000U;
+}
+
+/*===========================================================================*/
+/* Flash exercise, shared by both cores.                                     */
+/*===========================================================================*/
+
+#define TEST_SECTOR         (RP_FLASH_SECTORS_COUNT - 1U)
+#define TEST_OFFSET         ((flash_offset_t)TEST_SECTOR * RP_FLASH_SECTOR_SIZE)
+#define TEST_PAGES          (RP_FLASH_SECTOR_SIZE / RP_FLASH_PAGE_SIZE)
+
+uint32_t flash_cycle(uint8_t pattern) {
+  static uint8_t buf[RP_FLASH_PAGE_SIZE];
+  BaseFlash *bfp = (BaseFlash *)&EFLD1;
+  uint32_t errors = 0U;
+  flash_error_t err;
+  unsigned page;
+
+  err = flashStartEraseSector(bfp, TEST_SECTOR);
+  if (err != FLASH_NO_ERROR) {
+    return 1U;
+  }
+  while (flashQueryErase(bfp, NULL) == FLASH_BUSY_ERASING) {
+  }
+
+  for (page = 0U; page < TEST_PAGES; page++) {
+    memset(buf, (int)(uint8_t)(pattern + page), sizeof buf);
+    err = flashProgram(bfp, TEST_OFFSET + (page * RP_FLASH_PAGE_SIZE),
+                       RP_FLASH_PAGE_SIZE, buf);
+    if (err != FLASH_NO_ERROR) {
+      errors++;
+    }
+  }
+
+  for (page = 0U; page < TEST_PAGES; page++) {
+    uint8_t expected = (uint8_t)(pattern + page);
+    unsigned i;
+
+    err = flashRead(bfp, TEST_OFFSET + (page * RP_FLASH_PAGE_SIZE),
+                    RP_FLASH_PAGE_SIZE, buf);
+    if (err != FLASH_NO_ERROR) {
+      errors++;
+      continue;
+    }
+    for (i = 0U; i < RP_FLASH_PAGE_SIZE; i++) {
+      if (buf[i] != expected) {
+        errors++;
+        break;
+      }
+    }
+  }
+
+  return errors;
+}
+
+/*===========================================================================*/
+/* Core 0 heartbeat thread, flash-resident tight loop.                       */
+/*===========================================================================*/
+
+static volatile bool hb_stop;
+
+static CH_MEM_PRIVATE_BSS(0) THD_WORKING_AREA(waHeartbeat, 256);
+static THD_FUNCTION(HeartbeatThread, arg) {
+
+  (void)arg;
+  chRegSetThreadName("heartbeat");
+  while (!hb_stop) {
+    c0_heartbeat++;
+  }
+}
+
+/*
+ * Application entry point, core 0.
+ */
+int main(void) {
+  uint32_t hb_before, fi_before, c1hb_before;
+  uint32_t my_errors;
+  unsigned i;
+
+  halInit();
+  chSysInit();
+  chSemObjectInit(&c1_ready_sem, 0);
+
+  /* UART0 console on GPIO0/GPIO1.*/
+  palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+
+  palSetLineMode(25U, PAL_MODE_OUTPUT_PUSHPULL);
+
+  chprintf(chp, "\r\n*** EFL SMP lockout validation\r\n");
+  chprintf(chp, "*** Flash sector under test: %u\r\n", TEST_SECTOR);
+
+  eflStart(&EFLD1, NULL);
+
+  fastirq_start();
+
+  chThdCreateStatic(waHeartbeat, sizeof(waHeartbeat),
+                    NORMALPRIO - 1, HeartbeatThread, NULL);
+
+  /* Waiting for core 1 to come alive.*/
+  chSemWait(&c1_ready_sem);
+
+  /*
+   * Phase A: core 1 flashes, core 0 executes from flash throughout.
+   */
+  chprintf(chp, "--- Phase A: core 1 flashing, core 0 on flash\r\n");
+  hb_before = c0_heartbeat;
+  fi_before = fastirq_count;
+  c1_go = 1U;
+
+  for (i = 0U; (c1_done == 0U) && (i < 1200U); i++) {
+    chThdSleepMilliseconds(100);
+  }
+
+  report("phase A completed", c1_done != 0U);
+  report("core 1 flash cycles clean",
+         (c1_errors == 0U) && (c1_cycles == C1_FLASH_CYCLES));
+  report("core 0 heartbeat advanced", c0_heartbeat != hb_before);
+  report("fast IRQ serviced", fastirq_count != fi_before);
+
+  /*
+   * Phase B: mirrored, core 0 flashes while core 1 executes from flash.
+   */
+  chprintf(chp, "--- Phase B: core 0 flashing, core 1 on flash\r\n");
+  c1hb_before = c1_heartbeat;
+  fi_before = fastirq_count;
+  my_errors = 0U;
+  for (i = 0U; i < C0_FLASH_CYCLES; i++) {
+    my_errors += flash_cycle((uint8_t)(0xA0U + i));
+  }
+
+  report("core 0 flash cycles clean", my_errors == 0U);
+  report("core 1 heartbeat advanced", c1_heartbeat != c1hb_before);
+  report("fast IRQ serviced", fastirq_count != fi_before);
+
+  chprintf(chp, "\r\nResults: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "*** FAILURES DETECTED ***\r\n");
+  }
+
+  hb_stop = true;
+  while (true) {
+    palToggleLine(25U);
+    chThdSleepMilliseconds(500);
+  }
+}

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
@@ -113,7 +113,17 @@ uint32_t flash_cycle(uint8_t pattern) {
   if (err != FLASH_NO_ERROR) {
     return 1U;
   }
-  while (flashQueryErase(bfp, NULL) == FLASH_BUSY_ERASING) {
+  {
+    uint32_t polls = 0U;
+
+    while ((err = flashQueryErase(bfp, NULL)) == FLASH_BUSY_ERASING) {
+      if (++polls > 5000000U) {
+        return 1U;
+      }
+    }
+    if (err != FLASH_NO_ERROR) {
+      return 1U;
+    }
   }
 
   for (page = 0U; page < TEST_PAGES; page++) {
@@ -214,18 +224,25 @@ int main(void) {
 
   /*
    * Phase B: mirrored, core 0 flashes while core 1 executes from flash.
+   * Skipped if phase A never completed, core 1 could still be inside
+   * flash_cycle().
    */
-  chprintf(chp, "--- Phase B: core 0 flashing, core 1 on flash\r\n");
-  c1hb_before = c1_heartbeat;
-  fi_before = fastirq_count;
-  my_errors = 0U;
-  for (i = 0U; i < C0_FLASH_CYCLES; i++) {
-    my_errors += flash_cycle((uint8_t)(0xA0U + i));
-  }
+  if (c1_done != 0U) {
+    chprintf(chp, "--- Phase B: core 0 flashing, core 1 on flash\r\n");
+    c1hb_before = c1_heartbeat;
+    fi_before = fastirq_count;
+    my_errors = 0U;
+    for (i = 0U; i < C0_FLASH_CYCLES; i++) {
+      my_errors += flash_cycle((uint8_t)(0xA0U + i));
+    }
 
-  report("core 0 flash cycles clean", my_errors == 0U);
-  report("core 1 heartbeat advanced", c1_heartbeat != c1hb_before);
-  report("fast IRQ serviced", fastirq_count != fi_before);
+    report("core 0 flash cycles clean", my_errors == 0U);
+    report("core 1 heartbeat advanced", c1_heartbeat != c1hb_before);
+    report("fast IRQ serviced", fastirq_count != fi_before);
+  }
+  else {
+    report("phase B skipped, phase A incomplete", false);
+  }
 
   chprintf(chp, "\r\nResults: %u pass, %u fail\r\n", pass_count, fail_count);
   if (fail_count == 0U) {

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
@@ -202,8 +202,17 @@ int main(void) {
   chThdCreateStatic(waHeartbeat, sizeof(waHeartbeat),
                     NORMALPRIO - 1, HeartbeatThread, NULL);
 
-  /* Waiting for core 1 to come alive.*/
-  chSemWait(&c1_ready_sem);
+  /* Waiting for core 1 to come alive; a core that never starts must
+     produce a report rather than an eternal hang.*/
+  if (chSemWaitTimeout(&c1_ready_sem, TIME_S2I(5)) != MSG_OK) {
+    report("core 1 became ready", false);
+    chprintf(chp, "\r\nResults: %u pass, %u fail\r\n", pass_count, fail_count);
+    chprintf(chp, "*** FAILURES DETECTED ***\r\n");
+    while (true) {
+      palToggleLine(25U);
+      chThdSleepMilliseconds(100);
+    }
+  }
 
   /*
    * Phase A: core 1 flashes, core 0 executes from flash throughout.

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
@@ -47,7 +47,9 @@ volatile uint32_t c1_go;
 volatile uint32_t c1_done;
 volatile uint32_t fastirq_count;
 
-semaphore_t c1_ready_sem;
+/* Statically initialized: core 1 can signal it before core 0's main()
+   runs any code after chSysInit().*/
+SEMAPHORE_DECL(c1_ready_sem, 0);
 
 /*===========================================================================*/
 /* Report helpers.                                                           */
@@ -182,7 +184,6 @@ int main(void) {
 
   halInit();
   chSysInit();
-  chSemObjectInit(&c1_ready_sem, 0);
 
   /* UART0 console on GPIO0/GPIO1.*/
   palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);


### PR DESCRIPTION
Fixes item 1 of the RP2040 implementation review (flash erase/programming unsafe in SMP: the other core could fetch XIP while it was globally disabled), extending the RP2350 lockout work to RP2040.

- **ARMv6-M RP2 port**: ports the SMP flash lockout services from the ARMv8-M-ML-ALT port — spinlock-serialized requesters, SIO-FIFO LOCKOUT/ACK/UNLOCK handshake with a 100 ms timeout, RAM-resident parked wait with interrupts masked, buffered delivery of application FIFO messages. RP2040 adaptation: separate per-core FIFO IRQs 15/16 with one shared service routine.
- **RP2040 EFL**: `RP_EFL_XIP_SAFETY` strategy selection mirroring RP2350; SMP EFL builds fail with an explicit configuration error unless a strategy is chosen; `rp_flash_safety.c` provides the strong hook pair. PRIMASK deferral added inside the RAM flash sequences.
- **Tests**: RP2040 port of EFL-SMP-LOCKOUT (no fast-interrupt leg — ARMv6-M has no above-kernel tier), peer-liveness checks after each phase, bounded core-1 readiness wait (CodeRabbit findings incorporated in both variants).

Validation on the bench Pico (RP2040):
- EFL-SMP-LOCKOUT: 7/7 — each core erases/programs the last sector while the other executes from flash, and is proven alive afterwards.
- Negative control: the same test built with `RP_EFL_XIP_SAFETY_NONE` dies at the start of phase A — the lockout is what keeps the flash-resident core alive.
- XIP-VALIDATION all-PASS, EFL-MFS suite SUCCESS, SMP demo boots; non-SMP builds unaffected; RP2350 targets build.
- CodeRabbit: 2 minor findings (bound readiness waits), both incorporated and revalidated. Codex: implementation accepted — IRQ mapping, M0+ atomicity (spinlock+PRIMASK, no LDREX dependency), flash-veneer safety and RAM-closure of the parked wait all verified; its peer-liveness test gap finding was fixed and its negative-control suggestion adopted.