### PR TITLE
Clock tree: support extra mux input bits

### DIFF
--- a/os/hal/ports/STM32/STM32G4xx_TEST/cfg/clocktree.xml
+++ b/os/hal/ports/STM32/STM32G4xx_TEST/cfg/clocktree.xml
@@ -390,9 +390,15 @@
       <description>RTC</description>
       <mux name="RTCSEL" field="RCC_BDCR_RTCSEL" offset="8U">
         <input point="NONE" label="NOCLOCK" encoding="0U" default="yes" />
-        <input point="LSE" encoding="1U" />
-        <input point="LSI" encoding="2U" />
-        <input point="HSEDIV" encoding="3U" />
+        <input point="LSE" encoding="1U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="LSI" encoding="2U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="HSEDIV" encoding="3U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
       </mux>
     </clock>
     <clock point="USART1" enable="always" dynamic="no">

--- a/os/hal/ports/STM32/STM32G4xx_TEST/clocktree.h
+++ b/os/hal/ports/STM32/STM32G4xx_TEST/clocktree.h
@@ -2081,19 +2081,22 @@
   #endif
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSE)
   #if (STM32_RTC_ENABLED == TRUE) || defined(__DOXYGEN__)
-    #define STM32_RTC_BITS                  RCC_BDCR_RTCSEL_LSE
+    #define STM32_RTC_BITS                  (RCC_BDCR_RTCSEL_LSE |          \
+                                             RCC_BDCR_RTCEN)
   #else
     #define STM32_RTC_BITS                  0U
   #endif
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSI)
   #if (STM32_RTC_ENABLED == TRUE) || defined(__DOXYGEN__)
-    #define STM32_RTC_BITS                  RCC_BDCR_RTCSEL_LSI
+    #define STM32_RTC_BITS                  (RCC_BDCR_RTCSEL_LSI |          \
+                                             RCC_BDCR_RTCEN)
   #else
     #define STM32_RTC_BITS                  0U
   #endif
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_HSEDIV)
   #if (STM32_RTC_ENABLED == TRUE) || defined(__DOXYGEN__)
-    #define STM32_RTC_BITS                  RCC_BDCR_RTCSEL_HSEDIV
+    #define STM32_RTC_BITS                  (RCC_BDCR_RTCSEL_HSEDIV |       \
+                                             RCC_BDCR_RTCEN)
   #else
     #define STM32_RTC_BITS                  0U
   #endif

--- a/os/hal/ports/STM32/STM32U3xx_TEST/cfg/clocktree.xml
+++ b/os/hal/ports/STM32/STM32U3xx_TEST/cfg/clocktree.xml
@@ -754,9 +754,15 @@
       <description>RTC clock</description>
       <mux name="RTC" field="RCC_BDCR_RTCSEL" offset="8U">
         <input point="NONE" label="NOCLOCK" encoding="0U" default="yes" />
-        <input point="LSE" encoding="1U" />
-        <input point="LSI" encoding="2U" />
-        <input point="HSEDIV" encoding="3U" />
+        <input point="LSE" encoding="1U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="LSI" encoding="2U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="HSEDIV" encoding="3U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
       </mux>
     </clock>
     <clock point="LSCO" enable="always" dynamic="no">

--- a/os/hal/ports/STM32/STM32U3xx_TEST/clocktree.h
+++ b/os/hal/ports/STM32/STM32U3xx_TEST/clocktree.h
@@ -4253,11 +4253,14 @@
 #if (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_NOCLOCK
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSE)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_LSE
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_LSE |          \
+                                             RCC_BDCR_RTCEN)
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSI)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_LSI
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_LSI |          \
+                                             RCC_BDCR_RTCEN)
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_HSEDIV)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_HSEDIV
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_HSEDIV |       \
+                                             RCC_BDCR_RTCEN)
 #else
   #error "invalid STM32_CFG_RTC_SEL value specified"
 #endif

--- a/os/hal/ports/STM32/STM32U5xx/cfg/clocktree.xml
+++ b/os/hal/ports/STM32/STM32U5xx/cfg/clocktree.xml
@@ -976,9 +976,15 @@
       <description>RTC and TAMP clock</description>
       <mux name="RTC" field="RCC_BDCR_RTCSEL" offset="8U">
         <input point="NONE" label="NOCLOCK" encoding="0U" default="yes" />
-        <input point="LSE" encoding="1U" />
-        <input point="LSI" encoding="2U" />
-        <input point="HSEDIV" encoding="3U" />
+        <input point="LSE" encoding="1U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="LSI" encoding="2U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="HSEDIV" encoding="3U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
       </mux>
     </clock>
     <clock point="LSCO" enable="always" dynamic="no">

--- a/os/hal/ports/STM32/STM32U5xx/clocktree.h
+++ b/os/hal/ports/STM32/STM32U5xx/clocktree.h
@@ -3608,17 +3608,29 @@
 /**
  * @brief   TIMICSEL_HSI16_SOURCE sink demand state.
  */
-#define STM32_TIMICSEL_HSI16_SOURCE_DEMANDED (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK)
+#if (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK) || defined(__DOXYGEN__)
+  #define STM32_TIMICSEL_HSI16_SOURCE_DEMANDED TRUE
+#else
+  #define STM32_TIMICSEL_HSI16_SOURCE_DEMANDED FALSE
+#endif
 
 /**
  * @brief   TIMICSEL_MSIS_SOURCE sink demand state.
  */
-#define STM32_TIMICSEL_MSIS_SOURCE_DEMANDED (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK)
+#if (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK) || defined(__DOXYGEN__)
+  #define STM32_TIMICSEL_MSIS_SOURCE_DEMANDED TRUE
+#else
+  #define STM32_TIMICSEL_MSIS_SOURCE_DEMANDED FALSE
+#endif
 
 /**
  * @brief   TIMICSEL_MSIK_SOURCE sink demand state.
  */
-#define STM32_TIMICSEL_MSIK_SOURCE_DEMANDED (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK)
+#if (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK) || defined(__DOXYGEN__)
+  #define STM32_TIMICSEL_MSIK_SOURCE_DEMANDED TRUE
+#else
+  #define STM32_TIMICSEL_MSIK_SOURCE_DEMANDED FALSE
+#endif
 
 /**
  * @brief   USB sink demand state.
@@ -6755,11 +6767,14 @@
 #if (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_NOCLOCK
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSE)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_LSE
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_LSE |          \
+                                             RCC_BDCR_RTCEN)
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSI)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_LSI
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_LSI |          \
+                                             RCC_BDCR_RTCEN)
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_HSEDIV)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_HSEDIV
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_HSEDIV |       \
+                                             RCC_BDCR_RTCEN)
 #else
   #error "invalid STM32_CFG_RTC_SEL value specified"
 #endif

--- a/os/xhal/ports/STM32/STM32U5xx/cfg/clocktree.xml
+++ b/os/xhal/ports/STM32/STM32U5xx/cfg/clocktree.xml
@@ -976,9 +976,15 @@
       <description>RTC and TAMP clock</description>
       <mux name="RTC" field="RCC_BDCR_RTCSEL" offset="8U">
         <input point="NONE" label="NOCLOCK" encoding="0U" default="yes" />
-        <input point="LSE" encoding="1U" />
-        <input point="LSI" encoding="2U" />
-        <input point="HSEDIV" encoding="3U" />
+        <input point="LSE" encoding="1U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="LSI" encoding="2U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+        <input point="HSEDIV" encoding="3U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
       </mux>
     </clock>
     <clock point="LSCO" enable="always" dynamic="no">

--- a/os/xhal/ports/STM32/STM32U5xx/clocktree.h
+++ b/os/xhal/ports/STM32/STM32U5xx/clocktree.h
@@ -3608,17 +3608,29 @@
 /**
  * @brief   TIMICSEL_HSI16_SOURCE sink demand state.
  */
-#define STM32_TIMICSEL_HSI16_SOURCE_DEMANDED (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK)
+#if (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK) || defined(__DOXYGEN__)
+  #define STM32_TIMICSEL_HSI16_SOURCE_DEMANDED TRUE
+#else
+  #define STM32_TIMICSEL_HSI16_SOURCE_DEMANDED FALSE
+#endif
 
 /**
  * @brief   TIMICSEL_MSIS_SOURCE sink demand state.
  */
-#define STM32_TIMICSEL_MSIS_SOURCE_DEMANDED (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK)
+#if (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK) || defined(__DOXYGEN__)
+  #define STM32_TIMICSEL_MSIS_SOURCE_DEMANDED TRUE
+#else
+  #define STM32_TIMICSEL_MSIS_SOURCE_DEMANDED FALSE
+#endif
 
 /**
  * @brief   TIMICSEL_MSIK_SOURCE sink demand state.
  */
-#define STM32_TIMICSEL_MSIK_SOURCE_DEMANDED (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK)
+#if (STM32_CFG_TIMICSEL != RCC_CCIPR1_TIMICSEL_NOCLOCK) || defined(__DOXYGEN__)
+  #define STM32_TIMICSEL_MSIK_SOURCE_DEMANDED TRUE
+#else
+  #define STM32_TIMICSEL_MSIK_SOURCE_DEMANDED FALSE
+#endif
 
 /**
  * @brief   USB sink demand state.
@@ -6755,11 +6767,14 @@
 #if (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_NOCLOCK
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSE)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_LSE
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_LSE |          \
+                                             RCC_BDCR_RTCEN)
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_LSI)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_LSI
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_LSI |          \
+                                             RCC_BDCR_RTCEN)
 #elif (STM32_CFG_RTC_SEL == RCC_BDCR_RTCSEL_HSEDIV)
-  #define STM32_RTC_BITS                    RCC_BDCR_RTCSEL_HSEDIV
+  #define STM32_RTC_BITS                    (RCC_BDCR_RTCSEL_HSEDIV |       \
+                                             RCC_BDCR_RTCEN)
 #else
   #error "invalid STM32_CFG_RTC_SEL value specified"
 #endif

--- a/tools/ftl/libs/libclocks.ftlc
+++ b/tools/ftl/libs/libclocks.ftlc
@@ -870,27 +870,32 @@ function ParseClockPoint(clock, sourceonly, variants)
       local inputlabel = (input.@label[0]!inputpoint)?string
       local inputencoding = (input.@encoding[0]!"")?string
       local inputdefault = (input.@default[0]!"no")?string
-      if input.bits[0]??
-        if inputencoding != ""
-          stop ">>>> Input '" + inputpoint + "' mixes explicit bits and selector encoding in clock mux '" + clockname + "'"
-        endif
-        local inputbits = GetBitsValue(input)
-      else
-        if muxfield == "" || muxoffset == "" || inputencoding == ""
+      if inputencoding != ""
+        if muxfield == "" || muxoffset == ""
           stop ">>>> Missing selector encoding for input '" + inputpoint + "' in clock mux '" + clockname + "'"
         endif
-        local inputbits = GetGeneratedSelectorMacro(muxfield, inputlabel)
-        local muxselectors = muxselectors + [{"kind":"encoded", "field":muxfield, "macro":inputbits, "encoding":inputencoding, "offset":muxoffset}]
+        local inputvalue = GetGeneratedSelectorMacro(muxfield, inputlabel)
+        local muxselectors = muxselectors + [{"kind":"encoded", "field":muxfield, "macro":inputvalue, "encoding":inputencoding, "offset":muxoffset}]
+        if input.bits[0]??
+          local inputbits = "(" + inputvalue + " | " + GetBitsValue(input) + ")"
+        else
+          local inputbits = inputvalue
+        endif
+      elseif input.bits[0]??
+        local inputvalue = GetBitsValue(input)
+        local inputbits = inputvalue
+      else
+        stop ">>>> Missing selector encoding for input '" + inputpoint + "' in clock mux '" + clockname + "'"
       endif
-      if muxvalues?seq_contains(inputbits)
-        stop ">>>> Duplicate selector value '" + inputbits + "' in clock mux '" + clockname + "'"
+      if muxvalues?seq_contains(inputvalue)
+        stop ">>>> Duplicate selector value '" + inputvalue + "' in clock mux '" + clockname + "'"
       endif
-      local muxvalues = muxvalues + [inputbits]
+      local muxvalues = muxvalues + [inputvalue]
       if inputdefault == "yes"
-        local muxdefault = inputbits
+        local muxdefault = inputvalue
       endif
-      local muxinputs = muxinputs + [{"point":inputpoint, "bits":inputbits, "default":inputdefault}]
-      local muxbranches = muxbranches + [{"type":"input", "point":inputpoint, "value":inputbits, "bits":inputbits, "default":inputdefault, "condition":""}]
+      local muxinputs = muxinputs + [{"point":inputpoint, "value":inputvalue, "bits":inputbits, "default":inputdefault}]
+      local muxbranches = muxbranches + [{"type":"input", "point":inputpoint, "value":inputvalue, "bits":inputbits, "default":inputdefault, "condition":""}]
     endlist
     if muxinputs?size == 0
       stop ">>>> Missing input for clock mux '" + clockname + "'"
@@ -1531,7 +1536,7 @@ function GetDemandConditions(point)
       local selmacro = GetMuxSettingMacro(downstream)
       list downstream["inputs"] as input
         if input["point"] == point["name"]
-          local conditions = conditions + [{"demander":downstream["name"], "terms":[enmacro + " == TRUE", selmacro + " == " + input["bits"]], "requires":AddExternalMacroRequirements(["TRUE"], [input["bits"]])}]
+          local conditions = conditions + [{"demander":downstream["name"], "terms":[enmacro + " == TRUE", selmacro + " == " + input["value"]], "requires":AddExternalMacroRequirements(["TRUE"], [input["value"]])}]
         endif
       endlist
     elseif downstream["type"] == "divider" || downstream["type"] == "multiplier"
@@ -2592,8 +2597,8 @@ macro EmitClockFrequencyChecks(point)
               emit "\e"
             endif
             local inputfreq = GetDefaultFrequencyExpression(input["point"])
-            local active = BuildAndExpression([enmacro + " == TRUE", selmacro + " == " + input["bits"]])
-            local requires = AddExternalMacroRequirements(["TRUE"], [input["bits"]])
+            local active = BuildAndExpression([enmacro + " == TRUE", selmacro + " == " + input["value"]])
+            local requires = AddExternalMacroRequirements(["TRUE"], [input["value"]])
             ppcode.EmitPPAssert(
               expression="!(" + active + ") || (" + inputfreq + " >= " + minval + ")",
               message="\"" + freqmacro + " below minimum frequency\"",
@@ -2615,8 +2620,8 @@ macro EmitClockFrequencyChecks(point)
               emit "\e"
             endif
             local inputfreq = GetDefaultFrequencyExpression(input["point"])
-            local active = BuildAndExpression([enmacro + " == TRUE", selmacro + " == " + input["bits"]])
-            local requires = AddExternalMacroRequirements(["TRUE"], [input["bits"]])
+            local active = BuildAndExpression([enmacro + " == TRUE", selmacro + " == " + input["value"]])
+            local requires = AddExternalMacroRequirements(["TRUE"], [input["value"]])
             ppcode.EmitPPAssert(
               expression="!(" + active + ") || (" + inputfreq + " <= " + maxval + ")",
               message="\"" + freqmacro + " above maximum frequency\"",
@@ -2922,7 +2927,7 @@ macro EmitClockFrequency(point)
     local clockmacro = GetClockCurrentMacro(point["name"])
     local enmacro = GetEnableMacro(point)
     list point["inputs"] as input
-      local condition = "(" + enmacro + " == TRUE) && (" + selmacro + " == " + input["bits"] + ")"
+      local condition = "(" + enmacro + " == TRUE) && (" + selmacro + " == " + input["value"] + ")"
       if input?is_first
         EmitStateCondition(keyword="#if", expression=condition, doxygen=true)
       else

--- a/tools/ftl/schema/clocks/README.md
+++ b/tools/ftl/schema/clocks/README.md
@@ -281,6 +281,20 @@ Use `NONE` inputs only for real selectable no-clock mux values, such as output
 pin clocks or backup-domain selectors that explicitly support a no-clock
 selection. Do not use `NONE` to model a disabled peripheral selector encoding.
 
+An encoded mux input can also emit additional register bits. The `encoding`
+generates the selector macro used by the configuration and dependency checks;
+the nested `bits` value is ORed with that selector only in the generated clock
+point bits macro:
+
+```xml
+<mux name="RTC" field="RCC_BDCR_RTCSEL" offset="8U">
+  <input point="NONE" label="NOCLOCK" encoding="0U" default="yes" />
+  <input point="LSE" encoding="1U">
+    <bits value="RCC_BDCR_RTCEN" />
+  </input>
+</mux>
+```
+
 If a disabled peripheral clock requires register selector bits, put those bits
 in clock-level disabled bits:
 

--- a/tools/ftl/tests/clocktree/valid/mux_generated_selector_extra_bits.xml
+++ b/tools/ftl/tests/clocktree/valid/mux_generated_selector_extra_bits.xml
@@ -1,0 +1,33 @@
+<clocktree>
+  <settings>
+    <prefixes clock_points="TCLK_" macros="TST_" cfgs="TST_CFG_" />
+    <suffixes frequency="_FREQ" values="_VALUE" bits="_BITS"
+              selector="_SEL" enable="_ENABLE" enabled="_ENABLED" />
+    <configs>
+      <config name="CLOCK_DYNAMIC" type="bool" default="FALSE"
+              role="dynamic_mode">
+        <description>Enables dynamic clock handling.</description>
+      </config>
+    </configs>
+  </settings>
+  <sources>
+    <source point="NONE" enable="never" dynamic="no" frequency="0U">
+      <description>pseudo-clock for disabled sources</description>
+    </source>
+  </sources>
+  <clocks>
+    <clock point="LSE" enable="always" dynamic="no">
+      <description>low speed oscillator</description>
+      <derived frequency="32768U" />
+    </clock>
+    <clock point="RTC" enable="always" dynamic="no">
+      <description>RTC clock</description>
+      <mux name="RTC" field="RCC_BDCR_RTCSEL" offset="8U">
+        <input point="NONE" label="NOCLOCK" encoding="0U" default="yes" />
+        <input point="LSE" encoding="1U">
+          <bits value="RCC_BDCR_RTCEN" />
+        </input>
+      </mux>
+    </clock>
+  </clocks>
+</clocktree>

--- a/tools/ftl/tests/clocktree/valid/mux_generated_selector_extra_bits.xml.checks
+++ b/tools/ftl/tests/clocktree/valid/mux_generated_selector_extra_bits.xml.checks
@@ -1,0 +1,7 @@
+# Encoded input values remain selector-only while emitted bits include extras.
+#define RCC_BDCR_RTCSEL_NOCLOCK            ((0U) << 8U)
+#define RCC_BDCR_RTCSEL_LSE                ((1U) << 8U)
+TST_CFG_RTC_SEL                   RCC_BDCR_RTCSEL_NOCLOCK
+#define TST_RTC_BITS                      RCC_BDCR_RTCSEL_NOCLOCK
+RCC_BDCR_RTCEN)
+ABSENT:TST_CFG_RTC_SEL                   (RCC_BDCR_RTCSEL_LSE | RCC_BDCR_RTCEN)


### PR DESCRIPTION
## Summary
- keep encoded mux selector values separate from branch register bits
- emit `RCC_BDCR_RTCEN` for active RTC selections on STM32U5, STM32U3_TEST, and STM32G4_TEST
- add generator documentation and a regression fixture for encoded inputs with extra bits
- regenerate HAL and XHAL clock-tree headers

## Testing
- `bash tools/ftl/tests/clocktree/run.sh`
- `make -f make/stm32u575zi_nucleo144.make USE_COPT=-Werror all` in `demos/STM32/RT-STM32-MULTI`
- `make -f make/stm32g474re_nucleo64_clocktree.make USE_COPT=-Werror all` in `demos/STM32/RT-STM32-MULTI`
- `make -f make/stm32u575zi_nucleo144.make USE_COPT=-Werror all` in `testxhal/ADC-GPT`
- `make -f make/stm32u385rg_nucleo64_clocktree.make all` in `demos/STM32/RT-STM32-MULTI`

The U3 target builds normally; its existing undefined MSI enable macro warnings prevent a clean `-Werror` build and are unrelated to this change.
