### PR TITLE
RP SPIv1: spell out the supported select modes in the config error

### DIFF
--- a/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.h
+++ b/os/hal/ports/RP/LLD/SPIv1/hal_spi_lld.h
@@ -98,7 +98,7 @@
    this check the mode would compile into silent no-ops and a caller could
    believe chip select was asserted while no pin changed.*/
 #if SPI_SELECT_MODE == SPI_SELECT_MODE_LLD
-#error "SPI_SELECT_MODE_LLD is not implemented by the RP SPI driver, use SPI_SELECT_MODE_LINE, _PORT, _PAD or _NONE"
+#error "SPI_SELECT_MODE_LLD is not implemented by the RP SPI driver, use SPI_SELECT_MODE_LINE, SPI_SELECT_MODE_PORT, SPI_SELECT_MODE_PAD or SPI_SELECT_MODE_NONE"
 #endif
 
 /* Device selection checks.*/


### PR DESCRIPTION
Post-merge Copilot review follow-up for MR #114.

The select-mode #error abbreviated the alternatives as _PORT, _PAD and _NONE, which are not real macro names a user can search for; the four macros are now named in full.

Compile-negative verified: forcing SPI_SELECT_MODE_LLD emits the new full-macro message. Compile-only by design, matching MR #114. Local CodeRabbit and Codex passes clean.