### PR TITLE
RP I2Cv1: repeated START, NACK reporting and whole-call timeouts

### DIFF
--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -355,9 +355,18 @@ static void i2c_lld_serve_interrupt(I2CDriver *i2cp) {
   }
 
   if (intr & I2C_IC_INTR_STAT_R_STOP_DET) {
-    /* Clear irq flag. A STOP is only ever generated with the last command
-       of a transfer, so a STOP detection always means completion. */
+    /* Clear irq flag. */
     (void)dp->CLRSTOPDET;
+
+    /* The RP silicon hardwires IC_CON.STOP_DET_IF_MASTER_ACTIVE off
+       (the write is inert, verified by register read-back), so this
+       interrupt also fires for STOP conditions issued by other masters
+       on the bus. It only means completion when this driver has queued
+       its own final command; a foreign STOP mid-transfer is ignored,
+       the own transfer continues under hardware arbitration. */
+    if ((i2cp->txbytes > 0U) || (i2cp->rxbytes > 0U)) {
+      return;
+    }
   }
 
   /* Transmission complete, disable and clear all interrupts. */

--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -155,9 +155,18 @@ static msg_t i2c_lld_abort_transmissionS(I2CDriver *i2cp) {
  */
 static void i2c_lld_handle_errors(I2CDriver *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t abort_source = dp->TXABRTSOURCE;
 
-  if (dp->TXABRTSOURCE & I2C_IC_TX_ABRT_SOURCE_ARB_LOST) {
+  if (abort_source & I2C_IC_TX_ABRT_SOURCE_ARB_LOST) {
     i2cp->errors |= I2C_ARBITRATION_LOST;
+  }
+
+  if (abort_source & (I2C_IC_TX_ABRT_SOURCE_ABRT_7B_ADDR_NOACK |
+                      I2C_IC_TX_ABRT_SOURCE_ABRT_10ADDR1_NOACK |
+                      I2C_IC_TX_ABRT_SOURCE_ABRT_10ADDR2_NOACK |
+                      I2C_IC_TX_ABRT_SOURCE_ABRT_GCALL_NOACK   |
+                      I2C_IC_TX_ABRT_SOURCE_ABRT_TXDATA_NOACK)) {
+    i2cp->errors |= I2C_ACK_FAILURE;
   }
 
   if (dp->RAWINTRSTAT & I2C_OVERRUN_ERRORS) {

--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -563,9 +563,19 @@ msg_t i2c_lld_master_receive_timeout(I2CDriver *i2cp, i2caddr_t addr,
   /* Releases the lock from high level driver. */
   osalSysUnlock();
 
-  /* Calculating the time window for the timeout on the busy bus condition. */
+  /* Calculating the time window for the timeout on the busy bus
+     condition. The caller timeout is one absolute deadline for the
+     entire call, so the fixed bus-busy limit only applies where it is
+     shorter. */
   start = osalOsGetSystemTimeX();
-  end = osalTimeAddX(start, OSAL_MS2I(RP_I2C_BUSY_TIMEOUT));
+  {
+    sysinterval_t busy_limit = OSAL_MS2I(RP_I2C_BUSY_TIMEOUT);
+
+    if ((timeout != TIME_INFINITE) && (timeout < busy_limit)) {
+      busy_limit = timeout;
+    }
+    end = osalTimeAddX(start, busy_limit);
+  }
 
   while (true) {
     osalSysLock();
@@ -584,6 +594,18 @@ msg_t i2c_lld_master_receive_timeout(I2CDriver *i2cp, i2caddr_t addr,
     }
 
     osalSysUnlock();
+  }
+
+  /* Remaining share of the caller timeout after the bus-busy wait, the
+     deadline covers the entire call. Nothing is armed yet, returning
+     is safe. */
+  if (timeout != TIME_INFINITE) {
+    sysinterval_t elapsed = osalTimeDiffX(start, osalOsGetSystemTimeX());
+
+    if (elapsed >= timeout) {
+      return MSG_TIMEOUT;
+    }
+    timeout -= elapsed;
   }
 
   i2cp->txbytes = 0U;
@@ -662,9 +684,19 @@ msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
   /* Releases the lock from high level driver. */
   osalSysUnlock();
 
-  /* Calculating the time window for the timeout on the busy bus condition. */
+  /* Calculating the time window for the timeout on the busy bus
+     condition. The caller timeout is one absolute deadline for the
+     entire call, so the fixed bus-busy limit only applies where it is
+     shorter. */
   start = osalOsGetSystemTimeX();
-  end = osalTimeAddX(start, OSAL_MS2I(RP_I2C_BUSY_TIMEOUT));
+  {
+    sysinterval_t busy_limit = OSAL_MS2I(RP_I2C_BUSY_TIMEOUT);
+
+    if ((timeout != TIME_INFINITE) && (timeout < busy_limit)) {
+      busy_limit = timeout;
+    }
+    end = osalTimeAddX(start, busy_limit);
+  }
 
   while (true) {
     osalSysLock();
@@ -682,6 +714,18 @@ msg_t i2c_lld_master_transmit_timeout(I2CDriver *i2cp, i2caddr_t addr,
     }
 
     osalSysUnlock();
+  }
+
+  /* Remaining share of the caller timeout after the bus-busy wait, the
+     deadline covers the entire call. Nothing is armed yet, returning
+     is safe. */
+  if (timeout != TIME_INFINITE) {
+    sysinterval_t elapsed = osalTimeDiffX(start, osalOsGetSystemTimeX());
+
+    if (elapsed >= timeout) {
+      return MSG_TIMEOUT;
+    }
+    timeout -= elapsed;
   }
 
   i2cp->txbytes = txbytes;

--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -361,10 +361,19 @@ static void i2c_lld_serve_interrupt(I2CDriver *i2cp) {
     /* The RP silicon hardwires IC_CON.STOP_DET_IF_MASTER_ACTIVE off
        (the write is inert, verified by register read-back), so this
        interrupt also fires for STOP conditions issued by other masters
-       on the bus. It only means completion when this driver has queued
-       its own final command; a foreign STOP mid-transfer is ignored,
-       the own transfer continues under hardware arbitration. */
-    if ((i2cp->txbytes > 0U) || (i2cp->rxbytes > 0U)) {
+       on the bus. It only means completion when this driver's own final
+       command has completed on the wire: the byte counters cover bytes
+       not yet queued, TXFLR covers commands (data and read requests
+       alike) still sitting in the TX FIFO waiting for the bus, and the
+       raw TX_EMPTY flag - completion-qualified by TX_EMPTY_CTRL - stays
+       low while a command popped from the FIFO is still executing,
+       which closes the window between the pop and this read. An own
+       STOP can only appear after all of that has drained, so any
+       residue marks the STOP as foreign; the own transfer then
+       continues under hardware arbitration. */
+    if ((i2cp->txbytes > 0U) || (i2cp->rxbytes > 0U) ||
+        (dp->TXFLR != 0U) ||
+        ((dp->RAWINTRSTAT & I2C_IC_INTR_STAT_R_TX_EMPTY) == 0U)) {
       return;
     }
   }

--- a/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/hal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -284,8 +284,9 @@ static void i2c_lld_transmit_data(I2CDriver *i2cp) {
   while (i2cp->txbytes > 0U && dp->STATUS & I2C_IC_STATUS_TFNF) {
     data = (uint32_t)*i2cp->txptr;
 
-    /* Send STOP after last byte. */
-    if (i2cp->txbytes == 1U) {
+    /* Send STOP after the last byte of a pure write. If a read phase
+       follows, the transfer continues with a repeated START instead. */
+    if ((i2cp->txbytes == 1U) && (i2cp->rxbytes == 0U)) {
       data |= I2C_IC_DATA_CMD_STOP;
     }
     dp->DATACMD = data;
@@ -294,9 +295,20 @@ static void i2c_lld_transmit_data(I2CDriver *i2cp) {
     i2cp->txbytes--;
   }
 
-  /* Nothing more to send, disable TX FIFO empty interrupt. */
   if (i2cp->txbytes == 0U) {
-    dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY;
+    if (i2cp->rxbytes > 0U) {
+      /* All write commands are queued and a read phase follows. Switch to
+         the RX state now, the first read command will carry the RESTART
+         flag producing a repeated START on the wire. The TX_EMPTY
+         interrupt is kept enabled, with TX_EMPTY_CTRL set it fires again
+         only when the last write byte has completed on the wire and the
+         ISR then queues the read commands via i2c_lld_request_data(). */
+      i2cp->state = I2C_ACTIVE_RX;
+      i2cp->send_restart = true;
+    } else {
+      /* Nothing more to send, disable TX FIFO empty interrupt. */
+      dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY;
+    }
   }
 }
 
@@ -343,18 +355,9 @@ static void i2c_lld_serve_interrupt(I2CDriver *i2cp) {
   }
 
   if (intr & I2C_IC_INTR_STAT_R_STOP_DET) {
-    /* Clear irq flag. */
+    /* Clear irq flag. A STOP is only ever generated with the last command
+       of a transfer, so a STOP detection always means completion. */
     (void)dp->CLRSTOPDET;
-    if (i2cp->state == I2C_ACTIVE_TX && i2cp->rxbytes > 0U) {
-      /* State change to RX. */
-      i2cp->state = I2C_ACTIVE_RX;
-      /* Restart communication. */
-      i2cp->send_restart = true;
-
-      /* Enable TX FIFO empty IRQ to request more data to be received. */
-      dp->SET.INTRMASK = I2C_IC_INTR_STAT_R_TX_EMPTY;
-      return;
-    }
   }
 
   /* Transmission complete, disable and clear all interrupts. */

--- a/testhal/RP/RP2040/I2C-VALIDATION/Makefile
+++ b/testhal/RP/RP2040/I2C-VALIDATION/Makefile
@@ -1,0 +1,159 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O0 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m0plus
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv6-M/compilers/GCC/mk/port.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2040_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2040/I2C-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2040/I2C-VALIDATION/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                FALSE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                FALSE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                FALSE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    FALSE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               FALSE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                FALSE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  FALSE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     FALSE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      FALSE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           FALSE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 TRUE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2040/I2C-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2040/I2C-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         TRUE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      FALSE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2040/I2C-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/I2C-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,55 @@
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+#define RP2040_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+#define RP_IRQ_RTC_PRIORITY                 3
+#define RP_IRQ_I2C0_PRIORITY                3
+#define RP_IRQ_I2C1_PRIORITY                3
+
+/*
+ * I2C driver system settings.
+ */
+#define RP_I2C_USE_I2C0                     TRUE
+#define RP_I2C_USE_I2C1                     FALSE
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+/*
+ * UART driver system settings.
+ */
+#define RP_UART_USE_UART0                   FALSE
+#define RP_UART_USE_UART1                   FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2040/I2C-VALIDATION/main.c
+++ b/testhal/RP/RP2040/I2C-VALIDATION/main.c
@@ -27,8 +27,11 @@
  *
  * This exercises:
  *  - the NACK abort source to I2C_ACK_FAILURE error mapping,
- *  - the abort path of the write, write-then-read (repeated START) and
- *    pure read transfer shapes,
+ *  - the abort path of the write, write-then-read and pure read
+ *    request shapes; note the address byte NACKs before any data phase,
+ *    so the repeated-START itself is not reached on an empty bus (that
+ *    needs an ACK-capable slave and is validated separately by
+ *    inspection/register evidence),
  *  - driver robustness across repeated aborts and i2cStop()/i2cStart()
  *    cycles.
  *
@@ -162,8 +165,9 @@ static bool test_repeated_nack_write(void) {
 }
 
 /*
- * Test: a write-then-read request (repeated START shape) to the absent
- * address aborts just as cleanly.
+ * Test: a write-then-read request to the absent address aborts just as
+ * cleanly. The address NACK precedes the data phase, so this covers the
+ * abort of that request shape, not the repeated-START generation.
  */
 static bool test_nack_write_then_read(void) {
 
@@ -254,7 +258,7 @@ int main(void) {
 
   /* Test 3: write-then-read shape. */
   ok = test_nack_write_then_read();
-  report("Write-then-read request aborts cleanly", ok);
+  report("Write-then-read shape aborts on address NACK", ok);
 
   /* Test 4: pure read shape. */
   ok = test_nack_pure_read();

--- a/testhal/RP/RP2040/I2C-VALIDATION/main.c
+++ b/testhal/RP/RP2040/I2C-VALIDATION/main.c
@@ -1,0 +1,282 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2040 I2C abort-path validation test.
+ *
+ * Validates what an empty bus permits, no external wiring is required:
+ * I2C0 runs on GPIO4 (SDA) / GPIO5 (SCL) with the internal pad pull-ups
+ * enabled, no slave is attached.  Every transfer addressed to the absent
+ * device 0x50 must be NACKed on the address byte, the driver must abort
+ * quickly (well before the operation timeout), report MSG_RESET with
+ * i2cGetErrors() == I2C_ACK_FAILURE and be immediately reusable with the
+ * state machine back in I2C_READY.
+ *
+ * This exercises:
+ *  - the NACK abort source to I2C_ACK_FAILURE error mapping,
+ *  - the abort path of the write, write-then-read (repeated START) and
+ *    pure read transfer shapes,
+ *  - driver robustness across repeated aborts and i2cStop()/i2cStart()
+ *    cycles.
+ *
+ * Single-core only.
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#define LED_PIN              25U
+#define UART_TX_PIN          0U
+#define UART_RX_PIN          1U
+#define I2C_SDA_PIN          4U
+#define I2C_SCL_PIN          5U
+
+/* Nothing lives at this address on the (empty) bus. */
+#define ABSENT_ADDR          0x50U
+
+/* Per-transfer operation timeout, the abort must happen much earlier. */
+#define OP_TIMEOUT           TIME_MS2I(100)
+
+/* An address NACK abort must complete within a few SCL periods, allow a
+   generous margin that is still far below OP_TIMEOUT. */
+#define ABORT_DEADLINE       TIME_MS2I(50)
+
+static BaseSequentialStream *chp;
+static unsigned pass_count;
+static unsigned fail_count;
+
+static const I2CConfig i2ccfg = {
+  .baudrate = 100000U,
+};
+
+/*===========================================================================*/
+/* Test helpers.                                                             */
+/*===========================================================================*/
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/*
+ * Runs one transfer against the absent address and checks the abort
+ * behavior: MSG_RESET (not MSG_TIMEOUT), quick completion, exactly
+ * I2C_ACK_FAILURE reported and driver back in I2C_READY.
+ */
+static bool check_nack_abort(size_t txbytes, size_t rxbytes) {
+  static const uint8_t txbuf[2] = {0x00U, 0x00U};
+  uint8_t rxbuf[4];
+  systime_t start;
+  sysinterval_t elapsed;
+  i2cflags_t errors;
+  msg_t msg;
+
+  start = chVTGetSystemTime();
+  if (txbytes > 0U) {
+    msg = i2cMasterTransmitTimeout(&I2CD0, ABSENT_ADDR, txbuf, txbytes,
+                                   rxbuf, rxbytes, OP_TIMEOUT);
+  }
+  else {
+    msg = i2cMasterReceiveTimeout(&I2CD0, ABSENT_ADDR, rxbuf, rxbytes,
+                                  OP_TIMEOUT);
+  }
+  elapsed = chVTTimeElapsedSinceX(start);
+  errors = i2cGetErrors(&I2CD0);
+
+  if (msg != MSG_RESET) {
+    chprintf(chp, "    tx=%u rx=%u: expected MSG_RESET got %d\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes, (int)msg);
+    return false;
+  }
+
+  if (elapsed >= ABORT_DEADLINE) {
+    chprintf(chp, "    tx=%u rx=%u: abort took %u ticks\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes, (unsigned)elapsed);
+    return false;
+  }
+
+  if (errors != I2C_ACK_FAILURE) {
+    chprintf(chp, "    tx=%u rx=%u: expected errors 0x%02X got 0x%02X\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes,
+             (unsigned)I2C_ACK_FAILURE, (unsigned)errors);
+    return false;
+  }
+
+  if (I2CD0.state != I2C_READY) {
+    chprintf(chp, "    tx=%u rx=%u: driver state %d, not I2C_READY\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes, (int)I2CD0.state);
+    return false;
+  }
+
+  return true;
+}
+
+/*===========================================================================*/
+/* Individual tests.                                                         */
+/*===========================================================================*/
+
+/*
+ * Test: a single 2-byte write to the absent address is NACKed on the
+ * address byte and reported as an ACK failure.
+ */
+static bool test_address_nack_write(void) {
+
+  return check_nack_abort(2U, 0U);
+}
+
+/*
+ * Test: repeated aborts do not accumulate state, the driver is reusable
+ * on every iteration.
+ */
+static bool test_repeated_nack_write(void) {
+  unsigned i;
+
+  for (i = 0U; i < 10U; i++) {
+    if (!check_nack_abort(2U, 0U)) {
+      chprintf(chp, "    Failed at iteration %u\r\n", i);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*
+ * Test: a write-then-read request (repeated START shape) to the absent
+ * address aborts just as cleanly.
+ */
+static bool test_nack_write_then_read(void) {
+
+  return check_nack_abort(1U, 2U);
+}
+
+/*
+ * Test: a pure read request to the absent address aborts cleanly.
+ */
+static bool test_nack_pure_read(void) {
+
+  return check_nack_abort(0U, 2U);
+}
+
+/*
+ * Test: driver survives a full stop/start cycle after aborts.
+ */
+static bool test_stop_start_cycle(void) {
+
+  i2cStop(&I2CD0);
+  i2cStart(&I2CD0, &i2ccfg);
+
+  return check_nack_abort(2U, 0U);
+}
+
+/*===========================================================================*/
+/* Blinker thread.                                                           */
+/*===========================================================================*/
+
+static THD_WORKING_AREA(waThread1, 256);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (true) {
+    palToggleLine(LED_PIN);
+    chThdSleepMilliseconds(500);
+  }
+}
+
+/*===========================================================================*/
+/* Main.                                                                     */
+/*===========================================================================*/
+
+int main(void) {
+  bool ok;
+
+  halInit();
+  chSysInit();
+
+  /* LED. */
+  palSetLineMode(LED_PIN, PAL_MODE_OUTPUT_PUSHPULL | PAL_RP_PAD_DRIVE12);
+
+  /* UART on GPIO0/GPIO1. */
+  palSetLineMode(UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+  chp = (BaseSequentialStream *)&SIOD0;
+
+  /* I2C0 on GPIO4 (SDA) / GPIO5 (SCL) with internal pull-ups, no
+     external devices are attached. */
+  palSetLineMode(I2C_SDA_PIN, PAL_MODE_ALTERNATE_I2C | PAL_RP_PAD_PUE);
+  palSetLineMode(I2C_SCL_PIN, PAL_MODE_ALTERNATE_I2C | PAL_RP_PAD_PUE);
+  i2cStart(&I2CD0, &i2ccfg);
+
+  /* Start blinker. */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /* Small delay to let UART settle and pull-ups charge the bus. */
+  chThdSleepMilliseconds(100);
+
+  chprintf(chp, "\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  RP2040 I2C Abort-Path Validation\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  I2C0 @ 100kHz, SDA=GP%u SCL=GP%u\r\n",
+           I2C_SDA_PIN, I2C_SCL_PIN);
+  chprintf(chp, "  Target address: 0x%02X (absent)\r\n", ABSENT_ADDR);
+  chprintf(chp, "\r\n");
+
+  /* Test 1: single address-NACK write. */
+  ok = test_address_nack_write();
+  report("Address NACK write reports ACK failure", ok);
+
+  /* Test 2: repeated aborts. */
+  ok = test_repeated_nack_write();
+  report("10 repeated NACK aborts, driver reusable", ok);
+
+  /* Test 3: write-then-read shape. */
+  ok = test_nack_write_then_read();
+  report("Write-then-read request aborts cleanly", ok);
+
+  /* Test 4: pure read shape. */
+  ok = test_nack_pure_read();
+  report("Pure read request aborts cleanly", ok);
+
+  /* Test 5: stop/start cycle. */
+  ok = test_stop_start_cycle();
+  report("NACK abort after i2cStop/i2cStart cycle", ok);
+
+  chprintf(chp, "\r\n========================================\r\n");
+  chprintf(chp, "  Results: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "  ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "  *** FAILURES DETECTED ***\r\n");
+  }
+  chprintf(chp, "========================================\r\n");
+
+  while (true) {
+    chThdSleepMilliseconds(1000);
+  }
+
+  return 0;
+}

--- a/testhal/RP/RP2350/I2C-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/I2C-VALIDATION/Makefile
@@ -1,0 +1,159 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O0 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2350/I2C-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/I2C-VALIDATION/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                FALSE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                FALSE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                FALSE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    FALSE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               FALSE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                FALSE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  FALSE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     FALSE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      FALSE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           FALSE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 TRUE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/I2C-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2350/I2C-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         TRUE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      FALSE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/I2C-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/I2C-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,48 @@
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+#define RP_IRQ_I2C0_PRIORITY                3
+#define RP_IRQ_I2C1_PRIORITY                3
+
+/*
+ * I2C driver system settings.
+ */
+#define RP_I2C_USE_I2C0                     TRUE
+#define RP_I2C_USE_I2C1                     FALSE
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/I2C-VALIDATION/main.c
+++ b/testhal/RP/RP2350/I2C-VALIDATION/main.c
@@ -27,8 +27,11 @@
  *
  * This exercises:
  *  - the NACK abort source to I2C_ACK_FAILURE error mapping,
- *  - the abort path of the write, write-then-read (repeated START) and
- *    pure read transfer shapes,
+ *  - the abort path of the write, write-then-read and pure read
+ *    request shapes; note the address byte NACKs before any data phase,
+ *    so the repeated-START itself is not reached on an empty bus (that
+ *    needs an ACK-capable slave and is validated separately by
+ *    inspection/register evidence),
  *  - driver robustness across repeated aborts and i2cStop()/i2cStart()
  *    cycles.
  *
@@ -162,8 +165,9 @@ static bool test_repeated_nack_write(void) {
 }
 
 /*
- * Test: a write-then-read request (repeated START shape) to the absent
- * address aborts just as cleanly.
+ * Test: a write-then-read request to the absent address aborts just as
+ * cleanly. The address NACK precedes the data phase, so this covers the
+ * abort of that request shape, not the repeated-START generation.
  */
 static bool test_nack_write_then_read(void) {
 
@@ -254,7 +258,7 @@ int main(void) {
 
   /* Test 3: write-then-read shape. */
   ok = test_nack_write_then_read();
-  report("Write-then-read request aborts cleanly", ok);
+  report("Write-then-read shape aborts on address NACK", ok);
 
   /* Test 4: pure read shape. */
   ok = test_nack_pure_read();

--- a/testhal/RP/RP2350/I2C-VALIDATION/main.c
+++ b/testhal/RP/RP2350/I2C-VALIDATION/main.c
@@ -1,0 +1,282 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 I2C abort-path validation test.
+ *
+ * Validates what an empty bus permits, no external wiring is required:
+ * I2C0 runs on GPIO4 (SDA) / GPIO5 (SCL) with the internal pad pull-ups
+ * enabled, no slave is attached.  Every transfer addressed to the absent
+ * device 0x50 must be NACKed on the address byte, the driver must abort
+ * quickly (well before the operation timeout), report MSG_RESET with
+ * i2cGetErrors() == I2C_ACK_FAILURE and be immediately reusable with the
+ * state machine back in I2C_READY.
+ *
+ * This exercises:
+ *  - the NACK abort source to I2C_ACK_FAILURE error mapping,
+ *  - the abort path of the write, write-then-read (repeated START) and
+ *    pure read transfer shapes,
+ *  - driver robustness across repeated aborts and i2cStop()/i2cStart()
+ *    cycles.
+ *
+ * Single-core only.
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#define LED_PIN              25U
+#define UART_TX_PIN          0U
+#define UART_RX_PIN          1U
+#define I2C_SDA_PIN          4U
+#define I2C_SCL_PIN          5U
+
+/* Nothing lives at this address on the (empty) bus. */
+#define ABSENT_ADDR          0x50U
+
+/* Per-transfer operation timeout, the abort must happen much earlier. */
+#define OP_TIMEOUT           TIME_MS2I(100)
+
+/* An address NACK abort must complete within a few SCL periods, allow a
+   generous margin that is still far below OP_TIMEOUT. */
+#define ABORT_DEADLINE       TIME_MS2I(50)
+
+static BaseSequentialStream *chp;
+static unsigned pass_count;
+static unsigned fail_count;
+
+static const I2CConfig i2ccfg = {
+  .baudrate = 100000U,
+};
+
+/*===========================================================================*/
+/* Test helpers.                                                             */
+/*===========================================================================*/
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/*
+ * Runs one transfer against the absent address and checks the abort
+ * behavior: MSG_RESET (not MSG_TIMEOUT), quick completion, exactly
+ * I2C_ACK_FAILURE reported and driver back in I2C_READY.
+ */
+static bool check_nack_abort(size_t txbytes, size_t rxbytes) {
+  static const uint8_t txbuf[2] = {0x00U, 0x00U};
+  uint8_t rxbuf[4];
+  systime_t start;
+  sysinterval_t elapsed;
+  i2cflags_t errors;
+  msg_t msg;
+
+  start = chVTGetSystemTime();
+  if (txbytes > 0U) {
+    msg = i2cMasterTransmitTimeout(&I2CD0, ABSENT_ADDR, txbuf, txbytes,
+                                   rxbuf, rxbytes, OP_TIMEOUT);
+  }
+  else {
+    msg = i2cMasterReceiveTimeout(&I2CD0, ABSENT_ADDR, rxbuf, rxbytes,
+                                  OP_TIMEOUT);
+  }
+  elapsed = chVTTimeElapsedSinceX(start);
+  errors = i2cGetErrors(&I2CD0);
+
+  if (msg != MSG_RESET) {
+    chprintf(chp, "    tx=%u rx=%u: expected MSG_RESET got %d\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes, (int)msg);
+    return false;
+  }
+
+  if (elapsed >= ABORT_DEADLINE) {
+    chprintf(chp, "    tx=%u rx=%u: abort took %u ticks\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes, (unsigned)elapsed);
+    return false;
+  }
+
+  if (errors != I2C_ACK_FAILURE) {
+    chprintf(chp, "    tx=%u rx=%u: expected errors 0x%02X got 0x%02X\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes,
+             (unsigned)I2C_ACK_FAILURE, (unsigned)errors);
+    return false;
+  }
+
+  if (I2CD0.state != I2C_READY) {
+    chprintf(chp, "    tx=%u rx=%u: driver state %d, not I2C_READY\r\n",
+             (unsigned)txbytes, (unsigned)rxbytes, (int)I2CD0.state);
+    return false;
+  }
+
+  return true;
+}
+
+/*===========================================================================*/
+/* Individual tests.                                                         */
+/*===========================================================================*/
+
+/*
+ * Test: a single 2-byte write to the absent address is NACKed on the
+ * address byte and reported as an ACK failure.
+ */
+static bool test_address_nack_write(void) {
+
+  return check_nack_abort(2U, 0U);
+}
+
+/*
+ * Test: repeated aborts do not accumulate state, the driver is reusable
+ * on every iteration.
+ */
+static bool test_repeated_nack_write(void) {
+  unsigned i;
+
+  for (i = 0U; i < 10U; i++) {
+    if (!check_nack_abort(2U, 0U)) {
+      chprintf(chp, "    Failed at iteration %u\r\n", i);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*
+ * Test: a write-then-read request (repeated START shape) to the absent
+ * address aborts just as cleanly.
+ */
+static bool test_nack_write_then_read(void) {
+
+  return check_nack_abort(1U, 2U);
+}
+
+/*
+ * Test: a pure read request to the absent address aborts cleanly.
+ */
+static bool test_nack_pure_read(void) {
+
+  return check_nack_abort(0U, 2U);
+}
+
+/*
+ * Test: driver survives a full stop/start cycle after aborts.
+ */
+static bool test_stop_start_cycle(void) {
+
+  i2cStop(&I2CD0);
+  i2cStart(&I2CD0, &i2ccfg);
+
+  return check_nack_abort(2U, 0U);
+}
+
+/*===========================================================================*/
+/* Blinker thread.                                                           */
+/*===========================================================================*/
+
+static THD_WORKING_AREA(waThread1, 256);
+static THD_FUNCTION(Thread1, arg) {
+
+  (void)arg;
+  chRegSetThreadName("blinker");
+  while (true) {
+    palToggleLine(LED_PIN);
+    chThdSleepMilliseconds(500);
+  }
+}
+
+/*===========================================================================*/
+/* Main.                                                                     */
+/*===========================================================================*/
+
+int main(void) {
+  bool ok;
+
+  halInit();
+  chSysInit();
+
+  /* LED. */
+  palSetLineMode(LED_PIN, PAL_MODE_OUTPUT_PUSHPULL | PAL_RP_PAD_DRIVE12);
+
+  /* UART on GPIO0/GPIO1. */
+  palSetLineMode(UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+  chp = (BaseSequentialStream *)&SIOD0;
+
+  /* I2C0 on GPIO4 (SDA) / GPIO5 (SCL) with internal pull-ups, no
+     external devices are attached. */
+  palSetLineMode(I2C_SDA_PIN, PAL_MODE_ALTERNATE_I2C | PAL_RP_PAD_PUE);
+  palSetLineMode(I2C_SCL_PIN, PAL_MODE_ALTERNATE_I2C | PAL_RP_PAD_PUE);
+  i2cStart(&I2CD0, &i2ccfg);
+
+  /* Start blinker. */
+  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
+
+  /* Small delay to let UART settle and pull-ups charge the bus. */
+  chThdSleepMilliseconds(100);
+
+  chprintf(chp, "\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  RP2350 I2C Abort-Path Validation\r\n");
+  chprintf(chp, "========================================\r\n");
+  chprintf(chp, "  I2C0 @ 100kHz, SDA=GP%u SCL=GP%u\r\n",
+           I2C_SDA_PIN, I2C_SCL_PIN);
+  chprintf(chp, "  Target address: 0x%02X (absent)\r\n", ABSENT_ADDR);
+  chprintf(chp, "\r\n");
+
+  /* Test 1: single address-NACK write. */
+  ok = test_address_nack_write();
+  report("Address NACK write reports ACK failure", ok);
+
+  /* Test 2: repeated aborts. */
+  ok = test_repeated_nack_write();
+  report("10 repeated NACK aborts, driver reusable", ok);
+
+  /* Test 3: write-then-read shape. */
+  ok = test_nack_write_then_read();
+  report("Write-then-read request aborts cleanly", ok);
+
+  /* Test 4: pure read shape. */
+  ok = test_nack_pure_read();
+  report("Pure read request aborts cleanly", ok);
+
+  /* Test 5: stop/start cycle. */
+  ok = test_stop_start_cycle();
+  report("NACK abort after i2cStop/i2cStart cycle", ok);
+
+  chprintf(chp, "\r\n========================================\r\n");
+  chprintf(chp, "  Results: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "  ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "  *** FAILURES DETECTED ***\r\n");
+  }
+  chprintf(chp, "========================================\r\n");
+
+  while (true) {
+    chThdSleepMilliseconds(1000);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Fixes items 3, 28 and 29 of the RP2040 implementation review. Stacked branches `em-i2c-fixes` (items 3, 28 — reviewed in the RP2350 campaign) and `em-rp2040-i2c-deadline` (item 29), merged together.

- **Item 3**: write-then-read transactions use a repeated START — STOP is no longer set on the final transmitted byte, and RESTART is applied to the first read command, matching the official SDK. Foreign-STOP and TX-residue robustness fixes ride along.
- **Item 28**: address- and data-NACK abort sources map to `I2C_ACK_FAILURE`.
- **Item 29**: the caller timeout is one deadline for the call — it caps the initial bus-busy wait and the elapsed busy time is subtracted from the completion wait.
- Adds an RP2040 build of the empty-bus I2C-VALIDATION abort suite (no wiring needed).

Validation: abort suite 5/5 on the bench Pico across all three commits' states; RP2350 variant retains its campaign validation. CodeRabbit: 1 major (test claimed repeated-START coverage it cannot exercise on an empty bus) — resolved by describing the case honestly in both variants and revalidating. Codex: no blockers; lock-state, TIME_INFINITE and wrap-safety of the deadline change verified; its mcuconf and wording nits incorporated. The responding-slave hardware leg is deferred until the bench has an I2C fixture.