### PR TITLE
RP2350 EFL: architecture-neutral interrupt masking

### DIFF
--- a/os/common/ports/RISCV-HAZARD3/hazard3_irq.h
+++ b/os/common/ports/RISCV-HAZARD3/hazard3_irq.h
@@ -313,6 +313,39 @@ __STATIC_FORCEINLINE void hazard3_irq_context_restore(uint32_t ctx) {
 }
 
 /**
+ * @brief   Disables all maskable interrupts, saving the previous state.
+ * @details Atomically reads mstatus while clearing mstatus.MIE. Unlike
+ *          @p port_disable() this returns the previous enable state so it
+ *          can be restored exactly, which is required by code that must
+ *          run with all interrupts masked but may be reached with them
+ *          already disabled. NMI and fault-class exceptions are not masked.
+ *
+ * @return  An opaque mask cookie to pass to @p hazard3_irq_restore(); the
+ *          caller must not interpret it.
+ */
+__STATIC_FORCEINLINE uint32_t hazard3_irq_disable_save(void) {
+  uint32_t mstatus;
+
+  __asm__ volatile ("csrrc %0, mstatus, %1"
+    : "=r"(mstatus) : "r"(MSTATUS_MIE) : "memory");
+  return mstatus & MSTATUS_MIE;
+}
+
+/**
+ * @brief   Restores the interrupt enable state saved by
+ *          @p hazard3_irq_disable_save().
+ *
+ * @param[in] saved     mask cookie returned by
+ *                      @p hazard3_irq_disable_save()
+ */
+__STATIC_FORCEINLINE void hazard3_irq_restore(uint32_t saved) {
+
+  if (saved != 0U) {
+    __asm__ volatile ("csrs mstatus, %0" : : "r"(MSTATUS_MIE) : "memory");
+  }
+}
+
+/**
  * @brief   Initialize the Xh3irq interrupt controller.
  * @details Puts the controller in a known clean state by disabling all
  *          external interrupts (MEIEA), clearing all forced-pending bits

--- a/os/common/ports/RISCV-HAZARD3/hazard3_irq.h
+++ b/os/common/ports/RISCV-HAZARD3/hazard3_irq.h
@@ -339,10 +339,9 @@ __STATIC_FORCEINLINE uint32_t hazard3_irq_disable_save(void) {
  *                      @p hazard3_irq_disable_save()
  */
 __STATIC_FORCEINLINE void hazard3_irq_restore(uint32_t saved) {
-
-  if (saved != 0U) {
-    __asm__ volatile ("csrs mstatus, %0" : : "r"(MSTATUS_MIE) : "memory");
-  }
+  /* The cookie holds exactly the previous mstatus.MIE bit (or zero), so a
+     plain set restores it: zero sets nothing and leaves MIE disabled.*/
+  __asm__ volatile ("csrs mstatus, %0" : : "r"(saved) : "memory");
 }
 
 /**

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -726,6 +726,45 @@ RAMFUNC static flash_error_t rp_flash_erase_cmd(EFlashDriver *eflp,
 }
 
 /**
+ * @brief   Masks all interrupts at the architecture level.
+ * @details While XIP is disabled every handler is unreachable, including
+ *          fast interrupts above the kernel priority ceiling which a
+ *          BASEPRI-based lock would leave enabled. PRIMASK is used on ARM
+ *          and mstatus.MIE on RISC-V.
+ * @note    Forced inline so the masking code is guaranteed to reside in
+ *          the RAMFUNC callers.
+ *
+ * @return              The previous interrupt enable state.
+ */
+__attribute__((always_inline)) static inline uint32_t rp_flash_mask_irqs(void) {
+#if defined(__riscv)
+  uint32_t mstatus;
+  __asm volatile ("csrrci %0, mstatus, 8" : "=r" (mstatus) : : "memory");
+  return mstatus & (1U << 3);
+#else
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+  return primask;
+#endif
+}
+
+/**
+ * @brief   Restores the interrupt enable state saved by
+ *          @p rp_flash_mask_irqs().
+ *
+ * @param[in] state     saved interrupt enable state
+ */
+__attribute__((always_inline)) static inline void rp_flash_restore_irqs(uint32_t state) {
+#if defined(__riscv)
+  if (state != 0U) {
+    __asm volatile ("csrsi mstatus, 8" : : : "memory");
+  }
+#else
+  __set_PRIMASK(state);
+#endif
+}
+
+/**
  * @brief   Complete erase operation (runs entirely in RAM).
  * @note    This function MUST be in RAM. It handles the entire sequence
  *          from exit XIP to enter XIP so no flash code executes while
@@ -740,10 +779,8 @@ RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
                                                  uint8_t cmd,
                                                  uint32_t offset) {
   flash_error_t err = FLASH_NO_ERROR;
-  uint32_t primask = __get_PRIMASK();
-
   /* Defer fast interrupts too, their handlers may execute from flash.*/
-  __disable_irq();
+  uint32_t irqs = rp_flash_mask_irqs();
 
   /* Exit XIP mode. */
   if (!rp_flash_exit_xip(eflp)) {
@@ -761,7 +798,7 @@ RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
     err = FLASH_ERROR_HW_FAILURE;
   }
 
-  __set_PRIMASK(primask);
+  rp_flash_restore_irqs(irqs);
 
   return err;
 }
@@ -783,10 +820,8 @@ RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
                                                         const uint8_t *data,
                                                         size_t len) {
   flash_error_t err = FLASH_NO_ERROR;
-  uint32_t primask = __get_PRIMASK();
-
   /* Defer fast interrupts too, their handlers may execute from flash.*/
-  __disable_irq();
+  uint32_t irqs = rp_flash_mask_irqs();
 
   /* Exit XIP mode. */
   if (!rp_flash_exit_xip(eflp)) {
@@ -804,7 +839,7 @@ RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
     err = FLASH_ERROR_HW_FAILURE;
   }
 
-  __set_PRIMASK(primask);
+  rp_flash_restore_irqs(irqs);
 
   return err;
 }
@@ -824,10 +859,8 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
                                                     uint8_t *rx,
                                                     size_t count) {
   flash_error_t err = FLASH_NO_ERROR;
-  uint32_t primask = __get_PRIMASK();
-
   /* Defer fast interrupts too, their handlers may execute from flash.*/
-  __disable_irq();
+  uint32_t irqs = rp_flash_mask_irqs();
 
   /* Exit XIP mode. */
   if (!rp_flash_exit_xip(eflp)) {
@@ -845,7 +878,7 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
     err = FLASH_ERROR_HW_FAILURE;
   }
 
-  __set_PRIMASK(primask);
+  rp_flash_restore_irqs(irqs);
 
   return err;
 }

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -742,9 +742,11 @@ RAMFUNC static flash_error_t rp_flash_erase_cmd(EFlashDriver *eflp,
  */
 CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
 #if defined(__riscv)
+  /* MSTATUS_MIE is provided by riscv_csr.h via the device header.*/
   uint32_t mstatus;
-  __asm volatile ("csrrci %0, mstatus, 8" : "=r" (mstatus) : : "memory");
-  return mstatus & (1U << 3);
+  __asm volatile ("csrrc %0, mstatus, %1"
+                  : "=r" (mstatus) : "r" (MSTATUS_MIE) : "memory");
+  return mstatus & MSTATUS_MIE;
 #else
   uint32_t primask = __get_PRIMASK();
   __disable_irq();
@@ -763,7 +765,7 @@ CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
 CC_FORCE_INLINE static inline void rp_flash_restore_irqs(uint32_t state) {
 #if defined(__riscv)
   if (state != 0U) {
-    __asm volatile ("csrsi mstatus, 8" : : : "memory");
+    __asm volatile ("csrs mstatus, %0" : : "r" (MSTATUS_MIE) : "memory");
   }
 #else
   __set_PRIMASK(state);
@@ -785,8 +787,10 @@ RAMFUNC static flash_error_t rp_flash_erase_full(EFlashDriver *eflp,
                                                  uint8_t cmd,
                                                  uint32_t offset) {
   flash_error_t err = FLASH_NO_ERROR;
+  uint32_t irqs;
+
   /* Defer fast interrupts too, their handlers may execute from flash.*/
-  uint32_t irqs = rp_flash_mask_irqs();
+  irqs = rp_flash_mask_irqs();
 
   /* Exit XIP mode. */
   if (!rp_flash_exit_xip(eflp)) {
@@ -826,8 +830,10 @@ RAMFUNC static flash_error_t rp_flash_program_page_full(EFlashDriver *eflp,
                                                         const uint8_t *data,
                                                         size_t len) {
   flash_error_t err = FLASH_NO_ERROR;
+  uint32_t irqs;
+
   /* Defer fast interrupts too, their handlers may execute from flash.*/
-  uint32_t irqs = rp_flash_mask_irqs();
+  irqs = rp_flash_mask_irqs();
 
   /* Exit XIP mode. */
   if (!rp_flash_exit_xip(eflp)) {
@@ -865,8 +871,10 @@ RAMFUNC static flash_error_t rp_flash_read_uid_full(EFlashDriver *eflp,
                                                     uint8_t *rx,
                                                     size_t count) {
   flash_error_t err = FLASH_NO_ERROR;
+  uint32_t irqs;
+
   /* Defer fast interrupts too, their handlers may execute from flash.*/
-  uint32_t irqs = rp_flash_mask_irqs();
+  irqs = rp_flash_mask_irqs();
 
   /* Exit XIP mode. */
   if (!rp_flash_exit_xip(eflp)) {

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -735,7 +735,10 @@ RAMFUNC static flash_error_t rp_flash_erase_cmd(EFlashDriver *eflp,
  * @note    Forced inline so the masking code is guaranteed to reside in
  *          the RAMFUNC callers.
  *
- * @return              The previous interrupt enable state.
+ * @return              An opaque, architecture-specific mask state (the
+ *                      PRIMASK value on ARM, the saved mstatus.MIE bit
+ *                      on RISC-V), only meaningful as the argument to
+ *                      @p rp_flash_restore_irqs().
  */
 CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
 #if defined(__riscv)
@@ -753,7 +756,9 @@ CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
  * @brief   Restores the interrupt enable state saved by
  *          @p rp_flash_mask_irqs().
  *
- * @param[in] state     saved interrupt enable state
+ * @param[in] state     opaque mask state returned by
+ *                      @p rp_flash_mask_irqs(), not interpretable by the
+ *                      caller
  */
 CC_FORCE_INLINE static inline void rp_flash_restore_irqs(uint32_t state) {
 #if defined(__riscv)

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -29,6 +29,12 @@
 #include "hal.h"
 #include "rp_efl_lld.h"
 
+#if defined(__riscv)
+/* Hazard3 mstatus.MIE mask/restore primitives, not in the general HAL
+   include chain.*/
+#include "hazard3_irq.h"
+#endif
+
 #if (HAL_USE_EFL == TRUE) || defined(__DOXYGEN__)
 
 /*===========================================================================*/
@@ -742,11 +748,7 @@ RAMFUNC static flash_error_t rp_flash_erase_cmd(EFlashDriver *eflp,
  */
 CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
 #if defined(__riscv)
-  /* MSTATUS_MIE is provided by riscv_csr.h via the device header.*/
-  uint32_t mstatus;
-  __asm volatile ("csrrc %0, mstatus, %1"
-                  : "=r" (mstatus) : "r" (MSTATUS_MIE) : "memory");
-  return mstatus & MSTATUS_MIE;
+  return hazard3_irq_disable_save();
 #else
   uint32_t primask = __get_PRIMASK();
   __disable_irq();
@@ -764,9 +766,7 @@ CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
  */
 CC_FORCE_INLINE static inline void rp_flash_restore_irqs(uint32_t state) {
 #if defined(__riscv)
-  if (state != 0U) {
-    __asm volatile ("csrs mstatus, %0" : : "r" (MSTATUS_MIE) : "memory");
-  }
+  hazard3_irq_restore(state);
 #else
   __set_PRIMASK(state);
 #endif

--- a/os/hal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/hal/ports/RP/RP2350/hal_efl_lld.c
@@ -726,17 +726,18 @@ RAMFUNC static flash_error_t rp_flash_erase_cmd(EFlashDriver *eflp,
 }
 
 /**
- * @brief   Masks all interrupts at the architecture level.
+ * @brief   Masks all maskable interrupts at the architecture level.
  * @details While XIP is disabled every handler is unreachable, including
  *          fast interrupts above the kernel priority ceiling which a
  *          BASEPRI-based lock would leave enabled. PRIMASK is used on ARM
- *          and mstatus.MIE on RISC-V.
+ *          and mstatus.MIE on RISC-V; NMI and fault-class exceptions
+ *          remain unmasked on both architectures.
  * @note    Forced inline so the masking code is guaranteed to reside in
  *          the RAMFUNC callers.
  *
  * @return              The previous interrupt enable state.
  */
-__attribute__((always_inline)) static inline uint32_t rp_flash_mask_irqs(void) {
+CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
 #if defined(__riscv)
   uint32_t mstatus;
   __asm volatile ("csrrci %0, mstatus, 8" : "=r" (mstatus) : : "memory");
@@ -754,7 +755,7 @@ __attribute__((always_inline)) static inline uint32_t rp_flash_mask_irqs(void) {
  *
  * @param[in] state     saved interrupt enable state
  */
-__attribute__((always_inline)) static inline void rp_flash_restore_irqs(uint32_t state) {
+CC_FORCE_INLINE static inline void rp_flash_restore_irqs(uint32_t state) {
 #if defined(__riscv)
   if (state != 0U) {
     __asm volatile ("csrsi mstatus, 8" : : : "memory");


### PR DESCRIPTION
Stacked on #138 (retarget to master once that merges).

The RAM-resident flash operations in the RP2350 EFL driver mask
interrupts with the CMSIS PRIMASK intrinsics, which do not exist on the
Hazard3 RISC-V mode -- any RISC-V build enabling `HAL_USE_EFL` fails to
compile (found integrating the RP2350 RISC-V port into QMK, the first
RISC-V EFL consumer).

Replace the intrinsics with always-inline helpers that mask at the
architecture level: PRIMASK on ARM (behavior unchanged) and
`mstatus.MIE` on RISC-V. An OSAL/BASEPRI-based lock would not be
equivalent -- fast interrupts above the kernel priority ceiling must
also be deferred, because their handlers may execute from flash while
XIP is disabled. The helpers are forced inline so the masking code is
guaranteed to reside in the RAMFUNC callers.

The RISC-V mask/restore primitive lives in the Hazard3 port
(`hazard3_irq_disable_save()` / `hazard3_irq_restore()` in
`hazard3_irq.h`, alongside the existing `hazard3_irq_context_save/restore`
cookie idiom) rather than as raw `mstatus` CSR asm in the HAL driver, so
the driver's RISC-V arm is a named call symmetric with the ARM CMSIS
intrinsics. It is kept Hazard3-scoped, not promoted to the generic port
API which deliberately exposes only kernel-level locking; a full
interrupt disable is what this flash/XIP case specifically needs.

Verified the `__STATIC_FORCEINLINE` primitive inlines into the
RAM-resident flash functions (the `csrrc`/`csrs mstatus` land inside
`rp_flash_erase_full` at a `0x2000xxxx` SRAM address, not out-of-line in
XIP flash), so the RAMFUNC XIP-safety guarantee is preserved. Compile
coverage: ARM via the RP2350 EFL-SMP-LOCKOUT testhal, RISC-V via a QMK
Hazard3 build.