### PR TITLE
RP2040: validate achievable clock settings at compile time

### DIFF
--- a/os/hal/ports/RP/RP2040/hal_lld.h
+++ b/os/hal/ports/RP/RP2040/hal_lld.h
@@ -129,6 +129,15 @@
 #endif
 
 /*
+ * The watchdog tick generator divides the crystal down to the 1 MHz
+ * time base advertised to the OS and the timer; a non-integer-MHz
+ * crystal would silently produce a wrong tick frequency.
+ */
+#if (RP_XOSCCLK % 1000000) != 0
+#error "RP_XOSCCLK must be an integer number of MHz for the 1 MHz tick generator"
+#endif
+
+/*
  * PLL_SYS configuration checks.
  */
 #if (RP_PLL_SYS_REFDIV < 1) || (RP_PLL_SYS_REFDIV > 63)
@@ -150,6 +159,27 @@
 
 #if RP_PLL_SYS_POSTDIV1 < RP_PLL_SYS_POSTDIV2
 #error "RP_PLL_SYS_POSTDIV1 must be >= RP_PLL_SYS_POSTDIV2"
+#endif
+
+#if (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_SYS_REFDIV"
+#endif
+
+#if (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
+#error "PLL_SYS reference frequency below 5 MHz minimum"
+#endif
+
+#if (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not an integer multiple of the PLL_SYS reference frequency"
+#endif
+
+#if ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||      \
+    ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
+#error "PLL_SYS FBDIV out of valid range (16-320)"
+#endif
+
+#if (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not divisible by RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2"
 #endif
 
 /*
@@ -176,8 +206,37 @@
 #error "RP_PLL_USB_POSTDIV1 must be >= RP_PLL_USB_POSTDIV2"
 #endif
 
+#if (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_USB_REFDIV"
+#endif
+
+#if (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
+#error "PLL_USB reference frequency below 5 MHz minimum"
+#endif
+
+#if (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not an integer multiple of the PLL_USB reference frequency"
+#endif
+
+#if ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||      \
+    ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
+#error "PLL_USB FBDIV out of valid range (16-320)"
+#endif
+
+#if (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not divisible by RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2"
+#endif
+
 #if RP_PLL_USB_CLK != 48000000
 #error "RP_PLL_USB_CLK must be 48 MHz for USB to work"
+#endif
+
+/*
+ * RP2040-E16 erratum check: reliable USB operation requires
+ * clk_sys >= 1.1 * clk_usb.
+ */
+#if ((RP_CLK_SYS_FREQ) * 10U) < ((RP_CLK_USB_FREQ) * 11U)
+#error "RP2040-E16: clk_sys must be at least 1.1 * clk_usb for reliable USB operation"
 #endif
 
 /**

--- a/os/hal/ports/RP/RP2040/rp_pll.c
+++ b/os/hal/ports/RP/RP2040/rp_pll.c
@@ -76,7 +76,11 @@ void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
   osalDbgAssert(vco_freq >= RP_PLL_VCO_MIN_FREQ &&
                 vco_freq <= RP_PLL_VCO_MAX_FREQ,
                 "VCO frequency out of range");
+  osalDbgAssert((RP_XOSCCLK % refdiv) == 0U, "XOSC not divisible by REFDIV");
+  osalDbgAssert(ref_freq >= 5000000U, "reference frequency below 5 MHz");
   osalDbgAssert(fbdiv >= 16U && fbdiv <= 320U, "FBDIV out of range");
+  osalDbgAssert((ref_freq * fbdiv) == vco_freq,
+                "VCO not an integer multiple of reference");
   osalDbgAssert(postdiv1 >= 1U && postdiv1 <= 7U, "POSTDIV1 out of range");
   osalDbgAssert(postdiv2 >= 1U && postdiv2 <= 7U, "POSTDIV2 out of range");
   osalDbgAssert(ref_freq <= (vco_freq / 16U), "Reference frequency too high");


### PR DESCRIPTION
Fixes items 17, 22 and 40 of the RP2040 implementation review, mirroring the RP2350 em-clock-checks work (MR #103).

- **Item 17**: both PLLs get compile-time checks for reference divisibility, the 5 MHz reference minimum, VCO being an integer multiple of the reference, the FBDIV range, and post-divider divisibility, mirrored as runtime assertions — an inexact configuration can no longer silently program a different frequency than advertised (the review's 13 MHz-crystal example now fails to compile).
- **Item 22**: an integer-MHz crystal is required at compile time; the watchdog tick generator divides the crystal by an integer to make the advertised 1 MHz time base, and a 12.288 MHz crystal made OS time run 2.4% fast.
- **Item 40**: RP2040-E16 (clk_sys >= 1.1 x clk_usb) is checked at compile time via the clock-point frequency macros.

Validation: default 12 MHz configuration builds cleanly and UART output on the bench Pico stays exact at 115200; 13 MHz and 12.288 MHz crystals and a 50 MHz clk_sys each fail with the intended diagnostics. CodeRabbit: 0 findings. Codex: confirmed the clk_sys macro choice against rp_clocks.c's mux setup (its RP_CLK_SYS_FREQ suggestion adopted), preprocessor-arithmetic range, the datasheet's 'at least 10%' wording for the E16 boundary, and that the integer-MHz requirement rejects nothing the port supports today.