### PR TITLE
RP PIOv1: Add allocation masks and SM handle access

### DIFF
--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
@@ -46,14 +46,35 @@ const rp_pio_block_t __rp_pio_blocks[RP_PIO_NUM_BLOCKS] = {
 #endif
 };
 
-/*===========================================================================*/
-/* Driver local variables and types.                                         */
-/*===========================================================================*/
-
 /**
  * @brief   PIO state machine descriptors.
  */
-static rp_pio_sm_t pio_sms[RP_PIO_NUM_BLOCKS][RP_PIO_NUM_STATE_MACHINES];
+const rp_pio_sm_t __rp_pio_sms[RP_PIO_NUM_BLOCKS][RP_PIO_NUM_STATE_MACHINES] = {
+  {
+    {&__rp_pio_blocks[0], 0U, 1U << 0},
+    {&__rp_pio_blocks[0], 1U, 1U << 1},
+    {&__rp_pio_blocks[0], 2U, 1U << 2},
+    {&__rp_pio_blocks[0], 3U, 1U << 3}
+  },
+  {
+    {&__rp_pio_blocks[1], 0U, 1U << 0},
+    {&__rp_pio_blocks[1], 1U, 1U << 1},
+    {&__rp_pio_blocks[1], 2U, 1U << 2},
+    {&__rp_pio_blocks[1], 3U, 1U << 3}
+  },
+#if RP_HAS_PIO2 == TRUE
+  {
+    {&__rp_pio_blocks[2], 0U, 1U << 0},
+    {&__rp_pio_blocks[2], 1U, 1U << 1},
+    {&__rp_pio_blocks[2], 2U, 1U << 2},
+    {&__rp_pio_blocks[2], 3U, 1U << 3}
+  },
+#endif
+};
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
 
 /**
  * @brief   Global PIO-related data structures.
@@ -221,11 +242,6 @@ void pioInit(void) {
     pio.blocks[b].imem_allocated    = 0U;
     for (s = 0U; s < RP_PIO_NUM_STATE_MACHINES; s++) {
       pio.blocks[b].sm[s].func = NULL;
-
-      /* Initialize state machine descriptors.*/
-      pio_sms[b][s].block  = &__rp_pio_blocks[b];
-      pio_sms[b][s].smidx  = s;
-      pio_sms[b][s].smmask = 1U << s;
     }
   }
 }
@@ -328,7 +344,7 @@ const rp_pio_sm_t *pioSmAllocI(const rp_pio_block_t *block,
         pio.blocks[b].c1_allocated_mask |= smmask;
       }
 
-      return &pio_sms[b][i];
+      return &__rp_pio_sms[b][i];
     }
   }
 
@@ -686,6 +702,55 @@ void pioSmInit(const rp_pio_sm_t *smp, uint32_t initial_pc,
   pioSmRestartX(smp);
   pioSmClkdivRestartX(smp);
   pioSmSetPCX(smp, initial_pc);
+}
+
+/**
+ * @brief   Returns the allocation mask of the state machines in a block.
+ * @details The returned mask is the union of the core 0 and core 1
+ *          allocations, bit N representing state machine N.
+ * @note    The mask is a snapshot and is advisory only: another core can
+ *          allocate or free state machines right after the mask is taken.
+ *          @p pioSmAllocI() re-checks availability under the system lock,
+ *          so allocation remains safe regardless.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @return              A bitmask where bit N represents state machine N.
+ *
+ * @api
+ */
+uint32_t pioGetSmAllocatedMask(const rp_pio_block_t *block) {
+  uint32_t mask;
+
+  osalDbgCheck(block != NULL);
+
+  osalSysLock();
+  mask = pio.blocks[block->pioidx].c0_allocated_mask |
+         pio.blocks[block->pioidx].c1_allocated_mask;
+  osalSysUnlock();
+
+  return mask;
+}
+
+/**
+ * @brief   Returns the allocation mask of the instruction memory in a block.
+ * @note    The mask is a snapshot and is advisory only, see
+ *          @p pioGetSmAllocatedMask().
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @return              A 32-bit mask representing the used instruction slots.
+ *
+ * @api
+ */
+uint32_t pioGetImemAllocatedMask(const rp_pio_block_t *block) {
+  uint32_t mask;
+
+  osalDbgCheck(block != NULL);
+
+  osalSysLock();
+  mask = pio.blocks[block->pioidx].imem_allocated;
+  osalSysUnlock();
+
+  return mask;
 }
 
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -345,6 +345,8 @@ typedef enum {
 
 #if !defined(__DOXYGEN__)
 extern const rp_pio_block_t __rp_pio_blocks[RP_PIO_NUM_BLOCKS];
+extern const rp_pio_sm_t __rp_pio_sms[RP_PIO_NUM_BLOCKS]
+                                     [RP_PIO_NUM_STATE_MACHINES];
 #endif
 
 #ifdef __cplusplus
@@ -371,6 +373,8 @@ extern "C" {
                          int32_t offset, uint32_t length);
   void pioSmInit(const rp_pio_sm_t *smp, uint32_t initial_pc,
                  const rp_pio_sm_config_t *cfgp);
+  uint32_t pioGetSmAllocatedMask(const rp_pio_block_t *block);
+  uint32_t pioGetImemAllocatedMask(const rp_pio_block_t *block);
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
   void pioSetGpioBase(const rp_pio_block_t *block, uint32_t base);
 #endif
@@ -381,6 +385,30 @@ extern "C" {
 /*===========================================================================*/
 /* Driver inline functions.                                                  */
 /*===========================================================================*/
+
+/**
+ * @brief   Returns the descriptor of a PIO state machine.
+ * @details The returned pointer is the same one @p pioSmAllocI() returns
+ *          for the state machine, so a handle can be recovered without
+ *          tracking the allocation-time pointer externally.
+ * @note    Holding a descriptor does not imply ownership: the state
+ *          machine must have been allocated with @p pioSmAlloc() or
+ *          @p pioSmAllocI() before it is operated on.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] smidx     index of the state machine
+ *                      (0..RP_PIO_NUM_STATE_MACHINES-1)
+ * @return              Pointer to the @p rp_pio_sm_t structure.
+ *
+ * @xclass
+ */
+__STATIC_INLINE const rp_pio_sm_t *pioGetSmHandleX(const rp_pio_block_t *block,
+                                                   uint32_t smidx) {
+
+  osalDbgCheck((block != NULL) && (smidx < RP_PIO_NUM_STATE_MACHINES));
+
+  return &__rp_pio_sms[block->pioidx][smidx];
+}
 
 /**
  * @name    State machine configuration builders

--- a/testhal/RP/RP2040/PIO-VALIDATION/c1_main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/c1_main.c
@@ -50,6 +50,21 @@ void c1_main(void) {
   pio_validation_barrier();         /* Free's effects before the flag.*/
   c1_free_done = 1U;
 
+  /* Waiting for core 0 to request an allocation from this core.*/
+  while (c1_do_alloc == 0U) {
+  }
+  pio_validation_barrier();
+
+  /* Cross-core allocation, the mask query on core 0 must report it as
+     part of the union of both cores' allocations.*/
+  chSysLock();
+  xcore_alloc_smp = pioSmAllocI(RP_PIO0_BLOCK, 1U, TEST_IRQ_PRIORITY,
+                                NULL, NULL);
+  chSysUnlock();
+
+  pio_validation_barrier();         /* Alloc's effects before the flag.*/
+  c1_alloc_done = 1U;
+
   while (true) {
   }
 }

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -52,6 +52,10 @@
  *    clear the pad isolation latch left set by the pad reset state.
  * 9. (RP2350) GPIOBASE window: the builder flow must work with the
  *    GPIO16..47 window through pioGpioToRel.
+ * 10. Allocation masks and handles: pioGetSmAllocatedMask must report
+ *    the union of both cores' allocations, pioGetImemAllocatedMask
+ *    must track program load and unload, and pioGetSmHandleX must
+ *    return the same descriptor pointer pioSmAlloc returned.
  *
  * The square wave is emitted on GPIO2 and read back through SIO GPIO_IN.
  * The report is emitted on UART0 (GPIO0/GPIO1) at the SIO default
@@ -72,14 +76,16 @@
 volatile uint32_t c1_ready;
 volatile uint32_t c1_do_free;
 volatile uint32_t c1_free_done;
+volatile uint32_t c1_do_alloc;
+volatile uint32_t c1_alloc_done;
 const rp_pio_sm_t * volatile xcore_smp;
+const rp_pio_sm_t * volatile xcore_alloc_smp;
 
 /*===========================================================================*/
 /* Test parameters.                                                          */
 /*===========================================================================*/
 
 #define TEST_GPIO           2U
-#define TEST_IRQ_PRIORITY   3U
 
 /* State machine clock and measurement window.*/
 #define SM_TEST_FREQ        10000U      /* SM clock in Hz.                  */
@@ -308,7 +314,7 @@ int main(void) {
   const rp_dma_channel_t *dmachp;
   rp_pio_sm_config_t cfg;
   int32_t park_off, sq_off, off32, off1, out_off;
-  uint32_t edges, rel, lvl, div_fp8, pinctrl_before, pinctrl_after;
+  uint32_t edges, rel, lvl, div_fp8, pinctrl_before, pinctrl_after, mask;
   unsigned i;
   bool ok;
 
@@ -758,6 +764,68 @@ int main(void) {
   pioSmFree(smp);
   pioProgramUnload(RP_PIO1_BLOCK, sq_off, sqwave_program.length);
 #endif /* RP_PIO_HAS_GPIOBASE == TRUE */
+
+  /*
+   * Test 10: allocation masks and state machine handle access.
+   */
+  chprintf(chp, "--- Test 10: allocation masks and handles\r\n");
+
+  report("SM mask empty on idle block", pioGetSmAllocatedMask(block) == 0U);
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  report("SM mask reports the core 0 allocation",
+         pioGetSmAllocatedMask(block) == 1U);
+  report("handle equals the allocation-time pointer",
+         pioGetSmHandleX(block, 0U) == smp);
+
+  /* Core 1 allocates SM1, the mask query must return the union of both
+     cores' allocations.*/
+  pio_validation_barrier();
+  c1_do_alloc = 1U;
+
+  for (i = 0U; (c1_alloc_done == 0U) && (i < 1000U); i++) {
+    chThdSleepMilliseconds(1);
+  }
+  report("core 1 allocation completed",
+         (c1_alloc_done != 0U) && (xcore_alloc_smp != NULL));
+  if ((c1_alloc_done == 0U) || (xcore_alloc_smp == NULL)) {
+    goto summary;
+  }
+
+  report("SM mask is the cross-core union",
+         pioGetSmAllocatedMask(block) == 3U);
+  report("handle equals the core 1 allocation-time pointer",
+         pioGetSmHandleX(block, 1U) == xcore_alloc_smp);
+
+  /* Instruction memory mask bookkeeping across load and unload.*/
+  mask = pioGetImemAllocatedMask(block);
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("program loaded for the imem mask check", sq_off >= 0);
+  if (sq_off >= 0) {
+    report("imem mask covers the loaded program",
+           pioGetImemAllocatedMask(block) ==
+           (mask | (uint32_t)(((1ULL << sqwave_program.length) - 1ULL) <<
+                              (uint32_t)sq_off)));
+
+    pioProgramUnload(block, sq_off, sqwave_program.length);
+    report("imem mask restored on unload",
+           pioGetImemAllocatedMask(block) == mask);
+  }
+  else {
+    report("imem mask covers the loaded program", false);
+    report("imem mask restored on unload", false);
+  }
+
+  /* The core 1 allocation is freed from this core, cross-core frees are
+     covered by test 4.*/
+  pioSmFree(xcore_alloc_smp);
+  pioSmFree(smp);
+  report("SM mask empty after the frees", pioGetSmAllocatedMask(block) == 0U);
 
   /*
    * Summary.

--- a/testhal/RP/RP2040/PIO-VALIDATION/pio_validation.h
+++ b/testhal/RP/RP2040/PIO-VALIDATION/pio_validation.h
@@ -27,9 +27,15 @@
  */
 #define pio_validation_barrier()    __sync_synchronize()
 
+/* IRQ priority shared by the allocations on both cores.*/
+#define TEST_IRQ_PRIORITY           3U
+
 extern volatile uint32_t c1_ready;
 extern volatile uint32_t c1_do_free;
 extern volatile uint32_t c1_free_done;
+extern volatile uint32_t c1_do_alloc;
+extern volatile uint32_t c1_alloc_done;
 extern const rp_pio_sm_t * volatile xcore_smp;
+extern const rp_pio_sm_t * volatile xcore_alloc_smp;
 
 #endif /* PIO_VALIDATION_H */

--- a/testhal/RP/RP2350/PIO-VALIDATION/c1_main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/c1_main.c
@@ -50,6 +50,21 @@ void c1_main(void) {
   pio_validation_barrier();         /* Free's effects before the flag.*/
   c1_free_done = 1U;
 
+  /* Waiting for core 0 to request an allocation from this core.*/
+  while (c1_do_alloc == 0U) {
+  }
+  pio_validation_barrier();
+
+  /* Cross-core allocation, the mask query on core 0 must report it as
+     part of the union of both cores' allocations.*/
+  chSysLock();
+  xcore_alloc_smp = pioSmAllocI(RP_PIO0_BLOCK, 1U, TEST_IRQ_PRIORITY,
+                                NULL, NULL);
+  chSysUnlock();
+
+  pio_validation_barrier();         /* Alloc's effects before the flag.*/
+  c1_alloc_done = 1U;
+
   while (true) {
   }
 }

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -52,6 +52,10 @@
  *    clear the pad isolation latch left set by the pad reset state.
  * 9. (RP2350) GPIOBASE window: the builder flow must work with the
  *    GPIO16..47 window through pioGpioToRel.
+ * 10. Allocation masks and handles: pioGetSmAllocatedMask must report
+ *    the union of both cores' allocations, pioGetImemAllocatedMask
+ *    must track program load and unload, and pioGetSmHandleX must
+ *    return the same descriptor pointer pioSmAlloc returned.
  *
  * The square wave is emitted on GPIO2 and read back through SIO GPIO_IN.
  * The report is emitted on UART0 (GPIO0/GPIO1) at the SIO default
@@ -72,14 +76,16 @@
 volatile uint32_t c1_ready;
 volatile uint32_t c1_do_free;
 volatile uint32_t c1_free_done;
+volatile uint32_t c1_do_alloc;
+volatile uint32_t c1_alloc_done;
 const rp_pio_sm_t * volatile xcore_smp;
+const rp_pio_sm_t * volatile xcore_alloc_smp;
 
 /*===========================================================================*/
 /* Test parameters.                                                          */
 /*===========================================================================*/
 
 #define TEST_GPIO           2U
-#define TEST_IRQ_PRIORITY   3U
 
 /* State machine clock and measurement window.*/
 #define SM_TEST_FREQ        10000U      /* SM clock in Hz.                  */
@@ -308,7 +314,7 @@ int main(void) {
   const rp_dma_channel_t *dmachp;
   rp_pio_sm_config_t cfg;
   int32_t park_off, sq_off, off32, off1, out_off;
-  uint32_t edges, rel, lvl, div_fp8, pinctrl_before, pinctrl_after;
+  uint32_t edges, rel, lvl, div_fp8, pinctrl_before, pinctrl_after, mask;
   unsigned i;
   bool ok;
 
@@ -758,6 +764,68 @@ int main(void) {
   pioSmFree(smp);
   pioProgramUnload(RP_PIO1_BLOCK, sq_off, sqwave_program.length);
 #endif /* RP_PIO_HAS_GPIOBASE == TRUE */
+
+  /*
+   * Test 10: allocation masks and state machine handle access.
+   */
+  chprintf(chp, "--- Test 10: allocation masks and handles\r\n");
+
+  report("SM mask empty on idle block", pioGetSmAllocatedMask(block) == 0U);
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  report("SM mask reports the core 0 allocation",
+         pioGetSmAllocatedMask(block) == 1U);
+  report("handle equals the allocation-time pointer",
+         pioGetSmHandleX(block, 0U) == smp);
+
+  /* Core 1 allocates SM1, the mask query must return the union of both
+     cores' allocations.*/
+  pio_validation_barrier();
+  c1_do_alloc = 1U;
+
+  for (i = 0U; (c1_alloc_done == 0U) && (i < 1000U); i++) {
+    chThdSleepMilliseconds(1);
+  }
+  report("core 1 allocation completed",
+         (c1_alloc_done != 0U) && (xcore_alloc_smp != NULL));
+  if ((c1_alloc_done == 0U) || (xcore_alloc_smp == NULL)) {
+    goto summary;
+  }
+
+  report("SM mask is the cross-core union",
+         pioGetSmAllocatedMask(block) == 3U);
+  report("handle equals the core 1 allocation-time pointer",
+         pioGetSmHandleX(block, 1U) == xcore_alloc_smp);
+
+  /* Instruction memory mask bookkeeping across load and unload.*/
+  mask = pioGetImemAllocatedMask(block);
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("program loaded for the imem mask check", sq_off >= 0);
+  if (sq_off >= 0) {
+    report("imem mask covers the loaded program",
+           pioGetImemAllocatedMask(block) ==
+           (mask | (uint32_t)(((1ULL << sqwave_program.length) - 1ULL) <<
+                              (uint32_t)sq_off)));
+
+    pioProgramUnload(block, sq_off, sqwave_program.length);
+    report("imem mask restored on unload",
+           pioGetImemAllocatedMask(block) == mask);
+  }
+  else {
+    report("imem mask covers the loaded program", false);
+    report("imem mask restored on unload", false);
+  }
+
+  /* The core 1 allocation is freed from this core, cross-core frees are
+     covered by test 4.*/
+  pioSmFree(xcore_alloc_smp);
+  pioSmFree(smp);
+  report("SM mask empty after the frees", pioGetSmAllocatedMask(block) == 0U);
 
   /*
    * Summary.

--- a/testhal/RP/RP2350/PIO-VALIDATION/pio_validation.h
+++ b/testhal/RP/RP2350/PIO-VALIDATION/pio_validation.h
@@ -27,9 +27,15 @@
  */
 #define pio_validation_barrier()    __sync_synchronize()
 
+/* IRQ priority shared by the allocations on both cores.*/
+#define TEST_IRQ_PRIORITY           3U
+
 extern volatile uint32_t c1_ready;
 extern volatile uint32_t c1_do_free;
 extern volatile uint32_t c1_free_done;
+extern volatile uint32_t c1_do_alloc;
+extern volatile uint32_t c1_alloc_done;
 extern const rp_pio_sm_t * volatile xcore_smp;
+extern const rp_pio_sm_t * volatile xcore_alloc_smp;
 
 #endif /* PIO_VALIDATION_H */


### PR DESCRIPTION
## Summary

This PR enhances the RP PIOv1 driver API by introducing new functions to query the allocation status of PIO state machines and their associated instruction memory. It also provides a convenient inline function, `pioGetSmHandleX`, to retrieve a descriptor handle for a specific state machine. These additions offer greater visibility and control over PIO resources, facilitating more robust and flexible application development by allowing users to check resource availability and easily access state machine configurations.

## Related

- Issue(s):
- Notes for reviewers: Reworked per review feedback — the state machine descriptor table (`__rp_pio_sms`) is now compile-time constant and exported `const`, so descriptors cannot be mutated by callers, handles are valid before `pioInit()` runs, and `pioGetSmHandleX()` calls with constant arguments fold to a constant descriptor. The accessor takes a block descriptor pointer, is `X`-suffixed/`@xclass`, and the allocation mask queries are documented as advisory snapshots (union of core 0 and core 1 allocations).

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files
- [x] Build check passed (RP2040 and RP2350 PIO-VALIDATION targets; the POSIX simulator does not build this RP-specific LLD)

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? Yes — `PIO-VALIDATION` (extended with a
  test for the new functions) run on real hardware: Pico W (RP2040,
  50 asserts), Pico 2 ARM (57 asserts) and Pico 2 RISC-V (57 asserts),
  all passing. UART reports captured with a logic analyzer.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitation are documented below
