### PR TITLE
RP EFL: bounded waits, error reporting and full QSPI pad restore

### DIFF
--- a/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld.c
+++ b/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld.c
@@ -168,6 +168,7 @@ flash_error_t efl_lld_read(void *instance, flash_offset_t offset,
 flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
                               size_t n, const uint8_t *pp) {
   EFlashDriver *devp = (EFlashDriver *)instance;
+  flash_error_t err = FLASH_NO_ERROR;
   syssts_t sts;
 
   osalDbgCheck((instance != NULL) && (pp != NULL) && (n > 0U));
@@ -206,10 +207,16 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
     sts = osalSysGetStatusAndLockX();
 
     /* Program the page. */
-    rp_efl_lld_program_page_full(devp, page_base, page_buf,
-                                 RP_FLASH_PAGE_SIZE);
+    err = rp_efl_lld_program_page_full(devp, page_base, page_buf,
+                                       RP_FLASH_PAGE_SIZE);
 
     osalSysRestoreStatusX(sts);
+
+    /* Stop on the first failing page, the error is reported to the
+     * caller after the XIP-restored notification below. */
+    if (err != FLASH_NO_ERROR) {
+      break;
+    }
 
     offset += chunk;
     pp += chunk;
@@ -222,7 +229,7 @@ flash_error_t efl_lld_program(void *instance, flash_offset_t offset,
   /* Ready state again. */
   devp->state = FLASH_READY;
 
-  return FLASH_NO_ERROR;
+  return err;
 }
 
 /**
@@ -258,6 +265,7 @@ flash_error_t efl_lld_start_erase_sector(void *instance,
                                          flash_sector_t sector) {
   EFlashDriver *devp = (EFlashDriver *)instance;
   flash_offset_t offset;
+  flash_error_t err;
   syssts_t sts;
 
   osalDbgCheck(instance != NULL);
@@ -283,7 +291,7 @@ flash_error_t efl_lld_start_erase_sector(void *instance,
   sts = osalSysGetStatusAndLockX();
 
   /* Perform the entire erase sequence in RAM. */
-  rp_efl_lld_erase_full(devp, RP_FLASH_CMD_SECTOR_ERASE, offset);
+  err = rp_efl_lld_erase_full(devp, RP_FLASH_CMD_SECTOR_ERASE, offset);
 
   /* Restore system state. */
   osalSysRestoreStatusX(sts);
@@ -294,7 +302,7 @@ flash_error_t efl_lld_start_erase_sector(void *instance,
   /* Back to ready state. */
   devp->state = FLASH_READY;
 
-  return FLASH_NO_ERROR;
+  return err;
 }
 
 /**
@@ -316,6 +324,7 @@ flash_error_t efl_lld_start_erase_block(void *instance,
                                         uint32_t block) {
   EFlashDriver *devp = (EFlashDriver *)instance;
   flash_offset_t offset;
+  flash_error_t err;
   syssts_t sts;
 
   osalDbgCheck(instance != NULL);
@@ -337,7 +346,7 @@ flash_error_t efl_lld_start_erase_block(void *instance,
   /* Erase is one uninterrupted RAM-resident XIP-off transaction, so the
    * whole helper runs under syslock. */
   sts = osalSysGetStatusAndLockX();
-  rp_efl_lld_erase_full(devp, cmd, offset);
+  err = rp_efl_lld_erase_full(devp, cmd, offset);
   osalSysRestoreStatusX(sts);
 
   /* Notify the application that XIP is available again. */
@@ -345,7 +354,7 @@ flash_error_t efl_lld_start_erase_block(void *instance,
 
   devp->state = FLASH_READY;
 
-  return FLASH_NO_ERROR;
+  return err;
 }
 
 /**
@@ -440,11 +449,15 @@ flash_error_t efl_lld_verify_erase(void *instance, flash_sector_t sector) {
  *
  * @param[in] eflp      pointer to a @p EFlashDriver structure
  * @param[out] uid      pointer to an 8-byte buffer for the unique ID
+ * @return              An error code.
+ * @retval FLASH_NO_ERROR           if the unique ID has been read.
+ * @retval FLASH_ERROR_HW_FAILURE   if access to the memory failed.
  *
  * @api
  */
-void efl_lld_read_unique_id(EFlashDriver *eflp, uint8_t *uid) {
+flash_error_t efl_lld_read_unique_id(EFlashDriver *eflp, uint8_t *uid) {
   uint8_t rx[4U + RP_FLASH_UNIQUE_ID_SIZE];
+  flash_error_t err;
   syssts_t sts;
 
   osalDbgCheck((eflp != NULL) && (uid != NULL));
@@ -453,13 +466,17 @@ void efl_lld_read_unique_id(EFlashDriver *eflp, uint8_t *uid) {
   rpEflBeforeXipOff();
 
   sts = osalSysGetStatusAndLockX();
-  rp_efl_lld_read_uid_full(eflp, rx, sizeof(rx));
+  err = rp_efl_lld_read_uid_full(eflp, rx, sizeof(rx));
   osalSysRestoreStatusX(sts);
 
   /* Notify the application that XIP is available again. */
   rpEflAfterXipOn();
 
-  memcpy(uid, rx + 4U, RP_FLASH_UNIQUE_ID_SIZE);
+  if (err == FLASH_NO_ERROR) {
+    memcpy(uid, rx + 4U, RP_FLASH_UNIQUE_ID_SIZE);
+  }
+
+  return err;
 }
 
 /**

--- a/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld.c
+++ b/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld.c
@@ -451,7 +451,12 @@ flash_error_t efl_lld_verify_erase(void *instance, flash_sector_t sector) {
  * @param[out] uid      pointer to an 8-byte buffer for the unique ID
  * @return              An error code.
  * @retval FLASH_NO_ERROR           if the unique ID has been read.
- * @retval FLASH_ERROR_HW_FAILURE   if access to the memory failed.
+ * @retval FLASH_ERROR_HW_FAILURE   on communication or controller
+ *                                  failures, including transfer
+ *                                  timeouts and XIP exit/restore
+ *                                  failures propagated from the lower
+ *                                  layer.  No other error codes are
+ *                                  returned by this function.
  *
  * @api
  */

--- a/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld.h
+++ b/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld.h
@@ -31,16 +31,16 @@ extern "C" {
 #endif
   void rp_efl_lld_init(void);
   void rp_efl_lld_start(EFlashDriver *eflp);
-  void rp_efl_lld_program_page_full(EFlashDriver *eflp,
-                                    uint32_t offset,
-                                    const uint8_t *data,
-                                    size_t len);
-  void rp_efl_lld_erase_full(EFlashDriver *eflp,
-                             uint8_t cmd,
-                             uint32_t offset);
-  void rp_efl_lld_read_uid_full(EFlashDriver *eflp,
-                                uint8_t *rx,
-                                size_t count);
+  flash_error_t rp_efl_lld_program_page_full(EFlashDriver *eflp,
+                                             uint32_t offset,
+                                             const uint8_t *data,
+                                             size_t len);
+  flash_error_t rp_efl_lld_erase_full(EFlashDriver *eflp,
+                                      uint8_t cmd,
+                                      uint32_t offset);
+  flash_error_t rp_efl_lld_read_uid_full(EFlashDriver *eflp,
+                                         uint8_t *rx,
+                                         size_t count);
 #ifdef __cplusplus
 }
 #endif

--- a/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld_api.inc
+++ b/os/hal/ports/RP/LLD/EFLv1/rp_efl_lld_api.inc
@@ -32,4 +32,4 @@ flash_error_t efl_lld_start_erase_block(void *instance,
                                         uint32_t block);
 flash_error_t efl_lld_query_erase(void *instance, uint32_t *wait_time);
 flash_error_t efl_lld_verify_erase(void *instance, flash_sector_t sector);
-void efl_lld_read_unique_id(EFlashDriver *eflp, uint8_t *uid);
+flash_error_t efl_lld_read_unique_id(EFlashDriver *eflp, uint8_t *uid);

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -158,26 +158,24 @@ RAMFUNC static bool rp_flash_ssi_tx8(SSI_TypeDef *ssi, uint8_t data) {
 }
 
 /**
- * @brief   Best-effort resynchronization of the SSI FIFOs.
+ * @brief   Resynchronization of the SSI FIFOs.
  * @details After a transfer timeout the engine may still be shifting and
  *          the RX FIFO may hold residue; without draining, a later
  *          status poll can consume stale bytes and a BUSY=0 answer need
- *          not belong to that poll. Bounded: a controller that never
- *          recovers leaves residue behind, which subsequent polls then
- *          fail on loudly.
+ *          not belong to that poll, a false idle would let XIP return
+ *          over a busy device. Deliberately unbounded, matching the
+ *          wait-ready doctrine: no later poll can be trusted until the
+ *          engine is clean; a controller which never recovers leaves the
+ *          system spinning here for a watchdog to catch.
  * @note    This function MUST be in RAM.
  *
  * @param[in] ssi       pointer to the SSI registers
  */
 RAMFUNC static void rp_flash_resync(SSI_TypeDef *ssi) {
-  uint32_t start = TIMER0->TIMERAWL;
 
   while (((ssi->SR & SSI_SR_BUSY) != 0U) || (ssi->RXFLR > 0U)) {
     if (ssi->RXFLR > 0U) {
       (void)ssi->DR[0];
-    }
-    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
-      return;
     }
   }
 }

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -256,19 +256,24 @@ RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
 RAMFUNC static bool rp_flash_wait_ready(EFlashDriver *eflp,
                                         uint32_t timeout_us) {
   uint32_t start = TIMER0->TIMERAWL;
+  bool timed_out = false;
   uint8_t status;
 
   do {
     if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
       return false;
     }
+    /* On timeout the error is recorded but the wait continues: XIP cannot
+       be restored while the device is still busy, fetches would return
+       garbage and fault. A device which never recovers leaves the system
+       spinning here, which is a watchdog's job to catch.*/
     if (((status & FLASH_STATUS_BUSY) != 0U) &&
         rp_flash_timeout(start, timeout_us)) {
-      return false;
+      timed_out = true;
     }
   } while ((status & FLASH_STATUS_BUSY) != 0U);
 
-  return true;
+  return !timed_out;
 }
 
 /**

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -105,6 +105,14 @@ EFlashDriver EFLD1 = {
  */
 CC_ALIGN_DATA(4) static uint8_t rp_boot2[252];
 
+/**
+ * @brief   PADS_QSPI SD0..SD3 values saved before the flash operation.
+ * @details rp_flash_connect_internal() hard-resets PADS_QSPI, so the
+ *          pre-operation values must be captured before that reset and
+ *          re-applied after boot2 has reconfigured the pads for XIP.
+ */
+static uint32_t rp_pads_save[4];
+
 /*===========================================================================*/
 /* Driver local functions.                                                   */
 /*===========================================================================*/
@@ -247,33 +255,47 @@ RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
 /**
  * @brief   Wait for flash to become ready.
  * @note    This function MUST be in RAM.
+ * @note    Neither a timeout nor a communication failure aborts the wait:
+ *          XIP cannot be restored while the device may still be busy,
+ *          fetches would return garbage and fault. Errors are recorded
+ *          and the polling continues until a successful status read
+ *          reports the device idle; a device or controller which never
+ *          recovers leaves the system spinning here, which is a
+ *          watchdog's job to catch.
  *
  * @param[in] eflp        pointer to the EFlashDriver object
  * @param[in] timeout_us  operation timeout in microseconds
- * @return                true on success, false on timeout or
- *                        communication failure.
+ * @param[in] timeout_err error reported when the operation exceeded the
+ *                        timeout (operation-specific category)
+ * @return                An error code, @p FLASH_ERROR_HW_FAILURE on
+ *                        communication failures.
  */
-RAMFUNC static bool rp_flash_wait_ready(EFlashDriver *eflp,
-                                        uint32_t timeout_us) {
+RAMFUNC static flash_error_t rp_flash_wait_ready(EFlashDriver *eflp,
+                                                 uint32_t timeout_us,
+                                                 flash_error_t timeout_err) {
   uint32_t start = TIMER0->TIMERAWL;
   bool timed_out = false;
+  bool comm_fail = false;
   uint8_t status;
 
   do {
     if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
-      return false;
+      comm_fail = true;
+      status = FLASH_STATUS_BUSY;
     }
-    /* On timeout the error is recorded but the wait continues: XIP cannot
-       be restored while the device is still busy, fetches would return
-       garbage and fault. A device which never recovers leaves the system
-       spinning here, which is a watchdog's job to catch.*/
     if (((status & FLASH_STATUS_BUSY) != 0U) &&
         rp_flash_timeout(start, timeout_us)) {
       timed_out = true;
     }
   } while ((status & FLASH_STATUS_BUSY) != 0U);
 
-  return !timed_out;
+  if (comm_fail) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  if (timed_out) {
+    return timeout_err;
+  }
+  return FLASH_NO_ERROR;
 }
 
 /**
@@ -327,8 +349,17 @@ RAMFUNC static void rp_flash_flush_cache(void) {
  */
 RAMFUNC static bool rp_flash_connect_internal(void) {
   uint32_t bits = RESETS_ALLREG_IO_QSPI | RESETS_ALLREG_PADS_QSPI;
+  PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
   uint32_t start;
   unsigned i;
+
+  /* Save the data pad controls before the hard reset below wipes them,
+     rp_flash_enter_xip() restores them verbatim once boot2 has brought
+     XIP back. */
+  rp_pads_save[0] = pads_qspi->GPIO_QSPI_SD0;
+  rp_pads_save[1] = pads_qspi->GPIO_QSPI_SD1;
+  rp_pads_save[2] = pads_qspi->GPIO_QSPI_SD2;
+  rp_pads_save[3] = pads_qspi->GPIO_QSPI_SD3;
 
   /* Hard-reset IO_QSPI and PADS_QSPI. */
   RESETS->SET.RESET = bits;
@@ -496,8 +527,13 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
  *          convention will not work with this driver.
  *
  * @param[in] eflp      pointer to the EFlashDriver object
+ * @return              @p true on success, @p false on failure (the
+ *                      restore still proceeds, XIP must come back no
+ *                      matter what).
  */
-RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_enter_xip(EFlashDriver *eflp) {
+  PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
+  bool ok = true;
   (void)eflp;
 
   /* Reset CS control to normal. */
@@ -511,7 +547,17 @@ RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
    * with 1 sets the Thumb bit required by BX on ARMv6-M. */
   ((void (*)(void))((uintptr_t)rp_boot2 | 1U))();
 
+  /* Boot2 reconfigures the pads for XIP; re-applying the values saved
+     in rp_flash_connect_internal() restores any board/application-
+     specific pad tuning that existed before the operation. */
+  pads_qspi->GPIO_QSPI_SD0 = rp_pads_save[0];
+  pads_qspi->GPIO_QSPI_SD1 = rp_pads_save[1];
+  pads_qspi->GPIO_QSPI_SD2 = rp_pads_save[2];
+  pads_qspi->GPIO_QSPI_SD3 = rp_pads_save[3];
+
   rp_flash_flush_cache();
+
+  return ok;
 }
 
 /**
@@ -522,18 +568,20 @@ RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
  * @param[in] offset    flash offset (must be page-aligned or within page)
  * @param[in] data      data to program
  * @param[in] len       number of bytes (must not cross page boundary)
- * @return              true on success, false on timeout or
- *                      communication failure.
+ * @return              An error code.
  */
-RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
-                                          const uint8_t *data, size_t len) {
+RAMFUNC static flash_error_t rp_flash_program_page(EFlashDriver *eflp,
+                                                   uint32_t offset,
+                                                   const uint8_t *data,
+                                                   size_t len) {
   SSI_TypeDef *ssi = eflp->ssi;
+  flash_error_t ready_err;
   uint8_t addr[3];
   bool ok;
 
-  /* Send write enable. */
+  /* Send write enable; nothing was launched on failure. */
   if (!rp_flash_write_enable(eflp)) {
-    return false;
+    return FLASH_ERROR_HW_FAILURE;
   }
 
   /* Prepare 24-bit address (big-endian). */
@@ -560,12 +608,16 @@ RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
   /* Deassert CS, also on failed transfers. */
   rp_flash_cs_force(eflp, true);
 
-  /* Wait for program to complete. */
-  if (ok) {
-    ok = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US);
-  }
+  /* The CS edge may have launched the program even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US,
+                                  FLASH_ERROR_PROGRAM);
 
-  return ok;
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
 }
 
 /**
@@ -575,16 +627,18 @@ RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
  * @param[in] eflp      pointer to the EFlashDriver object
  * @param[in] cmd       JEDEC erase command byte
  * @param[in] offset    flash offset (must be aligned to erase unit)
- * @return              true on success, false on timeout or
- *                      communication failure.
+ * @return              An error code.
  */
-RAMFUNC static bool rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
-                                       uint32_t offset) {
+RAMFUNC static flash_error_t rp_flash_erase_cmd(EFlashDriver *eflp,
+                                                uint8_t cmd,
+                                                uint32_t offset) {
+  flash_error_t ready_err;
   uint8_t addr[3];
+  bool ok;
 
-  /* Send write enable. */
+  /* Send write enable; nothing was launched on failure. */
   if (!rp_flash_write_enable(eflp)) {
-    return false;
+    return FLASH_ERROR_HW_FAILURE;
   }
 
   /* Prepare 24-bit address (big-endian). */
@@ -593,7 +647,18 @@ RAMFUNC static bool rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
   addr[2] = (uint8_t)offset;
 
   /* Send erase command with address. */
-  return rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+  ok = rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+
+  /* The CS edge may have launched the erase even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US,
+                                  FLASH_ERROR_ERASE);
+
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
 }
 
 /**
@@ -617,14 +682,15 @@ RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
     err = FLASH_ERROR_HW_FAILURE;
   }
   /* Send erase command and wait for erase to complete. */
-  else if (!rp_flash_erase_cmd(eflp, cmd, offset) ||
-           !rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US)) {
-    err = FLASH_ERROR_ERASE;
+  else {
+    err = rp_flash_erase_cmd(eflp, cmd, offset);
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
      without XIP restored. */
-  rp_flash_enter_xip(eflp);
+  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
   return err;
 }
@@ -652,13 +718,15 @@ RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
     err = FLASH_ERROR_HW_FAILURE;
   }
   /* Program the page. */
-  else if (!rp_flash_program_page(eflp, offset, data, len)) {
-    err = FLASH_ERROR_PROGRAM;
+  else {
+    err = rp_flash_program_page(eflp, offset, data, len);
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
      without XIP restored. */
-  rp_flash_enter_xip(eflp);
+  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
   return err;
 }
@@ -690,7 +758,9 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
      without XIP restored. */
-  rp_flash_enter_xip(eflp);
+  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
   return err;
 }

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -110,6 +110,44 @@ CC_ALIGN_DATA(4) static uint8_t rp_boot2[252];
 /*===========================================================================*/
 
 /**
+ * @brief   Checks elapsed time against the free-running 1 MHz timer.
+ * @note    This function MUST be in RAM.  TIMER0 is an APB peripheral
+ *          and remains readable while XIP is disabled; TIMERAWL has no
+ *          read side effects.
+ *
+ * @param[in] start       TIMERAWL value sampled when the wait started
+ * @param[in] timeout_us  allowed time in microseconds
+ * @return                true if the timeout expired.
+ */
+RAMFUNC static bool rp_flash_timeout(uint32_t start, uint32_t timeout_us) {
+
+  return (uint32_t)(TIMER0->TIMERAWL - start) > timeout_us;
+}
+
+/**
+ * @brief   Clocks one byte through the SSI and discards the RX byte.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] ssi       pointer to the SSI registers
+ * @param[in] data      data byte to transmit
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_ssi_tx8(SSI_TypeDef *ssi, uint8_t data) {
+  uint32_t start;
+
+  ssi->DR[0] = data;
+  start = TIMER0->TIMERAWL;
+  while (ssi->RXFLR == 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+  (void)ssi->DR[0];
+
+  return true;
+}
+
+/**
  * @brief   Force chip select high or low
  * @note    This function MUST be in RAM.
  *
@@ -137,13 +175,15 @@ RAMFUNC static void rp_flash_cs_force(EFlashDriver *eflp, bool high) {
  * @param[in] tx        transmit buffer (NULL to send zeros)
  * @param[out] rx       receive buffer (NULL to discard)
  * @param[in] count     number of bytes to transfer
+ * @return              true on success, false on timeout.
  */
-RAMFUNC static void rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
+RAMFUNC static bool rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
                                      uint8_t *rx, size_t count) {
   SSI_TypeDef *ssi = eflp->ssi;
   size_t tx_remaining = count;
   size_t rx_remaining = count;
   const size_t max_in_flight = 14U; /* FIFO is 16 deep so we leave a margin */
+  uint32_t start = TIMER0->TIMERAWL;
 
   while ((tx_remaining > 0U) || (rx_remaining > 0U)) {
     size_t in_flight = (count - tx_remaining) - (count - rx_remaining);
@@ -162,7 +202,13 @@ RAMFUNC static void rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
       }
       rx_remaining--;
     }
+
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
   }
+
+  return true;
 }
 
 /**
@@ -174,51 +220,79 @@ RAMFUNC static void rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
  * @param[in] tx        transmit data after command (NULL if none)
  * @param[out] rx       receive buffer (NULL to discard)
  * @param[in] count     number of bytes to transfer after command
+ * @return              true on success, false on timeout.
  */
-RAMFUNC static void rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
+RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
                                     const uint8_t *tx, uint8_t *rx,
                                     size_t count) {
+  bool ok;
+
   /* Assert CS. */
   rp_flash_cs_force(eflp, false);
 
   /* Send command byte. */
-  eflp->ssi->DR[0] = cmd;
-  while (eflp->ssi->RXFLR == 0U) {
-  }
-  (void)eflp->ssi->DR[0];
+  ok = rp_flash_ssi_tx8(eflp->ssi, cmd);
 
   /* Transfer remaining data. */
-  if (count > 0U) {
-    rp_flash_put_get(eflp, tx, rx, count);
+  if (ok && (count > 0U)) {
+    ok = rp_flash_put_get(eflp, tx, rx, count);
   }
 
-  /* Deassert CS. */
+  /* Deassert CS, also on failed transfers. */
   rp_flash_cs_force(eflp, true);
+
+  return ok;
 }
 
 /**
  * @brief   Wait for flash to become ready.
  * @note    This function MUST be in RAM.
  *
- * @param[in] eflp      pointer to the EFlashDriver object
+ * @param[in] eflp        pointer to the EFlashDriver object
+ * @param[in] timeout_us  operation timeout in microseconds
+ * @return                true on success, false on timeout or
+ *                        communication failure.
  */
-RAMFUNC static void rp_flash_wait_ready(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_wait_ready(EFlashDriver *eflp,
+                                        uint32_t timeout_us) {
+  uint32_t start = TIMER0->TIMERAWL;
   uint8_t status;
 
   do {
-    rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U);
+    if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+      return false;
+    }
+    if (((status & FLASH_STATUS_BUSY) != 0U) &&
+        rp_flash_timeout(start, timeout_us)) {
+      return false;
+    }
   } while ((status & FLASH_STATUS_BUSY) != 0U);
+
+  return true;
 }
 
 /**
- * @brief   Send write enable command.
+ * @brief   Send write enable command and verify the WEL latch.
  * @note    This function MUST be in RAM.
  *
  * @param[in] eflp      pointer to the EFlashDriver object
+ * @return              true on success, false on timeout or if the
+ *                      write enable latch did not set.
  */
-RAMFUNC static void rp_flash_write_enable(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_write_enable(EFlashDriver *eflp) {
+  uint8_t status;
 
-  rp_flash_do_cmd(eflp, FLASHCMD_WRITE_ENABLE, NULL, NULL, 0U);
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_WRITE_ENABLE, NULL, NULL, 0U)) {
+    return false;
+  }
+
+  /* Read back the status register and verify WEL is set, a device
+     that rejects the command would silently fail later. */
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+    return false;
+  }
+
+  return (status & FLASH_STATUS_WEL) != 0U;
 }
 
 /**
@@ -243,21 +317,30 @@ RAMFUNC static void rp_flash_flush_cache(void) {
 /**
  * @brief   Reset QSPI pads and mux to connect SSI to internal flash.
  * @note    This function MUST be in RAM.
+ *
+ * @return              true on success, false on timeout.
  */
-RAMFUNC static void rp_flash_connect_internal(void) {
+RAMFUNC static bool rp_flash_connect_internal(void) {
   uint32_t bits = RESETS_ALLREG_IO_QSPI | RESETS_ALLREG_PADS_QSPI;
+  uint32_t start;
   unsigned i;
 
   /* Hard-reset IO_QSPI and PADS_QSPI. */
   RESETS->SET.RESET = bits;
   RESETS->CLR.RESET = bits;
+  start = TIMER0->TIMERAWL;
   while ((RESETS->RESET_DONE & bits) != bits) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
   }
 
   /* Mux all QSPI GPIOs to function 0 (XIP). */
   for (i = 0U; i < 6U; i++) {
     IO_QSPI->GPIO[i].CTRL = 0U;
   }
+
+  return true;
 }
 
 /**
@@ -266,17 +349,25 @@ RAMFUNC static void rp_flash_connect_internal(void) {
  * @note    This follows a similar pattern to the ROM's flash_exit_xip()
  *
  * @param[in] eflp      pointer to the EFlashDriver object
+ * @return              true on success, false on timeout.  Also on
+ *                      failure the caller must re-enter XIP mode.
  */
-RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
   SSI_TypeDef *ssi = eflp->ssi;
   PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
   uint32_t padctrl_save;
   uint32_t padctrl_tmp;
+  uint32_t start;
   unsigned i;
   volatile unsigned delay;
+  bool ok = true;
 
   /* Wait for any pending work.*/
+  start = TIMER0->TIMERAWL;
   while ((ssi->SR & SSI_SR_BUSY) != 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
   }
 
   /* Default non XIP SPI configuration */
@@ -316,51 +407,61 @@ RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
   }
 
   /* Send 4 bytes / 32 clocks */
-  for (i = 0U; i < 4U; i++) {
-    ssi->DR[0] = 0U;
-    while (ssi->RXFLR == 0U) {
+  for (i = 0U; ok && (i < 4U); i++) {
+    ok = rp_flash_ssi_tx8(ssi, 0U);
+  }
+
+  if (ok) {
+    padctrl_tmp = (padctrl_tmp & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
+
+    /* 2. CS low */
+    rp_flash_cs_force(eflp, false);
+
+    pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
+
+    /* Delay of ~6000 cycles */
+    for (delay = 0U; delay < 2048U; delay++) {
     }
-    (void)ssi->DR[0];
-  }
 
-  padctrl_tmp = (padctrl_tmp & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
-
-  /* 2. CS low */
-  rp_flash_cs_force(eflp, false);
-
-  pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
-  pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
-  pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
-  pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
-
-  /* Delay of ~6000 cycles */
-  for (delay = 0U; delay < 2048U; delay++) {
-  }
-
-  /* Send 4 bytes / 32 clocks */
-  for (i = 0U; i < 4U; i++) {
-    ssi->DR[0] = 0U;
-    while (ssi->RXFLR == 0U) {
+    /* Send 4 bytes / 32 clocks */
+    for (i = 0U; ok && (i < 4U); i++) {
+      ok = rp_flash_ssi_tx8(ssi, 0U);
     }
-    (void)ssi->DR[0];
   }
 
-  /* Restore pad controls. */
+  /* Restore pad controls, also on failed sequences. */
   pads_qspi->GPIO_QSPI_SD0 = padctrl_save;
   pads_qspi->GPIO_QSPI_SD1 = padctrl_save;
   padctrl_save = (padctrl_save & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
   pads_qspi->GPIO_QSPI_SD2 = padctrl_save;
   pads_qspi->GPIO_QSPI_SD3 = padctrl_save;
 
+  if (!ok) {
+    rp_flash_cs_force(eflp, true);
+    return false;
+  }
+
   /* 3. Send 0xFF, 0xFF */
   rp_flash_cs_force(eflp, false);
   ssi->DR[0] = 0xFFU;
   ssi->DR[0] = 0xFFU;
+  start = TIMER0->TIMERAWL;
   while (ssi->RXFLR < 2U) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      ok = false;
+      break;
+    }
   }
-  (void)ssi->DR[0];
-  (void)ssi->DR[0];
+  if (ok) {
+    (void)ssi->DR[0];
+    (void)ssi->DR[0];
+  }
   rp_flash_cs_force(eflp, true);
+
+  return ok;
 }
 
 /**
@@ -416,14 +517,19 @@ RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
  * @param[in] offset    flash offset (must be page-aligned or within page)
  * @param[in] data      data to program
  * @param[in] len       number of bytes (must not cross page boundary)
+ * @return              true on success, false on timeout or
+ *                      communication failure.
  */
-RAMFUNC static void rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
+RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
                                           const uint8_t *data, size_t len) {
   SSI_TypeDef *ssi = eflp->ssi;
   uint8_t addr[3];
+  bool ok;
 
   /* Send write enable. */
-  rp_flash_write_enable(eflp);
+  if (!rp_flash_write_enable(eflp)) {
+    return false;
+  }
 
   /* Prepare 24-bit address (big-endian). */
   addr[0] = (uint8_t)(offset >> 16);
@@ -434,22 +540,27 @@ RAMFUNC static void rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
   rp_flash_cs_force(eflp, false);
 
   /* Send page program command. */
-  ssi->DR[0] = FLASHCMD_PAGE_PROGRAM;
-  while (ssi->RXFLR == 0U) {
-  }
-  (void)ssi->DR[0];
+  ok = rp_flash_ssi_tx8(ssi, FLASHCMD_PAGE_PROGRAM);
 
   /* Send address. */
-  rp_flash_put_get(eflp, addr, NULL, 3U);
+  if (ok) {
+    ok = rp_flash_put_get(eflp, addr, NULL, 3U);
+  }
 
   /* Send data. */
-  rp_flash_put_get(eflp, data, NULL, len);
+  if (ok) {
+    ok = rp_flash_put_get(eflp, data, NULL, len);
+  }
 
-  /* Deassert CS. */
+  /* Deassert CS, also on failed transfers. */
   rp_flash_cs_force(eflp, true);
 
   /* Wait for program to complete. */
-  rp_flash_wait_ready(eflp);
+  if (ok) {
+    ok = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US);
+  }
+
+  return ok;
 }
 
 /**
@@ -459,13 +570,17 @@ RAMFUNC static void rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
  * @param[in] eflp      pointer to the EFlashDriver object
  * @param[in] cmd       JEDEC erase command byte
  * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              true on success, false on timeout or
+ *                      communication failure.
  */
-RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
-                                        uint32_t offset) {
+RAMFUNC static bool rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
+                                       uint32_t offset) {
   uint8_t addr[3];
 
   /* Send write enable. */
-  rp_flash_write_enable(eflp);
+  if (!rp_flash_write_enable(eflp)) {
+    return false;
+  }
 
   /* Prepare 24-bit address (big-endian). */
   addr[0] = (uint8_t)(offset >> 16);
@@ -473,7 +588,7 @@ RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
   addr[2] = (uint8_t)offset;
 
   /* Send erase command with address. */
-  rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+  return rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
 }
 
 /**
@@ -485,22 +600,28 @@ RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
  * @param[in] eflp      pointer to the EFlashDriver object
  * @param[in] cmd       JEDEC erase command byte
  * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              An error code.
  */
-RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
-                                        uint32_t offset) {
+RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
+                                                 uint8_t cmd,
+                                                 uint32_t offset) {
+  flash_error_t err = FLASH_NO_ERROR;
 
   /* Connect SSI to flash and exit XIP mode. */
-  rp_flash_connect_internal();
-  rp_flash_exit_xip(eflp);
+  if (!rp_flash_connect_internal() || !rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Send erase command and wait for erase to complete. */
+  else if (!rp_flash_erase_cmd(eflp, cmd, offset) ||
+           !rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US)) {
+    err = FLASH_ERROR_ERASE;
+  }
 
-  /* Send erase command. */
-  rp_flash_erase_cmd(eflp, cmd, offset);
-
-  /* Wait for erase to complete. */
-  rp_flash_wait_ready(eflp);
-
-  /* Re-enter XIP mode. */
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. */
   rp_flash_enter_xip(eflp);
+
+  return err;
 }
 
 /**
@@ -513,21 +634,28 @@ RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
  * @param[in] offset    flash offset (must not cross page boundary)
  * @param[in] data      pointer to data in RAM
  * @param[in] len       number of bytes to program
+ * @return              An error code.
  */
-RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
-                                               uint32_t offset,
-                                               const uint8_t *data,
-                                               size_t len) {
+RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
+                                                        uint32_t offset,
+                                                        const uint8_t *data,
+                                                        size_t len) {
+  flash_error_t err = FLASH_NO_ERROR;
 
   /* Connect SSI to flash and exit XIP mode. */
-  rp_flash_connect_internal();
-  rp_flash_exit_xip(eflp);
-
+  if (!rp_flash_connect_internal() || !rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
   /* Program the page. */
-  rp_flash_program_page(eflp, offset, data, len);
+  else if (!rp_flash_program_page(eflp, offset, data, len)) {
+    err = FLASH_ERROR_PROGRAM;
+  }
 
-  /* Re-enter XIP mode. */
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. */
   rp_flash_enter_xip(eflp);
+
+  return err;
 }
 
 /**
@@ -539,19 +667,27 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
  * @param[in] eflp      pointer to the EFlashDriver object
  * @param[out] rx       receive buffer
  * @param[in] count     number of bytes to transfer after command
+ * @return              An error code.
  */
-RAMFUNC static void rp_flash_read_uid_full(EFlashDriver *eflp,
-                                           uint8_t *rx, size_t count) {
+RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
+                                                    uint8_t *rx,
+                                                    size_t count) {
+  flash_error_t err = FLASH_NO_ERROR;
 
   /* Connect SSI to flash and exit XIP mode. */
-  rp_flash_connect_internal();
-  rp_flash_exit_xip(eflp);
-
+  if (!rp_flash_connect_internal() || !rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
   /* Send read unique ID command. */
-  rp_flash_do_cmd(eflp, FLASHCMD_READ_UNIQUE_ID, NULL, rx, count);
+  else if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_UNIQUE_ID, NULL, rx, count)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
-  /* Re-enter XIP mode. */
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. */
   rp_flash_enter_xip(eflp);
+
+  return err;
 }
 
 /*===========================================================================*/
@@ -579,21 +715,26 @@ void rp_efl_lld_start(EFlashDriver *eflp) {
   /* Nothing to do - boot2 is copied during init. */
 }
 
-void rp_efl_lld_program_page_full(EFlashDriver *eflp,
-                                  uint32_t offset,
-                                  const uint8_t *data,
-                                  size_t len) {
-  rp_flash_program_page_full(eflp, offset, data, len);
+flash_error_t rp_efl_lld_program_page_full(EFlashDriver *eflp,
+                                           uint32_t offset,
+                                           const uint8_t *data,
+                                           size_t len) {
+
+  return rp_flash_program_page_full(eflp, offset, data, len);
 }
 
-void rp_efl_lld_erase_full(EFlashDriver *eflp, uint8_t cmd, uint32_t offset) {
-  rp_flash_erase_full(eflp, cmd, offset);
+flash_error_t rp_efl_lld_erase_full(EFlashDriver *eflp,
+                                    uint8_t cmd,
+                                    uint32_t offset) {
+
+  return rp_flash_erase_full(eflp, cmd, offset);
 }
 
-void rp_efl_lld_read_uid_full(EFlashDriver *eflp,
-                              uint8_t *rx,
-                              size_t count) {
-  rp_flash_read_uid_full(eflp, rx, count);
+flash_error_t rp_efl_lld_read_uid_full(EFlashDriver *eflp,
+                                       uint8_t *rx,
+                                       size_t count) {
+
+  return rp_flash_read_uid_full(eflp, rx, count);
 }
 
 #endif /* HAL_USE_EFL == TRUE */

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -106,12 +106,14 @@ EFlashDriver EFLD1 = {
 CC_ALIGN_DATA(4) static uint8_t rp_boot2[252];
 
 /**
- * @brief   PADS_QSPI SD0..SD3 values saved before the flash operation.
- * @details rp_flash_connect_internal() hard-resets PADS_QSPI, so the
- *          pre-operation values must be captured before that reset and
- *          re-applied after boot2 has reconfigured the pads for XIP.
+ * @brief   PADS_QSPI SCLK, SD0..SD3 and SS values saved before the
+ *          flash operation.
+ * @details rp_flash_connect_internal() hard-resets PADS_QSPI, wiping
+ *          all six QSPI pad controls, so the pre-operation values must
+ *          be captured before that reset and re-applied after boot2
+ *          has reconfigured the pads for XIP.
  */
-static uint32_t rp_pads_save[4];
+static uint32_t rp_pads_save[6];
 
 /*===========================================================================*/
 /* Driver local functions.                                                   */
@@ -153,6 +155,31 @@ RAMFUNC static bool rp_flash_ssi_tx8(SSI_TypeDef *ssi, uint8_t data) {
   (void)ssi->DR[0];
 
   return true;
+}
+
+/**
+ * @brief   Best-effort resynchronization of the SSI FIFOs.
+ * @details After a transfer timeout the engine may still be shifting and
+ *          the RX FIFO may hold residue; without draining, a later
+ *          status poll can consume stale bytes and a BUSY=0 answer need
+ *          not belong to that poll. Bounded: a controller that never
+ *          recovers leaves residue behind, which subsequent polls then
+ *          fail on loudly.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] ssi       pointer to the SSI registers
+ */
+RAMFUNC static void rp_flash_resync(SSI_TypeDef *ssi) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while (((ssi->SR & SSI_SR_BUSY) != 0U) || (ssi->RXFLR > 0U)) {
+    if (ssi->RXFLR > 0U) {
+      (void)ssi->DR[0];
+    }
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return;
+    }
+  }
 }
 
 /**
@@ -244,6 +271,13 @@ RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
   /* Transfer remaining data. */
   if (ok && (count > 0U)) {
     ok = rp_flash_put_get(eflp, tx, rx, count);
+  }
+
+  /* A failed transfer can leave the engine shifting and residue in the
+     RX FIFO; resynchronize before the CS edge so the next transaction
+     starts clean and later status polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(eflp->ssi);
   }
 
   /* Deassert CS, also on failed transfers. */
@@ -353,13 +387,15 @@ RAMFUNC static bool rp_flash_connect_internal(void) {
   uint32_t start;
   unsigned i;
 
-  /* Save the data pad controls before the hard reset below wipes them,
-     rp_flash_enter_xip() restores them verbatim once boot2 has brought
-     XIP back. */
-  rp_pads_save[0] = pads_qspi->GPIO_QSPI_SD0;
-  rp_pads_save[1] = pads_qspi->GPIO_QSPI_SD1;
-  rp_pads_save[2] = pads_qspi->GPIO_QSPI_SD2;
-  rp_pads_save[3] = pads_qspi->GPIO_QSPI_SD3;
+  /* Save all six QSPI pad controls (SCLK, SD0..SD3, SS) before the
+     hard reset below wipes them, rp_flash_enter_xip() restores them
+     verbatim once boot2 has brought XIP back. */
+  rp_pads_save[0] = pads_qspi->GPIO_QSPI_SCLK;
+  rp_pads_save[1] = pads_qspi->GPIO_QSPI_SD0;
+  rp_pads_save[2] = pads_qspi->GPIO_QSPI_SD1;
+  rp_pads_save[3] = pads_qspi->GPIO_QSPI_SD2;
+  rp_pads_save[4] = pads_qspi->GPIO_QSPI_SD3;
+  rp_pads_save[5] = pads_qspi->GPIO_QSPI_SS;
 
   /* Hard-reset IO_QSPI and PADS_QSPI. */
   RESETS->SET.RESET = bits;
@@ -549,11 +585,14 @@ RAMFUNC static bool rp_flash_enter_xip(EFlashDriver *eflp) {
 
   /* Boot2 reconfigures the pads for XIP; re-applying the values saved
      in rp_flash_connect_internal() restores any board/application-
-     specific pad tuning that existed before the operation. */
-  pads_qspi->GPIO_QSPI_SD0 = rp_pads_save[0];
-  pads_qspi->GPIO_QSPI_SD1 = rp_pads_save[1];
-  pads_qspi->GPIO_QSPI_SD2 = rp_pads_save[2];
-  pads_qspi->GPIO_QSPI_SD3 = rp_pads_save[3];
+     specific pad tuning that existed before the operation, on all six
+     QSPI pads (SCLK, SD0..SD3, SS). */
+  pads_qspi->GPIO_QSPI_SCLK = rp_pads_save[0];
+  pads_qspi->GPIO_QSPI_SD0  = rp_pads_save[1];
+  pads_qspi->GPIO_QSPI_SD1  = rp_pads_save[2];
+  pads_qspi->GPIO_QSPI_SD2  = rp_pads_save[3];
+  pads_qspi->GPIO_QSPI_SD3  = rp_pads_save[4];
+  pads_qspi->GPIO_QSPI_SS   = rp_pads_save[5];
 
   rp_flash_flush_cache();
 
@@ -603,6 +642,12 @@ RAMFUNC static flash_error_t rp_flash_program_page(EFlashDriver *eflp,
   /* Send data. */
   if (ok) {
     ok = rp_flash_put_get(eflp, data, NULL, len);
+  }
+
+  /* A failed transfer can leave engine residue behind; resynchronize
+     before the CS edge so the ready polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(ssi);
   }
 
   /* Deassert CS, also on failed transfers. */
@@ -687,8 +732,9 @@ RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
-     without XIP restored. */
-  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
     err = FLASH_ERROR_HW_FAILURE;
   }
 
@@ -723,8 +769,9 @@ RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
-     without XIP restored. */
-  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
     err = FLASH_ERROR_HW_FAILURE;
   }
 
@@ -757,8 +804,9 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
-     without XIP restored. */
-  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
     err = FLASH_ERROR_HW_FAILURE;
   }
 

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.h
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.h
@@ -104,6 +104,12 @@
 #define RP_FLASH_SIZE                       (2U * 1024U * 1024U)
 #endif
 
+/* The driver issues 24-bit (3-byte) JEDEC addresses; larger devices
+   would silently wrap around and corrupt low flash. */
+#if RP_FLASH_SIZE > (16U * 1024U * 1024U)
+#error "RP_FLASH_SIZE exceeds 24-bit flash addressing"
+#endif
+
 /**
  * @brief   Suggested wait time during erase operations polling.
  */

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.h
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.h
@@ -111,6 +111,32 @@
 #define RP_FLASH_WAIT_TIME_MS               1U
 #endif
 
+/**
+ * @brief   Timeout for SSI FIFO/BUSY waits in microseconds.
+ * @details Bounds the individual controller-level waits (FIFO drains,
+ *          SR BUSY polls, QSPI pad reset completion) performed while
+ *          XIP is disabled.
+ */
+#if !defined(RP_FLASH_SSI_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_SSI_TIMEOUT_US             1000U
+#endif
+
+/**
+ * @brief   Timeout for a page program operation in microseconds.
+ */
+#if !defined(RP_FLASH_PROGRAM_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_PROGRAM_TIMEOUT_US         20000U
+#endif
+
+/**
+ * @brief   Timeout for an erase operation in microseconds.
+ * @details Sized for the worst-case 64KB block erase time of common
+ *          QSPI flash devices.
+ */
+#if !defined(RP_FLASH_ERASE_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_ERASE_TIMEOUT_US           4000000U
+#endif
+
 /** @} */
 
 /*===========================================================================*/

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -262,33 +262,47 @@ RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
 /**
  * @brief   Wait for flash to become ready.
  * @note    This function MUST be in RAM.
+ * @note    Neither a timeout nor a communication failure aborts the wait:
+ *          XIP cannot be restored while the device may still be busy,
+ *          fetches would return garbage and fault. Errors are recorded
+ *          and the polling continues until a successful status read
+ *          reports the device idle; a device or controller which never
+ *          recovers leaves the system spinning here, which is a
+ *          watchdog's job to catch.
  *
  * @param[in] eflp        pointer to the EFlashDriver object
  * @param[in] timeout_us  operation timeout in microseconds
- * @return                true on success, false on timeout or
- *                        communication failure.
+ * @param[in] timeout_err error reported when the operation exceeded the
+ *                        timeout (operation-specific category)
+ * @return                An error code, @p FLASH_ERROR_HW_FAILURE on
+ *                        communication failures.
  */
-RAMFUNC static bool rp_flash_wait_ready(EFlashDriver *eflp,
-                                        uint32_t timeout_us) {
+RAMFUNC static flash_error_t rp_flash_wait_ready(EFlashDriver *eflp,
+                                                 uint32_t timeout_us,
+                                                 flash_error_t timeout_err) {
   uint32_t start = TIMER0->TIMERAWL;
   bool timed_out = false;
+  bool comm_fail = false;
   uint8_t status;
 
   do {
     if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
-      return false;
+      comm_fail = true;
+      status = FLASH_STATUS_BUSY;
     }
-    /* On timeout the error is recorded but the wait continues: XIP cannot
-       be restored while the device is still busy, fetches would return
-       garbage and fault. A device which never recovers leaves the system
-       spinning here, which is a watchdog's job to catch.*/
     if (((status & FLASH_STATUS_BUSY) != 0U) &&
         rp_flash_timeout(start, timeout_us)) {
       timed_out = true;
     }
   } while ((status & FLASH_STATUS_BUSY) != 0U);
 
-  return !timed_out;
+  if (comm_fail) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  if (timed_out) {
+    return timeout_err;
+  }
+  return FLASH_NO_ERROR;
 }
 
 /**
@@ -391,16 +405,24 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
   /* Default non XIP SPI configuration */
   qmi->DIRECT_CSR = QMI_DIRECT_CSR_EN | QMI_DIRECT_CSR_CLKDIV(6U);
 
-  /* Wait for the direct-mode interface to settle after enabling it,
-     an XIP access may still be draining through the serial interface. */
-  if (!rp_flash_direct_wait_idle(qmi)) {
-    return false;
-  }
+  /* Wait for the direct-mode interface to settle after enabling it
+     while draining stale RX data: a full RX FIFO can itself stall the
+     serial engine and hold BUSY high, so the drain must happen inside
+     the wait (matches the bootrom's entry sequence). */
+  {
+    uint32_t start = TIMER0->TIMERAWL;
 
-  /* Drain any stale data left in the RX FIFO so subsequent transfers
-     observe only their own responses. */
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
-    (void)qmi->DIRECT_RX;
+    while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
+      if ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
+        (void)qmi->DIRECT_RX;
+      }
+      if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+        return false;
+      }
+    }
+    while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
+      (void)qmi->DIRECT_RX;
+    }
   }
 
   /*
@@ -475,7 +497,14 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
    *    this command to leave QPI mode (e.g. some Winbond, ISSI parts).
    *    PSRAM on CS1 is unaffected — its CS is not asserted here and its
    *    QPI state is preserved across the flash operation via M1
-   *    save/restore. */
+   *    save/restore.
+   *
+   *    CS is still asserted from phase 2; a real deassert/reassert edge
+   *    is required so F5h starts a fresh transaction (the bootrom does
+   *    the same). */
+  rp_flash_cs_force(eflp, true);
+  for (delay = 0U; delay < 64U; delay++) {
+  }
   rp_flash_cs_force(eflp, false);
   qmi->DIRECT_TX = 0xF5U | QMI_DIRECT_TX_IWIDTH(QMI_DIRECT_TX_IWIDTH_Q) |
                    QMI_DIRECT_TX_OE | QMI_DIRECT_TX_NOPUSH;
@@ -527,13 +556,17 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
  *          (e.g. QSPI fast read).
  *
  * @param[in] eflp      pointer to the EFlashDriver object
+ * @return              @p true on success, @p false when the final idle
+ *                      wait timed out (the restore still proceeds, XIP
+ *                      must come back no matter what).
  */
-RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_enter_xip(EFlashDriver *eflp) {
   QMI_TypeDef *qmi = eflp->qmi;
+  bool ok;
 
   /* Wait for transfers to complete.  On timeout the restore proceeds
      anyway, XIP must come back no matter what. */
-  (void)rp_flash_direct_wait_idle(qmi);
+  ok = rp_flash_direct_wait_idle(qmi);
 
   /* Disable direct mode and restore saved XIP configuration (CS0 and CS1). */
   qmi->DIRECT_CSR = 0U;
@@ -547,6 +580,8 @@ RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
   qmi->M1_WCMD    = eflp->xip_m1_wcmd;
 
   rp_flash_flush_cache(eflp);
+
+  return ok;
 }
 
 /**
@@ -560,15 +595,18 @@ RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
  * @return              true on success, false on timeout or
  *                      communication failure.
  */
-RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
-                                          const uint8_t *data, size_t len) {
+RAMFUNC static flash_error_t rp_flash_program_page(EFlashDriver *eflp,
+                                                   uint32_t offset,
+                                                   const uint8_t *data,
+                                                   size_t len) {
   QMI_TypeDef *qmi = eflp->qmi;
+  flash_error_t ready_err;
   uint8_t addr[3];
   bool ok;
 
-  /* Send write enable. */
+  /* Send write enable; nothing was launched on failure. */
   if (!rp_flash_write_enable(eflp)) {
-    return false;
+    return FLASH_ERROR_HW_FAILURE;
   }
 
   /* Prepare 24-bit address (big-endian). */
@@ -595,12 +633,16 @@ RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
   /* Deassert CS, also on failed transfers. */
   rp_flash_cs_force(eflp, true);
 
-  /* Wait for program to complete. */
-  if (ok) {
-    ok = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US);
-  }
+  /* The CS edge may have launched the program even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US,
+                                  FLASH_ERROR_PROGRAM);
 
-  return ok;
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
 }
 
 /**
@@ -613,13 +655,16 @@ RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
  * @return              true on success, false on timeout or
  *                      communication failure.
  */
-RAMFUNC static bool rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
-                                       uint32_t offset) {
+RAMFUNC static flash_error_t rp_flash_erase_cmd(EFlashDriver *eflp,
+                                                uint8_t cmd,
+                                                uint32_t offset) {
+  flash_error_t ready_err;
   uint8_t addr[3];
+  bool ok;
 
-  /* Send write enable. */
+  /* Send write enable; nothing was launched on failure. */
   if (!rp_flash_write_enable(eflp)) {
-    return false;
+    return FLASH_ERROR_HW_FAILURE;
   }
 
   /* Prepare 24-bit address (big-endian). */
@@ -628,7 +673,18 @@ RAMFUNC static bool rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
   addr[2] = (uint8_t)offset;
 
   /* Send erase command with address. */
-  return rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+  ok = rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+
+  /* The CS edge may have launched the erase even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US,
+                                  FLASH_ERROR_ERASE);
+
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
 }
 
 /**
@@ -652,14 +708,15 @@ RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
     err = FLASH_ERROR_HW_FAILURE;
   }
   /* Send erase command and wait for erase to complete. */
-  else if (!rp_flash_erase_cmd(eflp, cmd, offset) ||
-           !rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US)) {
-    err = FLASH_ERROR_ERASE;
+  else {
+    err = rp_flash_erase_cmd(eflp, cmd, offset);
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
      without XIP restored. */
-  rp_flash_enter_xip(eflp);
+  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
   return err;
 }
@@ -687,13 +744,15 @@ RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
     err = FLASH_ERROR_HW_FAILURE;
   }
   /* Program the page. */
-  else if (!rp_flash_program_page(eflp, offset, data, len)) {
-    err = FLASH_ERROR_PROGRAM;
+  else {
+    err = rp_flash_program_page(eflp, offset, data, len);
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
      without XIP restored. */
-  rp_flash_enter_xip(eflp);
+  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
   return err;
 }
@@ -725,7 +784,9 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
      without XIP restored. */
-  rp_flash_enter_xip(eflp);
+  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
   return err;
 }
@@ -750,13 +811,15 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
  *                      outside the mapped size of its 4 MiB window.
  */
 static bool rp_flash_translate(QMI_TypeDef *qmi, uint32_t offset,
-                               uint32_t *physp) {
+                               uint32_t length, uint32_t *physp) {
   uint32_t at    = qmi->ATRANS[(offset >> 22) & 7U];
   uint32_t base  = ((at & QMI_ATRANS_BASE_Msk) >> QMI_ATRANS_BASE_Pos) << 12;
   uint32_t size  = ((at & QMI_ATRANS_SIZE_Msk) >> QMI_ATRANS_SIZE_Pos) << 12;
   uint32_t off4m = offset & 0x3FFFFFU;
 
-  if (off4m >= size) {
+  /* The whole extent must lie inside the window's mapped size, the
+     SIZE granularity (4 KiB) is finer than the large erase units. */
+  if ((off4m >= size) || ((size - off4m) < length)) {
     return false;
   }
   *physp = base + off4m;
@@ -789,10 +852,9 @@ flash_error_t rp_efl_lld_program_page_full(EFlashDriver *eflp,
                                            size_t len) {
   uint32_t phys;
 
-  /* Translate through ATRANS while XIP still works.  A page cannot
-     straddle a 4 MiB translation window because pages are aligned to
-     their (much smaller) size. */
-  if (!rp_flash_translate(eflp->qmi, offset, &phys)) {
+  /* Translate through ATRANS while XIP still works, validating the
+     whole page extent. */
+  if (!rp_flash_translate(eflp->qmi, offset, (uint32_t)len, &phys)) {
     return FLASH_ERROR_HW_FAILURE;
   }
 
@@ -803,12 +865,32 @@ flash_error_t rp_efl_lld_erase_full(EFlashDriver *eflp,
                                     uint8_t cmd,
                                     uint32_t offset) {
   uint32_t phys;
+  uint32_t esize;
 
-  /* Translate through ATRANS while XIP still works.  Erase units
-     (4 KiB, 32 KiB, 64 KiB) all divide 4 MiB and are aligned to
-     their size, so an erase unit cannot straddle two translation
-     windows. */
-  if (!rp_flash_translate(eflp->qmi, offset, &phys)) {
+  /* Erase extent per command byte. */
+  switch (cmd) {
+  case FLASHCMD_BLOCK_ERASE_64K:
+    esize = RP_FLASH_BLOCK_64K_SIZE;
+    break;
+  case FLASHCMD_BLOCK_ERASE_32K:
+    esize = RP_FLASH_BLOCK_32K_SIZE;
+    break;
+  default:
+    esize = RP_FLASH_SECTOR_SIZE;
+    break;
+  }
+
+  /* Translate through ATRANS while XIP still works, validating the
+     whole erase extent: the SIZE field is 4 KiB-granular so a large
+     erase can start inside a window yet overrun its mapped tail. */
+  if (!rp_flash_translate(eflp->qmi, offset, esize, &phys)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* The device aligns erase commands down to the erase unit; a BASE
+     that is not aligned to the unit would silently erase physical data
+     outside the translated extent. */
+  if ((phys & (esize - 1U)) != 0U) {
     return FLASH_ERROR_HW_FAILURE;
   }
 

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -386,6 +386,18 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
   /* Default non XIP SPI configuration */
   qmi->DIRECT_CSR = QMI_DIRECT_CSR_EN | QMI_DIRECT_CSR_CLKDIV(6U);
 
+  /* Wait for the direct-mode interface to settle after enabling it,
+     an XIP access may still be draining through the serial interface. */
+  if (!rp_flash_direct_wait_idle(qmi)) {
+    return false;
+  }
+
+  /* Drain any stale data left in the RX FIFO so subsequent transfers
+     observe only their own responses. */
+  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
+    (void)qmi->DIRECT_RX;
+  }
+
   /*
    * Exit continuous read / QPI mode sequence:
    * 1. CS high 32 clocks with IO pulled down

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -360,7 +360,7 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
   QMI_TypeDef *qmi = eflp->qmi;
   XIP_CTRL_TypeDef *xip_ctrl = XIP_CTRL;
   PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
-  uint32_t padctrl_save;
+  uint32_t padctrl_save[4];
   uint32_t padctrl_tmp;
   unsigned i;
   volatile unsigned delay;
@@ -405,10 +405,16 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
    * 3. F5h QPI exit in quad width, 16x NOP ones, FFh QPI exit in quad width
   */
 
-  /* Save pad control and configure with output disabled.*/
-  padctrl_save = pads_qspi->GPIO_QSPI_SD0;
-  padctrl_tmp = (padctrl_save & ~(PADS_QSPI_OD | PADS_QSPI_PUE |
-                                  PADS_QSPI_PDE))
+  /* Save all four data pad controls and configure with output
+     disabled.  Each pad is restored verbatim afterwards, SD2/SD3 may
+     be configured differently from SD0/SD1 (e.g. /WP and /HOLD
+     pull-ups on single-SPI boards). */
+  padctrl_save[0] = pads_qspi->GPIO_QSPI_SD0;
+  padctrl_save[1] = pads_qspi->GPIO_QSPI_SD1;
+  padctrl_save[2] = pads_qspi->GPIO_QSPI_SD2;
+  padctrl_save[3] = pads_qspi->GPIO_QSPI_SD3;
+  padctrl_tmp = (padctrl_save[0] & ~(PADS_QSPI_OD | PADS_QSPI_PUE |
+                                     PADS_QSPI_PDE))
                 | PADS_QSPI_OD | PADS_QSPI_PDE;
 
   /* 1. CS high */
@@ -449,12 +455,11 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
     }
   }
 
-  /* Restore pad controls, also on failed sequences. */
-  pads_qspi->GPIO_QSPI_SD0 = padctrl_save;
-  pads_qspi->GPIO_QSPI_SD1 = padctrl_save;
-  padctrl_save = (padctrl_save & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
-  pads_qspi->GPIO_QSPI_SD2 = padctrl_save;
-  pads_qspi->GPIO_QSPI_SD3 = padctrl_save;
+  /* Restore all pad controls verbatim, also on failed sequences. */
+  pads_qspi->GPIO_QSPI_SD0 = padctrl_save[0];
+  pads_qspi->GPIO_QSPI_SD1 = padctrl_save[1];
+  pads_qspi->GPIO_QSPI_SD2 = padctrl_save[2];
+  pads_qspi->GPIO_QSPI_SD3 = padctrl_save[3];
 
   if (!ok) {
     rp_flash_cs_force(eflp, true);

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -163,6 +163,32 @@ RAMFUNC static bool rp_flash_direct_tx8(QMI_TypeDef *qmi, uint32_t data) {
 }
 
 /**
+ * @brief   Best-effort resynchronization of the direct-mode FIFOs.
+ * @details After a transfer timeout the engine may still be shifting and
+ *          the RX FIFO may hold residue; without draining, a later
+ *          status poll can consume stale bytes and a BUSY=0 answer need
+ *          not belong to that poll. Bounded: a controller that never
+ *          recovers leaves residue behind, which subsequent polls then
+ *          fail on loudly.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ */
+RAMFUNC static void rp_flash_resync(QMI_TypeDef *qmi) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while (((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) ||
+         ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U)) {
+    if ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
+      (void)qmi->DIRECT_RX;
+    }
+    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+      return;
+    }
+  }
+}
+
+/**
  * @brief   Force chip select high or low
  * @note    This function MUST be in RAM.
  *
@@ -251,6 +277,13 @@ RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
   /* Transfer remaining data. */
   if (ok && (count > 0U)) {
     ok = rp_flash_put_get(eflp, tx, rx, count);
+  }
+
+  /* A failed transfer can leave the engine shifting and residue in the
+     RX FIFO; resynchronize before the CS edge so the next transaction
+     starts clean and later status polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(qmi);
   }
 
   /* Deassert CS, also on failed transfers. */
@@ -630,6 +663,12 @@ RAMFUNC static flash_error_t rp_flash_program_page(EFlashDriver *eflp,
     ok = rp_flash_put_get(eflp, data, NULL, len);
   }
 
+  /* A failed transfer can leave engine residue behind; resynchronize
+     before the CS edge so the ready polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(qmi);
+  }
+
   /* Deassert CS, also on failed transfers. */
   rp_flash_cs_force(eflp, true);
 
@@ -713,8 +752,9 @@ RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
-     without XIP restored. */
-  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
     err = FLASH_ERROR_HW_FAILURE;
   }
 
@@ -749,8 +789,9 @@ RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
-     without XIP restored. */
-  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
     err = FLASH_ERROR_HW_FAILURE;
   }
 
@@ -783,8 +824,9 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
   }
 
   /* Re-enter XIP mode unconditionally, the system cannot continue
-     without XIP restored. */
-  if (!rp_flash_enter_xip(eflp) && (err == FLASH_NO_ERROR)) {
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
     err = FLASH_ERROR_HW_FAILURE;
   }
 

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -163,27 +163,26 @@ RAMFUNC static bool rp_flash_direct_tx8(QMI_TypeDef *qmi, uint32_t data) {
 }
 
 /**
- * @brief   Best-effort resynchronization of the direct-mode FIFOs.
+ * @brief   Resynchronization of the direct-mode FIFOs.
  * @details After a transfer timeout the engine may still be shifting and
  *          the RX FIFO may hold residue; without draining, a later
  *          status poll can consume stale bytes and a BUSY=0 answer need
- *          not belong to that poll. Bounded: a controller that never
- *          recovers leaves residue behind, which subsequent polls then
- *          fail on loudly.
+ *          not belong to that poll, a false idle would let XIP return
+ *          over a busy device. Deliberately unbounded, matching the
+ *          wait-ready doctrine: no later poll can be trusted until the
+ *          engine is clean, and the CS edge that follows is only legal
+ *          with the engine idle; a controller which never recovers
+ *          leaves the system spinning here for a watchdog to catch.
  * @note    This function MUST be in RAM.
  *
  * @param[in] qmi       pointer to the QMI registers
  */
 RAMFUNC static void rp_flash_resync(QMI_TypeDef *qmi) {
-  uint32_t start = TIMER0->TIMERAWL;
 
   while (((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) ||
          ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U)) {
     if ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
       (void)qmi->DIRECT_RX;
-    }
-    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
-      return;
     }
   }
 }

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -725,6 +725,40 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
   return err;
 }
 
+/**
+ * @brief   Translates a logical XIP offset through the QMI address
+ *          translation registers.
+ * @details Program and erase commands are issued with physical flash
+ *          addresses while XIP reads go through the ATRANS windows.
+ *          With a non-identity mapping (e.g. bootrom-packaged images,
+ *          A/B partitions) the logical offset must be translated
+ *          before it is sent to the device.  The boot default is an
+ *          identity mapping, so behavior is unchanged on stock
+ *          systems.
+ * @note    Runs from flash while XIP is still enabled, must be called
+ *          before the RAM-resident sequence.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ * @param[in] offset    logical offset within the XIP address space
+ * @param[out] physp    translated physical flash offset
+ * @return              true on success, false if the offset falls
+ *                      outside the mapped size of its 4 MiB window.
+ */
+static bool rp_flash_translate(QMI_TypeDef *qmi, uint32_t offset,
+                               uint32_t *physp) {
+  uint32_t at    = qmi->ATRANS[(offset >> 22) & 7U];
+  uint32_t base  = ((at & QMI_ATRANS_BASE_Msk) >> QMI_ATRANS_BASE_Pos) << 12;
+  uint32_t size  = ((at & QMI_ATRANS_SIZE_Msk) >> QMI_ATRANS_SIZE_Pos) << 12;
+  uint32_t off4m = offset & 0x3FFFFFU;
+
+  if (off4m >= size) {
+    return false;
+  }
+  *physp = base + off4m;
+
+  return true;
+}
+
 /*===========================================================================*/
 /* Driver interrupt handlers.                                                */
 /*===========================================================================*/
@@ -748,15 +782,32 @@ flash_error_t rp_efl_lld_program_page_full(EFlashDriver *eflp,
                                            uint32_t offset,
                                            const uint8_t *data,
                                            size_t len) {
+  uint32_t phys;
 
-  return rp_flash_program_page_full(eflp, offset, data, len);
+  /* Translate through ATRANS while XIP still works.  A page cannot
+     straddle a 4 MiB translation window because pages are aligned to
+     their (much smaller) size. */
+  if (!rp_flash_translate(eflp->qmi, offset, &phys)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  return rp_flash_program_page_full(eflp, phys, data, len);
 }
 
 flash_error_t rp_efl_lld_erase_full(EFlashDriver *eflp,
                                     uint8_t cmd,
                                     uint32_t offset) {
+  uint32_t phys;
 
-  return rp_flash_erase_full(eflp, cmd, offset);
+  /* Translate through ATRANS while XIP still works.  Erase units
+     (4 KiB, 32 KiB, 64 KiB) all divide 4 MiB and are aligned to
+     their size, so an erase unit cannot straddle two translation
+     windows. */
+  if (!rp_flash_translate(eflp->qmi, offset, &phys)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  return rp_flash_erase_full(eflp, cmd, phys);
 }
 
 flash_error_t rp_efl_lld_read_uid_full(EFlashDriver *eflp,

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -106,6 +106,63 @@ EFlashDriver EFLD1 = {
 /*===========================================================================*/
 
 /**
+ * @brief   Checks elapsed time against the free-running 1 MHz timer.
+ * @note    This function MUST be in RAM.  TIMER0 is an APB peripheral
+ *          and remains readable while XIP is disabled; TIMERAWL has no
+ *          read side effects.
+ *
+ * @param[in] start       TIMERAWL value sampled when the wait started
+ * @param[in] timeout_us  allowed time in microseconds
+ * @return                true if the timeout expired.
+ */
+RAMFUNC static bool rp_flash_timeout(uint32_t start, uint32_t timeout_us) {
+
+  return (uint32_t)(TIMER0->TIMERAWL - start) > timeout_us;
+}
+
+/**
+ * @brief   Waits for the QMI direct-mode interface to become idle.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_direct_wait_idle(QMI_TypeDef *qmi) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Clocks one direct-mode TX word and discards the RX byte.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ * @param[in] data      DIRECT_TX value (data byte plus control bits)
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_direct_tx8(QMI_TypeDef *qmi, uint32_t data) {
+  uint32_t start;
+
+  qmi->DIRECT_TX = data;
+  start = TIMER0->TIMERAWL;
+  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) != 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+  (void)qmi->DIRECT_RX;
+
+  return true;
+}
+
+/**
  * @brief   Force chip select high or low
  * @note    This function MUST be in RAM.
  *
@@ -133,12 +190,14 @@ RAMFUNC static void rp_flash_cs_force(EFlashDriver *eflp, bool high) {
  * @param[in] tx        transmit buffer (NULL to send zeros)
  * @param[out] rx       receive buffer (NULL to discard)
  * @param[in] count     number of bytes to transfer
+ * @return              true on success, false on timeout.
  */
-RAMFUNC static void rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
+RAMFUNC static bool rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
                                      uint8_t *rx, size_t count) {
   QMI_TypeDef *qmi = eflp->qmi;
   size_t tx_remaining = count;
   size_t rx_remaining = count;
+  uint32_t start = TIMER0->TIMERAWL;
 
   while ((tx_remaining > 0U) || (rx_remaining > 0U)) {
     uint32_t csr = qmi->DIRECT_CSR;
@@ -157,7 +216,13 @@ RAMFUNC static void rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
       }
       rx_remaining--;
     }
+
+    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+      return false;
+    }
   }
+
+  return true;
 }
 
 /**
@@ -169,53 +234,80 @@ RAMFUNC static void rp_flash_put_get(EFlashDriver *eflp, const uint8_t *tx,
  * @param[in] tx        transmit data after command (NULL if none)
  * @param[out] rx       receive buffer (NULL to discard)
  * @param[in] count     number of bytes to transfer after command
+ * @return              true on success, false on timeout.
  */
-RAMFUNC static void rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
+RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
                                     const uint8_t *tx, uint8_t *rx,
                                     size_t count) {
   QMI_TypeDef *qmi = eflp->qmi;
+  bool ok;
 
   /* Assert CS. */
   rp_flash_cs_force(eflp, false);
 
   /* Send command byte. */
-  qmi->DIRECT_TX = cmd;
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) != 0U) {
-  }
-  (void)qmi->DIRECT_RX;
+  ok = rp_flash_direct_tx8(qmi, cmd);
 
   /* Transfer remaining data. */
-  if (count > 0U) {
-    rp_flash_put_get(eflp, tx, rx, count);
+  if (ok && (count > 0U)) {
+    ok = rp_flash_put_get(eflp, tx, rx, count);
   }
 
-  /* Deassert CS. */
+  /* Deassert CS, also on failed transfers. */
   rp_flash_cs_force(eflp, true);
+
+  return ok;
 }
 
 /**
  * @brief   Wait for flash to become ready.
  * @note    This function MUST be in RAM.
  *
- * @param[in] eflp      pointer to the EFlashDriver object
+ * @param[in] eflp        pointer to the EFlashDriver object
+ * @param[in] timeout_us  operation timeout in microseconds
+ * @return                true on success, false on timeout or
+ *                        communication failure.
  */
-RAMFUNC static void rp_flash_wait_ready(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_wait_ready(EFlashDriver *eflp,
+                                        uint32_t timeout_us) {
+  uint32_t start = TIMER0->TIMERAWL;
   uint8_t status;
 
   do {
-    rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U);
+    if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+      return false;
+    }
+    if (((status & FLASH_STATUS_BUSY) != 0U) &&
+        rp_flash_timeout(start, timeout_us)) {
+      return false;
+    }
   } while ((status & FLASH_STATUS_BUSY) != 0U);
+
+  return true;
 }
 
 /**
- * @brief   Send write enable command.
+ * @brief   Send write enable command and verify the WEL latch.
  * @note    This function MUST be in RAM.
  *
  * @param[in] eflp      pointer to the EFlashDriver object
+ * @return              true on success, false on timeout or if the
+ *                      write enable latch did not set.
  */
-RAMFUNC static void rp_flash_write_enable(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_write_enable(EFlashDriver *eflp) {
+  uint8_t status;
 
-  rp_flash_do_cmd(eflp, FLASHCMD_WRITE_ENABLE, NULL, NULL, 0U);
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_WRITE_ENABLE, NULL, NULL, 0U)) {
+    return false;
+  }
+
+  /* Read back the status register and verify WEL is set, a device
+     that rejects the command would silently fail later. */
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+    return false;
+  }
+
+  return (status & FLASH_STATUS_WEL) != 0U;
 }
 
 /**
@@ -260,8 +352,11 @@ RAMFUNC static void rp_flash_flush_cache(EFlashDriver *eflp) {
  * @note    This follows a similar pattern to the ROM's flash_exit_xip()
  *
  * @param[in] eflp      pointer to the EFlashDriver object
+ * @return              true on success, false on timeout.  Also on
+ *                      failure the caller must re-enter XIP mode, the
+ *                      saved configuration is valid in both cases.
  */
-RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
+RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
   QMI_TypeDef *qmi = eflp->qmi;
   XIP_CTRL_TypeDef *xip_ctrl = XIP_CTRL;
   PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
@@ -269,6 +364,7 @@ RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
   uint32_t padctrl_tmp;
   unsigned i;
   volatile unsigned delay;
+  bool ok = true;
 
   /* Save current XIP configuration (CS0 and CS1) before switching
    * to direct mode. */
@@ -283,7 +379,8 @@ RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
   eflp->xip_m1_wcmd    = qmi->M1_WCMD;
 
   /* Wait for any pending work.*/
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
+  if (!rp_flash_direct_wait_idle(qmi)) {
+    return false;
   }
 
   /* Default non XIP SPI configuration */
@@ -315,41 +412,42 @@ RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
   }
 
   /* Send 4 bytes / 32 clocks */
-  for (i = 0U; i < 4U; i++) {
-    qmi->DIRECT_TX = 0U;
-    while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) != 0U) {
+  for (i = 0U; ok && (i < 4U); i++) {
+    ok = rp_flash_direct_tx8(qmi, 0U);
+  }
+
+  if (ok) {
+    padctrl_tmp = (padctrl_tmp & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
+
+    /* 2. CS low */
+    rp_flash_cs_force(eflp, false);
+
+    pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
+
+    /* Delay of ~6000 cycles */
+    for (delay = 0U; delay < 2048U; delay++) {
     }
-    (void)qmi->DIRECT_RX;
-  }
 
-  padctrl_tmp = (padctrl_tmp & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
-
-  /* 2. CS low */
-  rp_flash_cs_force(eflp, false);
-
-  pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
-  pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
-  pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
-  pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
-
-  /* Delay of ~6000 cycles */
-  for (delay = 0U; delay < 2048U; delay++) {
-  }
-
-  /* Send 4 bytes / 32 clocks */
-  for (i = 0U; i < 4U; i++) {
-    qmi->DIRECT_TX = 0U;
-    while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) != 0U) {
+    /* Send 4 bytes / 32 clocks */
+    for (i = 0U; ok && (i < 4U); i++) {
+      ok = rp_flash_direct_tx8(qmi, 0U);
     }
-    (void)qmi->DIRECT_RX;
   }
 
-  /* Restore pad controls. */
+  /* Restore pad controls, also on failed sequences. */
   pads_qspi->GPIO_QSPI_SD0 = padctrl_save;
   pads_qspi->GPIO_QSPI_SD1 = padctrl_save;
   padctrl_save = (padctrl_save & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
   pads_qspi->GPIO_QSPI_SD2 = padctrl_save;
   pads_qspi->GPIO_QSPI_SD3 = padctrl_save;
+
+  if (!ok) {
+    rp_flash_cs_force(eflp, true);
+    return false;
+  }
 
   /* 3. QPI exit: F5h in quad width on CS0. Exits flash chips that use
    *    this command to leave QPI mode (e.g. some Winbond, ISSI parts).
@@ -359,31 +457,44 @@ RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
   rp_flash_cs_force(eflp, false);
   qmi->DIRECT_TX = 0xF5U | QMI_DIRECT_TX_IWIDTH(QMI_DIRECT_TX_IWIDTH_Q) |
                    QMI_DIRECT_TX_OE | QMI_DIRECT_TX_NOPUSH;
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
-  }
+  ok = rp_flash_direct_wait_idle(qmi);
   rp_flash_cs_force(eflp, true);
 
   /* Continuous-read recovery: CSn=0, MOSI=1, all other IOs Hi-Z, 16
    * clocks in single-width (Hardware Design with RP2350: Section 3.3,
    * RP2350 Datasheet: 5.4.8.7). Exits devices stuck in continuous-read
    * mode; QPI exit is handled separately by the FFh quad command below. */
-  rp_flash_cs_force(eflp, false);
-  for (i = 0U; i < 2U; i++) {
-    while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_TXFULL) != 0U) {
+  if (ok) {
+    rp_flash_cs_force(eflp, false);
+    for (i = 0U; ok && (i < 2U); i++) {
+      uint32_t start = TIMER0->TIMERAWL;
+
+      while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_TXFULL) != 0U) {
+        if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) {
+        qmi->DIRECT_TX = 0xFFU | QMI_DIRECT_TX_NOPUSH;
+      }
     }
-    qmi->DIRECT_TX = 0xFFU | QMI_DIRECT_TX_NOPUSH;
+    if (ok) {
+      ok = rp_flash_direct_wait_idle(qmi);
+    }
+    rp_flash_cs_force(eflp, true);
   }
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
-  }
-  rp_flash_cs_force(eflp, true);
 
   /* QPI exit: FFh in quad width (catches devices that ignore F5h). */
-  rp_flash_cs_force(eflp, false);
-  qmi->DIRECT_TX = 0xFFU | QMI_DIRECT_TX_IWIDTH(QMI_DIRECT_TX_IWIDTH_Q) |
-                   QMI_DIRECT_TX_OE | QMI_DIRECT_TX_NOPUSH;
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
+  if (ok) {
+    rp_flash_cs_force(eflp, false);
+    qmi->DIRECT_TX = 0xFFU | QMI_DIRECT_TX_IWIDTH(QMI_DIRECT_TX_IWIDTH_Q) |
+                     QMI_DIRECT_TX_OE | QMI_DIRECT_TX_NOPUSH;
+    ok = rp_flash_direct_wait_idle(qmi);
+    rp_flash_cs_force(eflp, true);
   }
-  rp_flash_cs_force(eflp, true);
+
+  return ok;
 }
 
 /**
@@ -398,9 +509,9 @@ RAMFUNC static void rp_flash_exit_xip(EFlashDriver *eflp) {
 RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
   QMI_TypeDef *qmi = eflp->qmi;
 
-  /* Wait for transfers to complete */
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
-  }
+  /* Wait for transfers to complete.  On timeout the restore proceeds
+     anyway, XIP must come back no matter what. */
+  (void)rp_flash_direct_wait_idle(qmi);
 
   /* Disable direct mode and restore saved XIP configuration (CS0 and CS1). */
   qmi->DIRECT_CSR = 0U;
@@ -424,14 +535,19 @@ RAMFUNC static void rp_flash_enter_xip(EFlashDriver *eflp) {
  * @param[in] offset    flash offset (must be page-aligned or within page)
  * @param[in] data      data to program
  * @param[in] len       number of bytes (must not cross page boundary)
+ * @return              true on success, false on timeout or
+ *                      communication failure.
  */
-RAMFUNC static void rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
+RAMFUNC static bool rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
                                           const uint8_t *data, size_t len) {
   QMI_TypeDef *qmi = eflp->qmi;
   uint8_t addr[3];
+  bool ok;
 
   /* Send write enable. */
-  rp_flash_write_enable(eflp);
+  if (!rp_flash_write_enable(eflp)) {
+    return false;
+  }
 
   /* Prepare 24-bit address (big-endian). */
   addr[0] = (uint8_t)(offset >> 16);
@@ -442,22 +558,27 @@ RAMFUNC static void rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
   rp_flash_cs_force(eflp, false);
 
   /* Send page program command. */
-  qmi->DIRECT_TX = FLASHCMD_PAGE_PROGRAM;
-  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) != 0U) {
-  }
-  (void)qmi->DIRECT_RX;
+  ok = rp_flash_direct_tx8(qmi, FLASHCMD_PAGE_PROGRAM);
 
   /* Send address. */
-  rp_flash_put_get(eflp, addr, NULL, 3U);
+  if (ok) {
+    ok = rp_flash_put_get(eflp, addr, NULL, 3U);
+  }
 
   /* Send data. */
-  rp_flash_put_get(eflp, data, NULL, len);
+  if (ok) {
+    ok = rp_flash_put_get(eflp, data, NULL, len);
+  }
 
-  /* Deassert CS. */
+  /* Deassert CS, also on failed transfers. */
   rp_flash_cs_force(eflp, true);
 
   /* Wait for program to complete. */
-  rp_flash_wait_ready(eflp);
+  if (ok) {
+    ok = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US);
+  }
+
+  return ok;
 }
 
 /**
@@ -467,13 +588,17 @@ RAMFUNC static void rp_flash_program_page(EFlashDriver *eflp, uint32_t offset,
  * @param[in] eflp      pointer to the EFlashDriver object
  * @param[in] cmd       JEDEC erase command byte
  * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              true on success, false on timeout or
+ *                      communication failure.
  */
-RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
-                                        uint32_t offset) {
+RAMFUNC static bool rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
+                                       uint32_t offset) {
   uint8_t addr[3];
 
   /* Send write enable. */
-  rp_flash_write_enable(eflp);
+  if (!rp_flash_write_enable(eflp)) {
+    return false;
+  }
 
   /* Prepare 24-bit address (big-endian). */
   addr[0] = (uint8_t)(offset >> 16);
@@ -481,7 +606,7 @@ RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
   addr[2] = (uint8_t)offset;
 
   /* Send erase command with address. */
-  rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+  return rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
 }
 
 /**
@@ -493,21 +618,28 @@ RAMFUNC static void rp_flash_erase_cmd(EFlashDriver *eflp, uint8_t cmd,
  * @param[in] eflp      pointer to the EFlashDriver object
  * @param[in] cmd       JEDEC erase command byte
  * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              An error code.
  */
-RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
-                                         uint32_t offset) {
+RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
+                                                 uint8_t cmd,
+                                                 uint32_t offset) {
+  flash_error_t err = FLASH_NO_ERROR;
 
   /* Exit XIP mode. */
-  rp_flash_exit_xip(eflp);
+  if (!rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Send erase command and wait for erase to complete. */
+  else if (!rp_flash_erase_cmd(eflp, cmd, offset) ||
+           !rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US)) {
+    err = FLASH_ERROR_ERASE;
+  }
 
-  /* Send erase command. */
-  rp_flash_erase_cmd(eflp, cmd, offset);
-
-  /* Wait for erase to complete. */
-  rp_flash_wait_ready(eflp);
-
-  /* Re-enter XIP mode. */
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. */
   rp_flash_enter_xip(eflp);
+
+  return err;
 }
 
 /**
@@ -520,20 +652,28 @@ RAMFUNC static void rp_flash_erase_full(EFlashDriver *eflp, uint8_t cmd,
  * @param[in] offset    flash offset (must not cross page boundary)
  * @param[in] data      pointer to data in RAM
  * @param[in] len       number of bytes to program
+ * @return              An error code.
  */
-RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
-                                               uint32_t offset,
-                                               const uint8_t *data,
-                                               size_t len) {
+RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
+                                                        uint32_t offset,
+                                                        const uint8_t *data,
+                                                        size_t len) {
+  flash_error_t err = FLASH_NO_ERROR;
 
   /* Exit XIP mode. */
-  rp_flash_exit_xip(eflp);
-
+  if (!rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
   /* Program the page. */
-  rp_flash_program_page(eflp, offset, data, len);
+  else if (!rp_flash_program_page(eflp, offset, data, len)) {
+    err = FLASH_ERROR_PROGRAM;
+  }
 
-  /* Re-enter XIP mode. */
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. */
   rp_flash_enter_xip(eflp);
+
+  return err;
 }
 
 /**
@@ -545,18 +685,27 @@ RAMFUNC static void rp_flash_program_page_full(EFlashDriver *eflp,
  * @param[in] eflp      pointer to the EFlashDriver object
  * @param[out] rx       receive buffer
  * @param[in] count     number of bytes to transfer after command
+ * @return              An error code.
  */
-RAMFUNC static void rp_flash_read_uid_full(EFlashDriver *eflp,
-                                            uint8_t *rx, size_t count) {
+RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
+                                                    uint8_t *rx,
+                                                    size_t count) {
+  flash_error_t err = FLASH_NO_ERROR;
 
   /* Exit XIP mode. */
-  rp_flash_exit_xip(eflp);
-
+  if (!rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
   /* Send read unique ID command. */
-  rp_flash_do_cmd(eflp, FLASHCMD_READ_UNIQUE_ID, NULL, rx, count);
+  else if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_UNIQUE_ID, NULL, rx, count)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
 
-  /* Re-enter XIP mode. */
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. */
   rp_flash_enter_xip(eflp);
+
+  return err;
 }
 
 /*===========================================================================*/
@@ -578,21 +727,26 @@ void rp_efl_lld_start(EFlashDriver *eflp) {
 
   /* Nothing to do - flash is always accessible via XIP. */
 }
-void rp_efl_lld_program_page_full(EFlashDriver *eflp,
-                                  uint32_t offset,
-                                  const uint8_t *data,
-                                  size_t len) {
-  rp_flash_program_page_full(eflp, offset, data, len);
+flash_error_t rp_efl_lld_program_page_full(EFlashDriver *eflp,
+                                           uint32_t offset,
+                                           const uint8_t *data,
+                                           size_t len) {
+
+  return rp_flash_program_page_full(eflp, offset, data, len);
 }
 
-void rp_efl_lld_erase_full(EFlashDriver *eflp, uint8_t cmd, uint32_t offset) {
-  rp_flash_erase_full(eflp, cmd, offset);
+flash_error_t rp_efl_lld_erase_full(EFlashDriver *eflp,
+                                    uint8_t cmd,
+                                    uint32_t offset) {
+
+  return rp_flash_erase_full(eflp, cmd, offset);
 }
 
-void rp_efl_lld_read_uid_full(EFlashDriver *eflp,
-                              uint8_t *rx,
-                              size_t count) {
-  rp_flash_read_uid_full(eflp, rx, count);
+flash_error_t rp_efl_lld_read_uid_full(EFlashDriver *eflp,
+                                       uint8_t *rx,
+                                       size_t count) {
+
+  return rp_flash_read_uid_full(eflp, rx, count);
 }
 
 #endif /* HAL_USE_EFL == TRUE */

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -271,19 +271,24 @@ RAMFUNC static bool rp_flash_do_cmd(EFlashDriver *eflp, uint8_t cmd,
 RAMFUNC static bool rp_flash_wait_ready(EFlashDriver *eflp,
                                         uint32_t timeout_us) {
   uint32_t start = TIMER0->TIMERAWL;
+  bool timed_out = false;
   uint8_t status;
 
   do {
     if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
       return false;
     }
+    /* On timeout the error is recorded but the wait continues: XIP cannot
+       be restored while the device is still busy, fetches would return
+       garbage and fault. A device which never recovers leaves the system
+       spinning here, which is a watchdog's job to catch.*/
     if (((status & FLASH_STATUS_BUSY) != 0U) &&
         rp_flash_timeout(start, timeout_us)) {
-      return false;
+      timed_out = true;
     }
   } while ((status & FLASH_STATUS_BUSY) != 0U);
 
-  return true;
+  return !timed_out;
 }
 
 /**

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.h
@@ -104,6 +104,12 @@
 #define RP_FLASH_SIZE                       (4U * 1024U * 1024U)
 #endif
 
+/* The driver issues 24-bit (3-byte) JEDEC addresses; larger devices
+   would silently wrap around and corrupt low flash. */
+#if RP_FLASH_SIZE > (16U * 1024U * 1024U)
+#error "RP_FLASH_SIZE exceeds 24-bit flash addressing"
+#endif
+
 /**
  * @brief   Suggested wait time during erase operations polling.
  */

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.h
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.h
@@ -112,6 +112,31 @@
 #endif
 
 /**
+ * @brief   Timeout for QMI direct-mode FIFO/BUSY waits in microseconds.
+ * @details Bounds the individual controller-level waits (FIFO drains,
+ *          DIRECT_CSR BUSY polls) performed while XIP is disabled.
+ */
+#if !defined(RP_FLASH_QMI_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_QMI_TIMEOUT_US             1000U
+#endif
+
+/**
+ * @brief   Timeout for a page program operation in microseconds.
+ */
+#if !defined(RP_FLASH_PROGRAM_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_PROGRAM_TIMEOUT_US         20000U
+#endif
+
+/**
+ * @brief   Timeout for an erase operation in microseconds.
+ * @details Sized for the worst-case 64KB block erase time of common
+ *          QSPI flash devices.
+ */
+#if !defined(RP_FLASH_ERASE_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_ERASE_TIMEOUT_US           4000000U
+#endif
+
+/**
  * @brief   Enables PSRAM (CS1) cache handling in the EFL driver.
  * @details When enabled, the XIP cache flush performs a clean-before-
  *          invalidate sequence to write back dirty PSRAM cache lines

--- a/testhal/RP/RP2040/XIP-VALIDATION/main.c
+++ b/testhal/RP/RP2040/XIP-VALIDATION/main.c
@@ -58,7 +58,7 @@ typedef struct {
   uint32_t ssi_spi_ctrlr0;
   uint32_t ssi_rx_sample_dly;
   uint32_t ssi_txd_drive_edge;
-  uint32_t pads_qspi_sd[4];
+  uint32_t pads_qspi[6];
 } xip_snapshot_t;
 
 static void xip_snapshot_capture(xip_snapshot_t *s) {
@@ -70,10 +70,12 @@ static void xip_snapshot_capture(xip_snapshot_t *s) {
   s->ssi_spi_ctrlr0    = XIP_SSI->SPI_CTRLR0;
   s->ssi_rx_sample_dly = XIP_SSI->RX_SAMPLE_DLY;
   s->ssi_txd_drive_edge = XIP_SSI->TXD_DRIVE_EDGE;
-  s->pads_qspi_sd[0]   = PADS_QSPI->GPIO_QSPI_SD0;
-  s->pads_qspi_sd[1]   = PADS_QSPI->GPIO_QSPI_SD1;
-  s->pads_qspi_sd[2]   = PADS_QSPI->GPIO_QSPI_SD2;
-  s->pads_qspi_sd[3]   = PADS_QSPI->GPIO_QSPI_SD3;
+  s->pads_qspi[0]      = PADS_QSPI->GPIO_QSPI_SCLK;
+  s->pads_qspi[1]      = PADS_QSPI->GPIO_QSPI_SD0;
+  s->pads_qspi[2]      = PADS_QSPI->GPIO_QSPI_SD1;
+  s->pads_qspi[3]      = PADS_QSPI->GPIO_QSPI_SD2;
+  s->pads_qspi[4]      = PADS_QSPI->GPIO_QSPI_SD3;
+  s->pads_qspi[5]      = PADS_QSPI->GPIO_QSPI_SS;
 }
 
 static bool xip_snapshot_compare(const xip_snapshot_t *a,
@@ -91,10 +93,12 @@ static void xip_snapshot_dump(const xip_snapshot_t *s) {
   chprintf(chp, "    SPI_CTRLR0    = 0x%08X\r\n", s->ssi_spi_ctrlr0);
   chprintf(chp, "    RX_SAMPLE_DLY = 0x%08X\r\n", s->ssi_rx_sample_dly);
   chprintf(chp, "    TXD_DRV_EDGE  = 0x%08X\r\n", s->ssi_txd_drive_edge);
-  chprintf(chp, "    PADS SD0      = 0x%08X\r\n", s->pads_qspi_sd[0]);
-  chprintf(chp, "    PADS SD1      = 0x%08X\r\n", s->pads_qspi_sd[1]);
-  chprintf(chp, "    PADS SD2      = 0x%08X\r\n", s->pads_qspi_sd[2]);
-  chprintf(chp, "    PADS SD3      = 0x%08X\r\n", s->pads_qspi_sd[3]);
+  chprintf(chp, "    PADS SCLK     = 0x%08X\r\n", s->pads_qspi[0]);
+  chprintf(chp, "    PADS SD0      = 0x%08X\r\n", s->pads_qspi[1]);
+  chprintf(chp, "    PADS SD1      = 0x%08X\r\n", s->pads_qspi[2]);
+  chprintf(chp, "    PADS SD2      = 0x%08X\r\n", s->pads_qspi[3]);
+  chprintf(chp, "    PADS SD3      = 0x%08X\r\n", s->pads_qspi[4]);
+  chprintf(chp, "    PADS SS       = 0x%08X\r\n", s->pads_qspi[5]);
 }
 
 /*===========================================================================*/

--- a/testhal/RP/RP2040/XIP-VALIDATION/main.c
+++ b/testhal/RP/RP2040/XIP-VALIDATION/main.c
@@ -58,6 +58,7 @@ typedef struct {
   uint32_t ssi_spi_ctrlr0;
   uint32_t ssi_rx_sample_dly;
   uint32_t ssi_txd_drive_edge;
+  uint32_t pads_qspi_sd[4];
 } xip_snapshot_t;
 
 static void xip_snapshot_capture(xip_snapshot_t *s) {
@@ -69,6 +70,10 @@ static void xip_snapshot_capture(xip_snapshot_t *s) {
   s->ssi_spi_ctrlr0    = XIP_SSI->SPI_CTRLR0;
   s->ssi_rx_sample_dly = XIP_SSI->RX_SAMPLE_DLY;
   s->ssi_txd_drive_edge = XIP_SSI->TXD_DRIVE_EDGE;
+  s->pads_qspi_sd[0]   = PADS_QSPI->GPIO_QSPI_SD0;
+  s->pads_qspi_sd[1]   = PADS_QSPI->GPIO_QSPI_SD1;
+  s->pads_qspi_sd[2]   = PADS_QSPI->GPIO_QSPI_SD2;
+  s->pads_qspi_sd[3]   = PADS_QSPI->GPIO_QSPI_SD3;
 }
 
 static bool xip_snapshot_compare(const xip_snapshot_t *a,
@@ -86,6 +91,10 @@ static void xip_snapshot_dump(const xip_snapshot_t *s) {
   chprintf(chp, "    SPI_CTRLR0    = 0x%08X\r\n", s->ssi_spi_ctrlr0);
   chprintf(chp, "    RX_SAMPLE_DLY = 0x%08X\r\n", s->ssi_rx_sample_dly);
   chprintf(chp, "    TXD_DRV_EDGE  = 0x%08X\r\n", s->ssi_txd_drive_edge);
+  chprintf(chp, "    PADS SD0      = 0x%08X\r\n", s->pads_qspi_sd[0]);
+  chprintf(chp, "    PADS SD1      = 0x%08X\r\n", s->pads_qspi_sd[1]);
+  chprintf(chp, "    PADS SD2      = 0x%08X\r\n", s->pads_qspi_sd[2]);
+  chprintf(chp, "    PADS SD3      = 0x%08X\r\n", s->pads_qspi_sd[3]);
 }
 
 /*===========================================================================*/
@@ -149,12 +158,20 @@ static flash_error_t program_page(uint32_t block, unsigned sector_idx,
 static bool test_unique_id(void) {
   uint8_t uid0[RP_FLASH_UNIQUE_ID_SIZE];
   uint8_t uid1[RP_FLASH_UNIQUE_ID_SIZE];
+  flash_error_t err0, err1;
   bool all_zero = true;
   bool all_ff = true;
   unsigned i;
 
-  efl_lld_read_unique_id(&EFLD1, uid0);
-  efl_lld_read_unique_id(&EFLD1, uid1);
+  err0 = efl_lld_read_unique_id(&EFLD1, uid0);
+  err1 = efl_lld_read_unique_id(&EFLD1, uid1);
+
+  /* On a failed read the buffers are not valid, skip the consistency
+     and blank comparisons. */
+  if ((err0 != FLASH_NO_ERROR) || (err1 != FLASH_NO_ERROR)) {
+    chprintf(chp, "    UID read failed (%d, %d)\r\n", (int)err0, (int)err1);
+    return false;
+  }
 
   chprintf(chp, "    UID: ");
   for (i = 0U; i < RP_FLASH_UNIQUE_ID_SIZE; i++) {

--- a/testhal/RP/RP2350/XIP-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/XIP-VALIDATION/Makefile
@@ -128,6 +128,16 @@ CPPWARN = -Wall -Wextra -Wundef
 #
 
 # List all user C define here, like -D_DEBUG=1
+#
+# Timeout-injection variant: build with an absurdly small erase timeout
+# to exercise the EFL driver error paths at runtime (erases fail with an
+# error while XIP is still restored, so the failure is reported instead
+# of hanging):
+#   make UDEFS=-DRP_FLASH_ERASE_TIMEOUT_US=1
+# Note that UDEFS on the command line replaces the default below; add
+# -DCRT0_VTOR_INIT=1 as well if the image is expected to boot:
+#   make UDEFS="-DCRT0_VTOR_INIT=1 -DRP_FLASH_ERASE_TIMEOUT_US=1"
+# This is intentionally not the default because it fails at runtime.
 UDEFS = -DCRT0_VTOR_INIT=1
 
 # Define ASM defines here

--- a/testhal/RP/RP2350/XIP-VALIDATION/main.c
+++ b/testhal/RP/RP2350/XIP-VALIDATION/main.c
@@ -171,12 +171,20 @@ static flash_error_t program_page(uint32_t block, unsigned sector_idx,
 static bool test_unique_id(void) {
   uint8_t uid0[RP_FLASH_UNIQUE_ID_SIZE];
   uint8_t uid1[RP_FLASH_UNIQUE_ID_SIZE];
+  flash_error_t err0, err1;
   bool all_zero = true;
   bool all_ff = true;
   unsigned i;
 
-  efl_lld_read_unique_id(&EFLD1, uid0);
-  efl_lld_read_unique_id(&EFLD1, uid1);
+  err0 = efl_lld_read_unique_id(&EFLD1, uid0);
+  err1 = efl_lld_read_unique_id(&EFLD1, uid1);
+
+  /* On a failed read the buffers are not valid, skip the consistency
+     and blank comparisons. */
+  if ((err0 != FLASH_NO_ERROR) || (err1 != FLASH_NO_ERROR)) {
+    chprintf(chp, "    UID read failed (%d, %d)\r\n", (int)err0, (int)err1);
+    return false;
+  }
 
   chprintf(chp, "    UID: ");
   for (i = 0U; i < RP_FLASH_UNIQUE_ID_SIZE; i++) {

--- a/testhal/RP/RP2350/XIP-VALIDATION/main.c
+++ b/testhal/RP/RP2350/XIP-VALIDATION/main.c
@@ -65,20 +65,25 @@ typedef struct {
   uint32_t qmi_m1_rcmd;
   uint32_t qmi_m1_wfmt;
   uint32_t qmi_m1_wcmd;
+  uint32_t pads_qspi_sd[4];
 } xip_snapshot_t;
 
 static void xip_snapshot_capture(xip_snapshot_t *s) {
 
-  s->xip_ctrl       = XIP_CTRL->CTRL;
-  s->qmi_direct_csr = QMI->DIRECT_CSR;
-  s->qmi_m0_timing  = QMI->M0_TIMING;
-  s->qmi_m0_rfmt    = QMI->M0_RFMT;
-  s->qmi_m0_rcmd    = QMI->M0_RCMD;
-  s->qmi_m1_timing  = QMI->M1_TIMING;
-  s->qmi_m1_rfmt    = QMI->M1_RFMT;
-  s->qmi_m1_rcmd    = QMI->M1_RCMD;
-  s->qmi_m1_wfmt    = QMI->M1_WFMT;
-  s->qmi_m1_wcmd    = QMI->M1_WCMD;
+  s->xip_ctrl        = XIP_CTRL->CTRL;
+  s->qmi_direct_csr  = QMI->DIRECT_CSR;
+  s->qmi_m0_timing   = QMI->M0_TIMING;
+  s->qmi_m0_rfmt     = QMI->M0_RFMT;
+  s->qmi_m0_rcmd     = QMI->M0_RCMD;
+  s->qmi_m1_timing   = QMI->M1_TIMING;
+  s->qmi_m1_rfmt     = QMI->M1_RFMT;
+  s->qmi_m1_rcmd     = QMI->M1_RCMD;
+  s->qmi_m1_wfmt     = QMI->M1_WFMT;
+  s->qmi_m1_wcmd     = QMI->M1_WCMD;
+  s->pads_qspi_sd[0] = PADS_QSPI->GPIO_QSPI_SD0;
+  s->pads_qspi_sd[1] = PADS_QSPI->GPIO_QSPI_SD1;
+  s->pads_qspi_sd[2] = PADS_QSPI->GPIO_QSPI_SD2;
+  s->pads_qspi_sd[3] = PADS_QSPI->GPIO_QSPI_SD3;
 }
 
 static bool xip_snapshot_compare(const xip_snapshot_t *a,
@@ -99,6 +104,10 @@ static void xip_snapshot_dump(const xip_snapshot_t *s) {
   chprintf(chp, "    M1_RCMD     = 0x%08X\r\n", s->qmi_m1_rcmd);
   chprintf(chp, "    M1_WFMT     = 0x%08X\r\n", s->qmi_m1_wfmt);
   chprintf(chp, "    M1_WCMD     = 0x%08X\r\n", s->qmi_m1_wcmd);
+  chprintf(chp, "    PADS SD0    = 0x%08X\r\n", s->pads_qspi_sd[0]);
+  chprintf(chp, "    PADS SD1    = 0x%08X\r\n", s->pads_qspi_sd[1]);
+  chprintf(chp, "    PADS SD2    = 0x%08X\r\n", s->pads_qspi_sd[2]);
+  chprintf(chp, "    PADS SD3    = 0x%08X\r\n", s->pads_qspi_sd[3]);
 }
 
 /*===========================================================================*/

--- a/testhal/RP/RP2350/XIP-VALIDATION/main.c
+++ b/testhal/RP/RP2350/XIP-VALIDATION/main.c
@@ -451,6 +451,92 @@ static bool test_full_block_write_verify(uint32_t block) {
   return true;
 }
 
+/*
+ * Test: ATRANS-aware program offset translation.
+ *
+ * Programs QMI ATRANS window 1 (logical 0x400000-0x7FFFFF) to alias
+ * physical 0-4MiB (BASE=0, SIZE=0x400 in 4KiB units), then programs
+ * a pattern through the aliased logical offset of the physical last
+ * sector and verifies via a window-0 read at the original offset
+ * that the physical last sector changed.  Also verifies that an
+ * offset outside the mapped window size is rejected.  Only touches
+ * the sacrificial last sector; ATRANS[1] is saved and restored.
+ */
+static bool test_atrans_translation(void) {
+  flash_offset_t last_off = TEST_BLOCK * RP_FLASH_BLOCK_64K_SIZE +
+                            (SECTORS_PER_BLK - 1U) * RP_FLASH_SECTOR_SIZE;
+  uint32_t alias_off = 0x400000U + (uint32_t)last_off;
+  uint32_t atrans1_save = QMI->ATRANS[1];
+  flash_error_t err;
+  syssts_t sts;
+  unsigned i;
+  bool ok = true;
+
+  /* Start from an erased last sector (window 0, identity mapping). */
+  if (erase_sector(TEST_BLOCK, SECTORS_PER_BLK - 1U) != FLASH_NO_ERROR)
+    return false;
+
+  /* Alias window 1 to physical 0..4MiB. */
+  QMI->ATRANS[1] = (0x0U << QMI_ATRANS_BASE_Pos) |
+                   (0x400U << QMI_ATRANS_SIZE_Pos);
+
+  /* Program a pattern through the aliased offset.  The engine-level
+     API bounds offsets to the flash descriptor, so the per-chip entry
+     point is called directly under the same syslock bracket the
+     engine uses. */
+  memset(page_buf, 0xC3, RP_FLASH_PAGE_SIZE);
+  sts = osalSysGetStatusAndLockX();
+  err = rp_efl_lld_program_page_full(&EFLD1, alias_off, page_buf,
+                                     RP_FLASH_PAGE_SIZE);
+  osalSysRestoreStatusX(sts);
+  if (err != FLASH_NO_ERROR) {
+    chprintf(chp, "    Aliased program failed (%d)\r\n", (int)err);
+    ok = false;
+  }
+
+  /* Verify at the original window-0 offset that the physical last
+     sector changed. */
+  if (ok &&
+      (flashRead(bfp, last_off, RP_FLASH_PAGE_SIZE,
+                 page_buf) != FLASH_NO_ERROR)) {
+    ok = false;
+  }
+  if (ok) {
+    for (i = 0U; i < RP_FLASH_PAGE_SIZE; i++) {
+      if (page_buf[i] != 0xC3U) {
+        chprintf(chp, "    Byte %u: expected 0xC3 got 0x%02X\r\n",
+                 i, page_buf[i]);
+        ok = false;
+        break;
+      }
+    }
+  }
+
+  /* An offset beyond the mapped window size must be rejected while
+     XIP is still enabled. */
+  if (ok) {
+    QMI->ATRANS[1] = (0x0U << QMI_ATRANS_BASE_Pos) |
+                     (0x0U << QMI_ATRANS_SIZE_Pos);
+    sts = osalSysGetStatusAndLockX();
+    err = rp_efl_lld_program_page_full(&EFLD1, alias_off, page_buf,
+                                       RP_FLASH_PAGE_SIZE);
+    osalSysRestoreStatusX(sts);
+    if (err != FLASH_ERROR_HW_FAILURE) {
+      chprintf(chp, "    Unmapped offset not rejected (%d)\r\n", (int)err);
+      ok = false;
+    }
+  }
+
+  /* Restore the boot ATRANS window. */
+  QMI->ATRANS[1] = atrans1_save;
+
+  /* Leave the sector erased. */
+  if (erase_sector(TEST_BLOCK, SECTORS_PER_BLK - 1U) != FLASH_NO_ERROR)
+    ok = false;
+
+  return ok;
+}
+
 /*===========================================================================*/
 /* Blinker thread.                                                           */
 /*===========================================================================*/
@@ -565,6 +651,11 @@ int main(void) {
   chprintf(chp, "\r\n  Full 64KB write + XIP verify...\r\n");
   ok = test_full_block_write_verify(TEST_BLOCK);
   report("Full 64KB block write and XIP readback", ok);
+
+  /* Test 14: ATRANS translation. */
+  chprintf(chp, "\r\n  ATRANS translation...\r\n");
+  ok = test_atrans_translation();
+  report("atrans translation", ok);
 
   /* Cleanup. */
   chprintf(chp, "\r\n  Cleanup block erase...\r\n");

--- a/testhal/RP/RP2350/XIP-VALIDATION/main.c
+++ b/testhal/RP/RP2350/XIP-VALIDATION/main.c
@@ -462,31 +462,54 @@ static bool test_full_block_write_verify(uint32_t block) {
 /*
  * Test: ATRANS-aware program offset translation.
  *
- * Programs QMI ATRANS window 1 (logical 0x400000-0x7FFFFF) to alias
- * physical 0-4MiB (BASE=0, SIZE=0x400 in 4KiB units), then programs
- * a pattern through the aliased logical offset of the physical last
- * sector and verifies via a window-0 read at the original offset
- * that the physical last sector changed.  Also verifies that an
- * offset outside the mapped window size is rejected.  Only touches
- * the sacrificial last sector; ATRANS[1] is saved and restored.
+ * Picks the first free 4 MiB ATRANS window at or above the flash top
+ * and derives the physical address of the sacrificial last sector by
+ * translating its logical offset through the current mapping of the
+ * window containing it (no identity-mapping assumption).  The free
+ * window is aliased directly onto that physical sector (BASE is in
+ * 4 KiB units, SIZE covers one sector), a pattern is programmed
+ * through alias offset 0 and verified through the normal logical
+ * last-sector offset.  Also verifies that an offset outside the
+ * mapped window size (SIZE=0) is rejected.  Only touches the
+ * sacrificial last sector; the alias window is saved and restored
+ * and cleanup goes through the standard mapping.
  */
 static bool test_atrans_translation(void) {
   flash_offset_t last_off = TEST_BLOCK * RP_FLASH_BLOCK_64K_SIZE +
                             (SECTORS_PER_BLK - 1U) * RP_FLASH_SECTOR_SIZE;
-  uint32_t alias_off = 0x400000U + (uint32_t)last_off;
-  uint32_t atrans1_save = QMI->ATRANS[1];
+  uint32_t idx = (RP_FLASH_SIZE + 0x3FFFFFU) >> 22;
+  uint32_t win = ((uint32_t)last_off >> 22) & 7U;
+  uint32_t at, phys_last, alias_off, atrans_save;
   flash_error_t err;
   syssts_t sts;
   unsigned i;
   bool ok = true;
 
-  /* Start from an erased last sector (window 0, identity mapping). */
+  /* A flash filling the whole 32 MiB XIP space leaves no free alias
+     window; nothing can be validated without touching live mappings. */
+  if (idx > 7U) {
+    chprintf(chp, "    No free ATRANS window above flash top, skipped\r\n");
+    return true;
+  }
+
+  /* Physical address of the last sector, translated through the
+     current mapping of the window containing it. */
+  at          = QMI->ATRANS[win];
+  phys_last   = (((at & QMI_ATRANS_BASE_Msk) >> QMI_ATRANS_BASE_Pos) << 12) +
+                ((uint32_t)last_off & 0x3FFFFFU);
+  alias_off   = idx * 0x400000U;
+  atrans_save = QMI->ATRANS[idx];
+
+  chprintf(chp, "    Alias window %u -> phys 0x%08X\r\n", idx, phys_last);
+
+  /* Start from an erased last sector (normal logical offset). */
   if (erase_sector(TEST_BLOCK, SECTORS_PER_BLK - 1U) != FLASH_NO_ERROR)
     return false;
 
-  /* Alias window 1 to physical 0..4MiB. */
-  QMI->ATRANS[1] = (0x0U << QMI_ATRANS_BASE_Pos) |
-                   (0x400U << QMI_ATRANS_SIZE_Pos);
+  /* Alias window offset 0 exactly onto the physical last sector,
+     mapping a single sector. */
+  QMI->ATRANS[idx] = ((phys_last >> 12) << QMI_ATRANS_BASE_Pos) |
+                     ((RP_FLASH_SECTOR_SIZE >> 12) << QMI_ATRANS_SIZE_Pos);
 
   /* Program a pattern through the aliased offset.  The engine-level
      API bounds offsets to the flash descriptor, so the per-chip entry
@@ -502,8 +525,8 @@ static bool test_atrans_translation(void) {
     ok = false;
   }
 
-  /* Verify at the original window-0 offset that the physical last
-     sector changed. */
+  /* Verify through the normal logical last-sector offset that the
+     physical last sector changed. */
   if (ok &&
       (flashRead(bfp, last_off, RP_FLASH_PAGE_SIZE,
                  page_buf) != FLASH_NO_ERROR)) {
@@ -520,11 +543,11 @@ static bool test_atrans_translation(void) {
     }
   }
 
-  /* An offset beyond the mapped window size must be rejected while
-     XIP is still enabled. */
+  /* An offset beyond the mapped window size (SIZE=0) must be rejected
+     while XIP is still enabled. */
   if (ok) {
-    QMI->ATRANS[1] = (0x0U << QMI_ATRANS_BASE_Pos) |
-                     (0x0U << QMI_ATRANS_SIZE_Pos);
+    QMI->ATRANS[idx] = ((phys_last >> 12) << QMI_ATRANS_BASE_Pos) |
+                       (0x0U << QMI_ATRANS_SIZE_Pos);
     sts = osalSysGetStatusAndLockX();
     err = rp_efl_lld_program_page_full(&EFLD1, alias_off, page_buf,
                                        RP_FLASH_PAGE_SIZE);
@@ -535,10 +558,10 @@ static bool test_atrans_translation(void) {
     }
   }
 
-  /* Restore the boot ATRANS window. */
-  QMI->ATRANS[1] = atrans1_save;
+  /* Restore the saved ATRANS window. */
+  QMI->ATRANS[idx] = atrans_save;
 
-  /* Leave the sector erased. */
+  /* Leave the sector erased, cleaned up through the standard mapping. */
   if (erase_sector(TEST_BLOCK, SECTORS_PER_BLK - 1U) != FLASH_NO_ERROR)
     ok = false;
 

--- a/testhal/RP/RP2350/XIP-VALIDATION/main.c
+++ b/testhal/RP/RP2350/XIP-VALIDATION/main.c
@@ -462,8 +462,10 @@ static bool test_full_block_write_verify(uint32_t block) {
 /*
  * Test: ATRANS-aware program offset translation.
  *
- * Picks the first free 4 MiB ATRANS window at or above the flash top
- * and derives the physical address of the sacrificial last sector by
+ * Picks the first free CS0 4 MiB ATRANS window (ATRANS0-3; ATRANS4-7
+ * translate the CS1 half of the XIP space and cannot alias the CS0
+ * flash) at or above the flash top and derives the physical address
+ * of the sacrificial last sector by
  * translating its logical offset through the current mapping of the
  * window containing it (no identity-mapping assumption).  The free
  * window is aliased directly onto that physical sector (BASE is in
@@ -485,10 +487,11 @@ static bool test_atrans_translation(void) {
   unsigned i;
   bool ok = true;
 
-  /* A flash filling the whole 32 MiB XIP space leaves no free alias
-     window; nothing can be validated without touching live mappings. */
-  if (idx > 7U) {
-    chprintf(chp, "    No free ATRANS window above flash top, skipped\r\n");
+  /* Only ATRANS0-3 issue to CS0; a flash filling the whole 16 MiB CS0
+     half leaves no free alias window on its own chip select and
+     ATRANS4-7 would alias CS1 (PSRAM) instead. */
+  if (idx > 3U) {
+    chprintf(chp, "    No free CS0 ATRANS window above flash top, skipped\r\n");
     return true;
   }
 


### PR DESCRIPTION
Fixes items 14, 26 and 27 of the RP2040 implementation review (the RP2350-side work reviewed in the earlier campaign rides along).

- **Item 14**: SSI/flash-status/XIP-restore waits are bounded (`RP_FLASH_SSI/PROGRAM/ERASE_TIMEOUT_US`), WEL is verified after WREN, erase/program failures propagate a meaningful `flash_error_t` through the EFL wrapper instead of unconditional `FLASH_NO_ERROR`, and XIP is restored on every failure path.
- **Item 26**: `RP_FLASH_SIZE` beyond the 24-bit/16 MiB command-addressing limit is rejected with a configuration error.
- **Item 27**: all six QSPI pads (SCLK/SS/SD0..SD3) are saved individually before the pad reset and restored exactly, instead of mirroring SD0's value.

Merge note: this branch combines with the #115 lockout using the resolution recorded in the RP2350 campaign — hardening's error-path structure with the lockout's PRIMASK deferral inside the RAM sequences; Codex verified all six merged RAMFUNC bodies pair one PRIMASK save with a restore after the unconditional XIP re-enter on every path.

Validation on the bench Pico: XIP-VALIDATION 13/13 (branch extends it), EFL-SMP-LOCKOUT 7/7 on the combined code, EFL-MFS suite SUCCESS, and a fault-injection build (`RP_FLASH_ERASE_TIMEOUT_US=1`) fails the erase deterministically while the system keeps running from flash afterwards — the failure path restores XIP. RP2350 targets build. CodeRabbit: 0 findings.