### PR TITLE
RP EFL: align XIP-restore and translation documentation with the code

### DIFF
--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -561,13 +561,13 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
  *          convention will not work with this driver.
  *
  * @param[in] eflp      pointer to the EFlashDriver object
- * @return              @p true on success, @p false on failure (the
- *                      restore still proceeds, XIP must come back no
- *                      matter what).
+ * @return              always @p true, the RP2040 restore sequence has
+ *                      no detectable failure mode. The bool signature
+ *                      mirrors the RP2350 driver, where the QMI address
+ *                      translation can fail.
  */
 RAMFUNC static bool rp_flash_enter_xip(EFlashDriver *eflp) {
   PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
-  bool ok = true;
   (void)eflp;
 
   /* Reset CS control to normal. */
@@ -594,7 +594,7 @@ RAMFUNC static bool rp_flash_enter_xip(EFlashDriver *eflp) {
 
   rp_flash_flush_cache();
 
-  return ok;
+  return true;
 }
 
 /**

--- a/os/hal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2040/hal_efl_lld.c
@@ -563,8 +563,8 @@ RAMFUNC static bool rp_flash_exit_xip(EFlashDriver *eflp) {
  * @param[in] eflp      pointer to the EFlashDriver object
  * @return              always @p true, the RP2040 restore sequence has
  *                      no detectable failure mode. The bool signature
- *                      mirrors the RP2350 driver, where the QMI address
- *                      translation can fail.
+ *                      mirrors the RP2350 driver, where the final QMI
+ *                      direct-mode idle wait can time out.
  */
 RAMFUNC static bool rp_flash_enter_xip(EFlashDriver *eflp) {
   PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -865,9 +865,11 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
  *
  * @param[in] qmi       pointer to the QMI registers
  * @param[in] offset    logical offset within the XIP address space
+ * @param[in] length    length of the operation starting at @p offset
  * @param[out] physp    translated physical flash offset
- * @return              true on success, false if the offset falls
- *                      outside the mapped size of its 4 MiB window.
+ * @return              true on success, false if any part of the
+ *                      [offset, offset + length) extent falls outside
+ *                      the mapped size of its 4 MiB window.
  */
 static bool rp_flash_translate(QMI_TypeDef *qmi, uint32_t offset,
                                uint32_t length, uint32_t *physp) {

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/efl_smp_lockout.h
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/efl_smp_lockout.h
@@ -30,7 +30,6 @@ extern volatile uint32_t c1_cycles;
 extern volatile uint32_t c1_errors;
 extern volatile uint32_t c1_go;
 extern volatile uint32_t c1_done;
-extern volatile uint32_t fastirq_count;
 
 extern semaphore_t c1_ready_sem;
 


### PR DESCRIPTION
Post-merge Copilot review follow-ups for MRs #115 and #116.

- RP2350 hal_efl_lld.c: documents the length parameter and extent semantics of rp_flash_translate().
- RP2040 hal_efl_lld.c: rp_flash_enter_xip() documented a false return it could never produce; the doc now states the restore sequence has no detectable failure mode, the never-written ok local is dropped, and the bool signature is kept to mirror the RP2350 driver (whose final QMI direct-mode idle wait can time out).
- RP2040 EFL-SMP-LOCKOUT: drops an unused fastirq_count extern carried over from the RP2350 test.

Validation @ 41475916ef: XIP-VALIDATION 13/13 and EFL-SMP-LOCKOUT 7/7 PASS on the bench Pico; RP2350 XIP-VALIDATION 14/14 PASS on the Pico 2. Local CodeRabbit clean; one Codex wording finding incorporated (41475916ef).