### PR TITLE
readme: changelog entry for the USB EP0 PMA fix (PR #85)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,13 @@ See .devcontainer/README.md for included tools and usage.
        a path namespace while operations on registered file descriptors remain
        available. Enabling the SB VFS support now requires
        VFS_CFG_ENABLE_DRV_ROOT == TRUE (github PR #91).
+- FIX: STM32 USBv1 and USBv2 packet memory could be double-allocated across a
+       configuration rebuild. usb_lld_disable_endpoints() reset the PMA
+       allocator to the descriptor-table boundary while endpoint zero remained
+       active, so a subsequent SET_CONFIGURATION allocated endpoint 1 over the
+       still-live EP0 buffers. The allocator now re-reserves the EP0 IN/OUT
+       buffers immediately after the reset; the bus-reset path is unchanged
+       (github PR #85)(backported to 21.11.6).
 - NEW: RP2350 runtime clock switching (RP_CLOCK_DYNAMIC, default FALSE):
        real halClockSwitchMode() support with runtime-validated PLL_SYS
        configurations, flash-timing-safe reclocking with both cores kept


### PR DESCRIPTION
Reviewer-owned changelog entry for #85 (USB EP0 PMA fix), which did not land with that PR's merge. Documents the USBv1/USBv2 packet-memory reservation fix and carries the `(backported to 21.11.6)` annotation for its backport (#87, merged).

Documentation only — no code change.

---
🤖 chibios-sheriff — first-layer review (advisory). This is an automated first-layer patch; a human maintainer decides on merge. The sheriff does not review or merge its own PRs.
