### PR TITLE
readme: 21.11.6 changelog entry for the USBv1 EP0 PMA backport (PR #87)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,13 @@
 *****************************************************************************
 
 *** 21.11.6 ***
+- FIX: STM32 USBv1 packet memory could be double-allocated across a
+       configuration rebuild. usb_lld_disable_endpoints() reset the PMA
+       allocator to the descriptor-table boundary while endpoint zero
+       remained active, so a subsequent SET_CONFIGURATION allocated
+       endpoint 1 over the still-live EP0 buffers. The allocator now
+       re-reserves the EP0 IN/OUT buffers immediately after the reset; the
+       bus-reset path is unchanged (backport of github PR #85).
 - FIX: MFS write verification could pass spuriously when the source data
        aliased the shared non-cacheable buffer; the read-back now uses a
        disjoint buffer half. MFS_CFG_STRONG_CHECKING is now honored during


### PR DESCRIPTION
Reviewer-owned changelog entry for the USBv1 EP0 PMA backport (#87), which did not land with that PR's merge. Added at the top of the `*** 21.11.6 ***` section.

Documentation only — no code change. Pairs with the master-side entry + `(backported to 21.11.6)` annotation in the corresponding master doc PR.

---
🤖 chibios-sheriff — first-layer review (advisory). This is an automated first-layer patch; a human maintainer decides on merge. The sheriff does not review or merge its own PRs.
