### PR TITLE
RP PIOv1: sm_config builder, pin routing and DMA glue

### DIFF
--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
@@ -653,6 +653,41 @@ void pioProgramUnload(const rp_pio_block_t *block,
   osalSysUnlock();
 }
 
+/**
+ * @brief   Initializes a state machine with a configuration.
+ * @details Disables the state machine, applies the configuration, clears
+ *          the FIFOs and the FDEBUG flags, restarts the state machine and
+ *          its clock divider, then jumps to @p initial_pc. The FIFOs are
+ *          cleared after the configuration is applied so the configured
+ *          joining mode is preserved.
+ * @post    The state machine is left disabled; route pins and set pin
+ *          directions, then start it with @p pioSmEnableX().
+ * @note    Only registers private to the allocated state machine and the
+ *          atomic CTRL set/clear aliases are touched, so no locking is
+ *          required.
+ *
+ * @param[in] smp        pointer to a rp_pio_sm_t structure
+ * @param[in] initial_pc initial program counter, typically the offset
+ *                       returned by @p pioProgramLoad() (0..31)
+ * @param[in] cfgp       pointer to a rp_pio_sm_config_t structure
+ *
+ * @api
+ */
+void pioSmInit(const rp_pio_sm_t *smp, uint32_t initial_pc,
+               const rp_pio_sm_config_t *cfgp) {
+
+  osalDbgCheck((smp != NULL) && (cfgp != NULL) &&
+               (initial_pc < RP_PIO_NUM_INSTR_MEM));
+
+  pioSmDisableX(smp);
+  pioSmSetConfigX(smp, cfgp);
+  pioSmClearFifosX(smp);
+  pioClearDebugX(smp);
+  pioSmRestartX(smp);
+  pioSmClkdivRestartX(smp);
+  pioSmSetPCX(smp, initial_pc);
+}
+
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
 /**
  * @brief   Selects the GPIO window of a PIO block.

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -267,6 +267,21 @@ typedef struct {
 
 /**
  * @brief   PIO program descriptor.
+ * @note    Directly consumable from pioasm-generated headers compiled with
+ *          @p PICO_NO_HARDWARE=1: the generated instruction array becomes
+ *          @p instructions and the generated wrap defines are applied with
+ *          @p pioSmConfigSetWrapX() as "offset + name_wrap_target,
+ *          offset + name_wrap" where offset is the @p pioProgramLoad()
+ *          return value. What the stripped output does not carry must be
+ *          transcribed from the .pio source: the side-set parameters (one
+ *          @p pioSmConfigSetSidesetX() call mirroring the .side_set
+ *          directive) and a non-default .origin, which only appear in the
+ *          pico-sdk-only section of the generated header.
+ * @note    On devices with the @p RP_PIO_HAS_GPIOBASE capability a program
+ *          encoding absolute GPIO operands (notably WAIT GPIO) must be
+ *          assembled window-relative if the block runs with a non-zero
+ *          base, see @p pioGpioToRel(). This is a property of the
+ *          instruction encoding, no load-time adjustment can compensate.
  */
 typedef struct {
   const uint16_t        *instructions;  /**< @brief Instruction array.     */

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -274,6 +274,39 @@ typedef struct {
   int32_t               origin;         /**< @brief Load offset, -1 = any. */
 } rp_pio_program_t;
 
+/**
+ * @brief   PIO state machine configuration.
+ * @details Images of the four per-SM configuration registers, composed
+ *          with the @p pioSmConfig*() builder functions and applied with
+ *          @p pioSmSetConfigX() or @p pioSmInit().
+ */
+typedef struct {
+  uint32_t              clkdiv;         /**< @brief CLKDIV register image.  */
+  uint32_t              execctrl;       /**< @brief EXECCTRL register image.*/
+  uint32_t              shiftctrl;      /**< @brief SHIFTCTRL register image.*/
+  uint32_t              pinctrl;        /**< @brief PINCTRL register image. */
+} rp_pio_sm_config_t;
+
+/**
+ * @brief   FIFO joining modes.
+ */
+typedef enum {
+  RP_PIO_FIFO_JOIN_NONE = 0,            /**< @brief Two 4-deep FIFOs.      */
+  RP_PIO_FIFO_JOIN_TX   = 1,            /**< @brief 8-deep TX, no RX.      */
+  RP_PIO_FIFO_JOIN_RX   = 2             /**< @brief 8-deep RX, no TX.      */
+} rp_pio_fifo_join_t;
+
+/**
+ * @brief   MOV STATUS comparison sources.
+ */
+typedef enum {
+  RP_PIO_MOV_STATUS_TX_LESSTHAN = 0,    /**< @brief TX FIFO level < N.     */
+  RP_PIO_MOV_STATUS_RX_LESSTHAN = 1,    /**< @brief RX FIFO level < N.     */
+#if defined(RP2350) || defined(__DOXYGEN__)
+  RP_PIO_MOV_STATUS_IRQ_SET     = 2     /**< @brief IRQ flag N set.        */
+#endif
+} rp_pio_mov_status_t;
+
 /*===========================================================================*/
 /* Driver macros.                                                            */
 /*===========================================================================*/
@@ -321,6 +354,8 @@ extern "C" {
                           const rp_pio_program_t *program);
   void pioProgramUnload(const rp_pio_block_t *block,
                          int32_t offset, uint32_t length);
+  void pioSmInit(const rp_pio_sm_t *smp, uint32_t initial_pc,
+                 const rp_pio_sm_config_t *cfgp);
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
   void pioSetGpioBase(const rp_pio_block_t *block, uint32_t base);
 #endif
@@ -331,6 +366,367 @@ extern "C" {
 /*===========================================================================*/
 /* Driver inline functions.                                                  */
 /*===========================================================================*/
+
+/**
+ * @name    State machine configuration builders
+ * @details Pure data manipulation on a @p rp_pio_sm_config_t, callable
+ *          from any context; no hardware is accessed. Pin base fields are
+ *          window-relative (0..31): on devices with the
+ *          @p RP_PIO_HAS_GPIOBASE capability lower absolute GPIO numbers
+ *          with @p pioGpioToRel() first, elsewhere relative equals
+ *          absolute.
+ * @{
+ */
+
+/**
+ * @brief   Initializes a configuration with default values.
+ * @details Clock divider 1.0, wrap over the whole instruction memory,
+ *          both shift directions right, no autopush/autopull, FIFOs not
+ *          joined, no pins mapped.
+ *
+ * @param[out] cfgp     pointer to a rp_pio_sm_config_t structure
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigDefault(rp_pio_sm_config_t *cfgp) {
+
+  osalDbgCheck(cfgp != NULL);
+
+  cfgp->clkdiv    = PIO_SM_CLKDIV(1U, 0U);
+  cfgp->execctrl  = PIO_SM_EXECCTRL_WRAP(0U, 31U);
+  cfgp->shiftctrl = PIO_SM_SHIFTCTRL_IN_SHIFTDIR |
+                    PIO_SM_SHIFTCTRL_OUT_SHIFTDIR;
+  cfgp->pinctrl   = 0U;
+}
+
+/**
+ * @brief   Sets the program wrap range.
+ * @note    Both values are absolute instruction memory addresses: when the
+ *          program is loaded at a non-zero offset add the value returned
+ *          by @p pioProgramLoad() to the program's wrap_target/wrap
+ *          labels. JMP targets inside the program are relocated by the
+ *          loader but the wrap range is part of the SM configuration.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] bottom    address to wrap from, i.e. wrap_target (0..31)
+ * @param[in] top       address to wrap after, i.e. wrap (0..31)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetWrap(rp_pio_sm_config_t *cfgp,
+                                        uint32_t bottom, uint32_t top) {
+
+  osalDbgCheck((cfgp != NULL) && (bottom < 32U) && (top < 32U));
+
+  cfgp->execctrl = (cfgp->execctrl & ~(PIO_SM_EXECCTRL_WRAP_BOTTOM_Msk |
+                                       PIO_SM_EXECCTRL_WRAP_TOP_Msk)) |
+                   PIO_SM_EXECCTRL_WRAP(bottom, top);
+}
+
+/**
+ * @brief   Sets the side-set configuration.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] count     number of side-set bits, including the enable bit
+ *                      when @p optional is true (0..5)
+ * @param[in] optional  side-set is optional (instructions carry an enable
+ *                      bit)
+ * @param[in] pindirs   side-set affects pin directions instead of values
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetSideset(rp_pio_sm_config_t *cfgp,
+                                           uint32_t count, bool optional,
+                                           bool pindirs) {
+
+  osalDbgCheck((cfgp != NULL) && (count <= 5U) &&
+               (!optional || (count >= 1U)));
+
+  cfgp->pinctrl = (cfgp->pinctrl & ~PIO_SM_PINCTRL_SIDESET_COUNT_Msk) |
+                  (count << PIO_SM_PINCTRL_SIDESET_COUNT_Pos);
+  cfgp->execctrl = (cfgp->execctrl & ~(PIO_SM_EXECCTRL_SIDE_EN |
+                                       PIO_SM_EXECCTRL_SIDE_PINDIR)) |
+                   (optional ? PIO_SM_EXECCTRL_SIDE_EN : 0U) |
+                   (pindirs ? PIO_SM_EXECCTRL_SIDE_PINDIR : 0U);
+}
+
+/**
+ * @brief   Sets the first side-set pin.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] pin_base  first pin, window-relative (0..31)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetSidesetPins(rp_pio_sm_config_t *cfgp,
+                                               uint32_t pin_base) {
+
+  osalDbgCheck((cfgp != NULL) && (pin_base < 32U));
+
+  cfgp->pinctrl = (cfgp->pinctrl & ~PIO_SM_PINCTRL_SIDESET_BASE_Msk) |
+                  (pin_base << PIO_SM_PINCTRL_SIDESET_BASE_Pos);
+}
+
+/**
+ * @brief   Sets the OUT pin group.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] pin_base  first pin, window-relative (0..31)
+ * @param[in] count     number of pins (0..32)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetOutPins(rp_pio_sm_config_t *cfgp,
+                                           uint32_t pin_base,
+                                           uint32_t count) {
+
+  osalDbgCheck((cfgp != NULL) && (pin_base < 32U) && (count <= 32U));
+
+  cfgp->pinctrl = (cfgp->pinctrl & ~(PIO_SM_PINCTRL_OUT_BASE_Msk |
+                                     PIO_SM_PINCTRL_OUT_COUNT_Msk)) |
+                  (pin_base << PIO_SM_PINCTRL_OUT_BASE_Pos) |
+                  (count << PIO_SM_PINCTRL_OUT_COUNT_Pos);
+}
+
+/**
+ * @brief   Sets the SET pin group.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] pin_base  first pin, window-relative (0..31)
+ * @param[in] count     number of pins (0..5)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetSetPins(rp_pio_sm_config_t *cfgp,
+                                           uint32_t pin_base,
+                                           uint32_t count) {
+
+  osalDbgCheck((cfgp != NULL) && (pin_base < 32U) && (count <= 5U));
+
+  cfgp->pinctrl = (cfgp->pinctrl & ~(PIO_SM_PINCTRL_SET_BASE_Msk |
+                                     PIO_SM_PINCTRL_SET_COUNT_Msk)) |
+                  (pin_base << PIO_SM_PINCTRL_SET_BASE_Pos) |
+                  (count << PIO_SM_PINCTRL_SET_COUNT_Pos);
+}
+
+/**
+ * @brief   Sets the first IN pin.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] pin_base  first pin, window-relative (0..31)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetInPins(rp_pio_sm_config_t *cfgp,
+                                          uint32_t pin_base) {
+
+  osalDbgCheck((cfgp != NULL) && (pin_base < 32U));
+
+  cfgp->pinctrl = (cfgp->pinctrl & ~PIO_SM_PINCTRL_IN_BASE_Msk) |
+                  (pin_base << PIO_SM_PINCTRL_IN_BASE_Pos);
+}
+
+/**
+ * @brief   Sets the pin tested by JMP PIN instructions.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] pin       pin to test, window-relative (0..31)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetJmpPin(rp_pio_sm_config_t *cfgp,
+                                          uint32_t pin) {
+
+  osalDbgCheck((cfgp != NULL) && (pin < 32U));
+
+  cfgp->execctrl = (cfgp->execctrl & ~PIO_SM_EXECCTRL_JMP_PIN_Msk) |
+                   (pin << PIO_SM_EXECCTRL_JMP_PIN_Pos);
+}
+
+/**
+ * @brief   Sets the clock divider from integer and fractional parts.
+ * @note    An integer part of zero selects the maximum divider of 65536.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] intdiv    integer part (0..65535, 0 means 65536)
+ * @param[in] frac      fractional part in 1/256 units (0..255)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetClkdiv(rp_pio_sm_config_t *cfgp,
+                                          uint32_t intdiv, uint32_t frac) {
+
+  osalDbgCheck((cfgp != NULL) && (intdiv <= 0xFFFFU) && (frac <= 0xFFU) &&
+               !((intdiv == 0U) && (frac != 0U)));
+
+  cfgp->clkdiv = PIO_SM_CLKDIV(intdiv, frac);
+}
+
+/**
+ * @brief   Sets the clock divider from a target frequency.
+ * @details Computes the 16.8 fixed point divider from the system clock
+ *          frequency, same arithmetic as @p pioSmSetFrequencyX().
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] freq_hz   desired PIO clock frequency in Hz
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetFrequency(rp_pio_sm_config_t *cfgp,
+                                             uint32_t freq_hz) {
+  uint32_t div_fp8;
+
+  osalDbgCheck((cfgp != NULL) && (freq_hz > 0U));
+
+  div_fp8 = ((uint64_t)RP_CLK_SYS_FREQ << 8) / freq_hz;
+
+  /* Divider must be in [1.0, 65536.0]: the target frequency can neither
+     exceed the system clock nor undershoot sysclk / 65536.*/
+  osalDbgCheck((div_fp8 >= 0x100U) && (div_fp8 <= 0x1000000U));
+
+  cfgp->clkdiv = PIO_SM_CLKDIV(div_fp8 >> 8, div_fp8 & 0xFFU);
+}
+
+/**
+ * @brief   Sets the input shift register configuration.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] shift_right shift ISR to the right
+ * @param[in] autopush  enable automatic push on threshold
+ * @param[in] threshold push threshold in bits (1..32)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetInShift(rp_pio_sm_config_t *cfgp,
+                                           bool shift_right, bool autopush,
+                                           uint32_t threshold) {
+
+  osalDbgCheck((cfgp != NULL) && (threshold >= 1U) && (threshold <= 32U));
+
+  cfgp->shiftctrl = (cfgp->shiftctrl & ~(PIO_SM_SHIFTCTRL_IN_SHIFTDIR |
+                                         PIO_SM_SHIFTCTRL_AUTOPUSH |
+                                         PIO_SM_SHIFTCTRL_PUSH_THRESH_Msk)) |
+                    (shift_right ? PIO_SM_SHIFTCTRL_IN_SHIFTDIR : 0U) |
+                    (autopush ? PIO_SM_SHIFTCTRL_AUTOPUSH : 0U) |
+                    ((threshold & 0x1FU) << PIO_SM_SHIFTCTRL_PUSH_THRESH_Pos);
+}
+
+/**
+ * @brief   Sets the output shift register configuration.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] shift_right shift OSR to the right
+ * @param[in] autopull  enable automatic pull on threshold
+ * @param[in] threshold pull threshold in bits (1..32)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetOutShift(rp_pio_sm_config_t *cfgp,
+                                            bool shift_right, bool autopull,
+                                            uint32_t threshold) {
+
+  osalDbgCheck((cfgp != NULL) && (threshold >= 1U) && (threshold <= 32U));
+
+  cfgp->shiftctrl = (cfgp->shiftctrl & ~(PIO_SM_SHIFTCTRL_OUT_SHIFTDIR |
+                                         PIO_SM_SHIFTCTRL_AUTOPULL |
+                                         PIO_SM_SHIFTCTRL_PULL_THRESH_Msk)) |
+                    (shift_right ? PIO_SM_SHIFTCTRL_OUT_SHIFTDIR : 0U) |
+                    (autopull ? PIO_SM_SHIFTCTRL_AUTOPULL : 0U) |
+                    ((threshold & 0x1FU) << PIO_SM_SHIFTCTRL_PULL_THRESH_Pos);
+}
+
+/**
+ * @brief   Sets the FIFO joining mode.
+ * @note    The hardware flushes both FIFOs whenever the joining mode
+ *          changes.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] join      joining mode
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetFifoJoin(rp_pio_sm_config_t *cfgp,
+                                            rp_pio_fifo_join_t join) {
+
+  osalDbgCheck((cfgp != NULL) && ((uint32_t)join <= RP_PIO_FIFO_JOIN_RX));
+
+  cfgp->shiftctrl = (cfgp->shiftctrl & ~(PIO_SM_SHIFTCTRL_FJOIN_TX |
+                                         PIO_SM_SHIFTCTRL_FJOIN_RX)) |
+                    ((join == RP_PIO_FIFO_JOIN_TX) ? PIO_SM_SHIFTCTRL_FJOIN_TX : 0U) |
+                    ((join == RP_PIO_FIFO_JOIN_RX) ? PIO_SM_SHIFTCTRL_FJOIN_RX : 0U);
+}
+
+/**
+ * @brief   Sets the MOV STATUS comparison.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] sel       comparison source
+ * @param[in] n         comparison level or IRQ index
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetMovStatus(rp_pio_sm_config_t *cfgp,
+                                             rp_pio_mov_status_t sel,
+                                             uint32_t n) {
+
+  osalDbgCheck((cfgp != NULL) &&
+               ((((uint32_t)sel << PIO_SM_EXECCTRL_STATUS_SEL_Pos) &
+                 ~PIO_SM_EXECCTRL_STATUS_SEL_Msk) == 0U) &&
+               (((n << PIO_SM_EXECCTRL_STATUS_N_Pos) &
+                 ~PIO_SM_EXECCTRL_STATUS_N_Msk) == 0U));
+
+  cfgp->execctrl = (cfgp->execctrl & ~(PIO_SM_EXECCTRL_STATUS_SEL_Msk |
+                                       PIO_SM_EXECCTRL_STATUS_N_Msk)) |
+                   ((uint32_t)sel << PIO_SM_EXECCTRL_STATUS_SEL_Pos) |
+                   (n << PIO_SM_EXECCTRL_STATUS_N_Pos);
+}
+
+/**
+ * @brief   Sets the special OUT behaviors.
+ *
+ * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
+ * @param[in] sticky    re-assert the most recent OUT/SET pin values on
+ *                      every instruction
+ * @param[in] has_enable_pin use a data bit as an inline output enable
+ * @param[in] enable_pin_index data bit index used as the enable
+ *                      (0..31)
+ *
+ * @api
+ */
+__STATIC_INLINE void pioSmConfigSetOutSpecial(rp_pio_sm_config_t *cfgp,
+                                              bool sticky,
+                                              bool has_enable_pin,
+                                              uint32_t enable_pin_index) {
+
+  osalDbgCheck((cfgp != NULL) && (enable_pin_index < 32U));
+
+  cfgp->execctrl = (cfgp->execctrl & ~(PIO_SM_EXECCTRL_OUT_STICKY |
+                                       PIO_SM_EXECCTRL_INLINE_OUT_EN |
+                                       PIO_SM_EXECCTRL_OUT_EN_SEL_Msk)) |
+                   (sticky ? PIO_SM_EXECCTRL_OUT_STICKY : 0U) |
+                   (has_enable_pin ? PIO_SM_EXECCTRL_INLINE_OUT_EN : 0U) |
+                   (enable_pin_index << PIO_SM_EXECCTRL_OUT_EN_SEL_Pos);
+}
+/** @} */
+
+/**
+ * @brief   Applies a configuration to a state machine.
+ * @note    The state machine should be disabled; use @p pioSmInit() for
+ *          the full initialization sequence.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] cfgp      pointer to a rp_pio_sm_config_t structure
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetConfigX(const rp_pio_sm_t *smp,
+                                     const rp_pio_sm_config_t *cfgp) {
+
+  smp->block->pio->SM[smp->smidx].CLKDIV    = cfgp->clkdiv;
+  smp->block->pio->SM[smp->smidx].EXECCTRL  = cfgp->execctrl;
+  smp->block->pio->SM[smp->smidx].SHIFTCTRL = cfgp->shiftctrl;
+  smp->block->pio->SM[smp->smidx].PINCTRL   = cfgp->pinctrl;
+}
 
 /**
  * @brief   Enables a state machine.

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -42,6 +42,42 @@
 /** @} */
 
 /**
+ * @name    PADS_BANK0 pad control bits
+ * @note    Raw PADS_BANK0 register bit values for use with
+ *          @p pioGpioInitPadX(). Not interchangeable with the PAL
+ *          @p PAL_RP_PAD_* macros which carry the same bits pre-shifted
+ *          into the iomode word.
+ * @{
+ */
+#define RP_PIO_PAD_SLEWFAST             (1U << 0)
+#define RP_PIO_PAD_SCHMITT              (1U << 1)
+#define RP_PIO_PAD_PDE                  (1U << 2)
+#define RP_PIO_PAD_PUE                  (1U << 3)
+#define RP_PIO_PAD_DRIVE2               (0U << 4)
+#define RP_PIO_PAD_DRIVE4               (1U << 4)
+#define RP_PIO_PAD_DRIVE8               (2U << 4)
+#define RP_PIO_PAD_DRIVE12              (3U << 4)
+#define RP_PIO_PAD_IE                   (1U << 6)
+#define RP_PIO_PAD_OD                   (1U << 7)
+#if defined(RP2350) || defined(__DOXYGEN__)
+/**
+ * @brief   Pad isolation latch, RP2350 only.
+ * @note    Set out of reset on RP2350; while set, the pad is disconnected
+ *          from its peripheral. @p pioGpioInitPadX() clears it last.
+ */
+#define RP_PIO_PAD_ISO                  (1U << 8)
+#endif
+
+/**
+ * @brief   Default pad configuration for PIO pins.
+ * @details Input enabled with schmitt trigger, 4mA drive, no pulls.
+ */
+#define RP_PIO_PAD_DEFAULT              (RP_PIO_PAD_IE |                    \
+                                         RP_PIO_PAD_SCHMITT |               \
+                                         RP_PIO_PAD_DRIVE4)
+/** @} */
+
+/**
  * @name    PIO resource constants
  * @{
  */
@@ -84,6 +120,14 @@
 /** @} */
 
 /**
+ * @name    PIO FLEVEL register fields
+ * @{
+ */
+#define PIO_FLEVEL_TX(n, flevel)        (((flevel) >> ((n) * 8U)) & 0xFU)
+#define PIO_FLEVEL_RX(n, flevel)        (((flevel) >> (((n) * 8U) + 4U)) & 0xFU)
+/** @} */
+
+/**
  * @name    PIO state machine CLKDIV register bits
  * @{
  */
@@ -103,9 +147,19 @@
  * @name    PIO state machine EXECCTRL register bits
  * @{
  */
+#if defined(RP2350)
+/* The RP2350 widens STATUS_N to 5 bits and STATUS_SEL to 2 bits (adding
+   the IRQ comparison source).*/
+#define PIO_SM_EXECCTRL_STATUS_N_Pos    0U
+#define PIO_SM_EXECCTRL_STATUS_N_Msk    (0x1FU << PIO_SM_EXECCTRL_STATUS_N_Pos)
+#define PIO_SM_EXECCTRL_STATUS_SEL_Pos  5U
+#define PIO_SM_EXECCTRL_STATUS_SEL_Msk  (0x3U << PIO_SM_EXECCTRL_STATUS_SEL_Pos)
+#else
 #define PIO_SM_EXECCTRL_STATUS_N_Pos    0U
 #define PIO_SM_EXECCTRL_STATUS_N_Msk    (0xFU << PIO_SM_EXECCTRL_STATUS_N_Pos)
-#define PIO_SM_EXECCTRL_STATUS_SEL      (1U << 4U)
+#define PIO_SM_EXECCTRL_STATUS_SEL_Pos  4U
+#define PIO_SM_EXECCTRL_STATUS_SEL_Msk  (0x1U << PIO_SM_EXECCTRL_STATUS_SEL_Pos)
+#endif
 #define PIO_SM_EXECCTRL_WRAP_BOTTOM_Pos 7U
 #define PIO_SM_EXECCTRL_WRAP_BOTTOM_Msk (0x1FU << PIO_SM_EXECCTRL_WRAP_BOTTOM_Pos)
 #define PIO_SM_EXECCTRL_WRAP_TOP_Pos    12U

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -574,17 +574,20 @@ __STATIC_INLINE void pioSmConfigSetClkdiv(rp_pio_sm_config_t *cfgp,
  */
 __STATIC_INLINE void pioSmConfigSetFrequency(rp_pio_sm_config_t *cfgp,
                                              uint32_t freq_hz) {
-  uint32_t div_fp8;
+  uint64_t div_fp8;
 
   osalDbgCheck((cfgp != NULL) && (freq_hz > 0U));
 
+  /* Wide intermediate: narrowing before the range check could let a
+     truncated out-of-range divider pass it.*/
   div_fp8 = ((uint64_t)RP_CLK_SYS_FREQ << 8) / freq_hz;
 
   /* Divider must be in [1.0, 65536.0]: the target frequency can neither
      exceed the system clock nor undershoot sysclk / 65536.*/
   osalDbgCheck((div_fp8 >= 0x100U) && (div_fp8 <= 0x1000000U));
 
-  cfgp->clkdiv = PIO_SM_CLKDIV(div_fp8 >> 8, div_fp8 & 0xFFU);
+  cfgp->clkdiv = PIO_SM_CLKDIV((uint32_t)(div_fp8 >> 8),
+                               (uint32_t)(div_fp8 & 0xFFU));
 }
 
 /**

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -1047,6 +1047,10 @@ __STATIC_INLINE uint32_t pioSmGet(const rp_pio_sm_t *smp) {
  * @brief   Routes a GPIO pin to the PIO block that owns this state machine.
  * @details Sets IO_BANK0 FUNCSEL for the given pin to PIO0, PIO1, or PIO2
  *          based on the block index of the state machine.
+ * @note    Only the pin multiplexer is programmed; the pad control
+ *          register (input enable, schmitt trigger, drive strength, and
+ *          on the RP2350 the isolation latch) is left untouched. Use
+ *          @p pioGpioInitX() for complete pin routing.
  * @note    The @p gpio parameter is an absolute GPIO number. On devices
  *          with the @p RP_PIO_HAS_GPIOBASE capability (RP2350) the pin
  *          fields written into PINCTRL/EXECCTRL are instead relative to
@@ -1071,6 +1075,56 @@ __STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
   osalDbgCheck(gpio < RP_GPIO_NUM_LINES);
 
   IO_BANK0->GPIO[gpio].CTRL = funcsel[smp->block->pioidx];
+}
+
+/**
+ * @brief   Routes a GPIO pin to the PIO block with explicit pad control.
+ * @details Programs both the pin multiplexer and the pad control register.
+ *          On the RP2350 the pad is reprogrammed while still isolated and
+ *          the isolation latch is cleared only after the multiplexer
+ *          selects the PIO function, so the pin transitions glitch-free
+ *          from its reset state.
+ * @note    The pad control register is written as a whole: pulls, drive
+ *          strength and every other pad option not present in
+ *          @p padbits are cleared. Pass the required pulls explicitly,
+ *          e.g. @p RP_PIO_PAD_DEFAULT | @p RP_PIO_PAD_PUE for an
+ *          open-drain bus with pull-up.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] gpio      absolute GPIO pin number
+ * @param[in] padbits   pad control value, combination of @p RP_PIO_PAD_*
+ *                      bits (excluding @p RP_PIO_PAD_ISO)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioGpioInitPadX(const rp_pio_sm_t *smp,
+                                     uint32_t gpio, uint32_t padbits) {
+
+  osalDbgCheck((gpio < RP_GPIO_NUM_LINES) && (padbits <= 0xFFU));
+
+#if defined(RP2350)
+  PADS_BANK0->GPIO[gpio] = padbits | RP_PIO_PAD_ISO;
+  pioSmSetPinFunctionX(smp, gpio);
+  PADS_BANK0->GPIO[gpio] = padbits;
+#else
+  PADS_BANK0->GPIO[gpio] = padbits;
+  pioSmSetPinFunctionX(smp, gpio);
+#endif
+}
+
+/**
+ * @brief   Routes a GPIO pin to the PIO block with default pad control.
+ * @details Equivalent to @p pioGpioInitPadX() with @p RP_PIO_PAD_DEFAULT:
+ *          input enabled with schmitt trigger, 4mA drive, no pulls.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] gpio      absolute GPIO pin number
+ *
+ * @special
+ */
+__STATIC_INLINE void pioGpioInitX(const rp_pio_sm_t *smp, uint32_t gpio) {
+
+  pioGpioInitPadX(smp, gpio, RP_PIO_PAD_DEFAULT);
 }
 
 /**
@@ -1121,6 +1175,51 @@ __STATIC_INLINE uint32_t pioGpioToRel(const rp_pio_block_t *block,
 }
 
 /**
+ * @brief   Sets the direction of a range of consecutive pins.
+ * @details Executes SET PINDIRS instructions on the state machine using a
+ *          temporary PINCTRL configuration, in chunks of up to five pins,
+ *          then restores the original PINCTRL value. The temporary
+ *          PINCTRL has a zero side-set count so no side-set pins are
+ *          disturbed.
+ * @pre     The state machine must be disabled: the temporary PINCTRL
+ *          would corrupt the pin mapping of a running program.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] gpio      absolute GPIO number of the first pin; the whole
+ *                      range must fall within the block's GPIO window
+ * @param[in] count     number of consecutive pins (1..32)
+ * @param[in] out       true for outputs, false for inputs
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetConsecutivePindirsX(const rp_pio_sm_t *smp,
+                                                 uint32_t gpio,
+                                                 uint32_t count,
+                                                 bool out) {
+  PIO_TypeDef *pio = smp->block->pio;
+  uint32_t rel = pioGpioToRel(smp->block, gpio);
+  uint32_t pinctrl;
+
+  osalDbgCheck((count >= 1U) && (count <= 32U) && ((rel + count) <= 32U));
+  osalDbgAssert((pio->CTRL & PIO_CTRL_SM_ENABLE(smp->smidx)) == 0U,
+                "state machine enabled");
+
+  pinctrl = pio->SM[smp->smidx].PINCTRL;
+  do {
+    uint32_t chunk = (count > 5U) ? 5U : count;
+
+    pio->SM[smp->smidx].PINCTRL = (chunk << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                                  (rel << PIO_SM_PINCTRL_SET_BASE_Pos);
+    /* SET PINDIRS, all ones for outputs or all zeros for inputs; only the
+       low "chunk" bits take effect.*/
+    pioSmExecX(smp, (uint16_t)(0xE080U | (out ? 0x1FU : 0x00U)));
+    rel += chunk;
+    count -= chunk;
+  } while (count > 0U);
+  pio->SM[smp->smidx].PINCTRL = pinctrl;
+}
+
+/**
  * @brief   Sets the program counter of a state machine.
  * @details Executes a JMP instruction to the given address.
  *
@@ -1149,6 +1248,95 @@ __STATIC_INLINE void pioSmSetFrequencyX(const rp_pio_sm_t *smp, uint32_t freq_hz
   uint32_t frac_part = div_fp8 & 0xFFU;
 
   pioSmSetClkdivX(smp, PIO_SM_CLKDIV(int_part, frac_part));
+}
+
+/**
+ * @brief   Returns the TX DREQ number of a state machine.
+ * @note    The raw DREQ number must be wrapped with the chip's
+ *          @p DMA_CTRL_TRIG_TREQ_SEL() macro when composing a DMA mode
+ *          word, e.g.
+ *          @p DMA_CTRL_TRIG_TREQ_SEL(pioSmTxDreqX(smp)).
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @return              The DREQ number for TX FIFO pacing.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioSmTxDreqX(const rp_pio_sm_t *smp) {
+
+  return (smp->block->pioidx * 8U) + smp->smidx;
+}
+
+/**
+ * @brief   Returns the RX DREQ number of a state machine.
+ * @note    The raw DREQ number must be wrapped with the chip's
+ *          @p DMA_CTRL_TRIG_TREQ_SEL() macro when composing a DMA mode
+ *          word.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @return              The DREQ number for RX FIFO pacing.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioSmRxDreqX(const rp_pio_sm_t *smp) {
+
+  return (smp->block->pioidx * 8U) + 4U + smp->smidx;
+}
+
+/**
+ * @brief   Returns the address of a state machine's TX FIFO register.
+ * @note    Intended as a DMA write target, e.g.
+ *          @p dmaChannelSetDestinationX(dmachp, (uint32_t)pioSmTxFifoAddrX(smp)).
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @return              The TX FIFO register address.
+ *
+ * @special
+ */
+__STATIC_INLINE volatile uint32_t *pioSmTxFifoAddrX(const rp_pio_sm_t *smp) {
+
+  return &smp->block->pio->TXF[smp->smidx];
+}
+
+/**
+ * @brief   Returns the address of a state machine's RX FIFO register.
+ * @note    Intended as a DMA read source, e.g.
+ *          @p dmaChannelSetSourceX(dmachp, (uint32_t)pioSmRxFifoAddrX(smp)).
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @return              The RX FIFO register address.
+ *
+ * @special
+ */
+__STATIC_INLINE volatile const uint32_t *pioSmRxFifoAddrX(const rp_pio_sm_t *smp) {
+
+  return &smp->block->pio->RXF[smp->smidx];
+}
+
+/**
+ * @brief   Returns the TX FIFO fill level of a state machine.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @return              The number of words in the TX FIFO.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioSmTxFifoLevelX(const rp_pio_sm_t *smp) {
+
+  return PIO_FLEVEL_TX(smp->smidx, smp->block->pio->FLEVEL);
+}
+
+/**
+ * @brief   Returns the RX FIFO fill level of a state machine.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @return              The number of words in the RX FIFO.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioSmRxFifoLevelX(const rp_pio_sm_t *smp) {
+
+  return PIO_FLEVEL_RX(smp->smidx, smp->block->pio->FLEVEL);
 }
 
 #endif /* RP_PIO_H */

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -386,9 +386,9 @@ extern "C" {
  *
  * @param[out] cfgp     pointer to a rp_pio_sm_config_t structure
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigDefault(rp_pio_sm_config_t *cfgp) {
+__STATIC_INLINE void pioSmConfigDefaultX(rp_pio_sm_config_t *cfgp) {
 
   osalDbgCheck(cfgp != NULL);
 
@@ -411,9 +411,9 @@ __STATIC_INLINE void pioSmConfigDefault(rp_pio_sm_config_t *cfgp) {
  * @param[in] bottom    address to wrap from, i.e. wrap_target (0..31)
  * @param[in] top       address to wrap after, i.e. wrap (0..31)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetWrap(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetWrapX(rp_pio_sm_config_t *cfgp,
                                         uint32_t bottom, uint32_t top) {
 
   osalDbgCheck((cfgp != NULL) && (bottom < 32U) && (top < 32U));
@@ -433,9 +433,9 @@ __STATIC_INLINE void pioSmConfigSetWrap(rp_pio_sm_config_t *cfgp,
  *                      bit)
  * @param[in] pindirs   side-set affects pin directions instead of values
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetSideset(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetSidesetX(rp_pio_sm_config_t *cfgp,
                                            uint32_t count, bool optional,
                                            bool pindirs) {
 
@@ -456,9 +456,9 @@ __STATIC_INLINE void pioSmConfigSetSideset(rp_pio_sm_config_t *cfgp,
  * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
  * @param[in] pin_base  first pin, window-relative (0..31)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetSidesetPins(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetSidesetPinsX(rp_pio_sm_config_t *cfgp,
                                                uint32_t pin_base) {
 
   osalDbgCheck((cfgp != NULL) && (pin_base < 32U));
@@ -474,9 +474,9 @@ __STATIC_INLINE void pioSmConfigSetSidesetPins(rp_pio_sm_config_t *cfgp,
  * @param[in] pin_base  first pin, window-relative (0..31)
  * @param[in] count     number of pins (0..32)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetOutPins(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetOutPinsX(rp_pio_sm_config_t *cfgp,
                                            uint32_t pin_base,
                                            uint32_t count) {
 
@@ -495,9 +495,9 @@ __STATIC_INLINE void pioSmConfigSetOutPins(rp_pio_sm_config_t *cfgp,
  * @param[in] pin_base  first pin, window-relative (0..31)
  * @param[in] count     number of pins (0..5)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetSetPins(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetSetPinsX(rp_pio_sm_config_t *cfgp,
                                            uint32_t pin_base,
                                            uint32_t count) {
 
@@ -515,9 +515,9 @@ __STATIC_INLINE void pioSmConfigSetSetPins(rp_pio_sm_config_t *cfgp,
  * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
  * @param[in] pin_base  first pin, window-relative (0..31)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetInPins(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetInPinsX(rp_pio_sm_config_t *cfgp,
                                           uint32_t pin_base) {
 
   osalDbgCheck((cfgp != NULL) && (pin_base < 32U));
@@ -532,9 +532,9 @@ __STATIC_INLINE void pioSmConfigSetInPins(rp_pio_sm_config_t *cfgp,
  * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
  * @param[in] pin       pin to test, window-relative (0..31)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetJmpPin(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetJmpPinX(rp_pio_sm_config_t *cfgp,
                                           uint32_t pin) {
 
   osalDbgCheck((cfgp != NULL) && (pin < 32U));
@@ -551,9 +551,9 @@ __STATIC_INLINE void pioSmConfigSetJmpPin(rp_pio_sm_config_t *cfgp,
  * @param[in] intdiv    integer part (0..65535, 0 means 65536)
  * @param[in] frac      fractional part in 1/256 units (0..255)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetClkdiv(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetClkdivX(rp_pio_sm_config_t *cfgp,
                                           uint32_t intdiv, uint32_t frac) {
 
   osalDbgCheck((cfgp != NULL) && (intdiv <= 0xFFFFU) && (frac <= 0xFFU) &&
@@ -570,9 +570,9 @@ __STATIC_INLINE void pioSmConfigSetClkdiv(rp_pio_sm_config_t *cfgp,
  * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
  * @param[in] freq_hz   desired PIO clock frequency in Hz
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetFrequency(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetFrequencyX(rp_pio_sm_config_t *cfgp,
                                              uint32_t freq_hz) {
   uint64_t div_fp8;
 
@@ -598,9 +598,9 @@ __STATIC_INLINE void pioSmConfigSetFrequency(rp_pio_sm_config_t *cfgp,
  * @param[in] autopush  enable automatic push on threshold
  * @param[in] threshold push threshold in bits (1..32)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetInShift(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetInShiftX(rp_pio_sm_config_t *cfgp,
                                            bool shift_right, bool autopush,
                                            uint32_t threshold) {
 
@@ -622,9 +622,9 @@ __STATIC_INLINE void pioSmConfigSetInShift(rp_pio_sm_config_t *cfgp,
  * @param[in] autopull  enable automatic pull on threshold
  * @param[in] threshold pull threshold in bits (1..32)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetOutShift(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetOutShiftX(rp_pio_sm_config_t *cfgp,
                                             bool shift_right, bool autopull,
                                             uint32_t threshold) {
 
@@ -646,9 +646,9 @@ __STATIC_INLINE void pioSmConfigSetOutShift(rp_pio_sm_config_t *cfgp,
  * @param[in,out] cfgp  pointer to a rp_pio_sm_config_t structure
  * @param[in] join      joining mode
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetFifoJoin(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetFifoJoinX(rp_pio_sm_config_t *cfgp,
                                             rp_pio_fifo_join_t join) {
 
   osalDbgCheck((cfgp != NULL) && ((uint32_t)join <= RP_PIO_FIFO_JOIN_RX));
@@ -666,9 +666,9 @@ __STATIC_INLINE void pioSmConfigSetFifoJoin(rp_pio_sm_config_t *cfgp,
  * @param[in] sel       comparison source
  * @param[in] n         comparison level or IRQ index
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetMovStatus(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetMovStatusX(rp_pio_sm_config_t *cfgp,
                                              rp_pio_mov_status_t sel,
                                              uint32_t n) {
 
@@ -694,9 +694,9 @@ __STATIC_INLINE void pioSmConfigSetMovStatus(rp_pio_sm_config_t *cfgp,
  * @param[in] enable_pin_index data bit index used as the enable
  *                      (0..31)
  *
- * @api
+ * @xclass
  */
-__STATIC_INLINE void pioSmConfigSetOutSpecial(rp_pio_sm_config_t *cfgp,
+__STATIC_INLINE void pioSmConfigSetOutSpecialX(rp_pio_sm_config_t *cfgp,
                                               bool sticky,
                                               bool has_enable_pin,
                                               uint32_t enable_pin_index) {

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -1186,6 +1186,15 @@ __STATIC_INLINE uint32_t pioGpioToRel(const rp_pio_block_t *block,
  *          disturbed.
  * @pre     The state machine must be disabled: the temporary PINCTRL
  *          would corrupt the pin mapping of a running program.
+ * @note    When the configuration has @p PIO_SM_EXECCTRL_OUT_STICKY set,
+ *          the flag is cleared for the duration of the sequence and the
+ *          state machine is restarted before it is restored: SM_RESTART
+ *          clears "any pin write left asserted due to OUT_STICKY" (per
+ *          datasheet), so the exec'd direction writes cannot be
+ *          re-asserted once the state machine runs. The restart also
+ *          clears transient state (delay counter, IRQ wait, stalled
+ *          instruction), which is harmless on a disabled, not yet
+ *          started state machine.
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
  * @param[in] gpio      absolute GPIO number of the first pin; the whole
@@ -1201,13 +1210,20 @@ __STATIC_INLINE void pioSmSetConsecutivePindirsX(const rp_pio_sm_t *smp,
                                                  bool out) {
   PIO_TypeDef *pio = smp->block->pio;
   uint32_t rel = pioGpioToRel(smp->block, gpio);
-  uint32_t pinctrl;
+  uint32_t pinctrl, execctrl;
 
   osalDbgCheck((count >= 1U) && (count <= 32U) && ((rel + count) <= 32U));
   osalDbgAssert((pio->CTRL & PIO_CTRL_SM_ENABLE(smp->smidx)) == 0U,
                 "state machine enabled");
 
-  pinctrl = pio->SM[smp->smidx].PINCTRL;
+  pinctrl  = pio->SM[smp->smidx].PINCTRL;
+  execctrl = pio->SM[smp->smidx].EXECCTRL;
+
+  /* Sticky output must not capture the exec'd direction writes.*/
+  if ((execctrl & PIO_SM_EXECCTRL_OUT_STICKY) != 0U) {
+    pio->SM[smp->smidx].EXECCTRL = execctrl & ~PIO_SM_EXECCTRL_OUT_STICKY;
+  }
+
   do {
     uint32_t chunk = (count > 5U) ? 5U : count;
 
@@ -1219,7 +1235,14 @@ __STATIC_INLINE void pioSmSetConsecutivePindirsX(const rp_pio_sm_t *smp,
     rel += chunk;
     count -= chunk;
   } while (count > 0U);
+
   pio->SM[smp->smidx].PINCTRL = pinctrl;
+  if ((execctrl & PIO_SM_EXECCTRL_OUT_STICKY) != 0U) {
+    /* Clear any latched sticky pin write before re-enabling the flag,
+       SM_RESTART is documented to clear it.*/
+    pioSmRestartX(smp);
+    pio->SM[smp->smidx].EXECCTRL = execctrl;
+  }
 }
 
 /**

--- a/testhal/RP/RP2040/PIO-VALIDATION/c1_main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/c1_main.c
@@ -40,14 +40,14 @@ void c1_main(void) {
      this core.*/
   while (c1_do_free == 0U) {
   }
-  __DMB();
+  pio_validation_barrier();
 
   /* Cross-core free of a state machine allocated by core 0.*/
   chSysLock();
   pioSmFreeI(xcore_smp);
   chSysUnlock();
 
-  __DMB();                          /* Free's effects before the flag.*/
+  pio_validation_barrier();         /* Free's effects before the flag.*/
   c1_free_done = 1U;
 
   while (true) {

--- a/testhal/RP/RP2040/PIO-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2040/PIO-VALIDATION/cfg/mcuconf.h
@@ -46,6 +46,12 @@
 #define RP_PIO_REQUIRED
 
 /*
+ * DMA driver system settings.
+ * Note: needed by the PIO DMA glue test leg.
+ */
+#define RP_DMA_REQUIRED
+
+/*
  * IRQ system settings.
  */
 #define RP_IRQ_SYSTICK_PRIORITY             2

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -661,6 +661,21 @@ int main(void) {
   pinctrl_after = block->pio->SM[smp->smidx].PINCTRL;
   report("PINCTRL restored bit-exact", pinctrl_after == pinctrl_before);
 
+  /* A sticky-output configuration must survive the helper: the direction
+     write sequence must neither lose the configured EXECCTRL nor leave a
+     sticky direction write latched (the helper restarts the SM to clear
+     it).*/
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigSetOutSpecial(&cfg, true, false, 0U);
+  pioSmSetConfigX(smp, &cfg);
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  report("EXECCTRL sticky preserved",
+         (block->pio->SM[smp->smidx].EXECCTRL &
+          PIO_SM_EXECCTRL_OUT_STICKY) != 0U);
+  report("pindir applied with sticky config",
+         ((block->pio->DBG_PADOE >> rel) & 1U) == 1U);
+
   pioSmFree(smp);
 
 #if RP_HAS_PIO2 == TRUE

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -470,7 +470,7 @@ int main(void) {
   chprintf(chp, "--- Test 4: cross-core free\r\n");
 
   xcore_smp = smp;                      /* SM0, allocated by core 0.*/
-  __DMB();
+  pio_validation_barrier();
   c1_do_free = 1U;
 
   for (i = 0U; (c1_free_done == 0U) && (i < 1000U); i++) {

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -36,6 +36,22 @@
  * 4. Cross-core free: a state machine allocated by core 0 and freed by
  *    core 1 must actually be released so that all four state machines
  *    of the block can be allocated again.
+ * 5. sm_config builder: a configuration composed with the pioSmConfig*
+ *    builders must equal the hand-assembled register values, survive
+ *    the pioSmInit sequence into the hardware registers, and produce
+ *    the same square wave through pioGpioInitX and
+ *    pioSmSetConsecutivePindirsX.
+ * 6. DMA glue: a DMA channel paced by pioSmTxDreqX feeds the TX FIFO
+ *    of an autopull OUT program at a nonzero load offset; the DREQ
+ *    number must match the chip's named TREQ macro and the streamed
+ *    alternating bit pattern must appear on the pin.
+ * 7. Consecutive pindirs: an 8-pin range crosses the 5-pin SET chunk
+ *    limit; the direct pad output enable view (DBG_PADOE) must follow
+ *    and PINCTRL must be restored bit-exact.
+ * 8. (RP2350) PIO2 routing: pioGpioInitX must select FUNCSEL 8 and
+ *    clear the pad isolation latch left set by the pad reset state.
+ * 9. (RP2350) GPIOBASE window: the builder flow must work with the
+ *    GPIO16..47 window through pioGpioToRel.
  *
  * The square wave is emitted on GPIO2 and read back through SIO GPIO_IN.
  * The report is emitted on UART0 (GPIO0/GPIO1) at the SIO default
@@ -74,6 +90,17 @@ const rp_pio_sm_t * volatile xcore_smp;
 #define EXPECTED_EDGES      ((SM_TEST_FREQ / 10U) * 2U / 3U)
 #define EDGES_LO            ((EXPECTED_EDGES * 7U) / 10U)
 #define EDGES_HI            ((EXPECTED_EDGES * 13U) / 10U)
+
+/* The DMA test streams an alternating bit pattern at one bit per SM cycle,
+   expected edge count in the 100 ms window with a +/-30% margin. The stream
+   must outlast the window: 64 words x 32 bits at 10 kHz is 204.8 ms.*/
+#define DMA_WORDS           64U
+#define EXPECTED_DMA_EDGES  (SM_TEST_FREQ / 10U)
+#define DMA_EDGES_LO        ((EXPECTED_DMA_EDGES * 7U) / 10U)
+#define DMA_EDGES_HI        ((EXPECTED_DMA_EDGES * 13U) / 10U)
+
+/* Test 9 pin inside the GPIO16..47 window, free on the Pico boards.*/
+#define WINDOW_GPIO         22U
 
 /*===========================================================================*/
 /* PIO programs.                                                             */
@@ -137,6 +164,26 @@ static const rp_pio_program_t single_program = {
   .origin       = -1
 };
 
+/*
+ * Single-instruction DMA feed program: "out pins, 1" shifts one bit per
+ * cycle from the OSR to the OUT pin group; with autopull enabled the OSR
+ * refills from the TX FIFO and the state machine stalls when the FIFO
+ * runs empty.
+ *   out pins, 1     ; 0x6001  011_00000_000_00001 (dest pins, bitcount 1)
+ */
+static const uint16_t outpin_instructions[] = {
+  0x6001U
+};
+
+static const rp_pio_program_t outpin_program = {
+  .instructions = outpin_instructions,
+  .length       = 1U,
+  .origin       = -1
+};
+
+/* DMA source pattern, filled at run time with alternating bits.*/
+static uint32_t dma_pattern[DMA_WORDS];
+
 /*===========================================================================*/
 /* Report helpers.                                                           */
 /*===========================================================================*/
@@ -169,15 +216,15 @@ static void delay_us(uint32_t us) {
 }
 
 /**
- * @brief   Counts edges on TEST_GPIO by sampling SIO GPIO_IN for 100 ms.
+ * @brief   Counts edges on a GPIO by sampling SIO GPIO_IN for 100 ms.
  */
-static uint32_t count_edges(void) {
+static uint32_t count_edges(uint32_t gpio) {
   uint32_t edges = 0U;
   uint32_t start = TIMER0->TIMERAWL;
-  uint32_t prev = (SIO->GPIO_IN >> TEST_GPIO) & 1U;
+  uint32_t prev = (SIO->GPIO_IN >> gpio) & 1U;
 
   while ((uint32_t)(TIMER0->TIMERAWL - start) < MEASURE_US) {
-    uint32_t cur = (SIO->GPIO_IN >> TEST_GPIO) & 1U;
+    uint32_t cur = (SIO->GPIO_IN >> gpio) & 1U;
 
     if (cur != prev) {
       edges++;
@@ -258,8 +305,10 @@ int main(void) {
   const rp_pio_block_t *block = RP_PIO0_BLOCK;
   const rp_pio_sm_t *smp;
   const rp_pio_sm_t *sms[RP_PIO_NUM_STATE_MACHINES];
-  int32_t park_off, sq_off, off32, off1;
-  uint32_t edges;
+  const rp_dma_channel_t *dmachp;
+  rp_pio_sm_config_t cfg;
+  int32_t park_off, sq_off, off32, off1, out_off;
+  uint32_t edges, rel, lvl, div_fp8, pinctrl_before, pinctrl_after;
   unsigned i;
   bool ok;
 
@@ -305,7 +354,7 @@ int main(void) {
      offset.*/
   if ((smp != NULL) && (park_off == 0) && (sq_off >= 1)) {
     sqwave_start(smp, (uint32_t)sq_off);
-    edges = count_edges();
+    edges = count_edges(TEST_GPIO);
     chprintf(chp, "      edges: %u\r\n", edges);
     report("edge count in window", (edges >= EDGES_LO) && (edges <= EDGES_HI));
     report("PC stays within program",
@@ -369,7 +418,7 @@ int main(void) {
   }
 
   sqwave_start(smp, (uint32_t)sq_off);
-  edges = count_edges();
+  edges = count_edges(TEST_GPIO);
   chprintf(chp, "      edges before free: %u\r\n", edges);
   report("running before free", (edges >= EDGES_LO) && (edges <= EDGES_HI));
 
@@ -382,7 +431,7 @@ int main(void) {
 
   /* Restart without reloading the program.*/
   sqwave_start(smp, (uint32_t)sq_off);
-  edges = count_edges();
+  edges = count_edges(TEST_GPIO);
   chprintf(chp, "      edges after realloc: %u\r\n", edges);
   report("imem survives last SM free",
          (edges >= EDGES_LO) && (edges <= EDGES_HI));
@@ -406,7 +455,7 @@ int main(void) {
   }
 
   sqwave_start(smp, (uint32_t)sq_off);
-  edges = count_edges();
+  edges = count_edges(TEST_GPIO);
   chprintf(chp, "      edges after early load: %u\r\n", edges);
   report("load before first alloc works",
          (edges >= EDGES_LO) && (edges <= EDGES_HI));
@@ -444,6 +493,256 @@ int main(void) {
       pioSmFree(sms[i]);
     }
   }
+
+  /*
+   * Test 5: sm_config builder and pioSmInit.
+   */
+  chprintf(chp, "--- Test 5: sm_config builder\r\n");
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("program loaded and SM0 allocated", (sq_off >= 0) && (smp != NULL));
+  if ((sq_off < 0) || (smp == NULL)) {
+    goto summary;
+  }
+
+  rel = pioGpioToRel(block, TEST_GPIO);
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrap(&cfg, 0U, 31U);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+
+  /* The builder output must equal the values sqwave_start() assembles by
+     hand from the _Pos/_Msk macros.*/
+  div_fp8 = (uint32_t)(((uint64_t)RP_CLK_SYS_FREQ << 8) / SM_TEST_FREQ);
+  report("clkdiv equals hand-assembled value",
+         cfg.clkdiv == PIO_SM_CLKDIV(div_fp8 >> 8, div_fp8 & 0xFFU));
+  report("execctrl equals hand-assembled value",
+         cfg.execctrl == PIO_SM_EXECCTRL_WRAP(0U, 31U));
+  report("shiftctrl equals hand-assembled value",
+         cfg.shiftctrl == (PIO_SM_SHIFTCTRL_IN_SHIFTDIR |
+                           PIO_SM_SHIFTCTRL_OUT_SHIFTDIR));
+  report("pinctrl equals hand-assembled value",
+         cfg.pinctrl == ((1U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                         (rel << PIO_SM_PINCTRL_SET_BASE_Pos)));
+
+  pioSmInit(smp, (uint32_t)sq_off, &cfg);
+
+  /* EXEC_STALLED is read-only status, masked from the comparison.*/
+  report("configuration applied to hardware",
+         (block->pio->SM[smp->smidx].CLKDIV == cfg.clkdiv) &&
+         ((block->pio->SM[smp->smidx].EXECCTRL &
+           ~PIO_SM_EXECCTRL_EXEC_STALLED) == cfg.execctrl) &&
+         (block->pio->SM[smp->smidx].SHIFTCTRL == cfg.shiftctrl) &&
+         (block->pio->SM[smp->smidx].PINCTRL == cfg.pinctrl));
+  report("FIFOs empty after init",
+         (block->pio->FSTAT & (PIO_FSTAT_TXEMPTY(smp->smidx) |
+                               PIO_FSTAT_RXEMPTY(smp->smidx))) ==
+         (PIO_FSTAT_TXEMPTY(smp->smidx) | PIO_FSTAT_RXEMPTY(smp->smidx)));
+  report("FDEBUG clear after init",
+         (block->pio->FDEBUG & (PIO_FDEBUG_RXSTALL(smp->smidx) |
+                                PIO_FDEBUG_RXUNDER(smp->smidx) |
+                                PIO_FDEBUG_TXOVER(smp->smidx) |
+                                PIO_FDEBUG_TXSTALL(smp->smidx))) == 0U);
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  pioGpioInitX(smp, TEST_GPIO);
+  report("pad routed with default control",
+         PADS_BANK0->GPIO[TEST_GPIO] == RP_PIO_PAD_DEFAULT);
+
+  pioSmEnableX(smp);
+  edges = count_edges(TEST_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("builder square wave in window",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+
+  /*
+   * Test 6: DMA-fed TX FIFO through the DREQ and FIFO address glue.
+   */
+  chprintf(chp, "--- Test 6: DMA glue\r\n");
+
+  /* The raw DREQ numbers wrapped by the chip's TREQ_SEL macro must match
+     the chip's named TREQ macros (SM0 of PIO0 here).*/
+  report("TX DREQ matches named TREQ macro",
+         DMA_CTRL_TRIG_TREQ_SEL(pioSmTxDreqX(smp)) ==
+         DMA_CTRL_TRIG_TREQ_PIO0_TX0);
+  report("RX DREQ matches named TREQ macro",
+         DMA_CTRL_TRIG_TREQ_SEL(pioSmRxDreqX(smp)) ==
+         DMA_CTRL_TRIG_TREQ_PIO0_RX0);
+
+  park_off = pioProgramLoad(block, &park_program);
+  out_off = pioProgramLoad(block, &outpin_program);
+  report("OUT program at nonzero offset", (park_off == 0) && (out_off >= 1));
+  if (out_off < 1) {
+    goto summary;
+  }
+
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrap(&cfg, (uint32_t)out_off, (uint32_t)out_off);
+  pioSmConfigSetOutPins(&cfg, rel, 1U);
+  pioSmConfigSetOutShift(&cfg, true, true, 32U);
+  pioSmInit(smp, (uint32_t)out_off, &cfg);
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  pioGpioInitX(smp, TEST_GPIO);
+  pioSmEnableX(smp);                    /* Stalls on the empty TX FIFO.*/
+
+  for (i = 0U; i < DMA_WORDS; i++) {
+    dma_pattern[i] = 0x55555555U;
+  }
+
+  dmachp = dmaChannelAlloc(RP_DMA_CHANNEL_ID_ANY, TEST_IRQ_PRIORITY,
+                           NULL, NULL);
+  report("DMA channel allocated", dmachp != NULL);
+  if (dmachp == NULL) {
+    goto summary;
+  }
+
+  dmaChannelSetSourceX(dmachp, (uint32_t)dma_pattern);
+  dmaChannelSetDestinationX(dmachp, (uint32_t)pioSmTxFifoAddrX(smp));
+  dmaChannelSetCounterX(dmachp, DMA_WORDS);
+  dmaChannelSetModeX(dmachp,
+                     DMA_CTRL_TRIG_TREQ_SEL(pioSmTxDreqX(smp)) |
+                     DMA_CTRL_TRIG_DATA_SIZE_WORD |
+                     DMA_CTRL_TRIG_INCR_READ);
+  dmaChannelEnableX(dmachp);
+
+  /* The DMA fills the FIFO within microseconds while the SM drains one
+     word per 3.2 ms.*/
+  delay_us(200U);
+  lvl = pioSmTxFifoLevelX(smp);
+  chprintf(chp, "      level: %u\r\n", lvl);
+  report("TX FIFO fills", lvl >= 1U);
+
+  edges = count_edges(TEST_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("DMA-paced pattern in window",
+         (edges >= DMA_EDGES_LO) && (edges <= DMA_EDGES_HI));
+
+  /* The whole stream lasts 204.8 ms, wait out the tail with a generous
+     timeout: channel idle, FIFO drained, SM stalled on empty.*/
+  for (i = 0U; i < 3000U; i++) {
+    if (!dmaChannelIsBusyX(dmachp) &&
+        (pioSmTxFifoLevelX(smp) == 0U) &&
+        ((block->pio->FDEBUG & PIO_FDEBUG_TXSTALL(smp->smidx)) != 0U)) {
+      break;
+    }
+    delay_us(100U);
+  }
+  report("stream drains to stall",
+         !dmaChannelIsBusyX(dmachp) &&
+         (pioSmTxFifoLevelX(smp) == 0U) &&
+         ((block->pio->FDEBUG & PIO_FDEBUG_TXSTALL(smp->smidx)) != 0U));
+
+  dmaChannelFree(dmachp);
+  pioSmDisableX(smp);
+  pioProgramUnload(block, out_off, outpin_program.length);
+  pioProgramUnload(block, park_off, park_program.length);
+
+  /*
+   * Test 7: consecutive pindirs across the 5-pin SET chunk limit.
+   */
+  chprintf(chp, "--- Test 7: consecutive pindirs\r\n");
+
+  pinctrl_before = block->pio->SM[smp->smidx].PINCTRL;
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 8U, true);
+  ok = ((block->pio->DBG_PADOE >> rel) & 0xFFU) == 0xFFU;
+  report("8-pin range set to output", ok);
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 8U, false);
+  ok = ((block->pio->DBG_PADOE >> rel) & 0xFFU) == 0U;
+  report("8-pin range set to input", ok);
+
+  pinctrl_after = block->pio->SM[smp->smidx].PINCTRL;
+  report("PINCTRL restored bit-exact", pinctrl_after == pinctrl_before);
+
+  pioSmFree(smp);
+
+#if RP_HAS_PIO2 == TRUE
+  /*
+   * Test 8: PIO2 routing and pad isolation handling.
+   */
+  chprintf(chp, "--- Test 8: PIO2 routing\r\n");
+
+  /* Pad back to its RP2350 reset state: isolated, input-disabled.*/
+  PADS_BANK0->GPIO[TEST_GPIO] = RP_PIO_PAD_ISO | RP_PIO_PAD_PDE |
+                                RP_PIO_PAD_SCHMITT | RP_PIO_PAD_DRIVE4;
+
+  sq_off = pioProgramLoad(RP_PIO2_BLOCK, &sqwave_program);
+  smp = pioSmAlloc(RP_PIO2_BLOCK, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("PIO2 program loaded and SM0 allocated",
+         (sq_off >= 0) && (smp != NULL));
+  if ((sq_off < 0) || (smp == NULL)) {
+    goto summary;
+  }
+
+  rel = pioGpioToRel(RP_PIO2_BLOCK, TEST_GPIO);
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmInit(smp, (uint32_t)sq_off, &cfg);
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  pioGpioInitX(smp, TEST_GPIO);
+
+  report("FUNCSEL selects PIO2",
+         (IO_BANK0->GPIO[TEST_GPIO].CTRL & 0x1FU) == RP_PIO_FUNCSEL_PIO2);
+  report("pad de-isolated with default control",
+         PADS_BANK0->GPIO[TEST_GPIO] == RP_PIO_PAD_DEFAULT);
+
+  pioSmEnableX(smp);
+  edges = count_edges(TEST_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("PIO2 square wave in window",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioSmFree(smp);
+  pioProgramUnload(RP_PIO2_BLOCK, sq_off, sqwave_program.length);
+#endif /* RP_HAS_PIO2 == TRUE */
+
+#if RP_PIO_HAS_GPIOBASE == TRUE
+  /*
+   * Test 9: GPIOBASE=16 window through the builder flow.
+   */
+  chprintf(chp, "--- Test 9: GPIOBASE window\r\n");
+
+  pioSetGpioBase(RP_PIO1_BLOCK, 16U);
+
+  sq_off = pioProgramLoad(RP_PIO1_BLOCK, &sqwave_program);
+  smp = pioSmAlloc(RP_PIO1_BLOCK, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("PIO1 program loaded and SM0 allocated",
+         (sq_off >= 0) && (smp != NULL));
+  if ((sq_off < 0) || (smp == NULL)) {
+    goto summary;
+  }
+
+  rel = pioGpioToRel(RP_PIO1_BLOCK, WINDOW_GPIO);
+  report("GPIO lowered into window", rel == (WINDOW_GPIO - 16U));
+
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmInit(smp, (uint32_t)sq_off, &cfg);
+  pioSmSetConsecutivePindirsX(smp, WINDOW_GPIO, 1U, true);
+  pioGpioInitX(smp, WINDOW_GPIO);
+
+  pioSmEnableX(smp);
+  edges = count_edges(WINDOW_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("windowed square wave in window",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  /* Full teardown, the block reset on the last release clears
+     GPIOBASE.*/
+  pioSmDisableX(smp);
+  pioSmFree(smp);
+  pioProgramUnload(RP_PIO1_BLOCK, sq_off, sqwave_program.length);
+#endif /* RP_PIO_HAS_GPIOBASE == TRUE */
 
   /*
    * Summary.

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -507,10 +507,10 @@ int main(void) {
   }
 
   rel = pioGpioToRel(block, TEST_GPIO);
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetWrap(&cfg, 0U, 31U);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrapX(&cfg, 0U, 31U);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
 
   /* The builder output must equal the values sqwave_start() assembles by
      hand from the _Pos/_Msk macros.*/
@@ -580,11 +580,11 @@ int main(void) {
     goto summary;
   }
 
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetWrap(&cfg, (uint32_t)out_off, (uint32_t)out_off);
-  pioSmConfigSetOutPins(&cfg, rel, 1U);
-  pioSmConfigSetOutShift(&cfg, true, true, 32U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrapX(&cfg, (uint32_t)out_off, (uint32_t)out_off);
+  pioSmConfigSetOutPinsX(&cfg, rel, 1U);
+  pioSmConfigSetOutShiftX(&cfg, true, true, 32U);
   pioSmInit(smp, (uint32_t)out_off, &cfg);
 
   pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
@@ -665,9 +665,9 @@ int main(void) {
      write sequence must neither lose the configured EXECCTRL nor leave a
      sticky direction write latched (the helper restarts the SM to clear
      it).*/
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
-  pioSmConfigSetOutSpecial(&cfg, true, false, 0U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
+  pioSmConfigSetOutSpecialX(&cfg, true, false, 0U);
   pioSmSetConfigX(smp, &cfg);
   pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
   report("EXECCTRL sticky preserved",
@@ -697,9 +697,9 @@ int main(void) {
   }
 
   rel = pioGpioToRel(RP_PIO2_BLOCK, TEST_GPIO);
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
   pioSmInit(smp, (uint32_t)sq_off, &cfg);
   pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
   pioGpioInitX(smp, TEST_GPIO);
@@ -739,9 +739,9 @@ int main(void) {
   rel = pioGpioToRel(RP_PIO1_BLOCK, WINDOW_GPIO);
   report("GPIO lowered into window", rel == (WINDOW_GPIO - 16U));
 
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
   pioSmInit(smp, (uint32_t)sq_off, &cfg);
   pioSmSetConsecutivePindirsX(smp, WINDOW_GPIO, 1U, true);
   pioGpioInitX(smp, WINDOW_GPIO);

--- a/testhal/RP/RP2040/PIO-VALIDATION/pio_validation.h
+++ b/testhal/RP/RP2040/PIO-VALIDATION/pio_validation.h
@@ -21,6 +21,12 @@
 #ifndef PIO_VALIDATION_H
 #define PIO_VALIDATION_H
 
+/*
+ * Full memory barrier usable from both the ARM and RISC-V builds of the
+ * shared sources (__DMB is CMSIS, ARM only).
+ */
+#define pio_validation_barrier()    __sync_synchronize()
+
 extern volatile uint32_t c1_ready;
 extern volatile uint32_t c1_do_free;
 extern volatile uint32_t c1_free_done;

--- a/testhal/RP/RP2350/PIO-VALIDATION-RISCV/Makefile
+++ b/testhal/RP/RP2350/PIO-VALIDATION-RISCV/Makefile
@@ -1,0 +1,183 @@
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=4
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = no
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the RISC-V process stack. This stack is
+# the stack used by the main() thread.
+# Note: the 4 KiB scratch banks also hold the per-core OS instances
+# (~1 KiB each), 2 x 0x800 stacks plus the instance would overflow ram4.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x600
+endif
+
+# Stack size to the allocated to the RISC-V main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x600
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+# Hazard3 is RV32IMAC
+MCU  = rv32imac_zba_zbb_zbs_zbkb_zcb_zcmp
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+# Absolute paths: the shared ../PIO-VALIDATION sources put that directory
+# on the VPATH and its own build/ would otherwise satisfy the directory
+# targets of this project.
+BUILDDIR := $(abspath build)
+DEPDIR   := $(abspath .dep)
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk/startup_rp2350_riscv.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform_riscv.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/RISCV-HAZARD3/compilers/GCC/mk/port_rp2.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_RISCV_FLASH.ld
+
+# C sources, shared with the ARM build of the PIO validation.
+CSRC = $(ALLCSRC) \
+       ../PIO-VALIDATION/main.c ../PIO-VALIDATION/c1_main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC) ../PIO-VALIDATION
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_EXTRA_CORES_NUMBER=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_EXTRA_CORES_NUMBER=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/RISCV-HAZARD3/compilers/GCC/mk
+include $(RULESPATH)/riscv-none-elf.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/testhal/RP/RP2350/PIO-VALIDATION-RISCV/Makefile
+++ b/testhal/RP/RP2350/PIO-VALIDATION-RISCV/Makefile
@@ -59,7 +59,7 @@ ifeq ($(USE_PROCESS_STACKSIZE),)
   USE_PROCESS_STACKSIZE = 0x600
 endif
 
-# Stack size to the allocated to the RISC-V main/exceptions stack. This
+# Stack size to be allocated to the RISC-V main/exceptions stack. This
 # stack is used for processing interrupts and exceptions.
 ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
   USE_EXCEPTIONS_STACKSIZE = 0x600

--- a/testhal/RP/RP2350/PIO-VALIDATION-RISCV/cfg/chconf.h
+++ b/testhal/RP/RP2350/PIO-VALIDATION-RISCV/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     TRUE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/PIO-VALIDATION-RISCV/cfg/halconf.h
+++ b/testhal/RP/RP2350/PIO-VALIDATION-RISCV/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      TRUE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 115200
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_LINE
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/PIO-VALIDATION-RISCV/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/PIO-VALIDATION-RISCV/cfg/mcuconf.h
@@ -1,0 +1,68 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+/*
+ * RP2350_MCUCONF drivers configuration.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest (4 bits on Cortex-M33).
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      TRUE
+
+/*
+ * PIO driver system settings.
+ * Note: the PIO helper driver has no per-block enable switches, it is
+ * compiled in whenever RP_PIO_REQUIRED is defined.
+ */
+#define RP_PIO_REQUIRED
+
+/*
+ * DMA driver system settings.
+ * Note: needed by the PIO DMA glue test leg.
+ */
+#define RP_DMA_REQUIRED
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/PIO-VALIDATION/c1_main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/c1_main.c
@@ -40,14 +40,14 @@ void c1_main(void) {
      this core.*/
   while (c1_do_free == 0U) {
   }
-  __DMB();
+  pio_validation_barrier();
 
   /* Cross-core free of a state machine allocated by core 0.*/
   chSysLock();
   pioSmFreeI(xcore_smp);
   chSysUnlock();
 
-  __DMB();                          /* Free's effects before the flag.*/
+  pio_validation_barrier();         /* Free's effects before the flag.*/
   c1_free_done = 1U;
 
   while (true) {

--- a/testhal/RP/RP2350/PIO-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/PIO-VALIDATION/cfg/mcuconf.h
@@ -46,6 +46,12 @@
 #define RP_PIO_REQUIRED
 
 /*
+ * DMA driver system settings.
+ * Note: needed by the PIO DMA glue test leg.
+ */
+#define RP_DMA_REQUIRED
+
+/*
  * IRQ system settings.
  */
 #define RP_IRQ_SYSTICK_PRIORITY             2

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -661,6 +661,21 @@ int main(void) {
   pinctrl_after = block->pio->SM[smp->smidx].PINCTRL;
   report("PINCTRL restored bit-exact", pinctrl_after == pinctrl_before);
 
+  /* A sticky-output configuration must survive the helper: the direction
+     write sequence must neither lose the configured EXECCTRL nor leave a
+     sticky direction write latched (the helper restarts the SM to clear
+     it).*/
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigSetOutSpecial(&cfg, true, false, 0U);
+  pioSmSetConfigX(smp, &cfg);
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  report("EXECCTRL sticky preserved",
+         (block->pio->SM[smp->smidx].EXECCTRL &
+          PIO_SM_EXECCTRL_OUT_STICKY) != 0U);
+  report("pindir applied with sticky config",
+         ((block->pio->DBG_PADOE >> rel) & 1U) == 1U);
+
   pioSmFree(smp);
 
 #if RP_HAS_PIO2 == TRUE

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -470,7 +470,7 @@ int main(void) {
   chprintf(chp, "--- Test 4: cross-core free\r\n");
 
   xcore_smp = smp;                      /* SM0, allocated by core 0.*/
-  __DMB();
+  pio_validation_barrier();
   c1_do_free = 1U;
 
   for (i = 0U; (c1_free_done == 0U) && (i < 1000U); i++) {

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -36,6 +36,22 @@
  * 4. Cross-core free: a state machine allocated by core 0 and freed by
  *    core 1 must actually be released so that all four state machines
  *    of the block can be allocated again.
+ * 5. sm_config builder: a configuration composed with the pioSmConfig*
+ *    builders must equal the hand-assembled register values, survive
+ *    the pioSmInit sequence into the hardware registers, and produce
+ *    the same square wave through pioGpioInitX and
+ *    pioSmSetConsecutivePindirsX.
+ * 6. DMA glue: a DMA channel paced by pioSmTxDreqX feeds the TX FIFO
+ *    of an autopull OUT program at a nonzero load offset; the DREQ
+ *    number must match the chip's named TREQ macro and the streamed
+ *    alternating bit pattern must appear on the pin.
+ * 7. Consecutive pindirs: an 8-pin range crosses the 5-pin SET chunk
+ *    limit; the direct pad output enable view (DBG_PADOE) must follow
+ *    and PINCTRL must be restored bit-exact.
+ * 8. (RP2350) PIO2 routing: pioGpioInitX must select FUNCSEL 8 and
+ *    clear the pad isolation latch left set by the pad reset state.
+ * 9. (RP2350) GPIOBASE window: the builder flow must work with the
+ *    GPIO16..47 window through pioGpioToRel.
  *
  * The square wave is emitted on GPIO2 and read back through SIO GPIO_IN.
  * The report is emitted on UART0 (GPIO0/GPIO1) at the SIO default
@@ -74,6 +90,17 @@ const rp_pio_sm_t * volatile xcore_smp;
 #define EXPECTED_EDGES      ((SM_TEST_FREQ / 10U) * 2U / 3U)
 #define EDGES_LO            ((EXPECTED_EDGES * 7U) / 10U)
 #define EDGES_HI            ((EXPECTED_EDGES * 13U) / 10U)
+
+/* The DMA test streams an alternating bit pattern at one bit per SM cycle,
+   expected edge count in the 100 ms window with a +/-30% margin. The stream
+   must outlast the window: 64 words x 32 bits at 10 kHz is 204.8 ms.*/
+#define DMA_WORDS           64U
+#define EXPECTED_DMA_EDGES  (SM_TEST_FREQ / 10U)
+#define DMA_EDGES_LO        ((EXPECTED_DMA_EDGES * 7U) / 10U)
+#define DMA_EDGES_HI        ((EXPECTED_DMA_EDGES * 13U) / 10U)
+
+/* Test 9 pin inside the GPIO16..47 window, free on the Pico boards.*/
+#define WINDOW_GPIO         22U
 
 /*===========================================================================*/
 /* PIO programs.                                                             */
@@ -137,6 +164,26 @@ static const rp_pio_program_t single_program = {
   .origin       = -1
 };
 
+/*
+ * Single-instruction DMA feed program: "out pins, 1" shifts one bit per
+ * cycle from the OSR to the OUT pin group; with autopull enabled the OSR
+ * refills from the TX FIFO and the state machine stalls when the FIFO
+ * runs empty.
+ *   out pins, 1     ; 0x6001  011_00000_000_00001 (dest pins, bitcount 1)
+ */
+static const uint16_t outpin_instructions[] = {
+  0x6001U
+};
+
+static const rp_pio_program_t outpin_program = {
+  .instructions = outpin_instructions,
+  .length       = 1U,
+  .origin       = -1
+};
+
+/* DMA source pattern, filled at run time with alternating bits.*/
+static uint32_t dma_pattern[DMA_WORDS];
+
 /*===========================================================================*/
 /* Report helpers.                                                           */
 /*===========================================================================*/
@@ -169,15 +216,15 @@ static void delay_us(uint32_t us) {
 }
 
 /**
- * @brief   Counts edges on TEST_GPIO by sampling SIO GPIO_IN for 100 ms.
+ * @brief   Counts edges on a GPIO by sampling SIO GPIO_IN for 100 ms.
  */
-static uint32_t count_edges(void) {
+static uint32_t count_edges(uint32_t gpio) {
   uint32_t edges = 0U;
   uint32_t start = TIMER0->TIMERAWL;
-  uint32_t prev = (SIO->GPIO_IN >> TEST_GPIO) & 1U;
+  uint32_t prev = (SIO->GPIO_IN >> gpio) & 1U;
 
   while ((uint32_t)(TIMER0->TIMERAWL - start) < MEASURE_US) {
-    uint32_t cur = (SIO->GPIO_IN >> TEST_GPIO) & 1U;
+    uint32_t cur = (SIO->GPIO_IN >> gpio) & 1U;
 
     if (cur != prev) {
       edges++;
@@ -258,8 +305,10 @@ int main(void) {
   const rp_pio_block_t *block = RP_PIO0_BLOCK;
   const rp_pio_sm_t *smp;
   const rp_pio_sm_t *sms[RP_PIO_NUM_STATE_MACHINES];
-  int32_t park_off, sq_off, off32, off1;
-  uint32_t edges;
+  const rp_dma_channel_t *dmachp;
+  rp_pio_sm_config_t cfg;
+  int32_t park_off, sq_off, off32, off1, out_off;
+  uint32_t edges, rel, lvl, div_fp8, pinctrl_before, pinctrl_after;
   unsigned i;
   bool ok;
 
@@ -305,7 +354,7 @@ int main(void) {
      offset.*/
   if ((smp != NULL) && (park_off == 0) && (sq_off >= 1)) {
     sqwave_start(smp, (uint32_t)sq_off);
-    edges = count_edges();
+    edges = count_edges(TEST_GPIO);
     chprintf(chp, "      edges: %u\r\n", edges);
     report("edge count in window", (edges >= EDGES_LO) && (edges <= EDGES_HI));
     report("PC stays within program",
@@ -369,7 +418,7 @@ int main(void) {
   }
 
   sqwave_start(smp, (uint32_t)sq_off);
-  edges = count_edges();
+  edges = count_edges(TEST_GPIO);
   chprintf(chp, "      edges before free: %u\r\n", edges);
   report("running before free", (edges >= EDGES_LO) && (edges <= EDGES_HI));
 
@@ -382,7 +431,7 @@ int main(void) {
 
   /* Restart without reloading the program.*/
   sqwave_start(smp, (uint32_t)sq_off);
-  edges = count_edges();
+  edges = count_edges(TEST_GPIO);
   chprintf(chp, "      edges after realloc: %u\r\n", edges);
   report("imem survives last SM free",
          (edges >= EDGES_LO) && (edges <= EDGES_HI));
@@ -406,7 +455,7 @@ int main(void) {
   }
 
   sqwave_start(smp, (uint32_t)sq_off);
-  edges = count_edges();
+  edges = count_edges(TEST_GPIO);
   chprintf(chp, "      edges after early load: %u\r\n", edges);
   report("load before first alloc works",
          (edges >= EDGES_LO) && (edges <= EDGES_HI));
@@ -444,6 +493,256 @@ int main(void) {
       pioSmFree(sms[i]);
     }
   }
+
+  /*
+   * Test 5: sm_config builder and pioSmInit.
+   */
+  chprintf(chp, "--- Test 5: sm_config builder\r\n");
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("program loaded and SM0 allocated", (sq_off >= 0) && (smp != NULL));
+  if ((sq_off < 0) || (smp == NULL)) {
+    goto summary;
+  }
+
+  rel = pioGpioToRel(block, TEST_GPIO);
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrap(&cfg, 0U, 31U);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+
+  /* The builder output must equal the values sqwave_start() assembles by
+     hand from the _Pos/_Msk macros.*/
+  div_fp8 = (uint32_t)(((uint64_t)RP_CLK_SYS_FREQ << 8) / SM_TEST_FREQ);
+  report("clkdiv equals hand-assembled value",
+         cfg.clkdiv == PIO_SM_CLKDIV(div_fp8 >> 8, div_fp8 & 0xFFU));
+  report("execctrl equals hand-assembled value",
+         cfg.execctrl == PIO_SM_EXECCTRL_WRAP(0U, 31U));
+  report("shiftctrl equals hand-assembled value",
+         cfg.shiftctrl == (PIO_SM_SHIFTCTRL_IN_SHIFTDIR |
+                           PIO_SM_SHIFTCTRL_OUT_SHIFTDIR));
+  report("pinctrl equals hand-assembled value",
+         cfg.pinctrl == ((1U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                         (rel << PIO_SM_PINCTRL_SET_BASE_Pos)));
+
+  pioSmInit(smp, (uint32_t)sq_off, &cfg);
+
+  /* EXEC_STALLED is read-only status, masked from the comparison.*/
+  report("configuration applied to hardware",
+         (block->pio->SM[smp->smidx].CLKDIV == cfg.clkdiv) &&
+         ((block->pio->SM[smp->smidx].EXECCTRL &
+           ~PIO_SM_EXECCTRL_EXEC_STALLED) == cfg.execctrl) &&
+         (block->pio->SM[smp->smidx].SHIFTCTRL == cfg.shiftctrl) &&
+         (block->pio->SM[smp->smidx].PINCTRL == cfg.pinctrl));
+  report("FIFOs empty after init",
+         (block->pio->FSTAT & (PIO_FSTAT_TXEMPTY(smp->smidx) |
+                               PIO_FSTAT_RXEMPTY(smp->smidx))) ==
+         (PIO_FSTAT_TXEMPTY(smp->smidx) | PIO_FSTAT_RXEMPTY(smp->smidx)));
+  report("FDEBUG clear after init",
+         (block->pio->FDEBUG & (PIO_FDEBUG_RXSTALL(smp->smidx) |
+                                PIO_FDEBUG_RXUNDER(smp->smidx) |
+                                PIO_FDEBUG_TXOVER(smp->smidx) |
+                                PIO_FDEBUG_TXSTALL(smp->smidx))) == 0U);
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  pioGpioInitX(smp, TEST_GPIO);
+  report("pad routed with default control",
+         PADS_BANK0->GPIO[TEST_GPIO] == RP_PIO_PAD_DEFAULT);
+
+  pioSmEnableX(smp);
+  edges = count_edges(TEST_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("builder square wave in window",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+
+  /*
+   * Test 6: DMA-fed TX FIFO through the DREQ and FIFO address glue.
+   */
+  chprintf(chp, "--- Test 6: DMA glue\r\n");
+
+  /* The raw DREQ numbers wrapped by the chip's TREQ_SEL macro must match
+     the chip's named TREQ macros (SM0 of PIO0 here).*/
+  report("TX DREQ matches named TREQ macro",
+         DMA_CTRL_TRIG_TREQ_SEL(pioSmTxDreqX(smp)) ==
+         DMA_CTRL_TRIG_TREQ_PIO0_TX0);
+  report("RX DREQ matches named TREQ macro",
+         DMA_CTRL_TRIG_TREQ_SEL(pioSmRxDreqX(smp)) ==
+         DMA_CTRL_TRIG_TREQ_PIO0_RX0);
+
+  park_off = pioProgramLoad(block, &park_program);
+  out_off = pioProgramLoad(block, &outpin_program);
+  report("OUT program at nonzero offset", (park_off == 0) && (out_off >= 1));
+  if (out_off < 1) {
+    goto summary;
+  }
+
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrap(&cfg, (uint32_t)out_off, (uint32_t)out_off);
+  pioSmConfigSetOutPins(&cfg, rel, 1U);
+  pioSmConfigSetOutShift(&cfg, true, true, 32U);
+  pioSmInit(smp, (uint32_t)out_off, &cfg);
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  pioGpioInitX(smp, TEST_GPIO);
+  pioSmEnableX(smp);                    /* Stalls on the empty TX FIFO.*/
+
+  for (i = 0U; i < DMA_WORDS; i++) {
+    dma_pattern[i] = 0x55555555U;
+  }
+
+  dmachp = dmaChannelAlloc(RP_DMA_CHANNEL_ID_ANY, TEST_IRQ_PRIORITY,
+                           NULL, NULL);
+  report("DMA channel allocated", dmachp != NULL);
+  if (dmachp == NULL) {
+    goto summary;
+  }
+
+  dmaChannelSetSourceX(dmachp, (uint32_t)dma_pattern);
+  dmaChannelSetDestinationX(dmachp, (uint32_t)pioSmTxFifoAddrX(smp));
+  dmaChannelSetCounterX(dmachp, DMA_WORDS);
+  dmaChannelSetModeX(dmachp,
+                     DMA_CTRL_TRIG_TREQ_SEL(pioSmTxDreqX(smp)) |
+                     DMA_CTRL_TRIG_DATA_SIZE_WORD |
+                     DMA_CTRL_TRIG_INCR_READ);
+  dmaChannelEnableX(dmachp);
+
+  /* The DMA fills the FIFO within microseconds while the SM drains one
+     word per 3.2 ms.*/
+  delay_us(200U);
+  lvl = pioSmTxFifoLevelX(smp);
+  chprintf(chp, "      level: %u\r\n", lvl);
+  report("TX FIFO fills", lvl >= 1U);
+
+  edges = count_edges(TEST_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("DMA-paced pattern in window",
+         (edges >= DMA_EDGES_LO) && (edges <= DMA_EDGES_HI));
+
+  /* The whole stream lasts 204.8 ms, wait out the tail with a generous
+     timeout: channel idle, FIFO drained, SM stalled on empty.*/
+  for (i = 0U; i < 3000U; i++) {
+    if (!dmaChannelIsBusyX(dmachp) &&
+        (pioSmTxFifoLevelX(smp) == 0U) &&
+        ((block->pio->FDEBUG & PIO_FDEBUG_TXSTALL(smp->smidx)) != 0U)) {
+      break;
+    }
+    delay_us(100U);
+  }
+  report("stream drains to stall",
+         !dmaChannelIsBusyX(dmachp) &&
+         (pioSmTxFifoLevelX(smp) == 0U) &&
+         ((block->pio->FDEBUG & PIO_FDEBUG_TXSTALL(smp->smidx)) != 0U));
+
+  dmaChannelFree(dmachp);
+  pioSmDisableX(smp);
+  pioProgramUnload(block, out_off, outpin_program.length);
+  pioProgramUnload(block, park_off, park_program.length);
+
+  /*
+   * Test 7: consecutive pindirs across the 5-pin SET chunk limit.
+   */
+  chprintf(chp, "--- Test 7: consecutive pindirs\r\n");
+
+  pinctrl_before = block->pio->SM[smp->smidx].PINCTRL;
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 8U, true);
+  ok = ((block->pio->DBG_PADOE >> rel) & 0xFFU) == 0xFFU;
+  report("8-pin range set to output", ok);
+
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 8U, false);
+  ok = ((block->pio->DBG_PADOE >> rel) & 0xFFU) == 0U;
+  report("8-pin range set to input", ok);
+
+  pinctrl_after = block->pio->SM[smp->smidx].PINCTRL;
+  report("PINCTRL restored bit-exact", pinctrl_after == pinctrl_before);
+
+  pioSmFree(smp);
+
+#if RP_HAS_PIO2 == TRUE
+  /*
+   * Test 8: PIO2 routing and pad isolation handling.
+   */
+  chprintf(chp, "--- Test 8: PIO2 routing\r\n");
+
+  /* Pad back to its RP2350 reset state: isolated, input-disabled.*/
+  PADS_BANK0->GPIO[TEST_GPIO] = RP_PIO_PAD_ISO | RP_PIO_PAD_PDE |
+                                RP_PIO_PAD_SCHMITT | RP_PIO_PAD_DRIVE4;
+
+  sq_off = pioProgramLoad(RP_PIO2_BLOCK, &sqwave_program);
+  smp = pioSmAlloc(RP_PIO2_BLOCK, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("PIO2 program loaded and SM0 allocated",
+         (sq_off >= 0) && (smp != NULL));
+  if ((sq_off < 0) || (smp == NULL)) {
+    goto summary;
+  }
+
+  rel = pioGpioToRel(RP_PIO2_BLOCK, TEST_GPIO);
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmInit(smp, (uint32_t)sq_off, &cfg);
+  pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
+  pioGpioInitX(smp, TEST_GPIO);
+
+  report("FUNCSEL selects PIO2",
+         (IO_BANK0->GPIO[TEST_GPIO].CTRL & 0x1FU) == RP_PIO_FUNCSEL_PIO2);
+  report("pad de-isolated with default control",
+         PADS_BANK0->GPIO[TEST_GPIO] == RP_PIO_PAD_DEFAULT);
+
+  pioSmEnableX(smp);
+  edges = count_edges(TEST_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("PIO2 square wave in window",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioSmFree(smp);
+  pioProgramUnload(RP_PIO2_BLOCK, sq_off, sqwave_program.length);
+#endif /* RP_HAS_PIO2 == TRUE */
+
+#if RP_PIO_HAS_GPIOBASE == TRUE
+  /*
+   * Test 9: GPIOBASE=16 window through the builder flow.
+   */
+  chprintf(chp, "--- Test 9: GPIOBASE window\r\n");
+
+  pioSetGpioBase(RP_PIO1_BLOCK, 16U);
+
+  sq_off = pioProgramLoad(RP_PIO1_BLOCK, &sqwave_program);
+  smp = pioSmAlloc(RP_PIO1_BLOCK, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("PIO1 program loaded and SM0 allocated",
+         (sq_off >= 0) && (smp != NULL));
+  if ((sq_off < 0) || (smp == NULL)) {
+    goto summary;
+  }
+
+  rel = pioGpioToRel(RP_PIO1_BLOCK, WINDOW_GPIO);
+  report("GPIO lowered into window", rel == (WINDOW_GPIO - 16U));
+
+  pioSmConfigDefault(&cfg);
+  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmInit(smp, (uint32_t)sq_off, &cfg);
+  pioSmSetConsecutivePindirsX(smp, WINDOW_GPIO, 1U, true);
+  pioGpioInitX(smp, WINDOW_GPIO);
+
+  pioSmEnableX(smp);
+  edges = count_edges(WINDOW_GPIO);
+  chprintf(chp, "      edges: %u\r\n", edges);
+  report("windowed square wave in window",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  /* Full teardown, the block reset on the last release clears
+     GPIOBASE.*/
+  pioSmDisableX(smp);
+  pioSmFree(smp);
+  pioProgramUnload(RP_PIO1_BLOCK, sq_off, sqwave_program.length);
+#endif /* RP_PIO_HAS_GPIOBASE == TRUE */
 
   /*
    * Summary.

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -507,10 +507,10 @@ int main(void) {
   }
 
   rel = pioGpioToRel(block, TEST_GPIO);
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetWrap(&cfg, 0U, 31U);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrapX(&cfg, 0U, 31U);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
 
   /* The builder output must equal the values sqwave_start() assembles by
      hand from the _Pos/_Msk macros.*/
@@ -580,11 +580,11 @@ int main(void) {
     goto summary;
   }
 
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetWrap(&cfg, (uint32_t)out_off, (uint32_t)out_off);
-  pioSmConfigSetOutPins(&cfg, rel, 1U);
-  pioSmConfigSetOutShift(&cfg, true, true, 32U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetWrapX(&cfg, (uint32_t)out_off, (uint32_t)out_off);
+  pioSmConfigSetOutPinsX(&cfg, rel, 1U);
+  pioSmConfigSetOutShiftX(&cfg, true, true, 32U);
   pioSmInit(smp, (uint32_t)out_off, &cfg);
 
   pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
@@ -665,9 +665,9 @@ int main(void) {
      write sequence must neither lose the configured EXECCTRL nor leave a
      sticky direction write latched (the helper restarts the SM to clear
      it).*/
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
-  pioSmConfigSetOutSpecial(&cfg, true, false, 0U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
+  pioSmConfigSetOutSpecialX(&cfg, true, false, 0U);
   pioSmSetConfigX(smp, &cfg);
   pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
   report("EXECCTRL sticky preserved",
@@ -697,9 +697,9 @@ int main(void) {
   }
 
   rel = pioGpioToRel(RP_PIO2_BLOCK, TEST_GPIO);
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
   pioSmInit(smp, (uint32_t)sq_off, &cfg);
   pioSmSetConsecutivePindirsX(smp, TEST_GPIO, 1U, true);
   pioGpioInitX(smp, TEST_GPIO);
@@ -739,9 +739,9 @@ int main(void) {
   rel = pioGpioToRel(RP_PIO1_BLOCK, WINDOW_GPIO);
   report("GPIO lowered into window", rel == (WINDOW_GPIO - 16U));
 
-  pioSmConfigDefault(&cfg);
-  pioSmConfigSetFrequency(&cfg, SM_TEST_FREQ);
-  pioSmConfigSetSetPins(&cfg, rel, 1U);
+  pioSmConfigDefaultX(&cfg);
+  pioSmConfigSetFrequencyX(&cfg, SM_TEST_FREQ);
+  pioSmConfigSetSetPinsX(&cfg, rel, 1U);
   pioSmInit(smp, (uint32_t)sq_off, &cfg);
   pioSmSetConsecutivePindirsX(smp, WINDOW_GPIO, 1U, true);
   pioGpioInitX(smp, WINDOW_GPIO);

--- a/testhal/RP/RP2350/PIO-VALIDATION/pio_validation.h
+++ b/testhal/RP/RP2350/PIO-VALIDATION/pio_validation.h
@@ -21,6 +21,12 @@
 #ifndef PIO_VALIDATION_H
 #define PIO_VALIDATION_H
 
+/*
+ * Full memory barrier usable from both the ARM and RISC-V builds of the
+ * shared sources (__DMB is CMSIS, ARM only).
+ */
+#define pio_validation_barrier()    __sync_synchronize()
+
 extern volatile uint32_t c1_ready;
 extern volatile uint32_t c1_do_free;
 extern volatile uint32_t c1_free_done;


### PR DESCRIPTION
## Summary

Adds a pico-sdk-equivalent configuration layer and pin/DMA glue to the RP PIOv1 driver, so PIO peripherals can be ported from .pio programs by transcription instead of hand-assembling EXECCTRL/SHIFTCTRL/PINCTRL register words:

- `rp_pio_sm_config_t` plus the `pioSmConfig*X` builder family (wrap, side-set, pin groups, JMP pin, clock divider, shift control, FIFO join, MOV STATUS, OUT specials), mirroring pico-sdk `sm_config` semantics. `pioSmSetConfigX()` applies the images; `pioSmInit()` performs the full `pio_sm_init` sequence.
- `pioGpioInitPadX()`/`pioGpioInitX()`: pin mux plus pad programming in one call (input enable, schmitt, drive strength; on the RP2350 the pad isolation latch is cleared last, in the glitch-free order). The existing `pioSmSetPinFunctionX()` programs only the mux and leaves an untouched RP2350 pad isolated.
- `pioSmSetConsecutivePindirsX()`: exec-based pindirs in chunks of up to five pins with bit-exact PINCTRL restore; OUT_STICKY configurations are neutralized via flag clear plus SM_RESTART so no direction write stays latched.
- DMA glue: `pioSmTxDreqX()`/`pioSmRxDreqX()` (raw DREQ numbers for the chip's `DMA_CTRL_TRIG_TREQ_SEL()` macro, valid on both the RP2040 and RP2350 numbering) and TX/RX FIFO address/level accessors, composing with the DMAv1 channel API.
- Fixes the latent per-chip EXECCTRL STATUS field layout (the RP2350 widens STATUS_N to 5 bits and STATUS_SEL to 2).
- Documents the supported pioasm consumption path: generated headers compiled with `PICO_NO_HARDWARE=1`, wrap defines applied via `pioSmConfigSetWrapX()`, side-set and .origin transcribed from the .pio source.

Builder pin fields are GPIOBASE-window-relative (lower absolute GPIOs with `pioGpioToRel()`); wrap values are absolute so callers add the `pioProgramLoad()` offset, matching pioasm's program-relative labels.

## Validation

The PIO-VALIDATION testhal apps gain tests 5-9: builder equivalence against hand-assembled values plus hardware readback, DMA-fed TX FIFO through the DREQ/FIFO-address glue, consecutive pindirs across the 5-pin chunk limit including a sticky-output configuration, and on the RP2350 the PIO2/FUNCSEL-8 pad-isolation path and the GPIOBASE=16 window. A new PIO-VALIDATION-RISCV app builds the shared sources for Hazard3.

Hardware runs via debug probe, self-checking through SIO GPIO_IN/register readback, report on UART0:

| Target | Result |
|---|---|
| RP2040 Cortex-M0+ | 39/39 pass |
| RP2350 Cortex-M33 | 46/46 pass |
| RP2350 Hazard3 RISC-V | 46/46 pass |

## Notes

- The builders carry the X suffix and `@xclass`: pure data manipulation callable from any context per the context-suffix conventions.
- Pre-existing and not addressed here: a clean build of HAZARD3-VALIDATION on master overflows ram5 at link (the per-core OS instances in the scratch banks no longer fit beside two 0x800 stacks). The new RISCV app sizes its stacks at 0x600 to fit.