### PR TITLE
RP RTCv2: fix build failure from wrong alarm mask field name

### DIFF
--- a/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+++ b/os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
@@ -599,7 +599,7 @@ void rtc_lld_set_alarm(RTCDriver *rtcp,
 
   (void)alarm;
 
-  if ((alarmspec == NULL) || (alarmspec->dtmask == RTC_ALARM_DISABLE_ALL_MATCHING)) {
+  if ((alarmspec == NULL) || (alarmspec->mask == RTC_ALARM_DISABLE_ALL_MATCHING)) {
     /* Entering a reentrant critical zone.*/
     syssts_t sts = osalSysGetStatusAndLockX();
 


### PR DESCRIPTION
## Problem

`rtc_lld_set_alarm()` in the RP RTCv2 LLD tests `alarmspec->dtmask`, but the
field on `RTCAlarm` is named `mask`. There is no `dtmask` member — `dtmask` is
only the name of a local variable in the RTCv1 LLD.

This is a hard compile error, so the RTCv2 LLD does not build for any consumer:

```
os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c: In function 'rtc_lld_set_alarm':
os/hal/ports/RP/LLD/RTCv2/hal_rtc_lld.c:602:42: error: 'RTCAlarm' has no member
named 'dtmask'; did you mean 'mask'?
```

## Fix

One character-level correction, `dtmask` -> `mask`.

The same function already uses `alarmspec->mask` correctly twice — once when
computing the next match and once when saving the driver state — so this reads
as a typo rather than a rename that was left half-applied.

## Validation

- `testhal/RP/RP2350/RTC-VALIDATION` fails to build on `master` and builds
  clean with this change.
- Hardware-validated on a Raspberry Pi Pico 2 (RP2350 A2): **8 passed,
  0 failed**. Full capture in the comment below.

Two of the checks exercise the corrected line directly — `mask-zero disable
clears saved state` and `mask-zero-disabled alarm does not fire` both drive
`rtc_lld_set_alarm()` through the
`alarmspec->mask == RTC_ALARM_DISABLE_ALL_MATCHING` branch that previously
would not compile.