### PR TITLE
XHAL: report invalid ETH handle operations

### DIFF
--- a/os/sb/open_points.md
+++ b/os/sb/open_points.md
@@ -45,6 +45,13 @@ Full assessment in [note_sb_isolation_security.md](note_sb_isolation_security.md
   host-mapped packet buffers, no descriptor sharing.
 - Improve host-side VETH validation in `vio/sbvio_eth.c`.
   Current validation is intentionally structural, not ownership-aware.
+- Align the VIO ETH handle-validity queries with the generic API contract.
+  The VIO client currently treats any nonzero opaque RX/TX handle as locally
+  valid. Handle operations remain safe because the host validates each use
+  through the native driver and returns an error, but
+  `ethIsRXHandleValidX()` and `ethIsTXHandleValidX()` cannot reliably
+  identify forged or stale handles. Decide whether to add host validity-query
+  operations or to narrow and document the VIO-local query semantics.
 - Review restart behavior and stale-handle behavior once sandbox restart and VETH reuse are exercised more aggressively.
 
 ### SPI

--- a/os/sb/vio/sbvio_eth.c
+++ b/os/sb/vio/sbvio_eth.c
@@ -277,8 +277,9 @@ void sb_fastc_vio_eth(sb_class_t *sbp, struct port_extctx *ectxp) {
           break;
         }
 
-        ethReleaseReceiveHandleX(unitp->ethp, rxh);
-        ectxp->r0 = (uint32_t)HAL_RET_SUCCESS;
+        ectxp->r0 = ethReleaseReceiveHandleX(unitp->ethp, rxh) ?
+                    (uint32_t)CH_RET_EINVAL :
+                    (uint32_t)HAL_RET_SUCCESS;
         break;
       }
     case SB_VETH_TXREL:
@@ -295,8 +296,9 @@ void sb_fastc_vio_eth(sb_class_t *sbp, struct port_extctx *ectxp) {
           break;
         }
 
-        ethReleaseTransmitHandleX(unitp->ethp, txh);
-        ectxp->r0 = (uint32_t)HAL_RET_SUCCESS;
+        ectxp->r0 = ethReleaseTransmitHandleX(unitp->ethp, txh) ?
+                    (uint32_t)CH_RET_EINVAL :
+                    (uint32_t)HAL_RET_SUCCESS;
         break;
       }
     case SB_VETH_RXGET:

--- a/os/various/lwip_bindings/lwipthread_xhal.c
+++ b/os/various/lwip_bindings/lwipthread_xhal.c
@@ -78,7 +78,7 @@ size_t lwip_write_transmit_handle(lwip_transmit_handle_t *txhp,
 
 void lwip_release_transmit_handle(lwip_transmit_handle_t *txhp) {
 
-  ethReleaseTransmitHandleX(&ETHD1, *txhp);
+  (void)ethReleaseTransmitHandleX(&ETHD1, *txhp);
 }
 
 msg_t lwip_wait_receive_handle(lwip_receive_handle_t *rxhp) {
@@ -110,7 +110,7 @@ size_t lwip_receive_size(lwip_receive_handle_t *rxhp) {
 
 void lwip_release_receive_handle(lwip_receive_handle_t *rxhp) {
 
-  ethReleaseReceiveHandleX(&ETHD1, *rxhp);
+  (void)ethReleaseReceiveHandleX(&ETHD1, *rxhp);
 }
 
 event_source_t *lwip_get_event_source(void) {

--- a/os/xhal/codegen/hal_eth.xml
+++ b/os/xhal/codegen/hal_eth.xml
@@ -255,7 +255,11 @@ return txh;]]></implementation>
               <xclass />
               <implementation><![CDATA[
 
-return eth_lld_get_receive_handle(self);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_get_receive_handle(self);
+}
+
+return (eth_receive_handle_t)0U;]]></implementation>
             </method>
             <method name="ethGetTransmitHandleX"
               ctype="eth_transmit_handle_t">
@@ -267,47 +271,77 @@ return eth_lld_get_receive_handle(self);]]></implementation>
               <xclass />
               <implementation><![CDATA[
 
-return eth_lld_get_transmit_handle(self);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_get_transmit_handle(self);
+}
+
+return (eth_transmit_handle_t)0U;]]></implementation>
             </method>
             <method name="ethIsRXHandleValidX"
               ctype="bool">
               <brief><![CDATA[Checks a receive handle validity.]]></brief>
+              <details><![CDATA[A receive handle is valid only while the
+                driver is ready and the handle is acquired by the caller and
+                has not been released.]]></details>
               <param name="rxh" ctype="eth_receive_handle_t"
                 dir="in"><![CDATA[Receive handle.]]></param>
               <return><![CDATA[The receive handle validity.]]></return>
+              <retval value="false">If the handle is invalid.</retval>
+              <retval value="true">If the handle is valid.</retval>
               <xclass />
               <implementation><![CDATA[
 
-return eth_lld_is_receive_handle_valid(self, rxh);]]></implementation>
+return (drvGetStateX(self) == HAL_DRV_STATE_READY) &&
+       eth_lld_is_receive_handle_valid(self, rxh);]]></implementation>
             </method>
             <method name="ethIsTXHandleValidX"
               ctype="bool">
               <brief><![CDATA[Checks a transmit handle validity.]]></brief>
+              <details><![CDATA[A transmit handle is valid only while the
+                driver is ready and the handle is acquired by the caller and
+                has not been released.]]></details>
               <param name="txh" ctype="eth_transmit_handle_t"
                 dir="in"><![CDATA[Transmit handle.]]></param>
               <return><![CDATA[The transmit handle validity.]]></return>
+              <retval value="false">If the handle is invalid.</retval>
+              <retval value="true">If the handle is valid.</retval>
               <xclass />
               <implementation><![CDATA[
 
-return eth_lld_is_transmit_handle_valid(self, txh);]]></implementation>
+return (drvGetStateX(self) == HAL_DRV_STATE_READY) &&
+       eth_lld_is_transmit_handle_valid(self, txh);]]></implementation>
             </method>
-            <method name="ethReleaseReceiveHandleX" ctype="void">
+            <method name="ethReleaseReceiveHandleX" ctype="bool">
               <brief><![CDATA[Releases a received frame.]]></brief>
               <param name="rxh" ctype="eth_receive_handle_t"
                 dir="in"><![CDATA[Receive handle.]]></param>
+              <return><![CDATA[The operation status.]]></return>
+              <retval value="false">If the frame has been released.</retval>
+              <retval value="true">If the operation failed.</retval>
               <xclass />
               <implementation><![CDATA[
 
-eth_lld_release_receive_handle(self, rxh);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_release_receive_handle(self, rxh);
+}
+
+return true;]]></implementation>
             </method>
-            <method name="ethReleaseTransmitHandleX" ctype="void">
+            <method name="ethReleaseTransmitHandleX" ctype="bool">
               <brief><![CDATA[Releases and transmits a frame.]]></brief>
               <param name="txh" ctype="eth_transmit_handle_t"
                 dir="in"><![CDATA[Transmit handle.]]></param>
+              <return><![CDATA[The operation status.]]></return>
+              <retval value="false">If the frame has been released.</retval>
+              <retval value="true">If the operation failed.</retval>
               <xclass />
               <implementation><![CDATA[
 
-eth_lld_release_transmit_handle(self, txh);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_release_transmit_handle(self, txh);
+}
+
+return true;]]></implementation>
             </method>
             <method name="ethReadReceiveHandleX" ctype="size_t">
               <brief><![CDATA[Reads data sequentially from a received frame.]]></brief>
@@ -318,10 +352,16 @@ eth_lld_release_transmit_handle(self, txh);]]></implementation>
               <return><![CDATA[The number of bytes read from the handle buffer,
                                this value can be less than the amount specified in the
                                parameter @p size if there are no more bytes to read.]]></return>
+              <retval value="0">If the handle is invalid or there are no more
+                bytes to read.</retval>
               <xclass />
               <implementation><![CDATA[
 
-return eth_lld_read_receive_handle(self, rxh, bp, n);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_read_receive_handle(self, rxh, bp, n);
+}
+
+return 0U;]]></implementation>
             </method>
             <method name="ethWriteTransmitHandleX" ctype="size_t">
               <brief><![CDATA[Writes data sequentially into a transmit frame.]]></brief>
@@ -333,10 +373,16 @@ return eth_lld_read_receive_handle(self, rxh, bp, n);]]></implementation>
               <return><![CDATA[The number of bytes written into the handle buffer
                                this value can be less than the amount specified in the
                                parameter @p size if the maximum frame size is reached.]]></return>
+              <retval value="0">If the handle is invalid or no more bytes can
+                be written.</retval>
               <xclass />
               <implementation><![CDATA[
 
-return eth_lld_write_transmit_handle(self, txh, bp, n);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_write_transmit_handle(self, txh, bp, n);
+}
+
+return 0U;]]></implementation>
             </method>
             <condition check="ETH_SUPPORTS_ZERO_COPY == TRUE">
               <method name="ethGetReceiveBufferX"
@@ -347,11 +393,20 @@ return eth_lld_write_transmit_handle(self, txh, bp, n);]]></implementation>
                 <param name="sizep" ctype="size_t *" dir="out"><![CDATA[Size of the
                 received frame.]]></param>
                 <return><![CDATA[Pointer to the received frame buffer or @p NULL if the
-                                 driver does not support memory-mapped direct access.]]></return>
+                                 handle is invalid or the driver does not support
+                                 memory-mapped direct access.]]></return>
                 <xclass />
                 <implementation><![CDATA[
 
-return eth_lld_get_receive_buffer(self, rxh, sizep);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_get_receive_buffer(self, rxh, sizep);
+}
+
+if (sizep != NULL) {
+  *sizep = 0U;
+}
+
+return NULL;]]></implementation>
               </method>
               <method name="ethGetTransmitBufferX"
                 ctype="uint8_t *">
@@ -360,12 +415,21 @@ return eth_lld_get_receive_buffer(self, rxh, sizep);]]></implementation>
                   dir="in"><![CDATA[Transmit handle.]]></param>
                 <param name="sizep" ctype="size_t *" dir="out"><![CDATA[Maximum size of the
                   transmit buffer.]]></param>
-                <return><![CDATA[Pointer to the transmit frame buffer or @p NULL if the driver does
-                                 not support memory-mapped direct access.]]></return>
+                <return><![CDATA[Pointer to the transmit frame buffer or @p NULL if the
+                                 handle is invalid or the driver does not support
+                                 memory-mapped direct access.]]></return>
                 <xclass />
                 <implementation><![CDATA[
 
-return eth_lld_get_transmit_buffer(self, txh, sizep);]]></implementation>
+if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+  return eth_lld_get_transmit_buffer(self, txh, sizep);
+}
+
+if (sizep != NULL) {
+  *sizep = 0U;
+}
+
+return NULL;]]></implementation>
               </method>
             </condition>
           </inline>

--- a/os/xhal/include/hal_eth.h
+++ b/os/xhal/include/hal_eth.h
@@ -368,7 +368,11 @@ CC_FORCE_INLINE
 static inline eth_receive_handle_t ethGetReceiveHandleX(void *ip) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_get_receive_handle(self);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_get_receive_handle(self);
+  }
+
+  return (eth_receive_handle_t)0U;
 }
 
 /**
@@ -384,15 +388,23 @@ CC_FORCE_INLINE
 static inline eth_transmit_handle_t ethGetTransmitHandleX(void *ip) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_get_transmit_handle(self);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_get_transmit_handle(self);
+  }
+
+  return (eth_transmit_handle_t)0U;
 }
 
 /**
  * @brief       Checks a receive handle validity.
+ * @details     A receive handle is valid only while the driver is ready and
+ *              the handle is acquired by the caller and has not been released.
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     rxh           Receive handle.
  * @return                      The receive handle validity.
+ * @retval false                If the handle is invalid.
+ * @retval true                 If the handle is valid.
  *
  * @xclass
  */
@@ -400,15 +412,20 @@ CC_FORCE_INLINE
 static inline bool ethIsRXHandleValidX(void *ip, eth_receive_handle_t rxh) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_is_receive_handle_valid(self, rxh);
+  return (drvGetStateX(self) == HAL_DRV_STATE_READY) &&
+         eth_lld_is_receive_handle_valid(self, rxh);
 }
 
 /**
  * @brief       Checks a transmit handle validity.
+ * @details     A transmit handle is valid only while the driver is ready and
+ *              the handle is acquired by the caller and has not been released.
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     txh           Transmit handle.
  * @return                      The transmit handle validity.
+ * @retval false                If the handle is invalid.
+ * @retval true                 If the handle is valid.
  *
  * @xclass
  */
@@ -416,7 +433,8 @@ CC_FORCE_INLINE
 static inline bool ethIsTXHandleValidX(void *ip, eth_transmit_handle_t txh) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_is_transmit_handle_valid(self, txh);
+  return (drvGetStateX(self) == HAL_DRV_STATE_READY) &&
+         eth_lld_is_transmit_handle_valid(self, txh);
 }
 
 /**
@@ -424,14 +442,21 @@ static inline bool ethIsTXHandleValidX(void *ip, eth_transmit_handle_t txh) {
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     rxh           Receive handle.
+ * @return                      The operation status.
+ * @retval false                If the frame has been released.
+ * @retval true                 If the operation failed.
  *
  * @xclass
  */
 CC_FORCE_INLINE
-static inline void ethReleaseReceiveHandleX(void *ip, eth_receive_handle_t rxh) {
+static inline bool ethReleaseReceiveHandleX(void *ip, eth_receive_handle_t rxh) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  eth_lld_release_receive_handle(self, rxh);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_release_receive_handle(self, rxh);
+  }
+
+  return true;
 }
 
 /**
@@ -439,15 +464,22 @@ static inline void ethReleaseReceiveHandleX(void *ip, eth_receive_handle_t rxh) 
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     txh           Transmit handle.
+ * @return                      The operation status.
+ * @retval false                If the frame has been released.
+ * @retval true                 If the operation failed.
  *
  * @xclass
  */
 CC_FORCE_INLINE
-static inline void ethReleaseTransmitHandleX(void *ip,
+static inline bool ethReleaseTransmitHandleX(void *ip,
                                              eth_transmit_handle_t txh) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  eth_lld_release_transmit_handle(self, txh);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_release_transmit_handle(self, txh);
+  }
+
+  return true;
 }
 
 /**
@@ -461,6 +493,8 @@ static inline void ethReleaseTransmitHandleX(void *ip,
  *                              buffer, this value can be less than the amount
  *                              specified in the parameter @p size if there are
  *                              no more bytes to read.
+ * @retval 0                    If the handle is invalid or there are no more
+ *                              bytes to read.
  *
  * @xclass
  */
@@ -469,7 +503,11 @@ static inline size_t ethReadReceiveHandleX(void *ip, eth_receive_handle_t rxh,
                                            uint8_t *bp, size_t n) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_read_receive_handle(self, rxh, bp, n);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_read_receive_handle(self, rxh, bp, n);
+  }
+
+  return 0U;
 }
 
 /**
@@ -483,6 +521,8 @@ static inline size_t ethReadReceiveHandleX(void *ip, eth_receive_handle_t rxh,
  *                              buffer this value can be less than the amount
  *                              specified in the parameter @p size if the
  *                              maximum frame size is reached.
+ * @retval 0                    If the handle is invalid or no more bytes can
+ *                              be written.
  *
  * @xclass
  */
@@ -492,7 +532,11 @@ static inline size_t ethWriteTransmitHandleX(void *ip,
                                              const uint8_t *bp, size_t n) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_write_transmit_handle(self, txh, bp, n);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_write_transmit_handle(self, txh, bp, n);
+  }
+
+  return 0U;
 }
 
 #if (ETH_SUPPORTS_ZERO_COPY == TRUE) || defined (__DOXYGEN__)
@@ -503,8 +547,8 @@ static inline size_t ethWriteTransmitHandleX(void *ip,
  * @param[in]     rxh           Receive handle.
  * @param[out]    sizep         Size of the received frame.
  * @return                      Pointer to the received frame buffer or @p NULL
- *                              if the driver does not support memory-mapped
- *                              direct access.
+ *                              if the handle is invalid or the driver does not
+ *                              support memory-mapped direct access.
  *
  * @xclass
  */
@@ -514,7 +558,15 @@ static inline const uint8_t *ethGetReceiveBufferX(void *ip,
                                                   size_t *sizep) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_get_receive_buffer(self, rxh, sizep);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_get_receive_buffer(self, rxh, sizep);
+  }
+
+  if (sizep != NULL) {
+    *sizep = 0U;
+  }
+
+  return NULL;
 }
 
 /**
@@ -524,8 +576,8 @@ static inline const uint8_t *ethGetReceiveBufferX(void *ip,
  * @param[in]     txh           Transmit handle.
  * @param[out]    sizep         Maximum size of the transmit buffer.
  * @return                      Pointer to the transmit frame buffer or @p NULL
- *                              if the driver does not support memory-mapped
- *                              direct access.
+ *                              if the handle is invalid or the driver does not
+ *                              support memory-mapped direct access.
  *
  * @xclass
  */
@@ -535,7 +587,15 @@ static inline uint8_t *ethGetTransmitBufferX(void *ip,
                                              size_t *sizep) {
   hal_eth_driver_c *self = (hal_eth_driver_c *)ip;
 
-  return eth_lld_get_transmit_buffer(self, txh, sizep);
+  if (drvGetStateX(self) == HAL_DRV_STATE_READY) {
+    return eth_lld_get_transmit_buffer(self, txh, sizep);
+  }
+
+  if (sizep != NULL) {
+    *sizep = 0U;
+  }
+
+  return NULL;
 }
 #endif /* ETH_SUPPORTS_ZERO_COPY == TRUE */
 /** @} */

--- a/os/xhal/ports/STM32/LLD/ETHv2/hal_eth_lld.c
+++ b/os/xhal/ports/STM32/LLD/ETHv2/hal_eth_lld.c
@@ -104,6 +104,7 @@ static const hal_eth_config_t default_config = {
 static stm32_eth_rx_descriptor_t __eth_private_rd[STM32_ETH_RECEIVE_BUFFERS];
 static stm32_eth_tx_descriptor_t __eth_private_td[STM32_ETH_TRANSMIT_BUFFERS];
 
+/* In the following state objects, a zero size means "not acquired".*/
 typedef struct {
   uint32_t                  offset;
   uint32_t                  size;
@@ -576,6 +577,11 @@ eth_receive_handle_t eth_lld_get_receive_handle(hal_eth_driver_c *ethp) {
     stm32_eth_rx_descriptor_t *rdp = ethp->rdp;
     stm32_eth_rx_state_t *rsp = &__eth_private_rs[rxdesc_index(rdp)];
 
+    /* An outstanding descriptor blocks further consumption of the ring.*/
+    if (rsp->size != 0U) {
+      return (eth_receive_handle_t)0U;
+    }
+
     /* Is it a valid frame?*/
     if (true &&
 #if STM32_ETH_IP_CHECKSUM_OFFLOAD
@@ -584,7 +590,8 @@ eth_receive_handle_t eth_lld_get_receive_handle(hal_eth_driver_c *ethp) {
         ((rdp->rdes2 & STM32_RDES2_DAF) == 0U) &&
         ((rdp->rdes3 & STM32_RDES3_ES) == 0U) &&
         ((rdp->rdes3 & STM32_RDES3_FD) != 0U) &&
-        ((rdp->rdes3 & STM32_RDES3_LD) != 0U)) {
+        ((rdp->rdes3 & STM32_RDES3_LD) != 0U) &&
+        ((rdp->rdes3 & STM32_RDES3_PL_MASK) > 2U)) {
 
       /* Found a valid one.*/
       rsp->offset = 0U;
@@ -630,9 +637,11 @@ eth_transmit_handle_t eth_lld_get_transmit_handle(hal_eth_driver_c *ethp) {
   }
 
   for (i = 0U; i < STM32_ETH_TRANSMIT_BUFFERS; i++) {
-    if (((tdp->tdes3 & STM32_TDES3_OWN) == 0U) &&
+    stm32_eth_tx_state_t *tsp = &__eth_private_ts[txdesc_index(tdp)];
+
+    if ((tsp->size == 0U) &&
+        ((tdp->tdes3 & STM32_TDES3_OWN) == 0U) &&
         (tdp->tdes1 == 0U)) {
-      stm32_eth_tx_state_t *tsp = &__eth_private_ts[txdesc_index(tdp)];
 
       /* Marks the current descriptor as locked.*/
       tdp->tdes1 = STM32_TDES1_LOCKED;
@@ -670,10 +679,21 @@ eth_transmit_handle_t eth_lld_get_transmit_handle(hal_eth_driver_c *ethp) {
  */
 bool eth_lld_is_receive_handle_valid(hal_eth_driver_c *ethp,
                                      eth_receive_handle_t rxh) {
+  stm32_eth_rx_descriptor_t *rdp;
+  stm32_eth_rx_state_t *rsp;
 
   (void)ethp;
 
-  return rxdesc_is_valid(rxh);
+  if (!rxdesc_is_valid(rxh)) {
+    return false;
+  }
+
+  rdp = (stm32_eth_rx_descriptor_t *)(uintptr_t)rxh;
+  rsp = &__eth_private_rs[rxdesc_index(rdp)];
+
+  return (rsp->size != 0U) &&
+         ((rdp->rdes3 & STM32_RDES3_OWN) == 0U) &&
+         (rsp->offset <= rsp->size);
 }
 
 /**
@@ -687,10 +707,22 @@ bool eth_lld_is_receive_handle_valid(hal_eth_driver_c *ethp,
  */
 bool eth_lld_is_transmit_handle_valid(hal_eth_driver_c *ethp,
                                       eth_transmit_handle_t txh) {
+  stm32_eth_tx_descriptor_t *tdp;
+  stm32_eth_tx_state_t *tsp;
 
   (void)ethp;
 
-  return txdesc_is_valid(txh);
+  if (!txdesc_is_valid(txh)) {
+    return false;
+  }
+
+  tdp = (stm32_eth_tx_descriptor_t *)(uintptr_t)txh;
+  tsp = &__eth_private_ts[txdesc_index(tdp)];
+
+  return (tsp->size != 0U) &&
+         ((tdp->tdes3 & STM32_TDES3_OWN) == 0U) &&
+         (tdp->tdes1 == STM32_TDES1_LOCKED) &&
+         (tsp->offset <= tsp->size);
 }
 
 /**
@@ -698,26 +730,33 @@ bool eth_lld_is_transmit_handle_valid(hal_eth_driver_c *ethp,
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     rxh           Receive handle.
+ * @return                      The operation status.
+ * @retval false                If the frame has been released.
+ * @retval true                 If the operation failed.
  *
  * @notapi
  */
-void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
+bool eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
                                     eth_receive_handle_t rxh) {
-  stm32_eth_rx_descriptor_t *rdp = (stm32_eth_rx_descriptor_t *)(uintptr_t)rxh;
-  stm32_eth_rx_state_t *rsp = &__eth_private_rs[rxdesc_index(rdp)];
+  stm32_eth_rx_descriptor_t *rdp;
+  stm32_eth_rx_state_t *rsp;
 
-  (void)ethp;
+  if (!eth_lld_is_receive_handle_valid(ethp, rxh)) {
+    return true;
+  }
 
-  osalDbgAssert((rdp->rdes3 & STM32_RDES3_OWN) == 0U,
-                "attempt to release descriptor already owned by DMA");
+  rdp = (stm32_eth_rx_descriptor_t *)(uintptr_t)rxh;
+  rsp = &__eth_private_rs[rxdesc_index(rdp)];
 
   /* Give buffer back to the Ethernet DMA.*/
   rsp->offset = 0U;
-  rsp->size   = 0U;
   rdp->rdes3 = STM32_RDES3_OWN | STM32_RDES3_IOC | STM32_RDES3_BUF1V;
+  rsp->size   = 0U;
 
   /* Re-triggers the DMA in case the ring went into suspend state.*/
   ETH->DMACRDTPR = ETH->DMACRDTPR;
+
+  return false;
 }
 
 /**
@@ -725,19 +764,24 @@ void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     txh           Transmit handle.
+ * @return                      The operation status.
+ * @retval false                If the frame has been released.
+ * @retval true                 If the operation failed.
  *
  * @notapi
  */
-void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
+bool eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
                                      eth_transmit_handle_t txh) {
-  stm32_eth_tx_descriptor_t *tdp = (stm32_eth_tx_descriptor_t *)(uintptr_t)txh;
-  stm32_eth_tx_state_t *tsp = &__eth_private_ts[txdesc_index(tdp)];
+  stm32_eth_tx_descriptor_t *tdp;
+  stm32_eth_tx_state_t *tsp;
   stm32_eth_tx_descriptor_t *next_tdp;
 
-  (void)ethp;
+  if (!eth_lld_is_transmit_handle_valid(ethp, txh)) {
+    return true;
+  }
 
-  osalDbgAssert((tdp->tdes3 & STM32_TDES3_OWN) == 0U,
-              "attempt to release descriptor already owned by DMA");
+  tdp = (stm32_eth_tx_descriptor_t *)(uintptr_t)txh;
+  tsp = &__eth_private_ts[txdesc_index(tdp)];
 
   /* Unlocks the descriptor and returns it to the DMA engine.*/
   tdp->tdes2 = STM32_TDES2_IOC | tsp->offset;
@@ -749,6 +793,8 @@ void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
 #else
   tdp->tdes3 = STM32_TDES3_LD | STM32_TDES3_FD | STM32_TDES3_OWN;
 #endif
+  tsp->offset = 0U;
+  tsp->size   = 0U;
 
   next_tdp = tdp + 1;
   if (next_tdp >= &__eth_private_td[STM32_ETH_TRANSMIT_BUFFERS]) {
@@ -757,6 +803,8 @@ void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
 
   __DSB();
   ETH->DMACTDTPR = txdesc_offset(next_tdp);
+
+  return false;
 }
 
 /**
@@ -770,19 +818,23 @@ void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
  *                              buffer, this value can be less than the amount
  *                              specified in the parameter @p size if there are
  *                              no more bytes to read.
+ * @retval 0                    If the handle is invalid or there are no more
+ *                              bytes to read.
  *
  * @notapi
  */
 size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
                                    eth_receive_handle_t rxh,
                                    uint8_t *bp, size_t n) {
-  stm32_eth_rx_descriptor_t *rdp = (stm32_eth_rx_descriptor_t *)(uintptr_t)rxh;
-  stm32_eth_rx_state_t *rsp = &__eth_private_rs[rxdesc_index(rdp)];
+  stm32_eth_rx_descriptor_t *rdp;
+  stm32_eth_rx_state_t *rsp;
 
-  (void)ethp;
+  if (!eth_lld_is_receive_handle_valid(ethp, rxh)) {
+    return 0U;
+  }
 
-  osalDbgAssert((rdp->rdes3 & STM32_RDES3_OWN) == 0U,
-                "attempt to read descriptor already owned by DMA");
+  rdp = (stm32_eth_rx_descriptor_t *)(uintptr_t)rxh;
+  rsp = &__eth_private_rs[rxdesc_index(rdp)];
 
   if (n > ((size_t)rsp->size - (size_t)rsp->offset)) {
     n = (size_t)rsp->size - (size_t)rsp->offset;
@@ -807,19 +859,23 @@ size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
  *                              buffer this value can be less than the amount
  *                              specified in the parameter @p size if the
  *                              maximum frame size is reached.
+ * @retval 0                    If the handle is invalid or no more bytes can
+ *                              be written.
  *
  * @notapi
  */
 size_t eth_lld_write_transmit_handle(hal_eth_driver_c *ethp,
                                      eth_transmit_handle_t txh,
                                      const uint8_t *bp, size_t n) {
-  stm32_eth_tx_descriptor_t *tdp = (stm32_eth_tx_descriptor_t *)(uintptr_t)txh;
-  stm32_eth_tx_state_t *tsp = &__eth_private_ts[txdesc_index(tdp)];
+  stm32_eth_tx_descriptor_t *tdp;
+  stm32_eth_tx_state_t *tsp;
 
-  (void)ethp;
+  if (!eth_lld_is_transmit_handle_valid(ethp, txh)) {
+    return 0U;
+  }
 
-  osalDbgAssert((tdp->tdes3 & STM32_TDES3_OWN) == 0U,
-                "attempt to write descriptor already owned by DMA");
+  tdp = (stm32_eth_tx_descriptor_t *)(uintptr_t)txh;
+  tsp = &__eth_private_ts[txdesc_index(tdp)];
 
   if (n > ((size_t)tsp->size - (size_t)tsp->offset)) {
     n = (size_t)tsp->size - (size_t)tsp->offset;
@@ -840,21 +896,27 @@ size_t eth_lld_write_transmit_handle(hal_eth_driver_c *ethp,
  * @param[in]     rxh           Receive handle.
  * @param[out]    sizep         Size of the received frame.
  * @return                      Pointer to the received frame buffer or @p NULL
- *                              if the driver does not support memory-mapped
- *                              direct access.
+ *                              if the handle is invalid or the driver does not
+ *                              support memory-mapped direct access.
  *
  * @notapi
  */
 const uint8_t *eth_lld_get_receive_buffer(hal_eth_driver_c *ethp,
                                           eth_receive_handle_t rxh,
                                           size_t *sizep) {
-  stm32_eth_rx_descriptor_t *rdp = (stm32_eth_rx_descriptor_t *)(uintptr_t)rxh;
-  stm32_eth_rx_state_t *rsp = &__eth_private_rs[rxdesc_index(rdp)];
+  stm32_eth_rx_descriptor_t *rdp;
+  stm32_eth_rx_state_t *rsp;
 
-  (void)ethp;
+  if (!eth_lld_is_receive_handle_valid(ethp, rxh)) {
+    if (sizep != NULL) {
+      *sizep = 0U;
+    }
 
-  osalDbgAssert((rdp->rdes3 & STM32_RDES3_OWN) == 0U,
-                "attempt to map descriptor already owned by DMA");
+    return NULL;
+  }
+
+  rdp = (stm32_eth_rx_descriptor_t *)(uintptr_t)rxh;
+  rsp = &__eth_private_rs[rxdesc_index(rdp)];
 
   if (sizep != NULL) {
     *sizep = (size_t)rsp->size - (size_t)rsp->offset;
@@ -870,21 +932,27 @@ const uint8_t *eth_lld_get_receive_buffer(hal_eth_driver_c *ethp,
  * @param[in]     txh           Transmit handle.
  * @param[out]    sizep         Maximum size of the transmit buffer.
  * @return                      Pointer to the transmit frame buffer or @p NULL
- *                              if the driver does not support memory-mapped
- *                              direct access.
+ *                              if the handle is invalid or the driver does not
+ *                              support memory-mapped direct access.
  *
  * @notapi
  */
 uint8_t *eth_lld_get_transmit_buffer(hal_eth_driver_c *ethp,
                                      eth_transmit_handle_t txh,
                                      size_t *sizep) {
-  stm32_eth_tx_descriptor_t *tdp = (stm32_eth_tx_descriptor_t *)(uintptr_t)txh;
-  stm32_eth_tx_state_t *tsp = &__eth_private_ts[txdesc_index(tdp)];
+  stm32_eth_tx_descriptor_t *tdp;
+  stm32_eth_tx_state_t *tsp;
 
-  (void)ethp;
+  if (!eth_lld_is_transmit_handle_valid(ethp, txh)) {
+    if (sizep != NULL) {
+      *sizep = 0U;
+    }
 
-  osalDbgAssert((tdp->tdes3 & STM32_TDES3_OWN) == 0U,
-                "attempt to map descriptor already owned by DMA");
+    return NULL;
+  }
+
+  tdp = (stm32_eth_tx_descriptor_t *)(uintptr_t)txh;
+  tsp = &__eth_private_ts[txdesc_index(tdp)];
 
   if (sizep != NULL) {
     *sizep = (size_t)tsp->size - (size_t)tsp->offset;

--- a/os/xhal/ports/STM32/LLD/ETHv2/hal_eth_lld.h
+++ b/os/xhal/ports/STM32/LLD/ETHv2/hal_eth_lld.h
@@ -319,9 +319,9 @@ extern "C" {
                                        eth_receive_handle_t rxh);
   bool eth_lld_is_transmit_handle_valid(hal_eth_driver_c *ethp,
                                         eth_transmit_handle_t txh);
-  void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
+  bool eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
                                       eth_receive_handle_t rxh);
-  void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
+  bool eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
                                        eth_transmit_handle_t txh);
   size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
                                      eth_receive_handle_t rxh,

--- a/os/xhal/ports/templates/hal_eth_lld.c
+++ b/os/xhal/ports/templates/hal_eth_lld.c
@@ -169,14 +169,19 @@ etc_transmit_handle_t eth_lld_get_transmit_handle(hal_eth_driver_c *ethp) {
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     rxh           Receive handle.
+ * @return                      The operation status.
+ * @retval false                If the frame has been released.
+ * @retval true                 If the operation failed.
  *
  * @notapi
  */
-void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
+bool eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
                                     etc_receive_handle_t rxh) {
 
   (void)ethp;
   (void)rxh;
+
+  return true;
 }
 
 /**
@@ -184,14 +189,19 @@ void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
  *
  * @param[in,out] ip            Pointer to a @p hal_eth_driver_c instance.
  * @param[in]     txh           Transmi] handle.
+ * @return                      The operation status.
+ * @retval false                If the frame has been released.
+ * @retval true                 If the operation failed.
  *
  * @notapi
  */
-void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
+bool eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
                                      etc_transmit_handle_t txh) {
 
   (void)ethp;
   (void)txh;
+
+  return true;
 }
 
 /**
@@ -205,6 +215,8 @@ void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
  *                              buffer, this value can be less than the amount
  *                              specified in the parameter @p size if there are
  *                              no more bytes to read.
+ * @retval 0                    If the handle is invalid or there are no more
+ *                              bytes to read.
  *
  * @notapi
  */
@@ -231,6 +243,8 @@ size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
  *                              buffer this value can be less than the amount
  *                              specified in the parameter @p size if the
  *                              maximum frame size is reached.
+ * @retval 0                    If the handle is invalid or no more bytes can
+ *                              be written.
  *
  * @notapi
  */
@@ -253,8 +267,8 @@ size_t eth_lld_write_transmit_handle(hal_eth_driver_c *ethp,
  * @param[in]     rxh           Receive handle.
  * @param[out]    sizep         Size of the received frame.
  * @return                      Pointer to the received frame buffer or @p NULL
- *                              if the driver does not support memory-mapped
- *                              direct access.
+ *                              if the handle is invalid or the driver does not
+ *                              support memory-mapped direct access.
  *
  * @notapi
  */
@@ -276,8 +290,8 @@ const uint8_t *eth_lld_get_receive_buffer(hal_eth_driver_c *ethp,
  * @param[in]     txh           Transmit handle.
  * @param[out]    sizep         Maximum size of the transmit buffer.
  * @return                      Pointer to the transmit frame buffer or @p NULL
- *                              if the driver does not support memory-mapped
- *                              direct access.
+ *                              if the handle is invalid or the driver does not
+ *                              support memory-mapped direct access.
  *
  * @notapi
  */

--- a/os/xhal/ports/templates/hal_eth_lld.h
+++ b/os/xhal/ports/templates/hal_eth_lld.h
@@ -80,9 +80,9 @@ extern "C" {
                                          unsigned cfgnum);
   etc_receive_handle_t eth_lld_get_receive_handle(hal_eth_driver_c *ethp);
   etc_transmit_handle_t eth_lld_get_transmit_handle(hal_eth_driver_c *ethp);
-  void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
+  bool eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
                                       etc_receive_handle_t rxh);
-  void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
+  bool eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
                                        etc_transmit_handle_t txh);
   size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
                                      etc_receive_handle_t rxh,

--- a/os/xhal/ports/vio/hal_eth_lld.c
+++ b/os/xhal/ports/vio/hal_eth_lld.c
@@ -254,18 +254,18 @@ bool eth_lld_is_transmit_handle_valid(hal_eth_driver_c *ethp,
   return txh != (eth_transmit_handle_t)0U;
 }
 
-void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
+bool eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
                                     eth_receive_handle_t rxh) {
 
   __syscall2r(99, VIO_CALL(SB_VETH_RXREL, ethp->nveth), rxh);
-  osalDbgAssert(r0 == HAL_RET_SUCCESS, "unexpected failure");
+  return (msg_t)r0 != HAL_RET_SUCCESS;
 }
 
-void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
+bool eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
                                      eth_transmit_handle_t txh) {
 
   __syscall2r(99, VIO_CALL(SB_VETH_TXREL, ethp->nveth), txh);
-  osalDbgAssert(r0 == HAL_RET_SUCCESS, "unexpected failure");
+  return (msg_t)r0 != HAL_RET_SUCCESS;
 }
 
 size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
@@ -273,7 +273,10 @@ size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
                                    uint8_t *bp, size_t n) {
 
   __syscall4r(99, VIO_CALL(SB_VETH_RXREAD, ethp->nveth), rxh, bp, n);
-  osalDbgAssert(((int32_t)r0) >= 0, "host RXREAD failed");
+  if (((int32_t)r0) < 0) {
+    return 0U;
+  }
+
   return (size_t)r0;
 }
 
@@ -282,7 +285,10 @@ size_t eth_lld_write_transmit_handle(hal_eth_driver_c *ethp,
                                      const uint8_t *bp, size_t n) {
 
   __syscall4r(99, VIO_CALL(SB_VETH_TXWRITE, ethp->nveth), txh, bp, n);
-  osalDbgAssert(((int32_t)r0) >= 0, "host TXWRITE failed");
+  if (((int32_t)r0) < 0) {
+    return 0U;
+  }
+
   return (size_t)r0;
 }
 

--- a/os/xhal/ports/vio/hal_eth_lld.h
+++ b/os/xhal/ports/vio/hal_eth_lld.h
@@ -156,9 +156,9 @@ extern "C" {
                                        eth_receive_handle_t rxh);
   bool eth_lld_is_transmit_handle_valid(hal_eth_driver_c *ethp,
                                         eth_transmit_handle_t txh);
-  void eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
+  bool eth_lld_release_receive_handle(hal_eth_driver_c *ethp,
                                       eth_receive_handle_t rxh);
-  void eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
+  bool eth_lld_release_transmit_handle(hal_eth_driver_c *ethp,
                                        eth_transmit_handle_t txh);
   size_t eth_lld_read_receive_handle(hal_eth_driver_c *ethp,
                                      eth_receive_handle_t rxh,


### PR DESCRIPTION
## Rationale

The VETH ABI passes native descriptor handles across the sandbox boundary. A sandbox can forge or reuse a handle, but the consequence should be an error in its own operation, not a host-side assertion. This change makes invalid ETH handle operations recoverable: boolean functions follow the ChibiOS true-means-error convention and size-returning functions return zero.

## Changes

- Make RX/TX handle release operations return an error state and enforce driver-state checks in the high-level ETH driver.
- Validate STM32 ETHv2 handles using descriptor ownership and size zero as the not-acquired marker; reject invalid reads, writes, releases, and RX length values.
- Propagate release, read, and write failures through the VIO guest and sandbox host layers.
- Record the remaining VIO-local handle-validity query limitation in the SB open-points document.

## Validation

- Validated the XML schema and regenerated the XHAL ETH sources with FMPP.
- Built the STM32H563 sandbox host configuration.
- Native RT-STM32-LWIP on STM32H563: 200 rapid pings with zero loss, 32 concurrent HTTP requests successful, and HTTP 200 response.
- Normal sandbox VIO path with the SB lwIP HTTP client: 230 pings with zero loss and 34 HTTP requests successful.
- Temporary injected sandbox negative tests confirmed that forged RX/TX release returns an error, forged RX read and TX write return zero, a valid TX handle still works, and duplicate TX release returns an error. After those tests, 200 pings had zero loss and 32 HTTP requests succeeded. The injection code was removed before committing.