### PR TITLE
sb: fix sbDup2 syscall selector

### DIFF
--- a/os/sb/user/sbuser.h
+++ b/os/sb/user/sbuser.h
@@ -314,7 +314,7 @@ static inline msg_t sbDup(int fd) {
  */
 static inline msg_t sbDup2(int oldfd, int newfd) {
 
-  __syscall3r(128, SB_POSIX_DUP, oldfd, newfd);
+  __syscall3r(128, SB_POSIX_DUP2, oldfd, newfd);
   return (msg_t)r0;
 }
 


### PR DESCRIPTION
Fixes sbDup2() so it dispatches SB_POSIX_DUP2 rather than SB_POSIX_DUP, allowing the requested new descriptor number to reach the host dup2 handler. Verified with the ARM RAMBox ls application build.