### PR TITLE
XHAL: lock stop-time waiter wakeups

### DIFF
--- a/os/xhal/codegen/hal_can.xml
+++ b/os/xhal/codegen/hal_can.xml
@@ -604,9 +604,11 @@ return msg;]]></implementation>
 can_lld_stop(self);
 can_lld_reset(self);
 #if CAN_USE_SYNCHRONIZATION == TRUE
+osalSysLock();
 osalThreadDequeueAllI(&self->rxqueue, MSG_RESET);
 osalThreadDequeueAllI(&self->txqueue, MSG_RESET);
 osalOsRescheduleS();
+osalSysUnlock();
 #endif]]></implementation>
             </method>
             <method shortname="setcfg">

--- a/os/xhal/codegen/hal_i2c.xml
+++ b/os/xhal/codegen/hal_i2c.xml
@@ -443,7 +443,10 @@ return msg;]]></implementation>
 i2c_lld_stop(self);
 self->errors = I2C_NO_ERROR;
 #if I2C_USE_SYNCHRONIZATION == TRUE
+osalSysLock();
 osalThreadResumeI(&self->sync_transfer, MSG_RESET);
+osalOsRescheduleS();
+osalSysUnlock();
 #endif]]></implementation>
             </method>
             <method shortname="setcfg">

--- a/os/xhal/codegen/hal_sdc.xml
+++ b/os/xhal/codegen/hal_sdc.xml
@@ -919,7 +919,10 @@ self->cardmode = 0U;
 self->rca = 0U;
 self->capacity = 0U;
 #if SDC_USE_SYNCHRONIZATION == TRUE
+osalSysLock();
 osalThreadResumeI(&self->sync_transfer, MSG_RESET);
+osalOsRescheduleS();
+osalSysUnlock();
 #endif]]></implementation>
             </method>
             <method shortname="setcfg">

--- a/os/xhal/codegen/hal_sio.xml
+++ b/os/xhal/codegen/hal_sio.xml
@@ -959,11 +959,13 @@ self->enabled = (sioevents_t)0;
 
 #if SIO_USE_SYNCHRONIZATION == TRUE
 /* Informing waiting threads, if any.*/
+osalSysLock();
 osalThreadResumeI(&self->sync_rx, MSG_RESET);
 osalThreadResumeI(&self->sync_rxidle, MSG_RESET);
 osalThreadResumeI(&self->sync_tx, MSG_RESET);
 osalThreadResumeI(&self->sync_txend, MSG_RESET);
 osalOsRescheduleS();
+osalSysUnlock();
 #endif]]></implementation>
             </method>
             <method shortname="setcfg">

--- a/os/xhal/codegen/hal_usb.xml
+++ b/os/xhal/codegen/hal_usb.xml
@@ -1580,6 +1580,9 @@ self->status        = 0U;
 self->address       = 0U;
 self->configuration = 0U;
 self->saved_state   = HAL_DRV_STATE_STOP;
+#if USB_USE_SYNCHRONIZATION == TRUE
+osalSysLock();
+#endif
 for (i = 0U; i <= (unsigned)USB_MAX_ENDPOINTS; i++) {
 #if USB_USE_SYNCHRONIZATION == TRUE
   if (self->epc[i] != NULL) {
@@ -1592,7 +1595,11 @@ for (i = 0U; i <= (unsigned)USB_MAX_ENDPOINTS; i++) {
   }
 #endif
   self->epc[i] = NULL;
-}]]></implementation>
+}
+#if USB_USE_SYNCHRONIZATION == TRUE
+osalOsRescheduleS();
+osalSysUnlock();
+#endif]]></implementation>
             </method>
             <method shortname="setcfg">
               <implementation><![CDATA[

--- a/os/xhal/codegen/hal_wspi.xml
+++ b/os/xhal/codegen/hal_wspi.xml
@@ -459,7 +459,10 @@ return msg;]]></implementation>
               <implementation><![CDATA[
 wspi_lld_stop(self);
 #if WSPI_USE_SYNCHRONIZATION == TRUE
+osalSysLock();
 osalThreadResumeI(&self->sync_transfer, MSG_RESET);
+osalOsRescheduleS();
+osalSysUnlock();
 #endif]]></implementation>
             </method>
             <method shortname="setcfg">

--- a/os/xhal/src/hal_can.c
+++ b/os/xhal/src/hal_can.c
@@ -163,9 +163,11 @@ void __can_stop_impl(void *ip) {
   can_lld_stop(self);
   can_lld_reset(self);
 #if CAN_USE_SYNCHRONIZATION == TRUE
+  osalSysLock();
   osalThreadDequeueAllI(&self->rxqueue, MSG_RESET);
   osalThreadDequeueAllI(&self->txqueue, MSG_RESET);
   osalOsRescheduleS();
+  osalSysUnlock();
 #endif
 }
 

--- a/os/xhal/src/hal_i2c.c
+++ b/os/xhal/src/hal_i2c.c
@@ -153,7 +153,10 @@ void __i2c_stop_impl(void *ip) {
   i2c_lld_stop(self);
   self->errors = I2C_NO_ERROR;
 #if I2C_USE_SYNCHRONIZATION == TRUE
+  osalSysLock();
   osalThreadResumeI(&self->sync_transfer, MSG_RESET);
+  osalOsRescheduleS();
+  osalSysUnlock();
 #endif
 }
 

--- a/os/xhal/src/hal_sdc.c
+++ b/os/xhal/src/hal_sdc.c
@@ -899,7 +899,10 @@ void __sdc_stop_impl(void *ip) {
   self->rca = 0U;
   self->capacity = 0U;
 #if SDC_USE_SYNCHRONIZATION == TRUE
+  osalSysLock();
   osalThreadResumeI(&self->sync_transfer, MSG_RESET);
+  osalOsRescheduleS();
+  osalSysUnlock();
 #endif
 }
 

--- a/os/xhal/src/hal_sio.c
+++ b/os/xhal/src/hal_sio.c
@@ -548,11 +548,13 @@ void __sio_stop_impl(void *ip) {
 
 #if SIO_USE_SYNCHRONIZATION == TRUE
   /* Informing waiting threads, if any.*/
+  osalSysLock();
   osalThreadResumeI(&self->sync_rx, MSG_RESET);
   osalThreadResumeI(&self->sync_rxidle, MSG_RESET);
   osalThreadResumeI(&self->sync_tx, MSG_RESET);
   osalThreadResumeI(&self->sync_txend, MSG_RESET);
   osalOsRescheduleS();
+  osalSysUnlock();
 #endif
 }
 

--- a/os/xhal/src/hal_usb.c
+++ b/os/xhal/src/hal_usb.c
@@ -1542,6 +1542,9 @@ void __usb_stop_impl(void *ip) {
   self->address       = 0U;
   self->configuration = 0U;
   self->saved_state   = HAL_DRV_STATE_STOP;
+#if USB_USE_SYNCHRONIZATION == TRUE
+  osalSysLock();
+#endif
   for (i = 0U; i <= (unsigned)USB_MAX_ENDPOINTS; i++) {
 #if USB_USE_SYNCHRONIZATION == TRUE
     if (self->epc[i] != NULL) {
@@ -1555,6 +1558,10 @@ void __usb_stop_impl(void *ip) {
 #endif
     self->epc[i] = NULL;
   }
+#if USB_USE_SYNCHRONIZATION == TRUE
+  osalOsRescheduleS();
+  osalSysUnlock();
+#endif
 }
 
 /**

--- a/os/xhal/src/hal_wspi.c
+++ b/os/xhal/src/hal_wspi.c
@@ -152,7 +152,10 @@ void __wspi_stop_impl(void *ip) {
   hal_wspi_driver_c *self = (hal_wspi_driver_c *)ip;
   wspi_lld_stop(self);
 #if WSPI_USE_SYNCHRONIZATION == TRUE
+  osalSysLock();
   osalThreadResumeI(&self->sync_transfer, MSG_RESET);
+  osalOsRescheduleS();
+  osalSysUnlock();
 #endif
 }
 

--- a/testxhal/EFL-MFS/main.c
+++ b/testxhal/EFL-MFS/main.c
@@ -67,6 +67,13 @@ int main(void) {
   drvStart(&EFLD1, NULL);
   drvStart(&bsio1, NULL);
 
+  /* Exercising the synchronized SIO stop and restart paths.*/
+  drvStop(&bsio1);
+  chDbgAssert(drvGetStateX(&bsio1) == HAL_DRV_STATE_STOP,
+              "SIO not stopped");
+  chDbgAssert(drvStart(&bsio1, NULL) == HAL_RET_SUCCESS,
+              "SIO restart failed");
+
   chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
 
   button_pressed = false;


### PR DESCRIPTION
## Summary

- restore the required system lock around I-class waiter wakeups in the CAN, I2C, SDC, SIO, USB, and WSPI stop implementations
- reschedule awakened waiters before releasing the lock
- keep physical low-level stop operations in thread context and outside the critical section
- update the XHAL code-generation XML together with the generated C sources
- add a synchronized buffered-SIO stop/restart regression to EFL-MFS

## Background

Commit c4fa36f51a moved physical driver start/stop implementations out of the system lock, making `drvStart()` and `drvStop()` exclusively thread-level lifecycle APIs. Several stop implementations still invoked `osalThreadResumeI()` or `osalThreadDequeueAllI()` without acquiring the system lock. With the state checker enabled, stopping SIO halted with `SV#11`.

This change locks only the waiter cleanup and rescheduling portion. LLD stop operations remain unlocked. It is intentionally separate from #144.

## Validation

- all six modified XML descriptions validate against `tools/ftl/schema/ccode/modules.xsd`
- style checker and `git diff --check` pass
- EFL-MFS builds: STM32G474RE and STM32WL55JC
- USB_CDC build: STM32G474RE
- WSPI-XSNOR-MFS builds: STM32H735IG and STM32L4R9
- synchronization-enabled temporary builds: CAN/I2C on STM32G474RE, SDC on STM32H563ZI
- SB VIO host/client builds: STM32G474RE
- CI smoke builds: POSIX simulator and ARMv7-M
- G4 hardware: focused buffered-SIO stop/restart remains running with both drivers READY
- G4 hardware: sandbox termination reaches SIO STOP, then restarts to READY with a replacement sandbox thread and no `SV#11`