### PR TITLE
RP2040: correct four register bitfield definitions

### DIFF
--- a/os/common/ext/RP/RP2040/rp2040.h
+++ b/os/common/ext/RP/RP2040/rp2040.h
@@ -2144,7 +2144,7 @@ typedef struct {
 #define UART_UARTLCR_H_SPS_Msk            (1U << UART_UARTLCR_H_SPS_Pos)
 #define UART_UARTLCR_H_SPS                UART_UARTLCR_H_SPS_Msk
 #define UART_UARTLCR_H_WLEN_Pos           5U
-#define UART_UARTLCR_H_WLEN_Msk           (1U << UART_UARTLCR_H_WLEN_Pos)
+#define UART_UARTLCR_H_WLEN_Msk           (3U << UART_UARTLCR_H_WLEN_Pos)
 #define UART_UARTLCR_H_WLEN(n)            ((n) << UART_UARTLCR_H_WLEN_Pos)
 #define UART_UARTLCR_H_WLEN_5BITS         UART_UARTLCR_H_WLEN(0U)
 #define UART_UARTLCR_H_WLEN_6BITS         UART_UARTLCR_H_WLEN(1U)
@@ -2549,7 +2549,7 @@ typedef struct {
 #define WATCHDOG_REASON_TIMER             WATCHDOG_REASON_TIMER_Msk
 
 #define WATCHDOG_TICK_COUNT_Pos           11U
-#define WATCHDOG_TICK_COUNT_Msk           (0xFF800U << WATCHDOG_TICK_COUNT_Pos)
+#define WATCHDOG_TICK_COUNT_Msk           (0x1FFU << WATCHDOG_TICK_COUNT_Pos)
 #define WATCHDOG_TICK_COUNT               WATCHDOG_TICK_COUNT_Msk
 #define WATCHDOG_TICK_RUNNING_Pos         10U
 #define WATCHDOG_TICK_RUNNING_Msk         (1U << WATCHDOG_TICK_RUNNING_Pos)
@@ -2857,7 +2857,7 @@ typedef struct {
 #define I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Msk               (0xFFU << I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Pos)
 #define I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD                   I2C_IC_SDA_HOLD_IC_SDA_RX_HOLD_Msk
 #define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos               0U
-#define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk               (0xFFU << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos)
+#define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk               (0xFFFFU << I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Pos)
 #define I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD                   I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD_Msk
 
 #define I2C_IC_TX_ABRT_SOURCE_TX_FLUSH_CNT_Pos           23U
@@ -2955,7 +2955,7 @@ typedef struct {
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Pos          16U
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Msk          (0xFFU << I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Pos)
 #define I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH              I2C_IC_COMP_PARAM_1_TX_BUFFER_DEPTH_Msk
-#define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos          0U
+#define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos          8U
 #define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Msk          (0xFFU << I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Pos)
 #define I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH              I2C_IC_COMP_PARAM_1_RX_BUFFER_DEPTH_Msk
 


### PR DESCRIPTION
An automated comparison against Raspberry Pi's generated RP2040 header found four field definitions that do not match the hardware:

- UART UARTLCR_H WLEN is a two-bit field at bits 6:5; the mask covered only bit 5. The WLEN_nBITS value macros were already correct.
- WATCHDOG TICK COUNT applied the position shift to an already-positioned mask value; the field is nine bits at 19:11 (0x000ff800).
- I2C IC_SDA_HOLD IC_SDA_TX_HOLD is sixteen bits, not eight. The I2C driver uses this as a write mask; hold counts computed from supported system clocks stay below 256, so the old mask was wrong but not practically observable.
- I2C IC_COMP_PARAM_1 RX_BUFFER_DEPTH sits at bits 15:8, not 7:0.

No driver compensated for the wrong values and no in-tree code observes different behavior from this correction.

## Summary

<!-- describe what changed, why is this change needed -->

## Related

- Issue(s):
- Notes for reviewers:

## Target Branch Check

<!-- put a x instead of the space in the [ ] to check the box [x] -->

- [ ] This PR targets `main` — all changes land on `main` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `main`

## Scope

- [ ] Change is focused and does not bundle unrelated work
- [ ] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [ ] Style check passed on changed `.c`/`.h` files
- [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [ ] Test run successfully locally
- Any other tests run on a device?

## Compatibility and Risk

- [ ] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
