### PR TITLE
RP2040 testhal: port the dual-core PIO validation app

### DIFF
--- a/testhal/RP/RP2040/PIO-VALIDATION/Makefile
+++ b/testhal/RP/RP2040/PIO-VALIDATION/Makefile
@@ -1,0 +1,171 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m0plus
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv6-M/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2040_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       \
+       main.c c1_main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1 -DCRT0_EXTRA_CORES_NUMBER=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1 -DCRT0_EXTRA_CORES_NUMBER=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+
+#
+# Custom rules
+##############################################################################

--- a/testhal/RP/RP2040/PIO-VALIDATION/c1_main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/c1_main.c
@@ -1,0 +1,55 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+#include "pio_validation.h"
+
+/**
+ * Core 1 entry point.
+ */
+void c1_main(void) {
+
+  /*
+   * Starting a new OS instance running on this core, we need to wait for
+   * system initialization on the other side.
+   */
+  chSysWaitSystemState(ch_sys_running);
+  chInstanceObjectInit(&ch1, &ch_core1_cfg);
+
+  /* It is alive now.*/
+  chSysUnlock();
+
+  c1_ready = 1U;
+
+  /* Waiting for core 0 to hand over a state machine to be freed from
+     this core.*/
+  while (c1_do_free == 0U) {
+  }
+  __DMB();
+
+  /* Cross-core free of a state machine allocated by core 0.*/
+  chSysLock();
+  pioSmFreeI(xcore_smp);
+  chSysUnlock();
+
+  __DMB();                          /* Free's effects before the flag.*/
+  c1_free_done = 1U;
+
+  while (true) {
+  }
+}

--- a/testhal/RP/RP2040/PIO-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2040/PIO-VALIDATION/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     TRUE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2040/PIO-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2040/PIO-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 115200
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_LINE
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2040/PIO-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/PIO-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,65 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * RP2040_MCUCONF drivers configuration.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest (2 bits on Cortex-M0+).
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#define RP2040_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      TRUE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * PIO driver system settings.
+ * Note: the PIO helper driver has no per-block enable switches, it is
+ * compiled in whenever RP_PIO_REQUIRED is defined.
+ */
+#define RP_PIO_REQUIRED
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -1,0 +1,464 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP PIOv1 driver validation.
+ *
+ * Exercises the PIO state machine and instruction memory allocator:
+ *
+ * 1. JMP relocation: a relocatable square-wave program loaded at a
+ *    non-zero offset must have its program-relative JMP target adjusted
+ *    by the load offset. A "jmp 0" parking program pinned at address 0
+ *    makes the failure deterministic: without relocation the state
+ *    machine jumps to absolute address 0 and sticks there, the pin
+ *    never toggles.
+ * 2. Instruction memory allocation masks for a full 32-instruction
+ *    program (1U << 32 is undefined behavior, evaluating to 1 on ARM,
+ *    so an unfixed driver tracks a full-memory program with an empty
+ *    mask and lets further loads overlap it).
+ * 3. Block reset lifetime: loaded programs must survive freeing the
+ *    last state machine and loading must work before the first state
+ *    machine allocation (unfixed, the block is still held in reset and
+ *    the instruction memory writes are lost).
+ * 4. Cross-core free: a state machine allocated by core 0 and freed by
+ *    core 1 must actually be released so that all four state machines
+ *    of the block can be allocated again.
+ *
+ * The square wave is emitted on GPIO2 and read back through SIO GPIO_IN.
+ * The report is emitted on UART0 (GPIO0/GPIO1) at the SIO default
+ * configuration bitrate (115200-8-N-1, SIO_DEFAULT_BITRATE override in
+ * this project's halconf.h).
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#include "pio_validation.h"
+
+/*===========================================================================*/
+/* Shared state, plain SRAM is coherent between the RP2040 cores.            */
+/*===========================================================================*/
+
+volatile uint32_t c1_ready;
+volatile uint32_t c1_do_free;
+volatile uint32_t c1_free_done;
+const rp_pio_sm_t * volatile xcore_smp;
+
+/*===========================================================================*/
+/* Test parameters.                                                          */
+/*===========================================================================*/
+
+#define TEST_GPIO           2U
+#define TEST_IRQ_PRIORITY   3U
+
+/* State machine clock and measurement window.*/
+#define SM_TEST_FREQ        10000U      /* SM clock in Hz.                  */
+#define MEASURE_US          100000U     /* 100 ms sampling window.          */
+
+/* The square-wave program loops over 3 instructions producing 2 edges per
+   loop, expected edge count in the 100 ms window with a +/-30% margin.*/
+#define EXPECTED_EDGES      ((SM_TEST_FREQ / 10U) * 2U / 3U)
+#define EDGES_LO            ((EXPECTED_EDGES * 7U) / 10U)
+#define EDGES_HI            ((EXPECTED_EDGES * 13U) / 10U)
+
+/*===========================================================================*/
+/* PIO programs.                                                             */
+/*===========================================================================*/
+
+/*
+ * Relocatable square-wave program:
+ *   .wrap_target                       (not used, loops via jmp)
+ *     set pins, 1     ; 0xE001  111_00000_000_00001 (dest pins=000, data=1)
+ *     set pins, 0     ; 0xE000
+ *     jmp 0           ; 0x0000  000_00000_000_00000 (cond always, addr 0,
+ *                                program-relative, needs relocation)
+ */
+static const uint16_t sqwave_instructions[] = {
+  0xE001U,
+  0xE000U,
+  0x0000U
+};
+
+static const rp_pio_program_t sqwave_program = {
+  .instructions = sqwave_instructions,
+  .length       = 3U,
+  .origin       = -1
+};
+
+/*
+ * Parking program pinned at address 0: "jmp 0" spins forever at address 0,
+ * so an unrelocated JMP landing there sticks and the test pin stops
+ * toggling, which makes the discrimination deterministic.
+ */
+static const uint16_t park_instructions[] = {
+  0x0000U
+};
+
+static const rp_pio_program_t park_program = {
+  .instructions = park_instructions,
+  .length       = 1U,
+  .origin       = 0
+};
+
+/*
+ * 32 x nop (mov y, y = 0xA042: 101_00000_010_00_010) filling the whole
+ * instruction memory.
+ */
+static uint16_t nop32_instructions[RP_PIO_NUM_INSTR_MEM];
+
+static const rp_pio_program_t nop32_program = {
+  .instructions = nop32_instructions,
+  .length       = RP_PIO_NUM_INSTR_MEM,
+  .origin       = -1
+};
+
+/* Single nop program.*/
+static const uint16_t single_instructions[] = {
+  0xA042U
+};
+
+static const rp_pio_program_t single_program = {
+  .instructions = single_instructions,
+  .length       = 1U,
+  .origin       = -1
+};
+
+/*===========================================================================*/
+/* Report helpers.                                                           */
+/*===========================================================================*/
+
+static BaseSequentialStream *chp = (BaseSequentialStream *)&SIOD0;
+
+static unsigned pass_count;
+static unsigned fail_count;
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/*===========================================================================*/
+/* Measurement helpers.                                                      */
+/*===========================================================================*/
+
+static void delay_us(uint32_t us) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((uint32_t)(TIMER0->TIMERAWL - start) < us) {
+  }
+}
+
+/**
+ * @brief   Counts edges on TEST_GPIO by sampling SIO GPIO_IN for 100 ms.
+ */
+static uint32_t count_edges(void) {
+  uint32_t edges = 0U;
+  uint32_t start = TIMER0->TIMERAWL;
+  uint32_t prev = (SIO->GPIO_IN >> TEST_GPIO) & 1U;
+
+  while ((uint32_t)(TIMER0->TIMERAWL - start) < MEASURE_US) {
+    uint32_t cur = (SIO->GPIO_IN >> TEST_GPIO) & 1U;
+
+    if (cur != prev) {
+      edges++;
+      prev = cur;
+    }
+  }
+
+  return edges;
+}
+
+/**
+ * @brief   Samples the state machine PC and checks it stays in a window.
+ */
+static bool check_addr_window(const rp_pio_sm_t *smp,
+                              uint32_t lo, uint32_t hi) {
+  unsigned i;
+
+  for (i = 0U; i < 64U; i++) {
+    uint32_t addr = pioSmGetAddrX(smp);
+
+    if ((addr < lo) || (addr > hi)) {
+      return false;
+    }
+    delay_us(37U);
+  }
+
+  return true;
+}
+
+/*===========================================================================*/
+/* State machine setup.                                                      */
+/*===========================================================================*/
+
+/**
+ * @brief   Configures a state machine for the square-wave program and
+ *          starts it from @p offset.
+ */
+static void sqwave_start(const rp_pio_sm_t *smp, uint32_t offset) {
+
+  pioSmDisableX(smp);
+
+  /* SM clock, clkdiv computed from the system clock.*/
+  pioSmSetFrequencyX(smp, SM_TEST_FREQ);
+
+  /* Full-range wrap, the program loops via its own JMP.*/
+  pioSmSetExecctrlX(smp, PIO_SM_EXECCTRL_WRAP(0U, 31U));
+
+  /* Default shift directions.*/
+  pioSmSetShiftctrlX(smp, PIO_SM_SHIFTCTRL_IN_SHIFTDIR |
+                          PIO_SM_SHIFTCTRL_OUT_SHIFTDIR);
+
+  /* SET pin group: one pin based at TEST_GPIO.*/
+  pioSmSetPinctrlX(smp, (1U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                        (TEST_GPIO << PIO_SM_PINCTRL_SET_BASE_Pos));
+
+  /* Route the pad to the owning PIO block.*/
+  pioSmSetPinFunctionX(smp, TEST_GPIO);
+
+  /* Clean restart.*/
+  pioSmClearFifosX(smp);
+  pioClearDebugX(smp);
+  pioSmRestartX(smp);
+  pioSmClkdivRestartX(smp);
+
+  /* Pin direction to output: "set pindirs, 1" through the SET group.*/
+  pioSmExecX(smp, 0xE081U);
+
+  /* Jump to the program start and go.*/
+  pioSmSetPCX(smp, offset);
+  pioSmEnableX(smp);
+}
+
+/*===========================================================================*/
+/* Application entry point, core 0.                                          */
+/*===========================================================================*/
+
+int main(void) {
+  const rp_pio_block_t *block = RP_PIO0_BLOCK;
+  const rp_pio_sm_t *smp;
+  const rp_pio_sm_t *sms[RP_PIO_NUM_STATE_MACHINES];
+  int32_t park_off, sq_off, off32, off1;
+  uint32_t edges;
+  unsigned i;
+  bool ok;
+
+  halInit();
+  chSysInit();
+
+  /* UART0 console on GPIO0/GPIO1, halconf sets SIO default to 115200.*/
+  palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+
+  palSetLineMode(25U, PAL_MODE_OUTPUT_PUSHPULL);
+
+  /* Test pin: PIO0 function with pad input enable so that the generated
+     square wave can be read back through SIO GPIO_IN.*/
+  palSetLineMode(TEST_GPIO, PAL_MODE_ALTERNATE_PIO0);
+
+  chprintf(chp, "\r\n*** PIO validation\r\n");
+  chprintf(chp, "*** Expected edges per window: %u (%u..%u)\r\n",
+           EXPECTED_EDGES, EDGES_LO, EDGES_HI);
+
+  /* Waiting for core 1 to come alive.*/
+  while (c1_ready == 0U) {
+    chThdSleepMilliseconds(1);
+  }
+
+  /*
+   * Test 1: JMP relocation on program load.
+   */
+  chprintf(chp, "--- Test 1: JMP relocation\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+
+  park_off = pioProgramLoad(block, &park_program);
+  report("parking program pinned at 0", park_off == 0);
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("square wave loaded at nonzero offset", sq_off >= 1);
+
+  /* Dependent steps only run with valid prerequisites, a failed
+     allocation or load must not be dereferenced or used as an
+     offset.*/
+  if ((smp != NULL) && (park_off == 0) && (sq_off >= 1)) {
+    sqwave_start(smp, (uint32_t)sq_off);
+    edges = count_edges();
+    chprintf(chp, "      edges: %u\r\n", edges);
+    report("edge count in window", (edges >= EDGES_LO) && (edges <= EDGES_HI));
+    report("PC stays within program",
+           check_addr_window(smp, (uint32_t)sq_off, (uint32_t)sq_off + 2U));
+
+    pioSmDisableX(smp);
+  }
+  else {
+    report("edge count in window", false);
+    report("PC stays within program", false);
+    goto summary;
+  }
+
+  /*
+   * Test 2: full instruction memory allocation masks.
+   *
+   * Note: on Cortex-M the pre-fix undefined expression (1U << 32)
+   * happens to evaluate through a register LSL to the correct mask, so
+   * this leg regression-tests the behavior but cannot discriminate the
+   * undefined-behavior fix on this target; that is a compile-time
+   * property covered by UBSan/static analysis, not by this run.
+   */
+  chprintf(chp, "--- Test 2: 32-instruction masks\r\n");
+
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+  pioProgramUnload(block, park_off, park_program.length);
+
+  for (i = 0U; i < RP_PIO_NUM_INSTR_MEM; i++) {
+    nop32_instructions[i] = 0xA042U;    /* NOP encoded as mov y, y.*/
+  }
+
+  off32 = pioProgramLoad(block, &nop32_program);
+  report("32-instruction program loads at 0", off32 == 0);
+
+  off1 = pioProgramLoad(block, &single_program);
+  report("full memory rejects further load", off1 == -1);
+
+  /* Unloads and dependent steps are gated on their prerequisite loads,
+     a failed leg must be reported, not turned into a driver assert.*/
+  if (off32 >= 0) {
+    pioProgramUnload(block, off32, nop32_program.length);
+  }
+
+  off1 = pioProgramLoad(block, &single_program);
+  report("reload after unload succeeds", off1 >= 0);
+
+  if (off1 >= 0) {
+    pioProgramUnload(block, off1, single_program.length);
+  }
+
+  /*
+   * Test 3: block reset lifetime vs. instruction memory.
+   */
+  chprintf(chp, "--- Test 3: reset lifetime\r\n");
+
+  /* 3a: instruction memory must survive freeing the last state machine.*/
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("square wave reloaded", sq_off >= 0);
+  if (sq_off < 0) {
+    goto summary;
+  }
+
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges();
+  chprintf(chp, "      edges before free: %u\r\n", edges);
+  report("running before free", (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmFree(smp);                       /* Last SM of the block.*/
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 re-allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  /* Restart without reloading the program.*/
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges();
+  chprintf(chp, "      edges after realloc: %u\r\n", edges);
+  report("imem survives last SM free",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+
+  /* 3b: loading must work before any state machine is allocated.*/
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+  pioSmFree(smp);                       /* Block fully idle, gets reset.*/
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("load before first alloc accepted", sq_off >= 0);
+  if (sq_off < 0) {
+    goto summary;
+  }
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated after load", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges();
+  chprintf(chp, "      edges after early load: %u\r\n", edges);
+  report("load before first alloc works",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+
+  /*
+   * Test 4: cross-core free, core 1 frees a state machine allocated by
+   * core 0, afterwards all four state machines must be allocatable.
+   */
+  chprintf(chp, "--- Test 4: cross-core free\r\n");
+
+  xcore_smp = smp;                      /* SM0, allocated by core 0.*/
+  __DMB();
+  c1_do_free = 1U;
+
+  for (i = 0U; (c1_free_done == 0U) && (i < 1000U); i++) {
+    chThdSleepMilliseconds(1);
+  }
+  report("core 1 free completed", c1_free_done != 0U);
+
+  ok = true;
+  for (i = 0U; i < RP_PIO_NUM_STATE_MACHINES; i++) {
+    sms[i] = pioSmAlloc(block, RP_PIO_SM_ID_ANY, TEST_IRQ_PRIORITY,
+                        NULL, NULL);
+    if (sms[i] == NULL) {
+      ok = false;
+    }
+  }
+  report("all four SMs allocatable after cross-core free", ok);
+
+  for (i = 0U; i < RP_PIO_NUM_STATE_MACHINES; i++) {
+    if (sms[i] != NULL) {
+      pioSmFree(sms[i]);
+    }
+  }
+
+  /*
+   * Summary.
+   */
+summary:
+  chprintf(chp, "\r\nResults: %u pass, %u fail\r\n", pass_count, fail_count);
+  if (fail_count == 0U) {
+    chprintf(chp, "ALL TESTS PASSED\r\n");
+  }
+  else {
+    chprintf(chp, "*** FAILURES DETECTED ***\r\n");
+  }
+
+  while (true) {
+    palToggleLine(25U);
+    chThdSleepMilliseconds(500);
+  }
+}

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -26,9 +26,9 @@
  *    machine jumps to absolute address 0 and sticks there, the pin
  *    never toggles.
  * 2. Instruction memory allocation masks for a full 32-instruction
- *    program (1U << 32 is undefined behavior, evaluating to 1 on ARM,
- *    so an unfixed driver tracks a full-memory program with an empty
- *    mask and lets further loads overlap it).
+ *    program (1U << 32 is undefined behavior; depending on compiler
+ *    and target an unfixed driver can track a full-memory program with
+ *    a wrong mask and let further loads overlap it).
  * 3. Block reset lifetime: loaded programs must survive freeing the
  *    last state machine and loading must work before the first state
  *    machine allocation (unfixed, the block is still held in reset and

--- a/testhal/RP/RP2040/PIO-VALIDATION/pio_validation.h
+++ b/testhal/RP/RP2040/PIO-VALIDATION/pio_validation.h
@@ -1,0 +1,29 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * Shared state between the two cores of the PIO validation.
+ */
+
+#ifndef PIO_VALIDATION_H
+#define PIO_VALIDATION_H
+
+extern volatile uint32_t c1_ready;
+extern volatile uint32_t c1_do_free;
+extern volatile uint32_t c1_free_done;
+extern const rp_pio_sm_t * volatile xcore_smp;
+
+#endif /* PIO_VALIDATION_H */


### PR DESCRIPTION
Cross-chip testhal coverage, same pattern as the other two port MRs: JMP relocation at nonzero offset, full 32-instruction allocation, block-reset program lifetime and the cross-core state-machine free, running dual-core on the ARMv6-M SMP port (CRT0_EXTRA_CORES_NUMBER=1, RP_CORE1_START). PIO0 with 4 state machines and 32 instruction slots is common to both chips.

Bench validation on the Pico: 17/17 at the initial port and again at the final tip after review fixes (Codex: stale softfp/fpv5 FPU block dropped for the soft-float Cortex-M0+, mcuconf priority comment corrected to the 2-bit range, commit message no longer claims the 32-instruction leg runtime-discriminates the shift-UB fix). Local CodeRabbit: no findings.