### PR TITLE
STM32H7xx: preserve overdrive during HAL initialization

### DIFF
--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.c
@@ -177,7 +177,10 @@ void hal_lld_init(void) {
   __rccResetAPB1H(~0);
   __rccResetAPB2(~0);
   __rccResetAPB3(~0);
-  __rccResetAPB4(~0);
+  /* SYSCFG is not reset because SYSCFG_PWRCR holds the ODEN bit set by
+     stm32_clock_init(). Resetting it here drops the core out of overdrive
+     while the PLL keeps running above STM32_SYSCLK_MAX_NOBOOST.*/
+  __rccResetAPB4(~RCC_APB4RSTR_SYSCFGRST);
 #endif /* STM32_NO_INIT == FALSE */
 
   /* DMA subsystems initialization.*/

--- a/os/xhal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/xhal/ports/STM32/STM32H7xx/hal_lld.c
@@ -177,7 +177,10 @@ void hal_lld_init(void) {
   __rccResetAPB1H(~0);
   __rccResetAPB2(~0);
   __rccResetAPB3(~0);
-  __rccResetAPB4(~0);
+  /* SYSCFG is not reset because SYSCFG_PWRCR holds the ODEN bit set by
+     stm32_clock_init(). Resetting it here drops the core out of overdrive
+     while the PLL keeps running above STM32_SYSCLK_MAX_NOBOOST.*/
+  __rccResetAPB4(~RCC_APB4RSTR_SYSCFGRST);
 #endif /* STM32_NO_INIT == FALSE */
 
   /* DMA subsystems initialization.*/

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,11 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: STM32H7xx HAL initialization reset the SYSCFG block, clearing the
+       overdrive enable (SYSCFG_PWRCR ODEN) set during clock initialization
+       and dropping the core out of overdrive while the PLL kept running above
+       the no-boost maximum. SYSCFG is no longer reset during hal_lld_init()
+       (github PR #132)(backported to 21.11.6).
 - NEW: SB sandbox VFS root is now optional and explicitly externally owned.
        sbSetFileSystem() is renamed sbSetRoot() and a matching sbGetRoot()
        accessor is added. A NULL root is allowed, leaving the sandbox without


### PR DESCRIPTION
## Summary

- keep SYSCFG out of the APB4 peripheral reset performed by `hal_lld_init()`
- preserve `SYSCFG_PWRCR.ODEN`, which is configured earlier by `stm32_clock_init()`
- apply the fix consistently to HAL and XHAL

Without this exclusion, H7 type-1 devices configured above `STM32_SYSCLK_MAX_NOBOOST` continue running at the overdrive frequency after ODEN has been cleared. This was identified and measured in [ArduPilot/ChibiOS#107](https://github.com/ArduPilot/ChibiOS/pull/107).

## Validation

- STM32H755ZI 480 MHz HAL demo builds with `-Werror`
- STM32H735IG XHAL demo builds with `-Werror`
- repository whitespace checks pass