### PR TITLE
RP2040: clean PLL misconfiguration diagnostics and runtime validation

### DIFF
--- a/os/hal/ports/RP/RP2040/hal_lld.h
+++ b/os/hal/ports/RP/RP2040/hal_lld.h
@@ -138,92 +138,60 @@
 #endif
 
 /*
- * PLL_SYS configuration checks.
+ * PLL_SYS configuration checks. The checks form a single chain so that
+ * a derived check dividing by a parameter is never evaluated while that
+ * parameter is out of range: a stray "division by zero in #if"
+ * diagnostic would bury the intended message.
  */
 #if (RP_PLL_SYS_REFDIV < 1) || (RP_PLL_SYS_REFDIV > 63)
 #error "RP_PLL_SYS_REFDIV out of valid range (1-63)"
-#endif
-
-#if (RP_PLL_SYS_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                          \
-    (RP_PLL_SYS_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#elif (RP_PLL_SYS_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_SYS_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
 #error "RP_PLL_SYS_VCO_FREQ out of valid range (750-1600 MHz)"
-#endif
-
-#if (RP_PLL_SYS_POSTDIV1 < 1) || (RP_PLL_SYS_POSTDIV1 > 7)
+#elif (RP_PLL_SYS_POSTDIV1 < 1) || (RP_PLL_SYS_POSTDIV1 > 7)
 #error "RP_PLL_SYS_POSTDIV1 out of valid range (1-7)"
-#endif
-
-#if (RP_PLL_SYS_POSTDIV2 < 1) || (RP_PLL_SYS_POSTDIV2 > 7)
+#elif (RP_PLL_SYS_POSTDIV2 < 1) || (RP_PLL_SYS_POSTDIV2 > 7)
 #error "RP_PLL_SYS_POSTDIV2 out of valid range (1-7)"
-#endif
-
-#if RP_PLL_SYS_POSTDIV1 < RP_PLL_SYS_POSTDIV2
+#elif RP_PLL_SYS_POSTDIV1 < RP_PLL_SYS_POSTDIV2
 #error "RP_PLL_SYS_POSTDIV1 must be >= RP_PLL_SYS_POSTDIV2"
-#endif
-
-#if (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
+#elif (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
 #error "RP_XOSCCLK is not divisible by RP_PLL_SYS_REFDIV"
-#endif
-
-#if (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
+#elif (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
 #error "PLL_SYS reference frequency below 5 MHz minimum"
-#endif
-
-#if (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
 #error "RP_PLL_SYS_VCO_FREQ is not an integer multiple of the PLL_SYS reference frequency"
-#endif
-
-#if ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||      \
-    ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
+#elif ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||    \
+      ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
 #error "PLL_SYS FBDIV out of valid range (16-320)"
-#endif
-
-#if (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
 #error "RP_PLL_SYS_VCO_FREQ is not divisible by RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2"
 #endif
 
 /*
- * PLL_USB configuration checks.
+ * PLL_USB configuration checks, chained for the same reason as the
+ * PLL_SYS checks above.
  */
 #if (RP_PLL_USB_REFDIV < 1) || (RP_PLL_USB_REFDIV > 63)
 #error "RP_PLL_USB_REFDIV out of valid range (1-63)"
-#endif
-
-#if (RP_PLL_USB_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                          \
-    (RP_PLL_USB_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#elif (RP_PLL_USB_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_USB_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
 #error "RP_PLL_USB_VCO_FREQ out of valid range (750-1600 MHz)"
-#endif
-
-#if (RP_PLL_USB_POSTDIV1 < 1) || (RP_PLL_USB_POSTDIV1 > 7)
+#elif (RP_PLL_USB_POSTDIV1 < 1) || (RP_PLL_USB_POSTDIV1 > 7)
 #error "RP_PLL_USB_POSTDIV1 out of valid range (1-7)"
-#endif
-
-#if (RP_PLL_USB_POSTDIV2 < 1) || (RP_PLL_USB_POSTDIV2 > 7)
+#elif (RP_PLL_USB_POSTDIV2 < 1) || (RP_PLL_USB_POSTDIV2 > 7)
 #error "RP_PLL_USB_POSTDIV2 out of valid range (1-7)"
-#endif
-
-#if RP_PLL_USB_POSTDIV1 < RP_PLL_USB_POSTDIV2
+#elif RP_PLL_USB_POSTDIV1 < RP_PLL_USB_POSTDIV2
 #error "RP_PLL_USB_POSTDIV1 must be >= RP_PLL_USB_POSTDIV2"
-#endif
-
-#if (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
+#elif (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
 #error "RP_XOSCCLK is not divisible by RP_PLL_USB_REFDIV"
-#endif
-
-#if (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
+#elif (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
 #error "PLL_USB reference frequency below 5 MHz minimum"
-#endif
-
-#if (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
+#elif (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
 #error "RP_PLL_USB_VCO_FREQ is not an integer multiple of the PLL_USB reference frequency"
-#endif
-
-#if ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||      \
-    ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
+#elif ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||    \
+      ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
 #error "PLL_USB FBDIV out of valid range (16-320)"
-#endif
-
-#if (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
+#elif (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
 #error "RP_PLL_USB_VCO_FREQ is not divisible by RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2"
 #endif
 

--- a/os/hal/ports/RP/RP2040/rp_pll.c
+++ b/os/hal/ports/RP/RP2040/rp_pll.c
@@ -69,12 +69,11 @@
 void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
                  uint32_t postdiv1, uint32_t postdiv2) {
 
-  uint32_t ref_freq, fbdiv;
-  uint32_t pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
+  uint32_t ref_freq, fbdiv, pdiv;
 
-  /* Parameters are asserted before any derived value is computed, a
-     zero or non-dividing REFDIV would otherwise truncate the derived
-     values first and the asserts would misdiagnose the problem. */
+  /* Raw parameters are asserted before anything is derived from them,
+     a zero REFDIV would otherwise fault on the division below before
+     any assert had fired. */
   osalDbgAssert(refdiv >= 1U && refdiv <= 63U, "REFDIV out of range");
   osalDbgAssert((RP_XOSCCLK % refdiv) == 0U, "XOSC not divisible by REFDIV");
   osalDbgAssert(vco_freq >= RP_PLL_VCO_MIN_FREQ &&
@@ -82,6 +81,8 @@ void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
                 "VCO frequency out of range");
   osalDbgAssert(postdiv1 >= 1U && postdiv1 <= 7U, "POSTDIV1 out of range");
   osalDbgAssert(postdiv2 >= 1U && postdiv2 <= 7U, "POSTDIV2 out of range");
+
+  pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
 
   ref_freq = RP_XOSCCLK / refdiv;
   osalDbgAssert(ref_freq >= 5000000U, "reference frequency below 5 MHz");

--- a/os/hal/ports/RP/RP2040/rp_pll.c
+++ b/os/hal/ports/RP/RP2040/rp_pll.c
@@ -81,6 +81,7 @@ void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
                 "VCO frequency out of range");
   osalDbgAssert(postdiv1 >= 1U && postdiv1 <= 7U, "POSTDIV1 out of range");
   osalDbgAssert(postdiv2 >= 1U && postdiv2 <= 7U, "POSTDIV2 out of range");
+  osalDbgAssert(postdiv1 >= postdiv2, "POSTDIV1 must be >= POSTDIV2");
 
   pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
 
@@ -92,6 +93,8 @@ void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
 
   fbdiv = vco_freq / ref_freq;
   osalDbgAssert(fbdiv >= 16U && fbdiv <= 320U, "FBDIV out of range");
+  osalDbgAssert((vco_freq % (postdiv1 * postdiv2)) == 0U,
+                "VCO frequency not divisible by POSTDIV1*POSTDIV2");
 
   /* Check if PLL is already configured */
   if ((pll->CS & PLL_CS_LOCK) &&

--- a/os/hal/ports/RP/RP2040/rp_pll.c
+++ b/os/hal/ports/RP/RP2040/rp_pll.c
@@ -69,21 +69,28 @@
 void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
                  uint32_t postdiv1, uint32_t postdiv2) {
 
-  uint32_t ref_freq = RP_XOSCCLK / refdiv;
-  uint32_t fbdiv = vco_freq / ref_freq;
+  uint32_t ref_freq, fbdiv;
   uint32_t pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
 
+  /* Parameters are asserted before any derived value is computed, a
+     zero or non-dividing REFDIV would otherwise truncate the derived
+     values first and the asserts would misdiagnose the problem. */
+  osalDbgAssert(refdiv >= 1U && refdiv <= 63U, "REFDIV out of range");
+  osalDbgAssert((RP_XOSCCLK % refdiv) == 0U, "XOSC not divisible by REFDIV");
   osalDbgAssert(vco_freq >= RP_PLL_VCO_MIN_FREQ &&
                 vco_freq <= RP_PLL_VCO_MAX_FREQ,
                 "VCO frequency out of range");
-  osalDbgAssert((RP_XOSCCLK % refdiv) == 0U, "XOSC not divisible by REFDIV");
-  osalDbgAssert(ref_freq >= 5000000U, "reference frequency below 5 MHz");
-  osalDbgAssert(fbdiv >= 16U && fbdiv <= 320U, "FBDIV out of range");
-  osalDbgAssert((ref_freq * fbdiv) == vco_freq,
-                "VCO not an integer multiple of reference");
   osalDbgAssert(postdiv1 >= 1U && postdiv1 <= 7U, "POSTDIV1 out of range");
   osalDbgAssert(postdiv2 >= 1U && postdiv2 <= 7U, "POSTDIV2 out of range");
+
+  ref_freq = RP_XOSCCLK / refdiv;
+  osalDbgAssert(ref_freq >= 5000000U, "reference frequency below 5 MHz");
   osalDbgAssert(ref_freq <= (vco_freq / 16U), "Reference frequency too high");
+  osalDbgAssert((vco_freq % ref_freq) == 0U,
+                "VCO not an integer multiple of reference");
+
+  fbdiv = vco_freq / ref_freq;
+  osalDbgAssert(fbdiv >= 16U && fbdiv <= 320U, "FBDIV out of range");
 
   /* Check if PLL is already configured */
   if ((pll->CS & PLL_CS_LOCK) &&


### PR DESCRIPTION
Post-merge Copilot review follow-ups for MR #119.

- hal_lld.h: converts the PLL_SYS/PLL_USB configuration checks to chained #elif so a REFDIV misconfigured as 0 produces only the intended #error instead of five additional "division by zero in #if" diagnostics (mirrors the RP2350 hal_lld.h pattern). Compile-negative verified: REFDIV=0 yields a single clean error on this branch vs 9 error lines on master.
- rp_pll.c: rp_pll_init() asserted constraints only after dividing by refdiv and the derived reference; raw parameters are now asserted first (including the previously unchecked REFDIV range), each value is derived only after what it divides by is validated, and divisibility is tested as vco_freq % ref_freq. The post-divider ordering and VCO/post-divider divisibility constraints, already enforced at compile time for in-tree call sites, are mirrored as debug asserts.

Validation: UART-VALIDATION PASS (clean output at exactly 115200) on the bench Pico at 3b99b30678 and re-run at 3811cb9b5b. Local Codex nit and CodeRabbit round-2 finding both incorporated as visible commits.