### PR TITLE
RP USBv1: correct RP2040 validation-app references and a declaration placement

### DIFF
--- a/os/hal/ports/RP/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/RP/LLD/USBv1/hal_usb_lld.c
@@ -226,8 +226,8 @@ static uint32_t usb_prepare_out_ep_buffer(USBDriver *usbp, usbep_t ep, uint8_t b
     buf_ctrl |= oesp->next_pid ? USB_BUFFER_BUFFER0_DATA_PID : 0;
     oesp->next_pid ^= 1U;
 
-    /* uint16_t is safe here, the clamp to out_maxsize (a hardware packet
-       size, at most 1023) is what bounds the value. */
+    /* The uint16_t width is safe here, the clamp to out_maxsize (a
+       hardware packet size, at most 1023) is what bounds the value. */
     buf_len = oesp->rxsize < epcp->out_maxsize ? oesp->rxsize : epcp->out_maxsize;
     buf_ctrl |= USB_BUFFER_BUFFER0_AVAILABLE | buf_len;
     buf_ctrl &= ~USB_BUFFER_BUFFER0_FULL;

--- a/os/hal/ports/RP/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/RP/LLD/USBv1/hal_usb_lld.c
@@ -220,6 +220,7 @@ static uint32_t usb_prepare_out_ep_buffer(USBDriver *usbp, usbep_t ep, uint8_t b
     uint32_t buf_ctrl = 0;
     const USBEndpointConfig *epcp = usbp->epc[ep];
     USBOutEndpointState *oesp = usbp->epc[ep]->out_state;
+    uint16_t buf_len;
 
     /* PID */
     buf_ctrl |= oesp->next_pid ? USB_BUFFER_BUFFER0_DATA_PID : 0;
@@ -227,7 +228,7 @@ static uint32_t usb_prepare_out_ep_buffer(USBDriver *usbp, usbep_t ep, uint8_t b
 
     /* uint16_t is safe here, the clamp to out_maxsize (a hardware packet
        size, at most 1023) is what bounds the value. */
-    uint16_t buf_len = oesp->rxsize < epcp->out_maxsize ? oesp->rxsize : epcp->out_maxsize;
+    buf_len = oesp->rxsize < epcp->out_maxsize ? oesp->rxsize : epcp->out_maxsize;
     buf_ctrl |= USB_BUFFER_BUFFER0_AVAILABLE | buf_len;
     buf_ctrl &= ~USB_BUFFER_BUFFER0_FULL;
 

--- a/testhal/RP/RP2040/USB-VALIDATION/README.md
+++ b/testhal/RP/RP2040/USB-VALIDATION/README.md
@@ -1,7 +1,7 @@
 # RP2040 USB-VALIDATION
 
 CDC-ACM echo test for the RP USBv1 low level driver (shared by RP2040 and
-RP2040). The firmware enumerates as a virtual COM port and echoes back every
+RP2350). The firmware enumerates as a virtual COM port and echoes back every
 byte it receives; a host script drives echo and reset stress legs against it.
 
 The transfer sizes are chosen to exercise the interesting LLD paths:
@@ -18,14 +18,14 @@ Build (requires arm-none-eabi-gcc):
 The build produces `build/ch.elf` and `build/ch.bin`. Flash either with
 openocd:
 
-    openocd -f interface/cmsis-dap.cfg -f target/rp2350.cfg \
+    openocd -f interface/cmsis-dap.cfg -f target/rp2040.cfg \
             -c "program build/ch.elf verify reset exit"
 
 or with picotool (device in BOOTSEL mode):
 
     picotool load -u -x build/ch.elf
 
-- USB: CDC-ACM on the Pico 2 micro-USB connector (EP1 bulk IN/OUT, EP2
+- USB: CDC-ACM on the Pico micro-USB connector (EP1 bulk IN/OUT, EP2
   interrupt IN). Shows up as `/dev/ttyACMx` on Linux.
 - Heartbeat/statistics: `usb: bytes=N resets=N state=N` on SIOD0
   (GPIO0 = TX, GPIO1 = RX, 38400-8-N-1) every 2 seconds.
@@ -36,7 +36,7 @@ or with picotool (device in BOOTSEL mode):
 Requires python3 and pyserial, nothing else.
 
 1. Flash the firmware.
-2. Plug the Pico 2 USB into the host, wait for the CDC ACM port to appear
+2. Plug the Pico USB into the host, wait for the CDC ACM port to appear
    (e.g. `/dev/ttyACM0`).
 3. Run:
 

--- a/testhal/RP/RP2040/USB-VALIDATION/host_check.py
+++ b/testhal/RP/RP2040/USB-VALIDATION/host_check.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Host-side checker for the RP2350 USB-VALIDATION CDC echo firmware.
+"""Host-side checker for the RP2040 USB-VALIDATION CDC echo firmware.
 
 Usage:
     python3 host_check.py /dev/ttyACM0

--- a/testhal/RP/RP2040/USB-VALIDATION/main.c
+++ b/testhal/RP/RP2040/USB-VALIDATION/main.c
@@ -24,7 +24,7 @@
  * IN transfers and bus reset handling.
  *
  * A heartbeat with transfer statistics is printed on SIOD0 (GPIO0 TX,
- * GPIO1 RX, 38400-8-N-1) once every 2 seconds. The Pico 2 LED toggles on
+ * GPIO1 RX, 38400-8-N-1) once every 2 seconds. The Pico LED toggles on
  * echo activity.
  *
  * Single-core, no SMP.

--- a/testhal/RP/RP2040/USB-VALIDATION/usbcfg.c
+++ b/testhal/RP/RP2040/USB-VALIDATION/usbcfg.c
@@ -15,7 +15,7 @@
 */
 
 /*
- * CDC-ACM configuration for the RP2350 USB validation test.
+ * CDC-ACM configuration for the RP2040 USB validation test.
  *
  * Descriptor set adapted from testhal/STM32/multi/USB_CDC/source/usbcfg.c,
  * endpoint configurations rewritten for the RP USBv1 USBEndpointConfig


### PR DESCRIPTION
Post-merge Copilot review follow-ups for MR #120.

- RP2040 USB-VALIDATION: corrects seven RP2350/Pico 2 references copied from the RP2350 app, including the wrong OpenOCD target config in the README flash instructions, wrong chip names in the usbcfg.c/host_check.py headers, and the "shared by RP2040 and RP2040" typo.
- hal_usb_lld.c: moves the buf_len declaration in usb_prepare_out_ep_buffer() to the block start per house declaration style.

Validation @ a89c312fc8 on the bench Pico: heartbeat leg PASS, host_check.py echo leg PASS (10 sizes x 50 rounds, 0 failures), reset leg PASS (degraded, close/open only). RP2350 build + uncabled heartbeat PASS on the Pico 2. Local CodeRabbit and Codex passes clean.