### PR TITLE
SB: add explicit sandbox lifecycle

### DIFF
--- a/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_NOSWITCH/main.c
+++ b/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_NOSWITCH/main.c
@@ -184,17 +184,35 @@ static void start_sb2(void) {
  * Messenger thread, times are in milliseconds.
  */
 static THD_WORKING_AREA(waThread1, 256);
+static thread_t *messengertp;
+
 static THD_FUNCTION(Thread1, arg) {
   unsigned i = 1U;
 
   (void)arg;
 
   chRegSetThreadName("messenger");
-  while (true) {
+  while (!chThdShouldTerminateX()) {
     chThdSleepMilliseconds(500);
-    sbSendMessage(&sbx2, (msg_t)i);
-    i++;
+    if (!chThdShouldTerminateX()) {
+      (void)sbSendMessageTimeout(&sbx2, (msg_t)i, TIME_MS2I(100));
+      i++;
+    }
   }
+}
+
+static void start_messenger(void) {
+
+  chDbgAssert(messengertp == NULL, "messenger already started");
+  messengertp = chThdCreateStatic(waThread1, sizeof waThread1,
+                                  NORMALPRIO+10, Thread1, NULL);
+}
+
+static void stop_messenger(void) {
+
+  chThdTerminate(messengertp);
+  (void)chThdWait(messengertp);
+  messengertp = NULL;
 }
 
 /*
@@ -286,7 +304,7 @@ int main(void) {
   /*
    * Creating a messenger thread.
    */
-  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO+10, Thread1, NULL);
+  start_messenger();
 
   /*
    * Listening to sandbox events.
@@ -302,17 +320,27 @@ int main(void) {
     if (chEvtWaitAnyTimeout(ALL_EVENTS, TIME_MS2I(500)) != (eventmask_t)0) {
 
       if (!sbIsThreadRunningX(&sbx1)) {
-        msg_t msg = sbWait(&sbx1);
+        msg_t msg = sbSync(&sbx1);
+
+        if (!sbFinalize(&sbx1)) {
+          chSysHalt("SB1 finalize");
+        }
         chprintf(oopGetIf(&SIOD1, chn), "SB1 terminated: 0x%08x\r\n", msg);
         chThdSleepMilliseconds(100);
         start_sb1();
       }
 
       if (!sbIsThreadRunningX(&sbx2)) {
-        msg_t msg = sbWait(&sbx2);
+        msg_t msg = sbSync(&sbx2);
+
+        stop_messenger();
+        if (!sbFinalize(&sbx2)) {
+          chSysHalt("SB2 finalize");
+        }
         chprintf(oopGetIf(&SIOD1, chn), "SB2 terminated: 0x%08x\r\n", msg);
         chThdSleepMilliseconds(100);
         start_sb2();
+        start_messenger();
       }
     }
   }

--- a/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_SWITCHED/main.c
+++ b/demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_SWITCHED/main.c
@@ -183,17 +183,35 @@ static void start_sb2(void) {
  * Messenger thread, times are in milliseconds.
  */
 static THD_WORKING_AREA(waThread1, 256);
+static thread_t *messengertp;
+
 static THD_FUNCTION(Thread1, arg) {
   unsigned i = 1U;
 
   (void)arg;
 
   chRegSetThreadName("messenger");
-  while (true) {
+  while (!chThdShouldTerminateX()) {
     chThdSleepMilliseconds(500);
-    sbSendMessage(&sbx2, (msg_t)i);
-    i++;
+    if (!chThdShouldTerminateX()) {
+      (void)sbSendMessageTimeout(&sbx2, (msg_t)i, TIME_MS2I(100));
+      i++;
+    }
   }
+}
+
+static void start_messenger(void) {
+
+  chDbgAssert(messengertp == NULL, "messenger already started");
+  messengertp = chThdCreateStatic(waThread1, sizeof waThread1,
+                                  NORMALPRIO+10, Thread1, NULL);
+}
+
+static void stop_messenger(void) {
+
+  chThdTerminate(messengertp);
+  (void)chThdWait(messengertp);
+  messengertp = NULL;
 }
 
 /*
@@ -267,7 +285,7 @@ int main(void) {
   /*
    * Creating a messenger thread.
    */
-  chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO+10, Thread1, NULL);
+  start_messenger();
 
   /*
    * Listening to sandbox events.
@@ -283,17 +301,27 @@ int main(void) {
     if (chEvtWaitAnyTimeout(ALL_EVENTS, TIME_MS2I(500)) != (eventmask_t)0) {
 
       if (!sbIsThreadRunningX(&sbx1)) {
-        msg_t msg = sbWait(&sbx1);
+        msg_t msg = sbSync(&sbx1);
+
+        if (!sbFinalize(&sbx1)) {
+          chSysHalt("SB1 finalize");
+        }
         chprintf(oopGetIf(&SIOD1, chn), "SB1 terminated: 0x%08x\r\n", msg);
         chThdSleepMilliseconds(100);
         start_sb1();
       }
 
       if (!sbIsThreadRunningX(&sbx2)) {
-        msg_t msg = sbWait(&sbx2);
+        msg_t msg = sbSync(&sbx2);
+
+        stop_messenger();
+        if (!sbFinalize(&sbx2)) {
+          chSysHalt("SB2 finalize");
+        }
         chprintf(oopGetIf(&SIOD1, chn), "SB2 terminated: 0x%08x\r\n", msg);
         chThdSleepMilliseconds(100);
         start_sb2();
+        start_messenger();
       }
     }
   }

--- a/demos/STM32/RT-STM32H563ZI-NUCLEO144-SB_HOST_SWITCHED/main.c
+++ b/demos/STM32/RT-STM32H563ZI-NUCLEO144-SB_HOST_SWITCHED/main.c
@@ -290,14 +290,22 @@ int main(void) {
     if (chEvtWaitAnyTimeout(ALL_EVENTS, TIME_MS2I(500)) != (eventmask_t)0) {
 
       if (!sbIsThreadRunningX(&sbx1)) {
-        msg_t msg = sbWait(&sbx1);
+        msg_t msg = sbSync(&sbx1);
+
+        if (!sbFinalize(&sbx1)) {
+          chSysHalt("SB1 finalize");
+        }
         chprintf(oopGetIf(&SIOD3, chn), "SB1 terminated: 0x%08x\r\n", msg);
         chThdSleepMilliseconds(100);
         start_sb1();
       }
 
       if (!sbIsThreadRunningX(&sbx2)) {
-        msg_t msg = sbWait(&sbx2);
+        msg_t msg = sbSync(&sbx2);
+
+        if (!sbFinalize(&sbx2)) {
+          chSysHalt("SB2 finalize");
+        }
         chprintf(oopGetIf(&SIOD3, chn), "SB2 terminated: 0x%08x\r\n", msg);
         chThdSleepMilliseconds(100);
         start_sb2();

--- a/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_DYNAMIC_RAMBOX/main.c
+++ b/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_DYNAMIC_RAMBOX/main.c
@@ -98,11 +98,15 @@ static THD_FUNCTION(thd1_func, arg) {
  * SB termination event.
  */
 static void SBHandler(eventid_t id) {
+  msg_t msg;
 
   (void)id;
 
   if (!sbIsThreadRunningX(&sbx1)) {
-    msg_t msg = sbWait(&sbx1);
+    msg = sbSync(&sbx1);
+    if (!sbFinalize(&sbx1)) {
+      chSysHalt("SBX1 finalize");
+    }
 
     chprintf((BaseSequentialStream *)&SD2, "SBX1 terminated (%08lx)\r\n", msg);
   }

--- a/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_STATIC_RAMBOX/main.c
+++ b/demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_STATIC_RAMBOX/main.c
@@ -101,11 +101,15 @@ static THD_FUNCTION(thd1_func, arg) {
  * SB termination event.
  */
 static void SBHandler(eventid_t id) {
+  msg_t msg;
 
   (void)id;
 
   if (!sbIsThreadRunningX(&sbx1)) {
-    msg_t msg = sbWait(&sbx1);
+    msg = sbSync(&sbx1);
+    if (!sbFinalize(&sbx1)) {
+      chSysHalt("SBX1 finalize");
+    }
 
     chprintf((BaseSequentialStream *)&SD2, "SBX1 terminated (%08lx)\r\n", msg);
   }

--- a/os/sb/host/sb.h
+++ b/os/sb/host/sb.h
@@ -201,6 +201,16 @@
 /*===========================================================================*/
 
 /**
+ * @brief   Sandbox lifecycle states.
+ */
+typedef enum {
+  SB_STATE_STOPPED = 0,                 /**< Sandbox ready to be started.   */
+  SB_STATE_STARTING,                    /**< Sandbox start in progress.     */
+  SB_STATE_RUNNING,                     /**< Sandbox execution active.      */
+  SB_STATE_STOPPING                     /**< Sandbox awaiting finalization. */
+} sb_state_t;
+
+/**
  * @brief   Type of a sandbox object.
  */
 typedef struct sb_class sb_class_t;
@@ -236,6 +246,10 @@ typedef struct {
  * @brief   Structure representing a sandbox object.
  */
 struct sb_class {
+  /**
+   * @brief   Sandbox lifecycle state.
+   */
+  volatile sb_state_t           state;
   /**
    * @brief   Indicates that the sandbox is dynamically allocated from heap.
    */

--- a/os/sb/host/sb.h
+++ b/os/sb/host/sb.h
@@ -204,7 +204,8 @@
  * @brief   Sandbox lifecycle states.
  */
 typedef enum {
-  SB_STATE_STOPPED = 0,                 /**< Sandbox ready to be started.   */
+  SB_STATE_UNINIT = 0,                  /**< Sandbox object not initialized. */
+  SB_STATE_STOPPED,                     /**< Sandbox ready to be started.   */
   SB_STATE_STARTING,                    /**< Sandbox start in progress.     */
   SB_STATE_RUNNING,                     /**< Sandbox execution active.      */
   SB_STATE_STOPPING                     /**< Sandbox awaiting finalization. */

--- a/os/sb/host/sbapi.c
+++ b/os/sb/host/sbapi.c
@@ -94,7 +94,13 @@ void sb_fastc_get_frequency(sb_class_t *sbp, struct port_extctx *ectxp) {
 
 void sb_sysc_exit(sb_class_t *sbp, struct port_extctx *ectxp) {
 
-  (void)sbp;
+  chSysLock();
+  chDbgAssert(sbp->state == SB_STATE_RUNNING, "invalid lifecycle state");
+  sbp->state = SB_STATE_STOPPING;
+#if SB_CFG_ENABLE_VRQ == TRUE
+  chVTResetI(&sbp->vrq.alarm_vt);
+#endif
+  chSysUnlock();
 
 #if SB_CFG_ENABLE_VFS == TRUE
   __sb_io_cleanup(sbp);
@@ -104,9 +110,6 @@ void sb_sysc_exit(sb_class_t *sbp, struct port_extctx *ectxp) {
 #endif
 
   chSysLock();
-#if SB_CFG_ENABLE_VRQ == TRUE
-  chVTResetI(&sbp->vrq.alarm_vt);
-#endif
 #if CH_CFG_USE_EVENTS == TRUE
   chEvtBroadcastI(&sb.termination_es);
 #endif

--- a/os/sb/host/sbhost.c
+++ b/os/sb/host/sbhost.c
@@ -612,7 +612,8 @@ void sbObjectInit(sb_class_t *sbp) {
  */
 bool sbIsThreadRunningX(sb_class_t *sbp) {
 
-  return !chThdTerminatedX(&sbp->thread);
+  return (sbp->state != SB_STATE_UNINIT) &&
+         !chThdTerminatedX(&sbp->thread);
 }
 
 /**

--- a/os/sb/host/sbhost.c
+++ b/os/sb/host/sbhost.c
@@ -424,6 +424,27 @@ static void sb_release_memory(thread_t *tp) {
 #endif
 }
 
+static bool sb_start_begin(sb_class_t *sbp) {
+  bool started;
+
+  chSysLock();
+  started = sbp->state == SB_STATE_STOPPED;
+  if (started) {
+    sbp->state = SB_STATE_STARTING;
+  }
+  chSysUnlock();
+
+  return started;
+}
+
+static void sb_start_failed(sb_class_t *sbp) {
+
+  chSysLock();
+  chDbgAssert(sbp->state == SB_STATE_STARTING, "invalid lifecycle state");
+  sbp->state = SB_STATE_STOPPED;
+  chSysUnlock();
+}
+
 static thread_t *sb_start_unprivileged(sb_class_t *sbp,
                                        const char *name,
                                        tprio_t prio,
@@ -513,7 +534,13 @@ static thread_t *sb_start_unprivileged(sb_class_t *sbp,
 #endif
 
   /* Starting the thread.*/
-  return chThdStart(utp);
+  chSysLock();
+  chDbgAssert(sbp->state == SB_STATE_STARTING, "invalid lifecycle state");
+  sbp->state = SB_STATE_RUNNING;
+  chThdStartI(utp);
+  chSysUnlock();
+
+  return utp;
 }
 
 /*===========================================================================*/
@@ -568,6 +595,7 @@ void sb_strv_copy(const char *sp[], void *dp, int n) {
 void sbObjectInit(sb_class_t *sbp) {
 
   memset((void *)sbp, 0, sizeof (sb_class_t));
+  sbp->state = SB_STATE_STOPPED;
 
   /* Marking the thread as terminated in order to make sbIsThreadRunningX()
      behave correctly.*/
@@ -585,6 +613,46 @@ void sbObjectInit(sb_class_t *sbp) {
 bool sbIsThreadRunningX(sb_class_t *sbp) {
 
   return !chThdTerminatedX(&sbp->thread);
+}
+
+/**
+ * @brief   Finalizes a terminated sandbox.
+ * @details The thread reference owned by the sandbox is released and the
+ *          lifecycle state is changed from @p SB_STATE_STOPPING to
+ *          @p SB_STATE_STOPPED.
+ * @pre     This function must not be called concurrently with another
+ *          sandbox lifecycle operation on the same object.
+ *
+ * @param[in] sbp       pointer to a @p sb_class_t structure
+ * @return              The operation status.
+ * @retval true         the sandbox has been finalized.
+ * @retval false        the sandbox is not stopping or its thread has not
+ *                      terminated, or there are outstanding thread
+ *                      references.
+ *
+ * @api
+ */
+bool sbFinalize(sb_class_t *sbp) {
+
+  chSysLock();
+  if ((sbp->state != SB_STATE_STOPPING) ||
+      !chThdTerminatedX(&sbp->thread) ||
+      (sbp->thread.refs != (trefs_t)1)) {
+    chSysUnlock();
+    return false;
+  }
+  chSysUnlock();
+
+  /* The lifecycle remains STOPPING while the dispose callback releases any
+     dynamic sandbox memory, so a new start cannot race with disposal.*/
+  chThdRelease(&sbp->thread);
+
+  chSysLock();
+  chDbgAssert(sbp->state == SB_STATE_STOPPING, "invalid lifecycle state");
+  sbp->state = SB_STATE_STOPPED;
+  chSysUnlock();
+
+  return true;
 }
 
 /**
@@ -607,7 +675,12 @@ thread_t *sbStart(sb_class_t *sbp, tprio_t prio, stkline_t *stkbase,
                   const char *argv[], const char *envp[]) {
   const sb_memory_region_t *codereg, *datareg;
   const sb_header_t *sbhp;
+  thread_t *utp;
   msg_t ret;
+
+  if (!sb_start_begin(sbp)) {
+    return NULL;
+  }
 
   /* Region zero is assumed to be executable and contain the start header.*/
   codereg = &sbp->regions[0];
@@ -615,7 +688,7 @@ thread_t *sbStart(sb_class_t *sbp, tprio_t prio, stkline_t *stkbase,
 
   ret = sb_check_header(sbhp, &codereg->area);
   if (CH_RET_IS_ERROR(ret)) {
-    return NULL;
+    goto failed;
   }
 #if SB_CFG_ENABLE_VRQ == TRUE
   sbp->vrq_entry = sbhp->hdr_vrq;
@@ -624,20 +697,29 @@ thread_t *sbStart(sb_class_t *sbp, tprio_t prio, stkline_t *stkbase,
   /* Locating region for data, it could be also region zero.*/
   datareg = sb_locate_data_region(sbp);
   if (datareg == NULL) {
-    return NULL;
+    goto failed;
   }
 
   /* Pushing arguments, environment variables and other startup information
      at the top of the data memory area.*/
   if (sb_init_environment(sbp, &datareg->area, argv, envp) == (size_t)0) {
-    return NULL;
+    goto failed;
   }
 
   /* No memory release.*/
   sbp->is_dynamic = false;
 
   /* Everything OK, starting the unprivileged thread inside the sandbox.*/
-  return sb_start_unprivileged(sbp, argv[0], prio, stkbase, sbhp->hdr_entry);
+  utp = sb_start_unprivileged(sbp, argv[0], prio, stkbase, sbhp->hdr_entry);
+  if (utp == NULL) {
+    goto failed;
+  }
+
+  return utp;
+
+failed:
+  sb_start_failed(sbp);
+  return NULL;
 }
 
 #if (SB_CFG_ENABLE_VFS == TRUE) || defined(__DOXYGEN__)
@@ -656,6 +738,7 @@ thread_t *sbStart(sb_class_t *sbp, tprio_t prio, stkline_t *stkbase,
  * @param[in] argv      arguments to be passed to the sandbox
  * @param[in] envp      environment variables to be passed to the sandbox
  * @return              The operation result.
+ * @retval CH_RET_EBUSY if the sandbox is not stopped
  * @retval CH_RET_ENOSYS if no VFS root is associated with the sandbox
  *
  * @api
@@ -663,20 +746,28 @@ thread_t *sbStart(sb_class_t *sbp, tprio_t prio, stkline_t *stkbase,
 msg_t sbExecStatic(sb_class_t *sbp, tprio_t prio,
                    stkline_t *stkbase, const char *path,
                    const char *argv[], const char *envp[]) {
-  memory_area_t ma = sbp->regions[0].area;
+  memory_area_t ma;
   const sb_header_t *sbhp;
   size_t totsize;
   msg_t ret;
 
+  if (!sb_start_begin(sbp)) {
+    return CH_RET_EBUSY;
+  }
+
+  ma = sbp->regions[0].area;
+
   if (sbGetRoot(sbp) == NULL) {
-    return CH_RET_ENOSYS;
+    ret = CH_RET_ENOSYS;
+    goto failed;
   }
 
   /* Pushing arguments, environment variables and other startup information
      at the top of the data memory area.*/
   totsize = sb_init_environment(sbp, &sbp->regions[0].area, argv, envp);
   if (totsize == (size_t)0) {
-    return CH_RET_ENOMEM;
+    ret = CH_RET_ENOMEM;
+    goto failed;
   }
 
   /* Adjusting the size of the memory area object, we don't want the loaded
@@ -685,14 +776,16 @@ msg_t sbExecStatic(sb_class_t *sbp, tprio_t prio,
 
   /* Loading sandbox code into the specified memory area.*/
   ret = sbElfLoadFile(sbGetRoot(sbp), path, &ma);
-  CH_RETURN_ON_ERROR(ret);
+  if (CH_RET_IS_ERROR(ret)) {
+    goto failed;
+  }
 
   /* Header location.*/
   sbhp = (const sb_header_t *)(void *)ma.base;
 
   ret = sb_check_header(sbhp, &ma);
   if (CH_RET_IS_ERROR(ret)) {
-    return ret;
+    goto failed;
   }
 #if SB_CFG_ENABLE_VRQ == TRUE
   sbp->vrq_entry = sbhp->hdr_vrq;
@@ -707,10 +800,15 @@ msg_t sbExecStatic(sb_class_t *sbp, tprio_t prio,
 
   /* Everything OK, starting the unprivileged thread inside the sandbox.*/
   if (sb_start_unprivileged(sbp, argv[0], prio, stkbase, sbhp->hdr_entry) == NULL) {
-    return CH_RET_ENOMEM;
+    ret = CH_RET_ENOMEM;
+    goto failed;
   }
 
   return CH_RET_SUCCESS;
+
+failed:
+  sb_start_failed(sbp);
+  return ret;
 }
 
 #if (PORT_SWITCHED_REGIONS_NUMBER > 0) && (CH_CFG_USE_HEAP == TRUE) || defined(__DOXYGEN__)
@@ -724,13 +822,14 @@ msg_t sbExecStatic(sb_class_t *sbp, tprio_t prio,
  * @param[in] argv      arguments to be passed to the sandbox
  * @param[in] envp      environment variables to be passed to the sandbox
  * @return              The operation result.
+ * @retval CH_RET_EBUSY if the sandbox is not stopped
  * @retval CH_RET_ENOSYS if no VFS root is associated with the sandbox
  *
  * @api
  */
 msg_t sbExecDynamic(sb_class_t *sbp, tprio_t prio, size_t heapsize,
                     const char *path, const char *argv[], const char *envp[]) {
-  memory_area_t *umap = &sbp->regions[0].area;
+  memory_area_t *umap;
   memory_area_t elfma;
   const sb_header_t *sbhp;
   vfs_file_node_c *fnp;
@@ -738,12 +837,21 @@ msg_t sbExecDynamic(sb_class_t *sbp, tprio_t prio, size_t heapsize,
   size_t size, basealign;
   msg_t ret;
 
+  if (!sb_start_begin(sbp)) {
+    return CH_RET_EBUSY;
+  }
+
+  umap = &sbp->regions[0].area;
+
   if (sbGetRoot(sbp) == NULL) {
-    return CH_RET_ENOSYS;
+    ret = CH_RET_ENOSYS;
+    goto failed;
   }
 
   ret = vfsFSOpenFile(sbGetRoot(sbp), path, VO_RDONLY, &fnp);
-  CH_RETURN_ON_ERROR(ret);
+  if (CH_RET_IS_ERROR(ret)) {
+    goto failed;
+  }
 
   /* Calculating bare-minimum space required by the elf file.*/
   ret = sbElfGetAllocation(fnp, &umap->size);
@@ -783,6 +891,7 @@ msg_t sbExecDynamic(sb_class_t *sbp, tprio_t prio, size_t heapsize,
      at the top of the data memory area.*/
   size = sb_init_environment(sbp, umap, argv, envp);
   if (size == (size_t)0) {
+    ret = CH_RET_ENOMEM;
     goto skip3;
   }
 
@@ -833,6 +942,8 @@ skip2:
   chHeapFree(umap->base);
 skip1:
   vfsClose((vfs_node_c *)fnp);
+failed:
+  sb_start_failed(sbp);
   return ret;
 }
 #endif /* CH_CFG_USE_HEAP == TRUE */

--- a/os/sb/host/sbhost.h
+++ b/os/sb/host/sbhost.h
@@ -121,8 +121,13 @@ static inline sb_state_t sbGetStateX(const sb_class_t *sbp) {
  * @brief   Blocks the execution of the invoking thread until the specified
  *          sandbox thread terminates then the exit code is returned.
  * @details The sandbox thread reference is not released.
+ * @pre     The sandbox must be in @p SB_STATE_RUNNING or
+ *          @p SB_STATE_STOPPING state.
+ * @pre     This function must not be called concurrently with another
+ *          sandbox lifecycle operation on the same object.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
+ * @post    The sandbox is in @p SB_STATE_STOPPING state.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @return              The exit code from the terminated sandbox thread.
@@ -132,13 +137,20 @@ static inline sb_state_t sbGetStateX(const sb_class_t *sbp) {
 static inline msg_t sbSync(sb_class_t *sbp) {
   msg_t msg;
 
+  chDbgAssert((sbp->state == SB_STATE_RUNNING) ||
+              (sbp->state == SB_STATE_STOPPING),
+              "invalid lifecycle state");
+
   msg = chThdSync(&sbp->thread);
+
+  chDbgAssert(sbp->state == SB_STATE_STOPPING, "invalid lifecycle state");
 
   return msg;
 }
 
 /**
  * @brief   Associates a memory area to a sandbox region.
+ * @pre     The sandbox must be in @p SB_STATE_STOPPED state.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @param[in] region    region number in range 0..SB_CFG_NUM_REGIONS-1
@@ -154,6 +166,7 @@ static inline void sbSetRegion(sb_class_t *sbp, unsigned region,
   sb_memory_region_t *mrp;
 
   chDbgCheck((region <= SB_CFG_NUM_REGIONS-1));
+  chDbgAssert(sbp->state == SB_STATE_STOPPED, "invalid lifecycle state");
 
   mrp = &sbp->regions[region];
   mrp->area.base = base;
@@ -177,7 +190,7 @@ static inline vfs_root_c *sbGetRoot(sb_class_t *sbp) {
 
 /**
  * @brief   Associates a VFS root with a sandbox.
- * @pre     The sandbox must not be running.
+ * @pre     The sandbox must be in @p SB_STATE_STOPPED state.
  * @note    The root is referenced directly and must remain valid while
  *          associated with the sandbox.
  * @note    A @p NULL root leaves the sandbox without a path namespace;
@@ -190,13 +203,14 @@ static inline vfs_root_c *sbGetRoot(sb_class_t *sbp) {
  */
 static inline void sbSetRoot(sb_class_t *sbp, vfs_root_c *rootp) {
 
-  chDbgAssert(!sbIsThreadRunningX(sbp), "sandbox running");
+  chDbgAssert(sbp->state == SB_STATE_STOPPED, "invalid lifecycle state");
 
   sbp->io.vfs_root = rootp;
 }
 
 /**
  * @brief   Registers a file descriptor on a sandbox.
+ * @pre     The sandbox must be in @p SB_STATE_STOPPED state.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @param[in] fd        file descriptor to be assigned
@@ -206,6 +220,7 @@ static inline void sbSetRoot(sb_class_t *sbp, vfs_root_c *rootp) {
  */
 static inline void sbRegisterDescriptor(sb_class_t *sbp, int fd, vfs_node_c *np) {
 
+  chDbgAssert(sbp->state == SB_STATE_STOPPED, "invalid lifecycle state");
   chDbgAssert(sb_is_available_descriptor(&sbp->io, fd), "invalid file descriptor");
 
   sbp->io.vfs_nodes[fd]  = np;
@@ -215,6 +230,7 @@ static inline void sbRegisterDescriptor(sb_class_t *sbp, int fd, vfs_node_c *np)
 #if (SB_CFG_ENABLE_VIO == TRUE) || defined(__DOXYGEN__)
 /**
  * @brief   Associates a VIO configuration to a sandbox.
+ * @pre     The sandbox must be in @p SB_STATE_STOPPED state.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @param[in] vioconf   pointer to a VIO configuration or @p NULL
@@ -222,6 +238,8 @@ static inline void sbRegisterDescriptor(sb_class_t *sbp, int fd, vfs_node_c *np)
  * @api
  */
 static inline void sbSetVirtualIO(sb_class_t *sbp, const vio_conf_t *vioconf) {
+
+  chDbgAssert(sbp->state == SB_STATE_STOPPED, "invalid lifecycle state");
 
   sbp->vioconf = vioconf;
 }

--- a/os/sb/host/sbhost.h
+++ b/os/sb/host/sbhost.h
@@ -67,6 +67,7 @@ extern "C" {
   void sb_strv_copy(const char *sp[], void *dp, int n);
   void sbObjectInit(sb_class_t *sbp);
   bool sbIsThreadRunningX(sb_class_t *sbp);
+  bool sbFinalize(sb_class_t *sbp);
   thread_t *sbStart(sb_class_t *sbp, tprio_t prio, stkline_t *stkbase,
                     const char *argv[], const char *envp[]);
 #if SB_CFG_ENABLE_VFS == TRUE
@@ -104,21 +105,34 @@ static inline void sbHostInit(void) {
 }
 
 /**
+ * @brief   Returns the sandbox lifecycle state.
+ *
+ * @param[in] sbp       pointer to a @p sb_class_t structure
+ * @return              The sandbox lifecycle state.
+ *
+ * @xclass
+ */
+static inline sb_state_t sbGetStateX(const sb_class_t *sbp) {
+
+  return sbp->state;
+}
+
+/**
  * @brief   Blocks the execution of the invoking thread until the specified
  *          sandbox thread terminates then the exit code is returned.
+ * @details The sandbox thread reference is not released.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @return              The exit code from the terminated sandbox thread.
- * @retval MSG_RESET    Sandbox thread not started.
  *
  * @api
  */
-static inline msg_t sbWait(sb_class_t *sbp) {
+static inline msg_t sbSync(sb_class_t *sbp) {
   msg_t msg;
 
-  msg = chThdWait(&sbp->thread);
+  msg = chThdSync(&sbp->thread);
 
   return msg;
 }

--- a/os/sb/host/sbsyscall.c
+++ b/os/sb/host/sbsyscall.c
@@ -905,7 +905,8 @@ static void sb_undef_handler(sb_class_t *sbp, struct port_extctx *ectxp) {
 void __sb_abort(msg_t msg) {
   sb_class_t *sbp = (sb_class_t *)chThdGetSelfX()->object;
 
-  (void)sbp; /* Could be unused.*/
+  chDbgAssert(sbp->state == SB_STATE_RUNNING, "invalid lifecycle state");
+  sbp->state = SB_STATE_STOPPING;
 
 #if SB_CFG_ENABLE_VRQ == TRUE
   chVTResetI(&sbp->vrq.alarm_vt);

--- a/os/sb/host/sbvrq.c
+++ b/os/sb/host/sbvrq.c
@@ -210,6 +210,7 @@ static void delay_cb(virtual_timer_t *vtp, void *arg) {
  * @details Flags are sent in the VRQ context and cleared, it is a fast way
  *          to transmit a (virtual) peripheral status information when a
  *          VRQ is triggered.
+ * @note    Calls made while the sandbox is not running are ignored.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @param[in] nvrq      number of VRQ to be activated
@@ -222,7 +223,14 @@ void sbVRQSetFlagsI(sb_class_t *sbp, sb_vrqnum_t nvrq, uint32_t flags) {
   const sb_vrqnum_t vrq_num =
     (sb_vrqnum_t)(sizeof sbp->vrq.flags / sizeof sbp->vrq.flags[0]);
 
+  chDbgCheckClassI();
+
   chDbgCheck(nvrq < vrq_num);
+
+  /* Ignoring stale producers outside the active sandbox execution.*/
+  if (sbp->state != SB_STATE_RUNNING) {
+    return;
+  }
 
   sbp->vrq.flags[nvrq] |= flags;
 }
@@ -231,6 +239,7 @@ void sbVRQSetFlagsI(sb_class_t *sbp, sb_vrqnum_t nvrq, uint32_t flags) {
  * @brief   Triggers VRQs on the specified sandbox.
  * @note    This function can only be used to send VRQs on sandboxes running
  *          on the same core.
+ * @note    Calls made while the sandbox is not running are ignored.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @param[in] nvrq      number of VRQ to be activated
@@ -244,13 +253,13 @@ void sbVRQTriggerS(sb_class_t *sbp, sb_vrqnum_t nvrq) {
   chDbgCheckClassS();
 
   chDbgCheck(nvrq < vrq_num);
-  chDbgAssert(sbp->thread.owner == currcore, "different core");
 
-  /* Late producers can still target a sandbox object during teardown or
-     restart windows, those VRQs must be ignored once the thread is dead.*/
-  if (chThdTerminatedX(&sbp->thread)) {
+  /* Ignoring stale producers outside the active sandbox execution.*/
+  if (sbp->state != SB_STATE_RUNNING) {
     return;
   }
+
+  chDbgAssert(sbp->thread.owner == currcore, "different core");
 
   /* Adding VRQ mask to the pending mask.*/
   sbp->vrq.wtmask |= (sb_vrqmask_t)(1U << nvrq);
@@ -296,6 +305,7 @@ void sbVRQTriggerS(sb_class_t *sbp, sb_vrqnum_t nvrq) {
  *          on the same core.
  * @note    This function must be called from IRQ context because
  *          it manipulates exception stack frames.
+ * @note    Calls made while the sandbox is not running are ignored.
  *
  * @param[in] sbp       pointer to a @p sb_class_t structure
  * @param[in] nvrq      number of VRQ to be activated
@@ -309,13 +319,13 @@ void sbVRQTriggerI(sb_class_t *sbp, sb_vrqnum_t nvrq) {
   chDbgCheckClassI();
 
   chDbgCheck(nvrq < vrq_num);
-  chDbgAssert(sbp->thread.owner == currcore, "different core");
 
-  /* Late producers can still target a sandbox object during teardown or
-     restart windows, those VRQs must be ignored once the thread is dead.*/
-  if (chThdTerminatedX(&sbp->thread)) {
+  /* Ignoring stale producers outside the active sandbox execution.*/
+  if (sbp->state != SB_STATE_RUNNING) {
     return;
   }
+
+  chDbgAssert(sbp->thread.owner == currcore, "different core");
 
   /* Adding VRQ mask to the pending mask.*/
   sbp->vrq.wtmask |= (sb_vrqmask_t)(1U << nvrq);

--- a/os/sb/note_sb_async_vfs.md
+++ b/os/sb/note_sb_async_vfs.md
@@ -127,9 +127,10 @@ cleanly:
 The worker is one of the non-VIO producers covered by
 [note_sb_lifecycle.md](note_sb_lifecycle.md). Sandbox termination enters
 `STOPPING`, which rejects completion VRQs, and restart is prohibited until
-the host has cancelled pending operations, stopped and joined the worker,
-and acknowledged producer quiescence through `sbFinalize()`. This avoids
-requiring generation-aware completion callbacks.
+the host has observed thread termination through `sbSync()`, cancelled
+pending operations, stopped and joined the worker, and acknowledged producer
+quiescence through `sbFinalize()`. This avoids requiring generation-aware
+completion callbacks.
 
 The worker holds private copies of all metadata, but it may still access SB
 memory for the final data copy-out or status write. That access must finish
@@ -164,9 +165,10 @@ other SBs' workers and host threads).
   `open` involves path resolution and can also be slow).
 - Decide the one-in-flight-per-FD question (simplest: yes, reject
   overlapping ops on the same descriptor).
-- Specify worker cancellation/join semantics and their ordering with
-  `sbFinalize()` and dynamic sandbox-memory release. In-flight slots must be
+- Define the operation-specific cancellation and drain mechanics. The generic
+  lifecycle ordering is fixed: after `sbSync()`, in-flight slots must be
   cancelled, or detached without retaining any sandbox reference, before
-  finalization permits the new instance to start.
+  `sbFinalize()` releases dynamic sandbox memory and permits the new instance
+  to start.
 - Guest runtime: green-thread wait/wake integration with the completion
   VRQ, and the idle policy (`vrq_wait`).

--- a/os/sb/note_sb_improvement_priorities.md
+++ b/os/sb/note_sb_improvement_priorities.md
@@ -43,20 +43,24 @@ done items are marked inline.
    (validate -> private privileged copy -> never re-dereference guest
    memory). Cheap to do now, and it *gates* both the async-VFS metadata
    path and the shared-memory API. (margin 1)
-4b. **Explicit sandbox lifecycle/finalization** — add independent
+4b. **Explicit sandbox lifecycle/finalization (implemented 2026-07-23)** —
+   independent
    `STOPPED`/`STARTING`/`RUNNING`/`STOPPING` state, gate VRQs on `RUNNING`,
    leave terminated sandboxes in `STOPPING`, and require the host to quiesce
    external producers before `sbFinalize()` permits restart. This closes the
    late-worker/late-IRQ restart contract without making every producer
-   generation-aware. Audit `sbWait()` and dynamic-memory release ordering.
+   generation-aware. The ordering is now direct: `sbSync()` retains the
+   controller-owned thread reference, the host quiesces producers, and
+   `sbFinalize()` releases the reference and dynamic sandbox memory.
    (note_sb_lifecycle.md; isolation note, margin 7)
 
 ## Tier 2 — Features (the functional payoff)
 
 5. **Async VFS** — submit/complete ABI, per-SB worker thread, VRQ-flags
    completion. Fixes the whole-SB stall on blocking POSIX calls, the
-   main limitation of the guest sub-scheduler threading model. Depends
-   on items 4 and 4b; submission wants item 6. (note_sb_async_vfs.md)
+   main limitation of the guest sub-scheduler threading model. Item 4b is
+   implemented; this still depends on item 4, and submission wants item 6.
+   (note_sb_async_vfs.md)
 6. **IRQ-like fastcalls** — per-handler
    `CH_IRQ_PROLOGUE`/lock/I-class/unlock/`CH_IRQ_EPILOGUE`, dispatcher
    untouched. The *cheapest* item on the whole list (macros, docs,

--- a/os/sb/note_sb_improvement_priorities.md
+++ b/os/sb/note_sb_improvement_priorities.md
@@ -45,12 +45,12 @@ done items are marked inline.
    path and the shared-memory API. (margin 1)
 4b. **Explicit sandbox lifecycle/finalization (implemented 2026-07-23)** —
    independent
-   `STOPPED`/`STARTING`/`RUNNING`/`STOPPING` state, gate VRQs on `RUNNING`,
-   leave terminated sandboxes in `STOPPING`, and require the host to quiesce
-   external producers before `sbFinalize()` permits restart. This closes the
-   late-worker/late-IRQ restart contract without making every producer
-   generation-aware. The ordering is now direct: `sbSync()` retains the
-   controller-owned thread reference, the host quiesces producers, and
+   `UNINIT`/`STOPPED`/`STARTING`/`RUNNING`/`STOPPING` state, gate VRQs on
+   `RUNNING`, leave terminated sandboxes in `STOPPING`, and require the host
+   to quiesce external producers before `sbFinalize()` permits restart. This
+   closes the late-worker/late-IRQ restart contract without making every
+   producer generation-aware. The ordering is now direct: `sbSync()` retains
+   the controller-owned thread reference, the host quiesces producers, and
    `sbFinalize()` releases the reference and dynamic sandbox memory.
    (note_sb_lifecycle.md; isolation note, margin 7)
 

--- a/os/sb/note_sb_isolation_security.md
+++ b/os/sb/note_sb_isolation_security.md
@@ -166,19 +166,21 @@ reconfiguration breaks that ordering.
 
 ### 7. Sandbox lifecycle vs. late asynchronous producers
 
-The current `chThdTerminatedX()` guards prevent VRQ injection into a dead
+The previous `chThdTerminatedX()` guards prevented VRQ injection into a dead
 thread, but the thread object embedded in `sb_class_t` is reused. A custom
-worker, timer, DMA completion path, or board IRQ that survives termination
-can therefore target the replacement execution after the thread becomes
+worker, timer, DMA completion path, or board IRQ that survived termination
+could therefore target the replacement execution after the thread became
 non-terminated again. A sandbox lifecycle cannot be inferred from reusable
 thread state.
 
-The preferred hardening is the explicit lifecycle protocol in
+The implemented hardening is the explicit lifecycle protocol in
 [note_sb_lifecycle.md](note_sb_lifecycle.md): termination enters a durable
 `STOPPING` state, all VRQ mutations are rejected outside `RUNNING`, and only
-the host can transition to `STOPPED` through `sbFinalize()` after it has
-synchronously quiesced every external producer. Start is accepted only from
-`STOPPED`. This avoids imposing generation tokens on ordinary producers.
+the host can transition to `STOPPED` after `sbSync()` has observed thread
+termination, every external producer has been synchronously quiesced, and
+`sbFinalize()` has released the controller-owned thread reference. Start is
+accepted only from `STOPPED`. This avoids imposing generation tokens on
+ordinary producers.
 
 The host-quiescence precondition is essential. An old and a new invocation of
 `sbVRQTriggerI(sbp, nvrq)` have identical arguments once the replacement is

--- a/os/sb/note_sb_lifecycle.md
+++ b/os/sb/note_sb_lifecycle.md
@@ -27,11 +27,13 @@ producer-quiescence contract.
 ## Proposed state machine
 
 ```text
-STOPPED -> STARTING -> RUNNING -> STOPPING
-   ^                                  |
-   +-------- explicit finalize -------+
+UNINIT -- object init --> STOPPED -> STARTING -> RUNNING -> STOPPING
+                            ^                                  |
+                            +-------- explicit finalize -------+
 ```
 
+- `UNINIT`: the sandbox object has not been initialized; zero-initialized
+  static storage has this state and no sandbox operation is permitted.
 - `STOPPED`: no producer may target the sandbox; a start operation is
   permitted.
 - `STARTING`: the thread and VRQ state are being prepared; VRQs are rejected.
@@ -39,6 +41,10 @@ STOPPED -> STARTING -> RUNNING -> STOPPING
 - `STOPPING`: the guest has exited or aborted and producer teardown is in
   progress; VRQs are rejected. This is a durable state, not an automatic
   transition to `STOPPED`.
+
+`sbObjectInit()` is the only transition from `UNINIT` to `STOPPED`. There is
+no transition back to `UNINIT`; object disposal is outside this execution
+lifecycle.
 
 Sandbox exit and abort must set `STOPPING` before disabling VIO callbacks,
 resetting timers, or notifying the host. Start APIs must accept only
@@ -55,7 +61,8 @@ the sandbox execution owns the event.
 
 Termination leaves the sandbox in `STOPPING`. The host must then:
 
-1. Call `sbSync()` to wait until the sandbox thread reaches its final state.
+1. Call `sbSync()` while the sandbox is `RUNNING` or `STOPPING` to wait until
+   its thread reaches the final state.
 2. Disable custom IRQ and DMA completion sources, cancel pending operations,
    and stop or join workers that can reference the sandbox or its memory.
 3. Call `sbFinalize()`.
@@ -63,7 +70,10 @@ Termination leaves the sandbox in `STOPPING`. The host must then:
 `sbSync()` replaces `sbWait()` and wraps `chThdSync()`. The original thread
 reference remains owned by `sb_class_t`, so synchronization does not invoke
 the thread dispose callback and dynamic sandbox memory remains valid while
-the host quiesces external producers.
+the host quiesces external producers. Calling it while the sandbox is
+`RUNNING` blocks until termination changes the lifecycle to `STOPPING`;
+calling it after that transition waits only if the thread has not reached its
+final state yet. It returns with the lifecycle still in `STOPPING`.
 
 `sbFinalize()` is preferable to a public state setter. It represents the
 host's assertion that every external producer is quiescent. It verifies that
@@ -113,7 +123,12 @@ cannot distinguish its old event after a new execution reaches `RUNNING`.
 ## Required validation
 
 - Normal guest exit and fault/abort both enter `STOPPING` before cleanup.
-- VRQs and flags raised in `STOPPING`, `STOPPED`, and `STARTING` are ignored.
+- Zero-initialized static storage reports `UNINIT`; start, finalization, VRQs,
+  and configuration are rejected until `sbObjectInit()` enters `STOPPED`.
+- VRQs and flags raised in `UNINIT`, `STOPPING`, `STOPPED`, and `STARTING` are
+  ignored.
+- `sbSync()` can be entered from `RUNNING` or `STOPPING` and returns in
+  `STOPPING`.
 - `sbSync()` does not release the controller-owned thread reference or dynamic
   sandbox memory.
 - Start is rejected before explicit finalization.

--- a/os/sb/note_sb_lifecycle.md
+++ b/os/sb/note_sb_lifecycle.md
@@ -1,9 +1,9 @@
 # Note: SB Lifecycle and Restart Protocol
 
-Design proposal, 2026-07-15. This note addresses sandbox termination,
-restart, and late asynchronous VRQ producers that are not necessarily owned
-by VIO, such as host worker threads, custom timers, DMA completion paths, or
-board-specific IRQ sources.
+Design proposed 2026-07-15 and implemented 2026-07-23. This note addresses
+sandbox termination, restart, and late asynchronous VRQ producers that are
+not necessarily owned by VIO, such as host worker threads, custom timers, DMA
+completion paths, or board-specific IRQ sources.
 
 ## Problem
 
@@ -51,31 +51,49 @@ performed under the system lock. Thread state remains relevant when choosing
 how to inject a VRQ into a running thread, but it no longer decides whether
 the sandbox execution owns the event.
 
-## Explicit finalization API
+## Explicit synchronization and finalization APIs
 
 Termination leaves the sandbox in `STOPPING`. The host must then:
 
-1. Disable custom IRQ and DMA completion sources.
-2. Cancel timers and pending asynchronous operations.
-3. Stop and join worker threads that can reference the sandbox or its memory.
-4. Call an explicit API, provisionally named `sbFinalize()`.
+1. Call `sbSync()` to wait until the sandbox thread reaches its final state.
+2. Disable custom IRQ and DMA completion sources, cancel pending operations,
+   and stop or join workers that can reference the sandbox or its memory.
+3. Call `sbFinalize()`.
+
+`sbSync()` replaces `sbWait()` and wraps `chThdSync()`. The original thread
+reference remains owned by `sb_class_t`, so synchronization does not invoke
+the thread dispose callback and dynamic sandbox memory remains valid while
+the host quiesces external producers.
 
 `sbFinalize()` is preferable to a public state setter. It represents the
-host's assertion that every external producer is quiescent, verifies that
+host's assertion that every external producer is quiescent. It verifies that
 the sandbox thread has terminated and that the lifecycle is `STOPPING`,
-clears the VRQ state under the system lock, and finally changes the state to
-`STOPPED`. A subsequent start is rejected until finalization succeeds.
-
-The implementation must define the ordering between `sbWait()`, thread
-release, dynamic sandbox-memory release, and `sbFinalize()`. Memory referenced
-by an asynchronous producer must not be released before that producer has
-been stopped or joined. This may require finalization to become the resource
-release boundary, or require memory-touching subsystems to participate in
-the termination cleanup before `sbWait()` releases the thread.
+releases the thread reference owned by `sb_class_t`, and changes the lifecycle
+to `STOPPED`. Releasing that reference is the dynamic sandbox-memory release
+boundary. A subsequent start is rejected until finalization succeeds.
 
 For a sandbox using only built-in VIO and the alarm timer, the existing
 termination cleanup already quiesces its producers, so the host can finalize
-immediately after observing termination.
+immediately after `sbSync()` returns.
+
+## Incremental implementation plan
+
+Each step must build and carry its own focused validation.
+
+1. Add `sbSync()` using `chThdSync()` while retaining the existing `sbWait()`.
+   Validate that `sbSync()` followed by `sbWait()` succeeds, proving that
+   synchronization did not consume the reference. **Implemented 2026-07-23.**
+2. Add the lifecycle state and `sbFinalize()` together with all start,
+   failed-start, normal-exit, and abort transitions. Temporarily implement
+   `sbWait()` as `sbSync()` followed by `sbFinalize()` so existing callers
+   remain functional. Validate finalization preconditions and restart.
+   **Implemented 2026-07-23.**
+3. Reject VRQ flag updates and triggers outside `RUNNING`. Validate acceptance
+   in `RUNNING` and rejection in the other lifecycle states.
+   **Implemented 2026-07-23.**
+4. Migrate callers to the explicit `sbSync()` -> producer quiescence ->
+   `sbFinalize()` protocol, validate a custom worker during that interval,
+   then remove `sbWait()`. **Implemented 2026-07-23.**
 
 ## VRQ producer contract
 
@@ -96,9 +114,12 @@ cannot distinguish its old event after a new execution reaches `RUNNING`.
 
 - Normal guest exit and fault/abort both enter `STOPPING` before cleanup.
 - VRQs and flags raised in `STOPPING`, `STOPPED`, and `STARTING` are ignored.
+- `sbSync()` does not release the controller-owned thread reference or dynamic
+  sandbox memory.
 - Start is rejected before explicit finalization.
 - Finalization is rejected while the thread is live or from the wrong state.
-- A custom worker is stopped and joined before finalization, then cannot
-  deliver a completion into the replacement execution.
+- A custom worker retaining sandbox memory is stopped and joined before
+  finalization; its late completion is rejected in `STOPPING`, and the joined
+  worker cannot deliver into the replacement execution.
 - Dynamic sandbox memory remains valid until every memory-touching producer
   has been quiesced.

--- a/os/sb/open_points.md
+++ b/os/sb/open_points.md
@@ -16,7 +16,6 @@ maintained in
 
 ## Host
 
-- Implement the explicit sandbox lifecycle and restart protocol proposed in [note_sb_lifecycle.md](note_sb_lifecycle.md) (2026-07-15): `STOPPED -> STARTING -> RUNNING -> STOPPING`, with termination remaining in `STOPPING` until the host synchronously quiesces every external VRQ producer and calls `sbFinalize()`. VRQs and flags are accepted only in `RUNNING`; start is permitted only from `STOPPED`. This replaces lifecycle decisions based only on the reusable thread state without requiring every producer to carry a generation. Audit the ordering of `sbWait()`, dynamic-memory release, and finalization for workers that access sandbox memory. **Masking atomicity remains resolved (2026-06-17):** the `vrq.isr`/`SB_VRQ_ISR_DISABLED` RMW sequences are safe by priority design and guarded in `host/sbvrq.c`.
 - Decide whether sandbox memory-range violations in host services should keep returning `CH_RET_EFAULT` or escalate to a sandbox fault/termination policy.
 - Add more host-side validation tests for multi-image bring-up, because incorrect flashing order can produce misleading startup failures during debug.
 - Evaluate whether a host-side integration demo/test should be added for the working host + SB1 + SB2 configuration used during VETH/lwIP bring-up.

--- a/testsb/SB_VIO-STM32G474RE-NUCLEO64-HOST/main.c
+++ b/testsb/SB_VIO-STM32G474RE-NUCLEO64-HOST/main.c
@@ -207,6 +207,10 @@ static vio_conf_t vio_config1 = {
 
 /* Privileged stacks for sandboxes.*/
 static SB_STACK(sbx1stk);
+static SB_STACK(sbx2stk);
+
+/* Invalid header used for failed-start lifecycle testing.*/
+static sb_header_t invalid_header;
 
 /* Arguments and environments for SB1.*/
 static const char *sbx1_argv[] = {
@@ -218,9 +222,106 @@ static const char *sbx1_envp[] = {
   NULL
 };
 
+/* External worker retaining a pointer into sandbox memory.*/
+typedef struct {
+  sb_class_t                    *sbp;
+  const volatile uint8_t        *memory;
+  volatile bool                 memory_accessed;
+} sb_worker_context_t;
+
+static THD_WORKING_AREA(sb_worker_wa, 256);
+static thread_t *sb_worker_tp;
+static sb_worker_context_t sb_worker_context;
+
 /*===========================================================================*/
 /* Main and generic code.                                                    */
 /*===========================================================================*/
+
+static void test_vrq_ignored(sb_class_t *sbp) {
+  const sb_vrqnum_t nvrq = 31U;
+  uint32_t flags;
+  sb_vrqmask_t wtmask;
+
+  chSysLock();
+  flags = sbp->vrq.flags[nvrq];
+  wtmask = sbp->vrq.wtmask;
+  sbVRQSetFlagsI(sbp, nvrq, 0xA5A5A5A5U);
+  sbVRQTriggerS(sbp, nvrq);
+  chDbgAssert(sbp->vrq.flags[nvrq] == flags, "VRQ flags changed");
+  chDbgAssert(sbp->vrq.wtmask == wtmask, "VRQ triggered");
+  chSysUnlock();
+}
+
+static void test_vrq_running(sb_class_t *sbp) {
+  const sb_vrqnum_t nvrq = 31U;
+  const sb_vrqmask_t vrqmask = (sb_vrqmask_t)(1U << nvrq);
+
+  chSysLock();
+  sbp->vrq.flags[nvrq] = 0U;
+  sbp->vrq.wtmask &= ~vrqmask;
+  sbVRQSetFlagsI(sbp, nvrq, 0xA5A5A5A5U);
+  sbVRQTriggerS(sbp, nvrq);
+  chDbgAssert(sbp->vrq.flags[nvrq] == 0xA5A5A5A5U,
+              "VRQ flags rejected");
+  chDbgAssert((sbp->vrq.wtmask & vrqmask) != 0U, "VRQ rejected");
+  sbp->vrq.flags[nvrq] = 0U;
+  sbp->vrq.wtmask &= ~vrqmask;
+  chSysUnlock();
+}
+
+static THD_FUNCTION(sb_worker, arg) {
+  sb_worker_context_t *wcp = (sb_worker_context_t *)arg;
+  uint8_t sample;
+
+  chRegSetThreadName("sb-worker");
+
+  while (!chThdShouldTerminateX()) {
+    chThdSleepMilliseconds(1);
+  }
+
+  /* This access must happen after sbSync() but before sbFinalize().*/
+  sample = *wcp->memory;
+  (void)sample;
+  wcp->memory_accessed = true;
+
+  /* A completion from the stopping execution must be ignored.*/
+  chSysLock();
+  sbVRQSetFlagsI(wcp->sbp, 31U, 0x5A5A5A5AU);
+  sbVRQTriggerS(wcp->sbp, 31U);
+  chSysUnlock();
+}
+
+static void start_sb_worker(void) {
+
+  sb_worker_context.sbp = &sbx1;
+  sb_worker_context.memory = sbx1.regions[1].area.base;
+  sb_worker_context.memory_accessed = false;
+  sb_worker_tp = chThdCreateStatic(sb_worker_wa, sizeof sb_worker_wa,
+                                   NORMALPRIO-5, sb_worker,
+                                   &sb_worker_context);
+  chDbgAssert(sb_worker_tp != NULL, "worker not started");
+}
+
+static void stop_sb_worker(void) {
+  uint32_t flags;
+  sb_vrqmask_t wtmask;
+
+  chSysLock();
+  flags = sbx1.vrq.flags[31U];
+  wtmask = sbx1.vrq.wtmask;
+  chSysUnlock();
+
+  chThdTerminate(sb_worker_tp);
+  (void)chThdWait(sb_worker_tp);
+  sb_worker_tp = NULL;
+
+  chDbgAssert(sb_worker_context.memory_accessed,
+              "sandbox memory not accessible");
+  chSysLock();
+  chDbgAssert(sbx1.vrq.flags[31U] == flags, "stale worker flags accepted");
+  chDbgAssert(sbx1.vrq.wtmask == wtmask, "stale worker VRQ accepted");
+  chSysUnlock();
+}
 
 static void start_sb1(void) {
   thread_t *utp;
@@ -230,6 +331,8 @@ static void start_sb1(void) {
   if (utp == NULL) {
     chSysHalt("sbx1 failed");
   }
+  chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_RUNNING,
+              "sandbox not running");
 }
 
 /*
@@ -276,8 +379,28 @@ int main(void) {
   sbSetRegion(&sbx1, 1, STARTUP_RAM1_BASE,   STARTUP_RAM1_SIZE, SB_REG_IS_DATA);
   sbSetVirtualIO(&sbx1, &vio_config1);
 
+  /* Lifecycle initialization and failed-start checks.*/
+  chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_STOPPED,
+              "sandbox not stopped");
+  test_vrq_ignored(&sbx1);
+  chDbgAssert(!sbFinalize(&sbx1), "stopped sandbox finalized");
+  sbObjectInit(&sbx2);
+  sbSetRegion(&sbx2, 0, (uint8_t *)&invalid_header,
+              sizeof invalid_header, SB_REG_IS_CODE);
+  chDbgAssert(sbStart(&sbx2, NORMALPRIO-10, sbx2stk,
+                      sbx1_argv, sbx1_envp) == NULL,
+              "invalid sandbox started");
+  chDbgAssert(sbGetStateX(&sbx2) == SB_STATE_STOPPED,
+              "failed start not stopped");
+
   /* Starting sandboxed threads.*/
   start_sb1();
+  start_sb_worker();
+  test_vrq_running(&sbx1);
+  chDbgAssert(!sbFinalize(&sbx1), "running sandbox finalized");
+  chDbgAssert(sbStart(&sbx1, NORMALPRIO-10, sbx1stk,
+                      sbx1_argv, sbx1_envp) == NULL,
+              "running sandbox restarted");
 
   /*
    * Listening to sandbox events.
@@ -293,7 +416,24 @@ int main(void) {
     if (chEvtWaitAnyTimeout(ALL_EVENTS, TIME_MS2I(500)) != (eventmask_t)0) {
 
       if (!sbIsThreadRunningX(&sbx1)) {
-        msg_t msg = sbWait(&sbx1);
+        bool finalized;
+        msg_t msg;
+
+        chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_STOPPING,
+                    "sandbox not stopping");
+        test_vrq_ignored(&sbx1);
+        msg = sbSync(&sbx1);
+        chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_STOPPING,
+                    "sync changed lifecycle");
+        stop_sb_worker();
+        chDbgAssert(sbStart(&sbx1, NORMALPRIO-10, sbx1stk,
+                            sbx1_argv, sbx1_envp) == NULL,
+                    "stopping sandbox restarted");
+        finalized = sbFinalize(&sbx1);
+        chDbgAssert(finalized, "sandbox not finalized");
+        (void)finalized;
+        chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_STOPPED,
+                    "sandbox not finalized");
 
         /* Re-starting the driver because the sandbox stops it on exit.*/
         if (drvStart(&LPSIOD1, NULL) != MSG_OK) {
@@ -304,6 +444,7 @@ int main(void) {
         drvStop(&LPSIOD1);
 
         start_sb1();
+        start_sb_worker();
       }
     }
   }

--- a/testsb/SB_VIO-STM32G474RE-NUCLEO64-HOST/main.c
+++ b/testsb/SB_VIO-STM32G474RE-NUCLEO64-HOST/main.c
@@ -233,6 +233,18 @@ static THD_WORKING_AREA(sb_worker_wa, 256);
 static thread_t *sb_worker_tp;
 static sb_worker_context_t sb_worker_context;
 
+/* Host thread synchronizing with the sandbox from RUNNING state. */
+typedef struct {
+  sb_class_t                    *sbp;
+  volatile bool                 entered;
+  volatile bool                 completed;
+  msg_t                         msg;
+} sb_sync_context_t;
+
+static THD_WORKING_AREA(sb_sync_wa, 256);
+static thread_t *sb_sync_tp;
+static sb_sync_context_t sb_sync_context;
+
 /*===========================================================================*/
 /* Main and generic code.                                                    */
 /*===========================================================================*/
@@ -323,6 +335,43 @@ static void stop_sb_worker(void) {
   chSysUnlock();
 }
 
+static THD_FUNCTION(sb_syncer, arg) {
+  sb_sync_context_t *scp = (sb_sync_context_t *)arg;
+
+  chRegSetThreadName("sb-sync");
+  scp->entered = true;
+  scp->msg = sbSync(scp->sbp);
+  scp->completed = true;
+}
+
+static void start_sb_syncer(void) {
+
+  chDbgAssert(sb_sync_tp == NULL, "syncer already started");
+  sb_sync_context.sbp = &sbx1;
+  sb_sync_context.entered = false;
+  sb_sync_context.completed = false;
+  sb_sync_tp = chThdCreateStatic(sb_sync_wa, sizeof sb_sync_wa,
+                                 NORMALPRIO-5, sb_syncer,
+                                 &sb_sync_context);
+  chDbgAssert(sb_sync_tp != NULL, "syncer not started");
+  while (!sb_sync_context.entered) {
+    chThdSleepMilliseconds(1);
+  }
+  chThdSleepMilliseconds(1);
+  chDbgAssert(!sb_sync_context.completed, "running sync did not block");
+}
+
+static msg_t wait_sb_syncer(void) {
+  msg_t msg;
+
+  (void)chThdWait(sb_sync_tp);
+  sb_sync_tp = NULL;
+  chDbgAssert(sb_sync_context.completed, "syncer not completed");
+  msg = sb_sync_context.msg;
+
+  return msg;
+}
+
 static void start_sb1(void) {
   thread_t *utp;
 
@@ -374,6 +423,15 @@ int main(void) {
   /*
    * Sandbox objects initialization, regions are assigned explicitly.
    */
+  chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_UNINIT,
+              "zeroed sandbox initialized");
+  chDbgAssert(!sbIsThreadRunningX(&sbx1), "uninitialized sandbox running");
+  test_vrq_ignored(&sbx1);
+  chDbgAssert(!sbFinalize(&sbx1), "uninitialized sandbox finalized");
+  chDbgAssert(sbStart(&sbx1, NORMALPRIO-10, sbx1stk,
+                      sbx1_argv, sbx1_envp) == NULL,
+              "uninitialized sandbox started");
+
   sbObjectInit(&sbx1);
   sbSetRegion(&sbx1, 0, STARTUP_FLASH1_BASE, STARTUP_FLASH1_SIZE, SB_REG_IS_CODE);
   sbSetRegion(&sbx1, 1, STARTUP_RAM1_BASE,   STARTUP_RAM1_SIZE, SB_REG_IS_DATA);
@@ -395,6 +453,7 @@ int main(void) {
 
   /* Starting sandboxed threads.*/
   start_sb1();
+  start_sb_syncer();
   start_sb_worker();
   test_vrq_running(&sbx1);
   chDbgAssert(!sbFinalize(&sbx1), "running sandbox finalized");
@@ -417,12 +476,14 @@ int main(void) {
 
       if (!sbIsThreadRunningX(&sbx1)) {
         bool finalized;
-        msg_t msg;
+        msg_t msg, stopped_msg;
 
         chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_STOPPING,
                     "sandbox not stopping");
         test_vrq_ignored(&sbx1);
-        msg = sbSync(&sbx1);
+        msg = wait_sb_syncer();
+        stopped_msg = sbSync(&sbx1);
+        chDbgAssert(stopped_msg == msg, "sync result changed");
         chDbgAssert(sbGetStateX(&sbx1) == SB_STATE_STOPPING,
                     "sync changed lifecycle");
         stop_sb_worker();
@@ -444,6 +505,7 @@ int main(void) {
         drvStop(&LPSIOD1);
 
         start_sb1();
+        start_sb_syncer();
         start_sb_worker();
       }
     }


### PR DESCRIPTION
## Summary

- add explicit UNINIT, STOPPED, STARTING, RUNNING, and STOPPING sandbox states
- make zero-initialized sandbox storage fail closed until sbObjectInit() transitions UNINIT to STOPPED
- add sbSync() and sbFinalize() so the host can quiesce external producers before releasing the controller-owned thread reference and dynamic sandbox memory
- permit sbSync() from RUNNING to wait for termination and from STOPPING to synchronize after the lifecycle transition
- require STOPPED for sandbox configuration helpers and reject external VRQ flag updates and triggers unless the sandbox is RUNNING
- migrate all host demos to the explicit synchronization and finalization protocol and remove sbWait()
- stop and join the persistent G474 messenger before SB2 finalization
- document the lifecycle contract and add focused zero-state, synchronization, restart, stale-VRQ, and memory-retaining worker coverage

## Rationale

The embedded thread object is reused when a sandbox restarts, so thread termination alone is not a lifecycle boundary. A late worker, DMA callback, timer, or board IRQ from the previous execution could otherwise observe the replacement thread as live and deliver a stale VRQ into it.

State zero is now UNINIT rather than STOPPED. Static or explicitly zeroed storage therefore cannot be started or configured accidentally; sbObjectInit() is the sole transition to STOPPED. There is no transition back to UNINIT because object disposal is outside the execution lifecycle.

Termination enters a durable STOPPING state. sbSync() can be entered while RUNNING and blocks until termination, or be called after STOPPING has already been observed. It waits without releasing the sandbox-owned thread reference, allowing workers that still reference sandbox memory to be cancelled and joined safely. sbFinalize() is the explicit host acknowledgement that producers are quiescent; it releases the reference and any dynamic allocation, then permits a new start from STOPPED. This avoids requiring every producer to carry a generation.

The API is named sbFinalize() because it ends one sandbox execution while leaving the sandbox object initialized and reusable; object disposal elsewhere denotes the end of the object lifetime.

## Validation

Built successfully:

- testsb/SB_VIO-STM32G474RE-NUCLEO64-HOST
- testsb/SB_VIO-XSHELL-CLIENT, 256k-08040000-32k-20018000 configuration
- demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_SWITCHED
- demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_NOSWITCH
- demos/STM32/RT-STM32H563ZI-NUCLEO144-SB_HOST_SWITCHED
- demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_STATIC_RAMBOX
- demos/STM32/RT-STM32L4R9-DISCOVERY-SB_HOST_DYNAMIC_RAMBOX
- POSIX simulator CI smoke target
- ARMv7-M CI smoke target

Additional checks:

- exact PR changed-line style gate: no findings across 12 changed C/H files
- git diff --check
- G474 hardware lifecycle checkpoints: RUNNING sbSync() blocked; guest termination woke it with MSG_OK; STOPPING sbSync() returned the same result; the sandbox thread was FINAL with its controller reference retained; finalization reached STOPPED; restart reached RUNNING with a fresh blocked synchronizer

The debugger-driven hardware termination bypassed the unrelated existing LPSIOD1 teardown path, which currently triggers the XHAL SIO SV#11 assertion because its stop implementation invokes S-class rescheduling outside a system lock.

All generated build artifacts were cleaned after validation.