### PR TITLE
RP RTCv1: correct the documented alarm identifier range

### DIFF
--- a/os/hal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
+++ b/os/hal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
@@ -236,7 +236,7 @@ void rtc_lld_get_time(RTCDriver *rtcp, RTCDateTime *timespec) {
  * @note    The function can be called from any context.
  *
  * @param[in] rtcp      pointer to RTC driver structure.
- * @param[in] alarm     alarm identifier. Can only be 0.
+ * @param[in] alarm     alarm identifier. Can be 0.
  * @param[in] alarmspec pointer to a @p RTCAlarm structure or @p NULL.
  *
  * @notapi

--- a/os/hal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
+++ b/os/hal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
@@ -236,7 +236,7 @@ void rtc_lld_get_time(RTCDriver *rtcp, RTCDateTime *timespec) {
  * @note    The function can be called from any context.
  *
  * @param[in] rtcp      pointer to RTC driver structure.
- * @param[in] alarm     alarm identifier. Can be 1.
+ * @param[in] alarm     alarm identifier. Can only be 0.
  * @param[in] alarmspec pointer to a @p RTCAlarm structure or @p NULL.
  *
  * @notapi


### PR DESCRIPTION
Post-merge Copilot review follow-up for MR #113.

The rtc_lld_set_alarm() Doxygen said the alarm identifier "Can be 1", but RTC_ALARMS is 1 and rtcSetAlarm() checks alarm < RTC_ALARMS, so the only valid identifier is 0. Wording follows the STM32 RTCv2 convention.

Validation @ 4e57b7e74d on the bench Pico: RTC-VALIDATION 8/8 PASS. Local CodeRabbit and Codex passes clean.