### PR TITLE
RP GPIOv1: PAL event affinity, latch preservation and E6 analogue pads

### DIFF
--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
@@ -143,6 +143,27 @@ void _pal_lld_init(void) {
   rp_peripheral_unreset(RESETS_ALLREG_IO_BANK0);
   rp_peripheral_unreset(RESETS_ALLREG_PADS_BANK0);
 
+#if defined(RP2040)
+  /* The PADS_BANK0 reset re-enables the digital input buffer and the
+     pull-down on the ADC-capable pads, undoing the boot-ROM mitigation
+     for erratum RP2040-E6 (increased leakage on GPIO26..GPIO29).
+     Analogue-safe state is restored immediately; configuring one of
+     these lines through the PAL deliberately makes it digital again.*/
+  {
+    unsigned pad;
+
+    for (pad = 26U; pad <= 29U; pad++) {
+      uint32_t padbits = PADS_BANK0->GPIO[pad];
+
+      /* The PAL_RP_PAD_* mode encodings carry the raw pad field at
+         bit position 24 upwards.*/
+      padbits &= ~((PAL_RP_PAD_PUE | PAL_RP_PAD_PDE | PAL_RP_PAD_IE) >> 24);
+      padbits |= (PAL_RP_PAD_OD >> 24);
+      PADS_BANK0->GPIO[pad] = padbits;
+    }
+  }
+#endif
+
   #if PAL_USE_CALLBACKS || PAL_USE_WAIT || defined(__DOXYGEN__)
   unsigned i;
 

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
@@ -150,7 +150,14 @@ void _pal_lld_init(void) {
     _pal_init_event(i);
   }
 
-  nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+  /* The ISR reads the interrupt statuses of the per-core PROC block
+     selected by RP_PAL_EVENT_CORE_AFFINITY and the NVIC is a per-core
+     resource, so the vector can only be enabled here when halInit() is
+     running on the affinity core. Otherwise the application must call
+     palRPEnableEventsIrqX() from the affinity core.*/
+  if (SIO->CPUID == (uint32_t)RP_PAL_EVENT_CORE_AFFINITY) {
+    nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+  }
   #endif
 }
 

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -104,7 +104,15 @@
 /** @} */
 
 #if !defined(RP_PAL_EVENT_CORE_AFFINITY)
-  /** @brief Core that handles all the PAL event interrupts. */
+  /**
+   * @brief   Core that handles all the PAL event interrupts.
+   * @note    The NVIC is a per-core resource, halInit() enables the events
+   *          interrupt vector only when it is executed on this core. When
+   *          the affinity core is not the core running halInit(), the
+   *          application must call @p palRPEnableEventsIrqX() from the
+   *          affinity core (e.g. from @p c1_main() after
+   *          @p chInstanceObjectInit()) before PAL events can be served.
+   */
   #define RP_PAL_EVENT_CORE_AFFINITY        0
 #endif
 
@@ -440,6 +448,25 @@ typedef uint32_t iopadid_t;
   /** @brief IRQ priority of the external pad events. */
   #define RP_IO_IRQ_BANK0_PRIORITY          2
 #endif
+
+/**
+ * @brief   Enables the PAL events interrupt vector on the calling core.
+ * @details The NVIC is a per-core resource and the PAL events interrupts are
+ *          routed to the core selected by @p RP_PAL_EVENT_CORE_AFFINITY.
+ *          halInit() enables the vector only when running on the affinity
+ *          core, otherwise this function must be called from the affinity
+ *          core after it has been started.
+ * @note    Must be called from the @p RP_PAL_EVENT_CORE_AFFINITY core.
+ *
+ * @special
+ */
+__STATIC_INLINE void palRPEnableEventsIrqX(void) {
+
+  osalDbgAssert(SIO->CPUID == (uint32_t)RP_PAL_EVENT_CORE_AFFINITY,
+                "wrong core");
+
+  nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+}
 
 #if !defined(__DOXYGEN__)
 extern palevent_t _pal_events[RP_GPIO_NUM_LINES];

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -363,8 +363,8 @@ typedef uint32_t iopadid_t;
  *          ALL concurrent output updates to the SAME port - including
  *          line/group set, clear and toggle - because an update landing
  *          between the read and the XOR write is folded into a value
- *          neither writer requested. The set/clear based APIs are only
- *          atomic among themselves. Different ports are independent.
+ *          neither writer requested. The set, clear and toggle APIs are
+ *          only atomic among themselves. Different ports are independent.
  */
 #define pal_lld_writeport(port, bits)                                       \
   do {                                                                      \

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -347,13 +347,15 @@ typedef uint32_t iopadid_t;
  * @notapi
  */
 /* @note    On RP2350, IOPORT2 maps to SIO GPIO_HI_OUT which is shared with
- *          QSPI/USB outputs in bits 31:16. This is a raw full-register write;
- *          use palSetPort()/palClearPort()/palTogglePort() when non-PAL high
- *          bits must be preserved.
+ *          QSPI/USB outputs in bits 31:16. Only the bits belonging to PAL
+ *          lines are updated, using a single write to the GPIO_OUT_XOR
+ *          alias, so the shared non-PAL latch bits are preserved.
  */
 #define pal_lld_writeport(port, bits)                                       \
   do {                                                                      \
-    RP_PAL_SIO_REG(GPIO_OUT, (port)) = (uint32_t)(bits);                    \
+    RP_PAL_SIO_REG(GPIO_OUT_XOR, (port)) =                                  \
+      (RP_PAL_SIO_REG(GPIO_OUT, (port)) ^ (uint32_t)(bits)) &               \
+      (uint32_t)RP_PAL_VALID_MASK(port);                                    \
   } while (false)
 
 /**

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -358,6 +358,12 @@ typedef uint32_t iopadid_t;
  *          QSPI/USB outputs in bits 31:16. Only the bits belonging to PAL
  *          lines are updated, using a single write to the GPIO_OUT_XOR
  *          alias, so the shared non-PAL latch bits are preserved.
+ * @note    The latch read and XOR write are not one atomic step:
+ *          concurrent full-port writes to the SAME port from both cores
+ *          are unsupported (they can combine into a value neither core
+ *          requested) and must be serialized by the application; the
+ *          set/clear based line and group APIs remain safe for
+ *          concurrent use. Different ports are independent.
  */
 #define pal_lld_writeport(port, bits)                                       \
   do {                                                                      \

--- a/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/hal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -358,12 +358,13 @@ typedef uint32_t iopadid_t;
  *          QSPI/USB outputs in bits 31:16. Only the bits belonging to PAL
  *          lines are updated, using a single write to the GPIO_OUT_XOR
  *          alias, so the shared non-PAL latch bits are preserved.
- * @note    The latch read and XOR write are not one atomic step:
- *          concurrent full-port writes to the SAME port from both cores
- *          are unsupported (they can combine into a value neither core
- *          requested) and must be serialized by the application; the
- *          set/clear based line and group APIs remain safe for
- *          concurrent use. Different ports are independent.
+ * @note    The latch read and XOR write are not one atomic step: a
+ *          full-port write must be serialized by the application against
+ *          ALL concurrent output updates to the SAME port - including
+ *          line/group set, clear and toggle - because an update landing
+ *          between the read and the XOR write is folded into a value
+ *          neither writer requested. The set/clear based APIs are only
+ *          atomic among themselves. Different ports are independent.
  */
 #define pal_lld_writeport(port, bits)                                       \
   do {                                                                      \

--- a/testhal/RP/multi/PAL/main.c
+++ b/testhal/RP/multi/PAL/main.c
@@ -38,6 +38,58 @@ static THD_FUNCTION(Thread1, arg) {
 }
 #endif
 
+#if (defined(RP_PAL_SIO_REG) && (RP_GPIO_NUM_LINES > 32U)) ||               \
+    defined(__DOXYGEN__)
+/*
+ * On RP devices with more than 32 GPIO lines (RP2350), IOPORT2 maps to SIO
+ * GPIO_HI_OUT which shares bits 31:16 with the QSPI/USB output latches.
+ * This one-shot boot check verifies that palWritePort() on IOPORT2 updates
+ * only the PAL line latches and preserves the shared high bits.
+ *
+ * This demo has no serial console, therefore a failure is signalled by
+ * blinking a fast SOS pattern on LED1 forever; on success the normal demo
+ * behavior follows.
+ */
+static void check_ioport2_latch_preservation(void) {
+  static const uint8_t sos[] = {1, 1, 1, 3, 3, 3, 1, 1, 1};
+  uint32_t hi_snapshot, saved_latch;
+  bool ok = true;
+
+  saved_latch = palReadLatch(IOPORT2) & 0xFFFFU;
+  hi_snapshot = SIO->GPIO_HI_OUT & 0xFFFF0000U;
+
+  palWritePort(IOPORT2, 0xAAAAU);
+  ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0xAAAAU);
+  ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
+
+  palWritePort(IOPORT2, 0x5555U);
+  ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0x5555U);
+  ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
+
+  palWritePort(IOPORT2, 0x0000U);
+  ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0x0000U);
+  ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
+
+  /* Restoring the original latch value.*/
+  palWritePort(IOPORT2, saved_latch);
+
+  while (!ok) {
+    unsigned i;
+
+    for (i = 0U; i < (sizeof sos / sizeof sos[0]); i++) {
+      palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_ON);
+      chThdSleepMilliseconds(50U * sos[i]);
+      palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_OFF);
+      chThdSleepMilliseconds(50U);
+    }
+    chThdSleepMilliseconds(300U);
+  }
+}
+#define CHECK_IOPORT2_LATCH_PRESERVATION()  check_ioport2_latch_preservation()
+#else
+#define CHECK_IOPORT2_LATCH_PRESERVATION()  do { } while (false)
+#endif
+
 #if PAL_USE_WAIT || defined(__DOXYGEN__)
 
 /*
@@ -57,6 +109,10 @@ int main(void) {
 
   /* Board-dependent GPIO setup code.*/
   portab_setup();
+
+  /* One-shot IOPORT2 shared-latch preservation check, no-op where IOPORT2
+     is not present.*/
+  CHECK_IOPORT2_LATCH_PRESERVATION();
 
 #if defined(PORTAB_LINE_LED2)
   /*
@@ -125,6 +181,10 @@ int main(void) {
   /* Board-dependent GPIO setup code.*/
   portab_setup();
 
+  /* One-shot IOPORT2 shared-latch preservation check, no-op where IOPORT2
+     is not present.*/
+  CHECK_IOPORT2_LATCH_PRESERVATION();
+
   /* Events initialization and registration.*/
   chEvtObjectInit(&button_pressed_event);
   chEvtObjectInit(&button_released_event);
@@ -177,6 +237,10 @@ int main(void) {
 
   /* Board-dependent GPIO setup code.*/
   portab_setup();
+
+  /* One-shot IOPORT2 shared-latch preservation check, no-op where IOPORT2
+     is not present.*/
+  CHECK_IOPORT2_LATCH_PRESERVATION();
 
 #if defined(PORTAB_LINE_LED2)
   /*

--- a/testhal/RP/multi/PAL/main.c
+++ b/testhal/RP/multi/PAL/main.c
@@ -52,10 +52,15 @@ static THD_FUNCTION(Thread1, arg) {
  */
 static void check_ioport2_latch_preservation(void) {
   static const uint8_t sos[] = {1, 1, 1, 3, 3, 3, 1, 1, 1};
-  uint32_t hi_snapshot, saved_latch;
+  uint32_t hi_original, hi_snapshot, saved_latch;
   bool ok = true;
 
   saved_latch = palReadLatch(IOPORT2) & 0xFFFFU;
+
+  /* The upper half is captured before seeding so it can be restored
+     exactly afterwards: the seeded bit may already be owned by earlier
+     firmware and must not be blindly cleared.*/
+  hi_original = SIO->GPIO_HI_OUT & 0xFFFF0000U;
 
   /* Seeding a non-GPIO latch bit so preservation is actually exercised,
      the QSPI/USB output latches are inert while their pads are not on
@@ -75,9 +80,11 @@ static void check_ioport2_latch_preservation(void) {
   ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0x0000U);
   ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
 
-  /* Restoring the original latch and clearing the seeded bit.*/
+  /* Restoring both halves exactly as found: the PAL lines through the
+     API, the shared upper half with an atomic masked XOR that cannot
+     disturb the lower half.*/
   palWritePort(IOPORT2, saved_latch);
-  SIO->GPIO_HI_OUT_CLR = 0x00010000U;
+  SIO->GPIO_HI_OUT_XOR = (SIO->GPIO_HI_OUT ^ hi_original) & 0xFFFF0000U;
 
   while (!ok) {
     unsigned i;

--- a/testhal/RP/multi/PAL/main.c
+++ b/testhal/RP/multi/PAL/main.c
@@ -56,6 +56,11 @@ static void check_ioport2_latch_preservation(void) {
   bool ok = true;
 
   saved_latch = palReadLatch(IOPORT2) & 0xFFFFU;
+
+  /* Seeding a non-GPIO latch bit so preservation is actually exercised,
+     the QSPI/USB output latches are inert while their pads are not on
+     the SIO function.*/
+  SIO->GPIO_HI_OUT_SET = 0x00010000U;
   hi_snapshot = SIO->GPIO_HI_OUT & 0xFFFF0000U;
 
   palWritePort(IOPORT2, 0xAAAAU);
@@ -70,8 +75,9 @@ static void check_ioport2_latch_preservation(void) {
   ok = ok && ((palReadLatch(IOPORT2) & 0xFFFFU) == 0x0000U);
   ok = ok && ((SIO->GPIO_HI_OUT & 0xFFFF0000U) == hi_snapshot);
 
-  /* Restoring the original latch value.*/
+  /* Restoring the original latch and clearing the seeded bit.*/
   palWritePort(IOPORT2, saved_latch);
+  SIO->GPIO_HI_OUT_CLR = 0x00010000U;
 
   while (!ok) {
     unsigned i;


### PR DESCRIPTION
Fixes items 36 and 39 of the RP2040 implementation review. Stacked branches `em-pal-fixes` (item 36 — re-landing the branch whose earlier MR #97 was closed unmerged; reviewed and hardware-validated in the RP2350 campaign) and `em-rp2040-pal-e6` (item 39), merged together.

- **Item 36**: the PAL event vector is enabled on the affinity core only, with `palRPEnableEventsIrqX()` for applications whose `halInit()` runs elsewhere; plus the full-port write concurrency contract and SIO latch preservation work from the original branch.
- **Item 39**: the PADS_BANK0 reset in `_pal_lld_init()` re-enabled the digital input buffer and pull-down on GPIO26..29, undoing the boot-ROM mitigation for erratum RP2040-E6. Analogue-safe state is restored immediately after the reset on RP2040; configuring those lines through the PAL makes them digital deliberately.

Validation: PADS_BANK0 GPIO26..29 read 0x92 after `halInit()` on the bench Pico (previously 0x56 — input buffer and pull-down enabled); the multi PAL test runs on RP2040 and both PAL variants build (the IOPORT2 latch self-check is RP2350-only by design and retains its campaign validation). CodeRabbit: 0 findings. Codex: no blocking findings — raw pad-bit derivation, init ordering, and `palSetLineMode()` compatibility verified; notes the intended behavior change for code relying on reset-default digital input without configuring the line.