### PR TITLE
ARMv6-M RP2: compile SMP support source out of non-SMP builds

### DIFF
--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -26,6 +26,11 @@
 
 #include "ch.h"
 
+/* This translation unit is always listed by port_rp2.mk, but its contents
+   depend on definitions made available only when the kernel is configured
+   for SMP; it compiles to nothing in a non-SMP configuration.*/
+#if (CH_CFG_SMP_MODE == TRUE) || defined(__DOXYGEN__)
+
 /*===========================================================================*/
 /* Module local definitions.                                                 */
 /*===========================================================================*/
@@ -168,5 +173,7 @@ void __port_spinlock_release(void) {
 
   port_spinlock_release();
 }
+
+#endif /* CH_CFG_SMP_MODE == TRUE */
 
 /** @} */


### PR DESCRIPTION
port_rp2.mk unconditionally lists chcoresmp.c, but the definitions it depends on (PORT_FIFO_PANIC_MESSAGE, the spinlock and SMP timer helpers) exist only when the kernel is configured for SMP, so an explicitly non-SMP build of the RP2 port failed to compile. The FIFO NVIC setup was already conditional; the FIFO vectors, panic halt and spinlock wrappers were not.

The whole translation unit is now guarded by CH_CFG_SMP_MODE and compiles to nothing in a non-SMP configuration. chcore.c only calls port_smp_init() when the macro exists, and it is only defined when chcoresmp.h is included in SMP mode, so nothing references the compiled-out symbols.

Verified: UART-VALIDATION rebuilt against port_rp2.mk with its non-SMP configuration now compiles, links and runs on hardware; the SMP demo is unchanged and still boots with a working core-1 shell.

## Summary

<!-- describe what changed, why is this change needed -->

## Related

- Issue(s):
- Notes for reviewers:

## Target Branch Check

<!-- put a x instead of the space in the [ ] to check the box [x] -->

- [ ] This PR targets `main` — all changes land on `main` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `main`

## Scope

- [ ] Change is focused and does not bundle unrelated work
- [ ] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [ ] Style check passed on changed `.c`/`.h` files
- [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [ ] Test run successfully locally
- Any other tests run on a device?

## Compatibility and Risk

- [ ] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
