### PR TITLE
Add RTCv2 for Pico 2 RP2350

### DIFF
--- a/os/hal/ports/RP/LLD/RTCv2/driver.mk
+++ b/os/hal/ports/RP/LLD/RTCv2/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_RTC TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/hal/ports/RP/LLD/RTCv2

--- a/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+++ b/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
@@ -1,0 +1,668 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    hal_rtc_lld.c
+ * @brief   RP2350 RTC subsystem low level driver source.
+ * @details This driver is built on the POWMAN "Always-On" timer.
+ *
+ * @addtogroup RTC
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/* POWMAN register block (RP2350 datasheet section 12.11/12.10).*/
+#define POWMAN_BASE                  0x40100000UL
+
+#define POWMAN_LPOSC_FREQ_KHZ_INT    (*(volatile uint32_t *)(POWMAN_BASE + 0x50UL))
+#define POWMAN_LPOSC_FREQ_KHZ_FRAC   (*(volatile uint32_t *)(POWMAN_BASE + 0x54UL))
+#define POWMAN_SET_TIME_63TO48       (*(volatile uint32_t *)(POWMAN_BASE + 0x60UL))
+#define POWMAN_SET_TIME_47TO32       (*(volatile uint32_t *)(POWMAN_BASE + 0x64UL))
+#define POWMAN_SET_TIME_31TO16       (*(volatile uint32_t *)(POWMAN_BASE + 0x68UL))
+#define POWMAN_SET_TIME_15TO0        (*(volatile uint32_t *)(POWMAN_BASE + 0x6CUL))
+#define POWMAN_READ_TIME_UPPER       (*(volatile uint32_t *)(POWMAN_BASE + 0x70UL))
+#define POWMAN_READ_TIME_LOWER       (*(volatile uint32_t *)(POWMAN_BASE + 0x74UL))
+#define POWMAN_ALARM_TIME_63TO48     (*(volatile uint32_t *)(POWMAN_BASE + 0x78UL))
+#define POWMAN_ALARM_TIME_47TO32     (*(volatile uint32_t *)(POWMAN_BASE + 0x7CUL))
+#define POWMAN_ALARM_TIME_31TO16     (*(volatile uint32_t *)(POWMAN_BASE + 0x80UL))
+#define POWMAN_ALARM_TIME_15TO0      (*(volatile uint32_t *)(POWMAN_BASE + 0x84UL))
+#define POWMAN_TIMER                 (*(volatile uint32_t *)(POWMAN_BASE + 0x88UL))
+#define POWMAN_INTE                  (*(volatile uint32_t *)(POWMAN_BASE + 0xE4UL))
+
+/* Writes to most POWMAN registers are ignored unless the top 16 bits
+   carry this password, to prevent accidental writes (RP2350 datasheet
+   12.11).*/
+#define POWMAN_PASSWORD_BITS         0x5AFE0000UL
+
+#define POWMAN_TIMER_ALARM_BITS      (1UL << 6)
+#define POWMAN_TIMER_ALARM_ENAB_BITS (1UL << 4)
+#define POWMAN_TIMER_RUN_BITS        (1UL << 1)
+#define POWMAN_TIMER_USE_LPOSC_BITS  (1UL << 8)
+
+#define POWMAN_INTE_TIMER_BITS       (1UL << 1)
+
+/* Nominal LPOSC frequency, matching the RP2350 power-on-reset default
+   for these registers (32.768kHz target for the internal low power
+   oscillator).*/
+#define POWMAN_LPOSC_NOMINAL_FREQ_KHZ_INT   32UL
+#define POWMAN_LPOSC_NOMINAL_FREQ_KHZ_FRAC  0xC49CUL
+
+#define MS_PER_DAY                   86400000ULL
+
+/* days_from_civil()/civil_from_days() below are expressed in days since
+   1970-01-01. The driver's own time base is ms since RTC_BASE_YEAR
+   (1980-01-01, see hal_rtc.h).*/
+#define RTC_BASE_YEAR_EPOCH_DAYS     3652 /* days_from_civil(1980, 1, 1) */
+
+/* Aliased set/clear register offsets (RP2350 atomic bit-set/clear
+   register aliasing convention).*/
+#define POWMAN_ALIAS_SET_OFFSET      0x2000UL
+#define POWMAN_ALIAS_CLR_OFFSET      0x3000UL
+
+/*===========================================================================*/
+/* Driver exported variables.                                               */
+/*===========================================================================*/
+
+/**
+ * @brief RTC driver identifier.
+ */
+RTCDriver RTCD1;
+
+/*===========================================================================*/
+/* Driver local variables and types.                                        */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Writes a password-protected POWMAN register.
+ *
+ * @notapi
+ */
+static void powman_write(volatile uint32_t *reg, uint32_t value) {
+
+  *reg = POWMAN_PASSWORD_BITS | value;
+}
+
+/**
+ * @brief   Atomically sets bits in a password-protected POWMAN register.
+ *
+ * @notapi
+ */
+static void powman_set_bits(volatile uint32_t *reg, uint32_t bits) {
+  volatile uint32_t *set_alias;
+
+  set_alias = (volatile uint32_t *)((volatile uint8_t *)reg +
+                                     POWMAN_ALIAS_SET_OFFSET);
+  *set_alias = POWMAN_PASSWORD_BITS | bits;
+}
+
+/**
+ * @brief   Atomically clears bits in a password-protected POWMAN register.
+ *
+ * @notapi
+ */
+static void powman_clear_bits(volatile uint32_t *reg, uint32_t bits) {
+  volatile uint32_t *clear_alias;
+
+  clear_alias = (volatile uint32_t *)((volatile uint8_t *)reg +
+                                       POWMAN_ALIAS_CLR_OFFSET);
+  *clear_alias = POWMAN_PASSWORD_BITS | bits;
+}
+
+/**
+ * @brief   Returns the current AON timer value.
+ * @details Value is expressed in milliseconds since RTC_BASE_YEAR.
+ *
+ * @notapi
+ */
+static uint64_t powman_now_ms(void) {
+  uint32_t upper_word, lower_word, upper_word_recheck;
+
+  /* The 64-bit counter is exposed as two 32-bit halves; re-reading the
+     upper word after the lower one detects a rollover race between the
+     two reads.*/
+  upper_word = POWMAN_READ_TIME_UPPER;
+  for (;;) {
+    lower_word = POWMAN_READ_TIME_LOWER;
+    upper_word_recheck = POWMAN_READ_TIME_UPPER;
+    if (upper_word_recheck == upper_word) {
+      break;
+    }
+    upper_word = upper_word_recheck;
+  }
+  return ((uint64_t)upper_word << 32) | lower_word;
+}
+
+/**
+ * @brief   Converts a calendar date to days since 1970-01-01.
+ * @details Howard Hinnant's public-domain civil calendar algorithm.
+ *
+ * @notapi
+ */
+static int64_t days_from_civil(int64_t year, unsigned month, unsigned day) {
+  int64_t era, day_of_era_i64;
+  unsigned year_of_era, months_since_march, day_of_year, day_of_era;
+
+  year -= (month <= 2U) ? 1 : 0;
+
+  era = (year >= 0 ? year : year - 399) / 400;
+  year_of_era = (unsigned)(year - era * 400);
+  months_since_march = (month > 2U) ? (month - 3U) : (month + 9U);
+  day_of_year = (153U * months_since_march + 2U) / 5U + day - 1U;
+  day_of_era = year_of_era * 365U + year_of_era / 4U - year_of_era / 100U +
+               day_of_year;
+  day_of_era_i64 = (int64_t)day_of_era;
+
+  return era * 146097 + day_of_era_i64 - 719468;
+}
+
+/**
+ * @brief   Converts days since 1970-01-01 to a calendar date.
+ * @details Howard Hinnant's public-domain civil calendar algorithm.
+ *
+ * @notapi
+ */
+static void civil_from_days(int64_t days_since_unix_epoch,
+                            int *yearp,
+                            unsigned *monthp,
+                            unsigned *dayp) {
+  int64_t z, era, year;
+  unsigned day_of_era, year_of_era, day_of_year, months_since_march;
+
+  z = days_since_unix_epoch + 719468;
+
+  era = (z >= 0 ? z : z - 146096) / 146097;
+  day_of_era = (unsigned)(z - era * 146097);
+  year_of_era = (day_of_era - day_of_era / 1460U + day_of_era / 36524U -
+                day_of_era / 146096U) / 365U;
+  year = (int64_t)year_of_era + era * 400;
+  day_of_year = day_of_era - (365U * year_of_era + year_of_era / 4U -
+               year_of_era / 100U);
+  months_since_march = (5U * day_of_year + 2U) / 153U;
+
+  *dayp = day_of_year - (153U * months_since_march + 2U) / 5U + 1U;
+  *monthp = (months_since_march < 10U) ? (months_since_march + 3U) :
+                                         (months_since_march - 9U);
+  /* Undo the "year starts in March" shift from days_from_civil().*/
+  *yearp = (int)(year + (*monthp <= 2U ? 1 : 0));
+}
+
+/**
+ * @brief   Converts an @p RTCDateTime to POWMAN milliseconds.
+ *
+ * @notapi
+ */
+static uint64_t rtcdt_to_ms64(const RTCDateTime *dt) {
+  int64_t days_since_base_year;
+
+  days_since_base_year = days_from_civil((int64_t)dt->year + RTC_BASE_YEAR,
+                                         dt->month, dt->day) -
+                         RTC_BASE_YEAR_EPOCH_DAYS;
+
+  return (uint64_t)days_since_base_year * MS_PER_DAY +
+         (uint64_t)dt->millisecond;
+}
+
+/**
+ * @brief   Converts POWMAN milliseconds to an @p RTCDateTime.
+ *
+ * @notapi
+ */
+static void ms64_to_rtcdt(uint64_t milliseconds, RTCDateTime *dt) {
+  int64_t days_since_unix_epoch;
+  uint32_t millisecond_of_day, day_of_week_from_sunday;
+  int year;
+  unsigned month, day;
+
+  /* Rebased to days since 1970 here, matching what civil_from_days()
+     and the weekday calculation below expect.*/
+  days_since_unix_epoch = (int64_t)(milliseconds / MS_PER_DAY) +
+                          RTC_BASE_YEAR_EPOCH_DAYS;
+  millisecond_of_day = (uint32_t)(milliseconds % MS_PER_DAY);
+
+  civil_from_days(days_since_unix_epoch, &year, &month, &day);
+
+  dt->year        = (uint32_t)(year - RTC_BASE_YEAR);
+  dt->month       = month;
+  dt->day         = day;
+  dt->millisecond = millisecond_of_day;
+  dt->dstflag     = 0;
+
+  day_of_week_from_sunday = (uint32_t)(((days_since_unix_epoch % 7) + 7 + 4) % 7);
+  dt->dayofweek = ((day_of_week_from_sunday + 6U) % 7U) + 1U;
+}
+
+#if (RTC_ALARMS > 0) || defined(__DOXYGEN__)
+/**
+ * @brief   Finds the next second-of-day satisfying the alarm mask.
+ * @details Searches for the smallest second-of-day (0..86399) greater
+ *          than or equal to @p min_second_of_day that satisfies the
+ *          hour/minute/second alarm mask against @p wanted_time.
+ *
+ * @return              Whether a matching second-of-day was found.
+ * @retval false         no match exists in
+ *                       [min_second_of_day, 86399].
+ *
+ * @notapi
+ */
+static bool find_time_of_day(const RTCDateTime *wanted_time,
+                             rtcdtmask_t mask,
+                             uint32_t min_second_of_day,
+                             uint32_t *second_of_day) {
+  uint32_t wanted_second_of_day, wanted_hour, wanted_minute, wanted_second;
+  uint32_t hour_low, hour_high, minute_low, minute_high, second_low, second_high;
+  uint32_t hour, minute, second, candidate_second_of_day;
+  bool hour_fixed, minute_fixed, second_fixed;
+
+  wanted_second_of_day = wanted_time->millisecond / 1000U;
+  wanted_hour = wanted_second_of_day / 3600U;
+  wanted_minute = (wanted_second_of_day / 60U) % 60U;
+  wanted_second = wanted_second_of_day % 60U;
+
+  hour_fixed = RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_HOUR);
+  minute_fixed = RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_MINUTE);
+  second_fixed = RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_SECOND);
+
+  if (!hour_fixed && !minute_fixed && !second_fixed) {
+    /* Every second of the day matches.*/
+    if (min_second_of_day > 86399U) {
+      return false;
+    }
+    *second_of_day = min_second_of_day;
+    return true;
+  }
+
+  hour_low   = hour_fixed   ? wanted_hour   : 0U;
+  hour_high  = hour_fixed   ? wanted_hour   : 23U;
+  minute_low = minute_fixed ? wanted_minute : 0U;
+  minute_high= minute_fixed ? wanted_minute : 59U;
+  second_low = second_fixed ? wanted_second : 0U;
+  second_high= second_fixed ? wanted_second : 59U;
+
+  for (hour = hour_low; hour <= hour_high; hour++) {
+    for (minute = minute_low; minute <= minute_high; minute++) {
+      for (second = second_low; second <= second_high; second++) {
+        candidate_second_of_day = hour * 3600U + minute * 60U + second;
+        if (candidate_second_of_day >= min_second_of_day) {
+          *second_of_day = candidate_second_of_day;
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief   Checks whether a date matches the alarm mask.
+ *
+ * @notapi
+ */
+static bool date_matches(const RTCDateTime *candidate,
+                         const RTCDateTime *wanted_time,
+                         rtcdtmask_t mask) {
+
+  if (RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_YEAR) &&
+      (candidate->year != wanted_time->year)) {
+    return false;
+  }
+  if (RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_MONTH) &&
+      (candidate->month != wanted_time->month)) {
+    return false;
+  }
+  if (RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_DAY) &&
+      (candidate->day != wanted_time->day)) {
+    return false;
+  }
+  if (RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_DOTW) &&
+      (candidate->dayofweek != wanted_time->dayofweek)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @brief   Finds the next absolute AON time satisfying the alarm mask.
+ * @details Searches strictly after @p from_ms for the next POWMAN
+ *          timestamp (ms since RTC_BASE_YEAR) that satisfies the alarm
+ *          mask against @p wanted_time.
+ *
+ * @return              The next matching timestamp, or zero if the
+ *                      mask can never match again (e.g. a requested
+ *                      year already in the past).
+ *
+ * @notapi
+ */
+static uint64_t next_match_ms(const RTCDateTime *wanted_time,
+                              rtcdtmask_t mask,
+                              uint64_t from_ms) {
+  RTCDateTime candidate;
+  uint32_t second_of_day, current_second_of_day, day_offset;
+  uint64_t day_start_ms, scan_start_ms, year_start_ms, candidate_day_start_ms;
+  RTCDateTime year_start;
+
+  day_start_ms = (from_ms / MS_PER_DAY) * MS_PER_DAY;
+  current_second_of_day = (uint32_t)((from_ms - day_start_ms) / 1000U);
+
+  ms64_to_rtcdt(day_start_ms, &candidate);
+  if (date_matches(&candidate, wanted_time, mask) &&
+      find_time_of_day(wanted_time, mask, current_second_of_day + 1U,
+                       &second_of_day)) {
+    return day_start_ms + (uint64_t)second_of_day * 1000U;
+  }
+
+  if (!find_time_of_day(wanted_time, mask, 0U, &second_of_day)) {
+    return 0;
+  }
+
+  scan_start_ms = day_start_ms + MS_PER_DAY;
+  if (RTC_ALARM_TEST_MATCH(mask, RTC_DT_ALARM_YEAR) &&
+      (wanted_time->year != candidate.year)) {
+    if (wanted_time->year < candidate.year) {
+      /* The requested year has already passed: unsatisfiable.*/
+      return 0;
+    }
+    year_start.year  = wanted_time->year;
+    year_start.month = 1U;
+    year_start.day   = 1U;
+    year_start.millisecond = 0U;
+    year_start.dstflag = 0U;
+    year_start.dayofweek = 0U;
+    year_start_ms = rtcdt_to_ms64(&year_start);
+    if (year_start_ms > scan_start_ms) {
+      scan_start_ms = year_start_ms;
+    }
+  }
+
+  for (day_offset = 0U; day_offset <= 366U; day_offset++) {
+    candidate_day_start_ms = scan_start_ms + (uint64_t)day_offset * MS_PER_DAY;
+    ms64_to_rtcdt(candidate_day_start_ms, &candidate);
+    if (date_matches(&candidate, wanted_time, mask)) {
+      return candidate_day_start_ms + (uint64_t)second_of_day * 1000U;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * @brief   Disables the alarm comparator and its interrupt.
+ *
+ * @notapi
+ */
+static void rtc_disable_alarm(RTCDriver *rtcp) {
+
+  (void)rtcp;
+  powman_clear_bits(&POWMAN_INTE, POWMAN_INTE_TIMER_BITS);
+  powman_clear_bits(&POWMAN_TIMER, POWMAN_TIMER_ALARM_ENAB_BITS);
+}
+
+/**
+ * @brief   Programs the alarm comparator and enables it.
+ * @note    The comparator must be disabled while its registers are
+ *          written.
+ *
+ * @notapi
+ */
+static void rtc_arm_alarm(uint64_t alarm_ms) {
+
+  powman_clear_bits(&POWMAN_TIMER, POWMAN_TIMER_ALARM_ENAB_BITS);
+  powman_write(&POWMAN_ALARM_TIME_15TO0, (uint32_t)(alarm_ms & 0xFFFFUL));
+  powman_write(&POWMAN_ALARM_TIME_31TO16,
+              (uint32_t)((alarm_ms >> 16) & 0xFFFFUL));
+  powman_write(&POWMAN_ALARM_TIME_47TO32,
+              (uint32_t)((alarm_ms >> 32) & 0xFFFFUL));
+  powman_write(&POWMAN_ALARM_TIME_63TO48,
+              (uint32_t)((alarm_ms >> 48) & 0xFFFFUL));
+
+  powman_clear_bits(&POWMAN_TIMER, POWMAN_TIMER_ALARM_BITS);
+  powman_set_bits(&POWMAN_INTE, POWMAN_INTE_TIMER_BITS);
+  powman_set_bits(&POWMAN_TIMER, POWMAN_TIMER_ALARM_ENAB_BITS);
+}
+#endif /* RTC_ALARMS > 0 */
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if (RTC_ALARMS > 0) || defined(__DOXYGEN__)
+/**
+ * @brief   POWMAN timer alarm interrupt handler.
+ *
+ * @isr
+ */
+OSAL_IRQ_HANDLER(RP_POWMAN_IRQ_TIMER_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  /* The alarm comparator is level-sensitive (alarm_time >= current_time),
+     so it must be disabled before the latched flag is cleared.*/
+  rtc_disable_alarm(&RTCD1);
+  powman_clear_bits(&POWMAN_TIMER, POWMAN_TIMER_ALARM_BITS);
+
+  if ((RTCD1.mask & RTC_ALARM_NON_REPEATING) != RTC_ALARM_NON_REPEATING) {
+    uint64_t next_alarm_ms = next_match_ms(&RTCD1.alarm, RTCD1.mask,
+                                           powman_now_ms());
+    if (next_alarm_ms != 0) {
+      rtc_arm_alarm(next_alarm_ms);
+    }
+  }
+
+#if RTC_SUPPORTS_CALLBACKS == TRUE
+  if (RTCD1.callback != NULL) {
+    RTCD1.callback(&RTCD1, RTC_EVENT_ALARM);
+  }
+#endif
+
+  OSAL_IRQ_EPILOGUE();
+}
+#endif
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Enable access to the POWMAN AON timer.
+ *
+ * @notapi
+ */
+void rtc_lld_init(void) {
+
+  /* RTC object initialization.*/
+  rtcObjectInit(&RTCD1);
+
+  /* Callback initially disabled.*/
+  RTCD1.callback = NULL;
+
+#if (RTC_ALARMS > 0)
+  RTCD1.mask = RTC_ALARM_DISABLE_ALL_MATCHING;
+#endif
+
+  /* POWMAN is in the Always-On power domain: it is not part of the
+     RESETS block and survives ordinary chip resets by design.*/
+  powman_write(&POWMAN_LPOSC_FREQ_KHZ_INT, POWMAN_LPOSC_NOMINAL_FREQ_KHZ_INT);
+  powman_write(&POWMAN_LPOSC_FREQ_KHZ_FRAC, POWMAN_LPOSC_NOMINAL_FREQ_KHZ_FRAC);
+  powman_set_bits(&POWMAN_TIMER, POWMAN_TIMER_USE_LPOSC_BITS);
+
+  if ((POWMAN_TIMER & POWMAN_TIMER_RUN_BITS) == 0) {
+    /* Timer not running: either first power-up of the AON domain, or a
+       previous explicit stop.*/
+    powman_set_bits(&POWMAN_TIMER, POWMAN_TIMER_RUN_BITS);
+  }
+
+  rtc_disable_alarm(&RTCD1);
+  powman_clear_bits(&POWMAN_TIMER, POWMAN_TIMER_ALARM_BITS);
+
+  nvicEnableVector(RP_POWMAN_IRQ_TIMER_NUMBER, RP_IRQ_RTC_PRIORITY);
+}
+
+/**
+ * @brief   Set current time.
+ * @note    Fractional seconds part will be silently ignored. There is no
+ *          possibility to set it on RP2350 platform.
+ * @note    The function can be called from any context.
+ *
+ * @param[in] rtcp      pointer to RTC driver structure
+ * @param[in] timespec  pointer to a @p RTCDateTime structure
+ *
+ * @notapi
+ */
+void rtc_lld_set_time(RTCDriver *rtcp, const RTCDateTime *timespec) {
+  uint64_t milliseconds;
+
+  (void)rtcp;
+  milliseconds = rtcdt_to_ms64(timespec);
+
+  /* Entering a reentrant critical zone.*/
+  syssts_t sts = osalSysGetStatusAndLockX();
+
+  /* SET_TIME_* may only be written while the timer is stopped.*/
+  powman_clear_bits(&POWMAN_TIMER, POWMAN_TIMER_RUN_BITS);
+  powman_write(&POWMAN_SET_TIME_15TO0, (uint32_t)(milliseconds & 0xFFFFUL));
+  powman_write(&POWMAN_SET_TIME_31TO16,
+              (uint32_t)((milliseconds >> 16) & 0xFFFFUL));
+  powman_write(&POWMAN_SET_TIME_47TO32,
+              (uint32_t)((milliseconds >> 32) & 0xFFFFUL));
+  powman_write(&POWMAN_SET_TIME_63TO48,
+              (uint32_t)((milliseconds >> 48) & 0xFFFFUL));
+  powman_set_bits(&POWMAN_TIMER, POWMAN_TIMER_RUN_BITS);
+
+  /* Leaving a reentrant critical zone.*/
+  osalSysRestoreStatusX(sts);
+}
+
+/**
+ * @brief   Get current time.
+ * @note    The function can be called from any context.
+ *
+ * @param[in]  rtcp      pointer to RTC driver structure
+ * @param[out] timespec pointer to a @p RTCDateTime structure
+ *
+ * @notapi
+ */
+void rtc_lld_get_time(RTCDriver *rtcp, RTCDateTime *timespec) {
+
+  (void)rtcp;
+  ms64_to_rtcdt(powman_now_ms(), timespec);
+}
+
+#if (RTC_ALARMS > 0) || defined(__DOXYGEN__)
+/**
+ * @brief   Set alarm time.
+ * @note    The alarm time can be partially specified by leaving fields as
+ *          zero and excluding them from the mask.
+ * @note    A specification with no matching fields enabled disables the
+ *          alarm.
+ * @note    The function can be called from any context.
+ *
+ * @param[in] rtcp      pointer to RTC driver structure.
+ * @param[in] alarm     alarm identifier. Can be 0.
+ * @param[in] alarmspec pointer to a @p RTCAlarm structure.
+ *
+ * @notapi
+ */
+void rtc_lld_set_alarm(RTCDriver *rtcp,
+                       rtcalarm_t alarm,
+                       const RTCAlarm *alarmspec) {
+  rtcdtmask_t dtmask;
+  uint64_t next_alarm_ms;
+
+  (void)alarm;
+  dtmask = alarmspec->mask;
+
+  if (dtmask == RTC_ALARM_DISABLE_ALL_MATCHING) {
+    /* Entering a reentrant critical zone.*/
+    syssts_t sts = osalSysGetStatusAndLockX();
+
+    rtc_disable_alarm(rtcp);
+    rtcp->mask = RTC_ALARM_DISABLE_ALL_MATCHING;
+
+    /* Leaving a reentrant critical zone.*/
+    osalSysRestoreStatusX(sts);
+    return;
+  }
+
+  next_alarm_ms = next_match_ms(&alarmspec->alarm, dtmask, powman_now_ms());
+
+  /* Entering a reentrant critical zone.*/
+  syssts_t sts = osalSysGetStatusAndLockX();
+
+  if (next_alarm_ms != 0) {
+    rtc_arm_alarm(next_alarm_ms);
+  }
+  else {
+    rtc_disable_alarm(rtcp);
+  }
+
+  rtcp->alarm = alarmspec->alarm;
+  rtcp->mask = dtmask;
+
+  /* Leaving a reentrant critical zone.*/
+  osalSysRestoreStatusX(sts);
+}
+
+/**
+ * @brief   Get alarm time.
+ * @note    The function can be called from any context.
+ *
+ * @param[in]  rtcp       pointer to RTC driver structure
+ * @param[in]  alarm      alarm identifier
+ * @param[in]  alarmspec pointer to a @p RTCAlarm structure
+ *
+ * @notapi
+ */
+void rtc_lld_get_alarm(RTCDriver *rtcp,
+                       rtcalarm_t alarm,
+                       RTCAlarm *alarmspec) {
+
+  (void)alarm;
+  alarmspec->alarm = rtcp->alarm;
+  alarmspec->mask = rtcp->mask;
+}
+#endif /* RTC_ALARMS > 0 */
+
+#if RTC_SUPPORTS_CALLBACKS == TRUE
+/**
+ * @brief   Enables or disables RTC callbacks.
+ * @details This function enables or disables callbacks. Use a @p NULL pointer
+ *          in order to disable a callback.
+ * @note    The function can be called from any context.
+ *
+ * @param[in] rtcp      pointer to RTC driver structure
+ * @param[in] callback  callback function pointer or @p NULL
+ *
+ * @notapi
+ */
+void rtc_lld_set_callback(RTCDriver *rtcp, rtccb_t callback) {
+
+  rtcp->callback = callback;
+}
+#endif /* RTC_SUPPORTS_CALLBACKS == TRUE */
+
+#endif /* HAL_USE_RTC */
+
+/** @} */

--- a/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+++ b/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
@@ -349,6 +349,9 @@ static bool date_matches(const RTCDateTime *candidate,
  * @details Searches strictly after @p from_ms for the next POWMAN
  *          timestamp (ms since RTC_BASE_YEAR) that satisfies the alarm
  *          mask against @p wanted_time.
+ * @note    The search is limited to the current day plus the following
+ *          366 days; alarm specifications that would next match farther
+ *          than one year ahead are treated as unsatisfiable.
  *
  * @return              The next matching timestamp, or zero if the
  *                      mask can never match again (e.g. a requested
@@ -575,6 +578,9 @@ void rtc_lld_get_time(RTCDriver *rtcp, RTCDateTime *timespec) {
  * @brief   Set alarm time.
  * @note    The alarm time can be partially specified by leaving fields as
  *          zero and excluding them from the mask.
+ * @note    Alarm matching is limited to the current day plus the following
+ *          366 days; specifications that would next match farther than one
+ *          year ahead are not armed.
  * @note    A specification with no matching fields enabled disables the
  *          alarm.
  * @note    The function can be called from any context.
@@ -588,13 +594,12 @@ void rtc_lld_get_time(RTCDriver *rtcp, RTCDateTime *timespec) {
 void rtc_lld_set_alarm(RTCDriver *rtcp,
                        rtcalarm_t alarm,
                        const RTCAlarm *alarmspec) {
-  rtcdtmask_t dtmask;
+
   uint64_t next_alarm_ms;
 
   (void)alarm;
-  dtmask = alarmspec->mask;
 
-  if (dtmask == RTC_ALARM_DISABLE_ALL_MATCHING) {
+  if ((alarmspec == NULL) || (alarmspec->dtmask == RTC_ALARM_DISABLE_ALL_MATCHING)) {
     /* Entering a reentrant critical zone.*/
     syssts_t sts = osalSysGetStatusAndLockX();
 
@@ -606,7 +611,7 @@ void rtc_lld_set_alarm(RTCDriver *rtcp,
     return;
   }
 
-  next_alarm_ms = next_match_ms(&alarmspec->alarm, dtmask, powman_now_ms());
+  next_alarm_ms = next_match_ms(&alarmspec->alarm, alarmspec->mask, powman_now_ms());
 
   /* Entering a reentrant critical zone.*/
   syssts_t sts = osalSysGetStatusAndLockX();
@@ -619,7 +624,7 @@ void rtc_lld_set_alarm(RTCDriver *rtcp,
   }
 
   rtcp->alarm = alarmspec->alarm;
-  rtcp->mask = dtmask;
+  rtcp->mask = alarmspec->mask;
 
   /* Leaving a reentrant critical zone.*/
   osalSysRestoreStatusX(sts);

--- a/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+++ b/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
@@ -72,7 +72,7 @@
 /* The days_from_civil()/civil_from_days() helpers below are expressed in
    days since 1970-01-01. The driver's own time base is ms since
    RTC_BASE_YEAR (1980-01-01, see hal_rtc.h).*/
-#define RTC_BASE_YEAR_EPOCH_DAYS     3652 /* days_from_civil(1980, 1, 1) */
+#define RTC_BASE_YEAR_EPOCH_DAYS     3652 /* Value of days_from_civil(1980, 1, 1).*/
 
 /* Aliased set/clear register offsets (RP2350 atomic bit-set/clear
    register aliasing convention).*/

--- a/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+++ b/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
@@ -69,9 +69,9 @@
 
 #define MS_PER_DAY                   86400000ULL
 
-/* days_from_civil()/civil_from_days() below are expressed in days since
-   1970-01-01. The driver's own time base is ms since RTC_BASE_YEAR
-   (1980-01-01, see hal_rtc.h).*/
+/* The days_from_civil()/civil_from_days() helpers below are expressed in
+   days since 1970-01-01. The driver's own time base is ms since
+   RTC_BASE_YEAR (1980-01-01, see hal_rtc.h).*/
 #define RTC_BASE_YEAR_EPOCH_DAYS     3652 /* days_from_civil(1980, 1, 1) */
 
 /* Aliased set/clear register offsets (RP2350 atomic bit-set/clear
@@ -295,12 +295,12 @@ static bool find_time_of_day(const RTCDateTime *wanted_time,
     return true;
   }
 
-  hour_low   = hour_fixed   ? wanted_hour   : 0U;
-  hour_high  = hour_fixed   ? wanted_hour   : 23U;
-  minute_low = minute_fixed ? wanted_minute : 0U;
-  minute_high= minute_fixed ? wanted_minute : 59U;
-  second_low = second_fixed ? wanted_second : 0U;
-  second_high= second_fixed ? wanted_second : 59U;
+  hour_low    = hour_fixed   ? wanted_hour   : 0U;
+  hour_high   = hour_fixed   ? wanted_hour   : 23U;
+  minute_low  = minute_fixed ? wanted_minute : 0U;
+  minute_high = minute_fixed ? wanted_minute : 59U;
+  second_low  = second_fixed ? wanted_second : 0U;
+  second_high = second_fixed ? wanted_second : 59U;
 
   for (hour = hour_low; hour <= hour_high; hour++) {
     for (minute = minute_low; minute <= minute_high; minute++) {

--- a/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.h
+++ b/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.h
@@ -1,0 +1,171 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    hal_rtc_lld.h
+ * @brief   RP2350 RTC subsystem low level driver header.
+ *
+ * @addtogroup RTC
+ * @{
+ */
+
+#ifndef HAL_RTC_LLD_H
+#define HAL_RTC_LLD_H
+
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Implementation capabilities
+ * @{
+ */
+/**
+ * @brief   Callback support in the driver.
+ */
+#define RTC_SUPPORTS_CALLBACKS      TRUE
+
+/**
+ * @brief   Number of alarms available.
+ * @note    The RP2350 POWMAN AON timer has a single 64-bit alarm
+ *          comparator.
+ */
+#define RTC_ALARMS                  1
+
+/**
+ * @brief   Presence of a local persistent storage.
+ */
+#define RTC_HAS_STORAGE             FALSE
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    PLATFORM configuration options
+ * @{
+ */
+/* Priority settings checks.*/
+#if !defined(RP_IRQ_RTC_PRIORITY)
+#error "RP_IRQ_RTC_PRIORITY not defined in mcuconf.h"
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/**
+ * @name    Date/time alarm setting values
+ * @{
+ */
+#define RTC_DT_ALARM_SECOND   0U
+#define RTC_DT_ALARM_MINUTE   1U
+#define RTC_DT_ALARM_HOUR     2U
+#define RTC_DT_ALARM_DAY      3U
+#define RTC_DT_ALARM_MONTH    4U
+#define RTC_DT_ALARM_YEAR     5U
+#define RTC_DT_ALARM_DOTW     6U
+/** @} */
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Type of an RTC event.
+ */
+typedef enum {
+  RTC_EVENT_ALARM     = 0,            /** Alarm.                        */
+ } rtcevent_t;
+
+/**
+ * @brief   Type of a generic RTC callback.
+ */
+typedef void (*rtccb_t)(RTCDriver *rtcp, rtcevent_t event);
+
+/**
+ * @brief   Type of a date/time mask.
+ */
+typedef uint8_t rtcdtmask_t;
+
+/**
+ * @brief   Type of a structure representing an RTC alarm time stamp.
+ */
+typedef struct {
+  /* End of the mandatory fields.*/
+  RTCDateTime       alarm;
+  rtcdtmask_t       mask;
+} RTCAlarm;
+
+/**
+ * @brief   Implementation-specific @p RTCDriver fields.
+ * @note    The POWMAN AON timer is accessed through fixed register
+ *          addresses, no peripheral pointer is required.
+ */
+#define rtc_lld_driver_fields                                               \
+  /* Callback pointer.*/                                                   \
+  rtccb_t           callback;                                              \
+  RTCDateTime       alarm;                                                 \
+  rtcdtmask_t       mask;
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+#define RTC_ALARM_ENABLE_MATCH(n)         (1U << n)
+#define RTC_ALARM_TEST_MATCH(a, n)        ((a & (1U << n)) != 0)
+#define RTC_ALARM_DISABLE_ALL_MATCHING    0U
+#define RTC_ALARM_ENABLE_ALL_MATCHING     0x7FU
+/* DOTW is not taken into consideration in a non-repeating alarm. */
+#define RTC_ALARM_NON_REPEATING           (RTC_ALARM_ENABLE_ALL_MATCHING     \
+              & ~(RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_DOTW)))
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+extern RTCDriver RTCD1;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rtc_lld_init(void);
+  void rtc_lld_set_time(RTCDriver *rtcp, const RTCDateTime *timespec);
+  void rtc_lld_get_time(RTCDriver *rtcp, RTCDateTime *timespec);
+#if RTC_ALARMS > 0
+  void rtc_lld_set_alarm(RTCDriver *rtcp,
+                         rtcalarm_t alarm,
+                         const RTCAlarm *alarmspec);
+  void rtc_lld_get_alarm(RTCDriver *rtcp,
+                         rtcalarm_t alarm,
+                         RTCAlarm *alarmspec);
+#endif
+#if RTC_SUPPORTS_CALLBACKS == TRUE
+  void rtc_lld_set_callback(RTCDriver *rtcp, rtccb_t callback);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_RTC == TRUE */
+
+#endif /* HAL_RTC_LLD_H */
+
+/** @} */

--- a/os/hal/ports/RP/RP2350/platform.mk
+++ b/os/hal/ports/RP/RP2350/platform.mk
@@ -43,6 +43,7 @@ include $(CHIBIOS)/os/hal/ports/RP/LLD/GPIOv1/driver.mk
 include $(CHIBIOS)/os/hal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/hal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/hal/ports/RP/LLD/UARTv1/driver.mk
+include $(CHIBIOS)/os/hal/ports/RP/LLD/RTCv2/driver.mk
 include $(CHIBIOS)/os/hal/ports/RP/LLD/WDGv1/driver.mk
 include $(CHIBIOS)/os/hal/ports/RP/LLD/USBv1/driver.mk
 include $(CHIBIOS)/os/hal/ports/RP/LLD/I2Cv1/driver.mk

--- a/os/hal/ports/RP/RP2350/rp_registry.h
+++ b/os/hal/ports/RP/RP2350/rp_registry.h
@@ -73,8 +73,9 @@
 #define RP_HAS_TIMER1                       TRUE
 #define RP_ST_NUM_ALARMS                    4
 
-/* RP2350 does NOT have an RTC */
-#define RP_HAS_RTC                          FALSE
+/* RP2350 has no dedicated RTC peripheral; time-keeping is emulated on
+   the POWMAN Always-On timer (see LLD/RTCv2). */
+#define RP_HAS_RTC                          TRUE
 
 /* SPI attributes.*/
 #define RP_HAS_SPI0                         TRUE

--- a/testhal/RP/RP2350/RTC-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/RTC-VALIDATION/Makefile
@@ -1,0 +1,159 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O0 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# HAL-OSAL files (optional).
+include $(CHIBIOS)/os/hal/hal.mk
+include $(CHIBIOS)/os/hal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port.mk
+# Other files (optional).
+include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+
+# Define linker script file here
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/testhal/RP/RP2350/RTC-VALIDATION/README.md
+++ b/testhal/RP/RP2350/RTC-VALIDATION/README.md
@@ -1,0 +1,37 @@
+# RP2350 RTC-VALIDATION
+
+This test application validates the RP2350 RTC alarm contract, implemented
+by the RTCv2 LLD on top of the POWMAN Always-On timer (the RP2350 has no
+dedicated RTC peripheral).
+
+## Purpose
+
+- A programmed alarm fires and invokes the registered callback.
+- `rtcGetAlarm()` reflects the armed alarm.
+- `rtcSetAlarm(..., NULL)` disables the alarm instead of faulting.
+- An alarm specification with an all-zero mask disables the alarm.
+- Both disable forms update the saved state read by `rtcGetAlarm()`.
+- A disabled alarm no longer fires.
+
+## Build
+
+From repository root:
+
+```sh
+cd testhal/RP/RP2350/RTC-VALIDATION
+make clean
+make -j$(nproc)
+```
+
+Produced artifacts are in the local `build/` directory (`ch.elf`, `ch.hex`, `ch.bin`).
+
+## Configuration Notes
+
+- HAL RTC and HAL SIO are enabled in [cfg/halconf.h](cfg/halconf.h).
+- The RTC interrupt priority is set in [cfg/mcuconf.h](cfg/mcuconf.h).
+
+## Runtime Notes
+
+- Results are printed as `PASS`/`FAIL` lines on SIO0 (GPIO0 TX, GPIO1 RX)
+  at the default bit rate, followed by a summary.
+- The board LED blinks slowly when every check passed and rapidly otherwise.

--- a/testhal/RP/RP2350/RTC-VALIDATION/cfg/chconf.h
+++ b/testhal/RP/RP2350/RTC-VALIDATION/cfg/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         FALSE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                FALSE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                FALSE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 FALSE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                FALSE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    FALSE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               FALSE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                FALSE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  FALSE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     FALSE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      FALSE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           FALSE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            FALSE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 TRUE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/RTC-VALIDATION/cfg/halconf.h
+++ b/testhal/RP/RP2350/RTC-VALIDATION/cfg/halconf.h
@@ -1,0 +1,584 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/halconf.h
+ * @brief   HAL configuration header.
+ * @details HAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup HAL_CONF
+ * @{
+ */
+
+#ifndef HALCONF_H
+#define HALCONF_H
+
+#define _CHIBIOS_HAL_CONF_
+#define _CHIBIOS_HAL_CONF_VER_9_1_
+
+#include "mcuconf.h"
+
+/**
+ * @brief   Enables the HAL safety subsystem.
+ */
+#if !defined(HAL_USE_SAFETY) || defined(__DOXYGEN__)
+#define HAL_USE_SAFETY                      FALSE
+#endif
+
+/**
+ * @brief   Enables the PAL subsystem.
+ */
+#if !defined(HAL_USE_PAL) || defined(__DOXYGEN__)
+#define HAL_USE_PAL                         TRUE
+#endif
+
+/**
+ * @brief   Enables the ADC subsystem.
+ */
+#if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
+#define HAL_USE_ADC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the CAN subsystem.
+ */
+#if !defined(HAL_USE_CAN) || defined(__DOXYGEN__)
+#define HAL_USE_CAN                         FALSE
+#endif
+
+/**
+ * @brief   Enables the cryptographic subsystem.
+ */
+#if !defined(HAL_USE_CRY) || defined(__DOXYGEN__)
+#define HAL_USE_CRY                         FALSE
+#endif
+
+/**
+ * @brief   Enables the DAC subsystem.
+ */
+#if !defined(HAL_USE_DAC) || defined(__DOXYGEN__)
+#define HAL_USE_DAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the display subsystem.
+ */
+#if !defined(HAL_USE_DSPL) || defined(__DOXYGEN__)
+#define HAL_USE_DSPL                        FALSE
+#endif
+
+/**
+ * @brief   Enables the EFlash subsystem.
+ */
+#if !defined(HAL_USE_EFL) || defined(__DOXYGEN__)
+#define HAL_USE_EFL                         FALSE
+#endif
+
+/**
+ * @brief   Enables the GPT subsystem.
+ */
+#if !defined(HAL_USE_GPT) || defined(__DOXYGEN__)
+#define HAL_USE_GPT                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2C subsystem.
+ */
+#if !defined(HAL_USE_I2C) || defined(__DOXYGEN__)
+#define HAL_USE_I2C                         FALSE
+#endif
+
+/**
+ * @brief   Enables the I2S subsystem.
+ */
+#if !defined(HAL_USE_I2S) || defined(__DOXYGEN__)
+#define HAL_USE_I2S                         FALSE
+#endif
+
+/**
+ * @brief   Enables the ICU subsystem.
+ */
+#if !defined(HAL_USE_ICU) || defined(__DOXYGEN__)
+#define HAL_USE_ICU                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MAC subsystem.
+ */
+#if !defined(HAL_USE_MAC) || defined(__DOXYGEN__)
+#define HAL_USE_MAC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the MMC_SPI subsystem.
+ */
+#if !defined(HAL_USE_MMC_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_MMC_SPI                     FALSE
+#endif
+
+/**
+ * @brief   Enables the PWM subsystem.
+ */
+#if !defined(HAL_USE_PWM) || defined(__DOXYGEN__)
+#define HAL_USE_PWM                         FALSE
+#endif
+
+/**
+ * @brief   Enables the RTC subsystem.
+ */
+#if !defined(HAL_USE_RTC) || defined(__DOXYGEN__)
+#define HAL_USE_RTC                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SDC subsystem.
+ */
+#if !defined(HAL_USE_SDC) || defined(__DOXYGEN__)
+#define HAL_USE_SDC                         FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL subsystem.
+ */
+#if !defined(HAL_USE_SERIAL) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL                      FALSE
+#endif
+
+/**
+ * @brief   Enables the SERIAL over USB subsystem.
+ */
+#if !defined(HAL_USE_SERIAL_USB) || defined(__DOXYGEN__)
+#define HAL_USE_SERIAL_USB                  FALSE
+#endif
+
+/**
+ * @brief   Enables the SIO subsystem.
+ */
+#if !defined(HAL_USE_SIO) || defined(__DOXYGEN__)
+#define HAL_USE_SIO                         TRUE
+#endif
+
+/**
+ * @brief   Enables the SPI subsystem.
+ */
+#if !defined(HAL_USE_SPI) || defined(__DOXYGEN__)
+#define HAL_USE_SPI                         FALSE
+#endif
+
+/**
+ * @brief   Enables the TRNG subsystem.
+ */
+#if !defined(HAL_USE_TRNG) || defined(__DOXYGEN__)
+#define HAL_USE_TRNG                        FALSE
+#endif
+
+/**
+ * @brief   Enables the UART subsystem.
+ */
+#if !defined(HAL_USE_UART) || defined(__DOXYGEN__)
+#define HAL_USE_UART                        FALSE
+#endif
+
+/**
+ * @brief   Enables the USB subsystem.
+ */
+#if !defined(HAL_USE_USB) || defined(__DOXYGEN__)
+#define HAL_USE_USB                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WDG subsystem.
+ */
+#if !defined(HAL_USE_WDG) || defined(__DOXYGEN__)
+#define HAL_USE_WDG                         FALSE
+#endif
+
+/**
+ * @brief   Enables the WSPI subsystem.
+ */
+#if !defined(HAL_USE_WSPI) || defined(__DOXYGEN__)
+#define HAL_USE_WSPI                        FALSE
+#endif
+
+/*===========================================================================*/
+/* PAL driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define PAL_USE_CALLBACKS                   FALSE
+#endif
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(PAL_USE_WAIT) || defined(__DOXYGEN__)
+#define PAL_USE_WAIT                        FALSE
+#endif
+
+/*===========================================================================*/
+/* ADC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_WAIT) || defined(__DOXYGEN__)
+#define ADC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p adcAcquireBus() and @p adcReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(ADC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define ADC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* CAN driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Sleep mode related APIs inclusion switch.
+ */
+#if !defined(CAN_USE_SLEEP_MODE) || defined(__DOXYGEN__)
+#define CAN_USE_SLEEP_MODE                  TRUE
+#endif
+
+/**
+ * @brief   Enforces the driver to use direct callbacks rather than OSAL events.
+ */
+#if !defined(CAN_ENFORCE_USE_CALLBACKS) || defined(__DOXYGEN__)
+#define CAN_ENFORCE_USE_CALLBACKS           FALSE
+#endif
+
+/*===========================================================================*/
+/* CRY driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the SW fall-back of the cryptographic driver.
+ * @details When enabled, this option, activates a fall-back software
+ *          implementation for algorithms not supported by the underlying
+ *          hardware.
+ * @note    Fall-back implementations may not be present for all algorithms.
+ */
+#if !defined(HAL_CRY_USE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_USE_FALLBACK                FALSE
+#endif
+
+/**
+ * @brief   Makes the driver forcibly use the fall-back implementations.
+ */
+#if !defined(HAL_CRY_ENFORCE_FALLBACK) || defined(__DOXYGEN__)
+#define HAL_CRY_ENFORCE_FALLBACK            FALSE
+#endif
+
+/*===========================================================================*/
+/* DAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_WAIT) || defined(__DOXYGEN__)
+#define DAC_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Enables the @p dacAcquireBus() and @p dacReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(DAC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define DAC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* I2C driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode API enable switch.
+ * @note    The low level driver must support this capability.
+ */
+#if !defined(I2C_ENABLE_SLAVE_MODE)
+#define I2C_ENABLE_SLAVE_MODE               FALSE
+#endif
+
+/**
+ * @brief   Enables the mutual exclusion APIs on the I2C bus.
+ */
+#if !defined(I2C_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define I2C_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* MAC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables the zero-copy API.
+ */
+#if !defined(MAC_USE_ZERO_COPY) || defined(__DOXYGEN__)
+#define MAC_USE_ZERO_COPY                   FALSE
+#endif
+
+/**
+ * @brief   Enables an event sources for incoming packets.
+ */
+#if !defined(MAC_USE_EVENTS) || defined(__DOXYGEN__)
+#define MAC_USE_EVENTS                      FALSE
+#endif
+
+/*===========================================================================*/
+/* MMC_SPI driver related settings.                                          */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout before assuming a failure while waiting for card idle.
+ * @note    Time is in milliseconds.
+ */
+#if !defined(MMC_IDLE_TIMEOUT_MS) || defined(__DOXYGEN__)
+#define MMC_IDLE_TIMEOUT_MS                 1000
+#endif
+
+/**
+ * @brief   Mutual exclusion on the SPI bus.
+ */
+#if !defined(MMC_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define MMC_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/*===========================================================================*/
+/* SDC driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of initialization attempts before rejecting the card.
+ * @note    Attempts are performed at 10mS intervals.
+ */
+#if !defined(SDC_INIT_RETRY) || defined(__DOXYGEN__)
+#define SDC_INIT_RETRY                      100
+#endif
+
+/**
+ * @brief   Include support for MMC cards.
+ * @note    MMC support is not yet implemented so this option must be kept
+ *          at @p FALSE.
+ */
+#if !defined(SDC_MMC_SUPPORT) || defined(__DOXYGEN__)
+#define SDC_MMC_SUPPORT                     FALSE
+#endif
+
+/**
+ * @brief   Delays insertions.
+ * @details If enabled this options inserts delays into the MMC waiting
+ *          routines releasing some extra CPU time for the threads with
+ *          lower priority, this may slow down the driver a bit however.
+ */
+#if !defined(SDC_NICE_WAITING) || defined(__DOXYGEN__)
+#define SDC_NICE_WAITING                    TRUE
+#endif
+
+/**
+ * @brief   OCR initialization constant for V20 cards.
+ */
+#if !defined(SDC_INIT_OCR_V20) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#endif
+
+/**
+ * @brief   OCR initialization constant for non-V20 cards.
+ */
+#if !defined(SDC_INIT_OCR) || defined(__DOXYGEN__)
+#define SDC_INIT_OCR                        0x80100000U
+#endif
+
+/*===========================================================================*/
+/* SERIAL driver related settings.                                           */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SERIAL_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SERIAL_DEFAULT_BITRATE              38400
+#endif
+
+/**
+ * @brief   Serial buffers size.
+ * @details Configuration parameter, you can change the depth of the queue
+ *          buffers depending on the requirements of your application.
+ * @note    The default is 16 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_BUFFERS_SIZE                 16
+#endif
+
+/*===========================================================================*/
+/* SIO driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Default bit rate.
+ * @details Configuration parameter, this is the baud rate selected for the
+ *          default configuration.
+ */
+#if !defined(SIO_DEFAULT_BITRATE) || defined(__DOXYGEN__)
+#define SIO_DEFAULT_BITRATE                 38400
+#endif
+
+/**
+ * @brief   Support for thread synchronization API.
+ */
+#if !defined(SIO_USE_SYNCHRONIZATION) || defined(__DOXYGEN__)
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#endif
+
+/*===========================================================================*/
+/* SERIAL_USB driver related setting.                                        */
+/*===========================================================================*/
+
+/**
+ * @brief   Serial over USB buffers size.
+ * @details Configuration parameter, the buffer size must be a multiple of
+ *          the USB data endpoint maximum packet size.
+ * @note    The default is 256 bytes for both the transmission and receive
+ *          buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_SIZE) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_SIZE             256
+#endif
+
+/**
+ * @brief   Serial over USB number of buffers.
+ * @note    The default is 2 buffers.
+ */
+#if !defined(SERIAL_USB_BUFFERS_NUMBER) || defined(__DOXYGEN__)
+#define SERIAL_USB_BUFFERS_NUMBER           2
+#endif
+
+/*===========================================================================*/
+/* SPI driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_WAIT) || defined(__DOXYGEN__)
+#define SPI_USE_WAIT                        TRUE
+#endif
+
+/**
+ * @brief   Inserts an assertion on function errors before returning.
+ */
+#if !defined(SPI_USE_ASSERT_ON_ERROR) || defined(__DOXYGEN__)
+#define SPI_USE_ASSERT_ON_ERROR             TRUE
+#endif
+
+/**
+ * @brief   Enables the @p spiAcquireBus() and @p spiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define SPI_USE_MUTUAL_EXCLUSION            TRUE
+#endif
+
+/**
+ * @brief   Handling method for SPI CS line.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define SPI_SELECT_MODE                     SPI_SELECT_MODE_PAD
+#endif
+
+/*===========================================================================*/
+/* UART driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_WAIT) || defined(__DOXYGEN__)
+#define UART_USE_WAIT                       FALSE
+#endif
+
+/**
+ * @brief   Enables the @p uartAcquireBus() and @p uartReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(UART_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define UART_USE_MUTUAL_EXCLUSION           FALSE
+#endif
+
+/*===========================================================================*/
+/* USB driver related settings.                                              */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(USB_USE_WAIT) || defined(__DOXYGEN__)
+#define USB_USE_WAIT                        FALSE
+#endif
+
+/**
+ * @brief   Moves EP0 request handling to thread context.
+ * @note    When enabled the legacy requests hook callback is not available
+ *          and the application must provide a dedicated EP0 worker thread.
+ */
+#if !defined(USB_USE_EP0_THREAD) || defined(__DOXYGEN__)
+#define USB_USE_EP0_THREAD                  FALSE
+#endif
+
+/*===========================================================================*/
+/* WSPI driver related settings.                                             */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables synchronous APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_WAIT) || defined(__DOXYGEN__)
+#define WSPI_USE_WAIT                       TRUE
+#endif
+
+/**
+ * @brief   Enables the @p wspiAcquireBus() and @p wspiReleaseBus() APIs.
+ * @note    Disabling this option saves both code and data space.
+ */
+#if !defined(WSPI_USE_MUTUAL_EXCLUSION) || defined(__DOXYGEN__)
+#define WSPI_USE_MUTUAL_EXCLUSION           TRUE
+#endif
+
+#endif /* HALCONF_H */
+
+/** @} */

--- a/testhal/RP/RP2350/RTC-VALIDATION/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/RTC-VALIDATION/cfg/mcuconf.h
@@ -1,0 +1,41 @@
+#ifndef MCUCONF_H
+#define MCUCONF_H
+
+#define RP2350_MCUCONF
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+#define RP_IRQ_RTC_PRIORITY                 3
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     FALSE
+#define RP_SPI_USE_SPI1                     FALSE
+
+#endif /* MCUCONF_H */

--- a/testhal/RP/RP2350/RTC-VALIDATION/main.c
+++ b/testhal/RP/RP2350/RTC-VALIDATION/main.c
@@ -1,0 +1,178 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 RTC validation test.
+ *
+ * The RP2350 has no dedicated RTC peripheral; this exercises the RTCv2
+ * LLD, which emulates the RTC contract on top of the POWMAN Always-On
+ * timer:
+ *  - a programmed alarm fires and invokes the callback;
+ *  - rtcGetAlarm() reflects the armed alarm;
+ *  - rtcSetAlarm(..., NULL) disables the alarm instead of faulting;
+ *  - a specification with an all-zero mask disables the alarm;
+ *  - both disable forms update the saved state read by rtcGetAlarm();
+ *  - a disabled alarm no longer fires.
+ *
+ * Results are reported on SIO0 (GPIO0/GPIO1) at the default bit rate.
+ */
+
+#include "ch.h"
+#include "hal.h"
+#include "chprintf.h"
+
+#define LED_PIN              25U
+#define UART_TX_PIN          0U
+#define UART_RX_PIN          1U
+
+static BaseSequentialStream *chp;
+
+static volatile unsigned alarm_events;
+
+static unsigned pass_count;
+static unsigned fail_count;
+
+static void alarm_cb(RTCDriver *rtcp, rtcevent_t event) {
+
+  (void)rtcp;
+  if (event == RTC_EVENT_ALARM) {
+    alarm_events++;
+  }
+}
+
+static void report(const char *name, bool ok) {
+
+  chprintf(chp, "  [%s] %s\r\n", ok ? "PASS" : "FAIL", name);
+  if (ok) {
+    pass_count++;
+  }
+  else {
+    fail_count++;
+  }
+}
+
+/* Builds a time-of-day for 2026-07-19 with the given seconds offset from
+   12:00:00.*/
+static void make_datetime(RTCDateTime *dt, uint32_t seconds_past_noon) {
+
+  dt->year        = 2026U - 1980U;
+  dt->month       = 7U;
+  dt->dstflag     = 0U;
+  dt->dayofweek   = 7U;
+  dt->day         = 19U;
+  dt->millisecond = ((12U * 3600U) + seconds_past_noon) * 1000U;
+}
+
+int main(void) {
+  RTCDateTime dt;
+  RTCAlarm alarmspec, readback;
+  unsigned i;
+
+  halInit();
+  chSysInit();
+
+  palSetLineMode(LED_PIN, PAL_MODE_OUTPUT_PUSHPULL);
+  palSetLineMode(UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+  sioStart(&SIOD0, NULL);
+  chp = (BaseSequentialStream *)&SIOD0;
+
+  chprintf(chp, "\r\nRTC-VALIDATION start\r\n");
+
+  /* Known base date/time.*/
+  make_datetime(&dt, 0U);
+  rtcSetTime(&RTCD1, &dt);
+
+  /* Time read-back plausibility.*/
+  rtcGetTime(&RTCD1, &dt);
+  chprintf(chp, "  read-back: ms=%u day=%u month=%u year=%u dow=%u\r\n",
+          (unsigned)dt.millisecond, dt.day, dt.month, dt.year, dt.dayofweek);
+  report("time read-back",
+         (dt.millisecond >= 12U * 3600U * 1000U) &&
+         (dt.millisecond <  (12U * 3600U + 3U) * 1000U) &&
+         (dt.day == 19U) && (dt.month == 7U) &&
+         (dt.year == 2026U - 1980U) && (dt.dayofweek == 7U));
+
+  /* Alarm three seconds ahead, matching hour, minute and second.*/
+  rtcSetCallback(&RTCD1, alarm_cb);
+  alarm_events = 0U;
+  make_datetime(&alarmspec.alarm, 3U);
+  alarmspec.mask = RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_HOUR)   |
+                   RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_MINUTE) |
+                   RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_SECOND);
+  rtcSetAlarm(&RTCD1, 0U, &alarmspec);
+
+  rtcGetAlarm(&RTCD1, 0U, &readback);
+  report("armed alarm reads back enabled",
+         (readback.mask == alarmspec.mask) &&
+         (readback.alarm.millisecond == alarmspec.alarm.millisecond));
+
+  for (i = 0U; (i < 50U) && (alarm_events == 0U); i++) {
+    chThdSleepMilliseconds(100);
+  }
+  report("alarm fires callback", alarm_events != 0U);
+
+  /* Re-arm a future alarm, then disable it with a NULL specification; on
+     faulty code the NULL call consumes ROM bytes as a specification
+     rather than disabling.*/
+  make_datetime(&alarmspec.alarm, 8U);
+  alarmspec.mask = RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_HOUR)   |
+                   RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_MINUTE) |
+                   RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_SECOND);
+  rtcSetAlarm(&RTCD1, 0U, &alarmspec);
+  rtcSetAlarm(&RTCD1, 0U, NULL);
+  report("NULL disable returns", true);
+
+  rtcGetAlarm(&RTCD1, 0U, &readback);
+  report("NULL disable clears saved state",
+         readback.mask == RTC_ALARM_DISABLE_ALL_MATCHING);
+
+  /* The NULL-disabled alarm was armed for 8 s past noon; cross that
+     moment and require silence from the hardware too.*/
+  alarm_events = 0U;
+  make_datetime(&dt, 6U);
+  rtcSetTime(&RTCD1, &dt);
+  chThdSleepMilliseconds(4000);
+  report("NULL-disabled alarm does not fire", alarm_events == 0U);
+
+  /* Re-arm another future alarm, then disable through an all-zero mask
+     specification.*/
+  make_datetime(&alarmspec.alarm, 13U);
+  alarmspec.mask = RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_HOUR)   |
+                   RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_MINUTE) |
+                   RTC_ALARM_ENABLE_MATCH(RTC_DT_ALARM_SECOND);
+  rtcSetAlarm(&RTCD1, 0U, &alarmspec);
+  alarmspec.mask = RTC_ALARM_DISABLE_ALL_MATCHING;
+  rtcSetAlarm(&RTCD1, 0U, &alarmspec);
+
+  rtcGetAlarm(&RTCD1, 0U, &readback);
+  report("mask-zero disable clears saved state",
+         readback.mask == RTC_ALARM_DISABLE_ALL_MATCHING);
+
+  /* Time is around 10 s past noon here; cross the 13 s trigger of the
+     mask-zero-disabled alarm and require silence.*/
+  alarm_events = 0U;
+  chThdSleepMilliseconds(4000);
+  report("mask-zero-disabled alarm does not fire", alarm_events == 0U);
+
+  chprintf(chp, "RTC-VALIDATION complete: %u passed, %u failed\r\n",
+          pass_count, fail_count);
+
+  while (true) {
+    palToggleLine(LED_PIN);
+    chThdSleepMilliseconds(fail_count == 0U ? 500 : 100);
+  }
+}


### PR DESCRIPTION
## Summary
- Driver implementation.
- Update make accordingly.
- Update RP registry.
- Add test app.

## Related
- Notes for reviewers:
  + This is a port from community implementation from .NET nanoFramework nanoframework/nf-interpreter#3479
 

## Target Branch Check

- [x] This PR targets `main` — all changes land on `main` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `main`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [ ] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [ ] Style check passed on changed `.c`/`.h` files
- [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [ ] Test run successfully locally
- Any other tests run on a device?
  + Has been tested in nanoFramework with cold/warm boot, TLS requests, etc.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
