### PR TITLE
sb: preserve r4 in ELF call trampoline

### DIFF
--- a/os/sb/apps/msh/source/callhdr.S
+++ b/os/sb/apps/msh/source/callhdr.S
@@ -50,7 +50,7 @@ __callelf_data:
                 .thumb_func
                 .global     __callelf
 __callelf:
-                push        {r5-r11}
+                push        {r4-r11}
                 ldr         r4, =__callelf_data
                 str         sp, [r4, #0]
                 str         lr, [r4, #4]
@@ -70,7 +70,7 @@ __returnelf:
                 ldr         r4, =__callelf_data
                 ldmia       r4, {r2, r3}
                 mov         sp, r2
-                pop         {r5-r11}
+                pop         {r4-r11}
                 bx          r3
 
 #endif /* !defined(__DOXYGEN__) */


### PR DESCRIPTION
## Summary
- preserve the AAPCS callee-saved r4 register across the ELF call trampoline
- save and restore r4-r11 as a matching eight-register frame

## Testing
- make all in os/sb/apps/msh (all four profiles)
- verified matching r4-r11 save and restore instructions in the deployed ELF disassembly