### PR TITLE
STM32H7xx: preserve overdrive during HAL initialization [21.11]

### DIFF
--- a/os/hal/ports/STM32/STM32H7xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32H7xx/hal_lld.c
@@ -177,7 +177,10 @@ void hal_lld_init(void) {
   __rccResetAPB1H(~0);
   __rccResetAPB2(~0);
   __rccResetAPB3(~0);
-  __rccResetAPB4(~0);
+  /* SYSCFG is not reset because SYSCFG_PWRCR holds the ODEN bit set by
+     stm32_clock_init(). Resetting it here drops the core out of overdrive
+     while the PLL keeps running above STM32_SYSCLK_MAX_NOBOOST.*/
+  __rccResetAPB4(~RCC_APB4RSTR_SYSCFGRST);
 #endif /* STM32_NO_INIT == FALSE */
 
   /* DMA subsystems initialization.*/

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,11 @@
 *****************************************************************************
 
 *** 21.11.6 ***
+- FIX: STM32H7xx HAL initialization reset the SYSCFG block, clearing the
+       overdrive enable (SYSCFG_PWRCR ODEN) set during clock initialization
+       and dropping the core out of overdrive while the PLL kept running above
+       the no-boost maximum. SYSCFG is no longer reset during hal_lld_init()
+       (backport of github PR #132).
 - FIX: STM32 USBv1 packet memory could be double-allocated across a
        configuration rebuild. usb_lld_disable_endpoints() reset the PMA
        allocator to the descriptor-table boundary while endpoint zero


### PR DESCRIPTION
## Summary

Backport the STM32H7 SYSCFG reset fix to `stable-21.11.x`. `hal_lld_init()` no longer resets SYSCFG after `stm32_clock_init()` has configured `SYSCFG_PWRCR.ODEN`, preventing 480 MHz configurations from losing overdrive while retaining their PLL frequency.

The issue was identified and measured in [ArduPilot/ChibiOS#107](https://github.com/ArduPilot/ChibiOS/pull/107).

## Validation

- STM32H755ZI 480 MHz HAL demo builds with `-Werror`
- repository whitespace checks pass