### PR TITLE
SB: add enhanced userspace shell

### DIFF
--- a/os/sb/apps/common/README.md
+++ b/os/sb/apps/common/README.md
@@ -9,7 +9,9 @@ The maintained command set currently includes:
 - `cat`, `chedit`, `cmp`, `cp`, `head`, `hexdump`, `ls`, `stat`, and `wc`
   for files.
 - `sleep` and `systime` for sandbox timing.
-- `msh` as the command loader and interactive shell.
+- `msh` as the minimal command loader and interactive shell.
+- `sbsh` as the enhanced shell with scripts, quoting, redirection, and
+  serialized pipelines.
 
 ## Command execution model
 
@@ -21,10 +23,37 @@ startup code passes `argc`, `argv`, and `envp` to:
 int main(int argc, char *argv[], char *envp[]);
 ```
 
-`msh` loads external commands into its unused heap and calls them through the
-support code in `elfexec/`. The loaded command remains in the same sandbox: it
-shares the sandbox VFS root, descriptors, current directory, and environment.
-It is not a separately isolated process.
+`msh` and `sbsh` load external commands into unused memory and call them
+through the support code in `elfexec/`. The loaded command remains in the same
+sandbox: it shares the sandbox VFS root, descriptors, current directory, and
+environment. It is not a separately isolated process.
+
+`sbsh` keeps parsing and glob expansion in fixed-size storage. Glob matches
+are copied into a bounded scratch arena directly below the loaded command,
+without advancing the shell heap break. This avoids accumulating heap
+fragmentation or permanently reducing the space available to later commands.
+
+## `sbsh` syntax
+
+`sbsh` can run interactively, execute one command list, or read a script:
+
+```sh
+sbsh
+sbsh -c 'echo hello >message'
+sbsh startup.sbsh
+```
+
+Scripts execute one bounded line at a time and accept LF or CRLF endings.
+Commands on a line can be separated with `;`. Single quotes, double quotes,
+backslash escapes, comments beginning at a token boundary, `<`, `>`, `>>`,
+and `|` are supported.
+
+Until separately spawned sandbox processes and real pipes are available,
+`sbsh` implements `|` by running each stage sequentially through temporary
+files. A pipeline is therefore non-streaming and should be kept small.
+Temporary files are created with exclusive access under `$TMPDIR` (or `/tmp`)
+and removed as each stage completes. Stateful builtins such as `cd` and
+`exit` are rejected in pipelines.
 
 Commands use the newlib adapters from `os/sb/user` for the supported POSIX
 operations. Host-side POSIX calls are currently synchronous, so a blocking
@@ -54,6 +83,8 @@ make clean      # Clean applications and remove the aggregate build directory.
 ```
 
 The `msh` application is sandbox-only and is not part of the POSIX target.
+`sbsh` has a native profile for parser and executor tests; native external
+commands are spawned only by that test build.
 Each application keeps its object and dependency trees locally under its own
 `build/` and `.dep/` directories. The aggregate `build/sb` and `build/posix`
 directories contain only the final executables for easy deployment.

--- a/os/sb/apps/common/elfexec/elfexec.c
+++ b/os/sb/apps/common/elfexec/elfexec.c
@@ -24,13 +24,13 @@
 extern int __callelf(sb_header_t *sbhp, int argc, char *argv[], char *envp[]);
 extern int __returnelf(void);
 
-int sbRunElf(int argc, char *argv[], char *envp[]) {
+int sbRunElfAt(int argc, char *argv[], char *envp[], void *base) {
   uint8_t *buf, *bufend;
   sb_header_t *sbhp;
   msg_t ret;
 
   /* Boundaries of available RAM in the sandbox.*/
-  buf = sbrk(0);
+  buf = base;
   bufend = __sb_parameters.heap_end;
 
   /* Aligning the start address.*/
@@ -62,4 +62,9 @@ int sbRunElf(int argc, char *argv[], char *envp[]) {
   sbhp->hdr_exit = (uint32_t)__returnelf;
   sbhp->user[0]  = (uint32_t)bufend;
   return __callelf(sbhp, argc, argv, envp);
+}
+
+int sbRunElf(int argc, char *argv[], char *envp[]) {
+
+  return sbRunElfAt(argc, argv, envp, sbrk(0));
 }

--- a/os/sb/apps/common/elfexec/elfexec.h
+++ b/os/sb/apps/common/elfexec/elfexec.h
@@ -20,6 +20,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+  /* The base address must point into unused, writable sandbox heap memory.*/
+  int sbRunElfAt(int argc, char *argv[], char *envp[], void *base);
   int sbRunElf(int argc, char *argv[], char *envp[]);
 #ifdef __cplusplus
 }

--- a/os/sb/apps/common/manifest.mk
+++ b/os/sb/apps/common/manifest.mk
@@ -2,8 +2,8 @@
 # Paths are relative to os/sb/apps. Install paths are relative to the
 # sandbox VFS root.
 
-SBAPP_DEPLOY_APPS := cat chedit cmp cp head hexdump ls msh sleep stat systime wc
-SBAPP_POSIX_APPS  := cat chedit cmp cp head hexdump ls sleep stat systime wc
+SBAPP_DEPLOY_APPS := cat chedit cmp cp head hexdump ls msh sbsh sleep stat systime wc
+SBAPP_POSIX_APPS  := cat chedit cmp cp head hexdump ls sbsh sleep stat systime wc
 
 SBAPP_DEPLOY_cat_MAKEFILE := make/cat-rambox-deploy.make
 SBAPP_DEPLOY_cat_ARTIFACT := cat.elf
@@ -36,6 +36,10 @@ SBAPP_DEPLOY_ls_PATH     := bin/ls.elf
 SBAPP_DEPLOY_msh_MAKEFILE := make/msh-rambox-deploy.make
 SBAPP_DEPLOY_msh_ARTIFACT := msh.elf
 SBAPP_DEPLOY_msh_PATH     := bin/msh.elf
+
+SBAPP_DEPLOY_sbsh_MAKEFILE := make/sbsh-rambox-deploy.make
+SBAPP_DEPLOY_sbsh_ARTIFACT := sbsh.elf
+SBAPP_DEPLOY_sbsh_PATH     := bin/sbsh.elf
 
 SBAPP_DEPLOY_sleep_MAKEFILE := make/sleep-rambox-deploy.make
 SBAPP_DEPLOY_sleep_ARTIFACT := sleep.elf

--- a/os/sb/apps/sbsh/Makefile
+++ b/os/sb/apps/sbsh/Makefile
@@ -1,0 +1,1 @@
+include ../common/make/multi.mk

--- a/os/sb/apps/sbsh/README.md
+++ b/os/sb/apps/sbsh/README.md
@@ -1,0 +1,174 @@
+# sbsh
+
+`sbsh` is the enhanced command shell for ChibiOS sandboxes. It is a separate
+project from the intentionally minimal `msh`, so new shell features do not add
+complexity or compatibility constraints to the original command loader.
+
+The initial implementation focuses on predictable resource use and features
+that work before separately spawned sandbox processes are available:
+
+- interactive command entry and history;
+- sequential command lists and script files;
+- quoting, escaping, comments, and bounded glob expansion;
+- input, output, and append redirection;
+- non-streaming pipelines implemented with temporary files.
+
+## Invocation
+
+```text
+sbsh
+sbsh -c command
+sbsh script
+```
+
+With no operands, `sbsh` displays a prompt and reads commands interactively.
+The `PROMPT` environment variable overrides the default `sbsh> ` prompt.
+Up-arrow and down-arrow recall the eight most recent non-empty lines,
+Backspace edits the current line, and Ctrl-D on an empty line exits.
+
+The `-c` form executes one command list without displaying the interactive
+banner. The script form reads and executes one line at a time. Both LF and
+CRLF script line endings are accepted.
+
+Scripts continue after ordinary nonzero command statuses. A syntax error,
+overlong line, or read error stops the script. The shell returns the status of
+the last command that ran, or status 2 for a syntax or usage error.
+
+## Command syntax
+
+Commands can be separated with `;`:
+
+```text
+echo first; echo second
+```
+
+Single quotes preserve all enclosed characters. Double quotes and backslash
+escapes prevent spaces and operators from separating an argument. Quoted or
+escaped `*` and `?` characters remain literal, including when combined with
+unquoted wildcards in the same word.
+
+An unquoted `#` begins a comment when it occurs where a new token would start:
+
+```text
+echo value # this is a comment
+echo value#this-is-not-a-comment
+```
+
+The supported redirections are:
+
+```text
+command <input
+command >output
+command >>output
+```
+
+Only one input and one output redirection are accepted per command. Input
+redirection is allowed on the first pipeline stage, and output redirection is
+allowed on the last stage.
+
+## Globbing
+
+Unquoted `*` and `?` are expanded against directory entries in the final path
+component. A pattern that has no matches is passed to the command unchanged.
+Expansion order is the directory enumeration order and is not sorted.
+
+The initial implementation does not recursively expand wildcard directory
+components. For example, `dir/*.txt` is supported, while `dir*/file.txt` is
+treated as an unmatched literal pattern.
+
+## Builtins
+
+The initial builtins are:
+
+- `cd <path>`
+- `echo [argument ...]`
+- `env`
+- `exit [status]`, where status is from 0 through 255
+- `help`
+- `mkdir <directory>`
+- `mv <old> <new>`
+- `path`
+- `pwd`
+- `rm <file>`
+- `rmdir <directory>`
+
+`path` prints the current `PATH`. For sandbox execution, `PATH` entries must
+be absolute. If `PATH` is unset, `/bin` is used. Commands found through
+`PATH` receive the `.elf` extension automatically; command names containing
+`/` are executed exactly as written.
+
+## Temporary-file pipelines
+
+The `|` operator is currently implemented as sequential execution through
+temporary files:
+
+```text
+producer | filter | consumer
+```
+
+Each stage runs to completion, its output file is rewound, and the next stage
+then consumes it. Files are created exclusively with mode 0600 under
+`$TMPDIR`, or `/tmp` when `TMPDIR` is unset, and are removed as soon as they
+are no longer needed.
+
+These pipelines are deliberately not streaming. They are unsuitable for
+unbounded producers, commands that require simultaneous interaction, or data
+larger than the available temporary filesystem. `cd` and `exit` are rejected
+inside pipelines because their stateful behavior would be misleading.
+
+This executor can later be replaced with `posix_spawn()` and real pipes
+without changing the parser or command syntax.
+
+## Resource limits
+
+The parser and executor use fixed-size tables:
+
+- 127 input characters plus the terminating zero;
+- 32 parsed words and 64 words after glob expansion;
+- eight commands, eight command lists, and eight redirections per line;
+- a 4 KiB bounded arena for copied glob matches.
+
+On the sandbox target, directory enumeration uses a fixed aligned buffer and
+does not allocate a `DIR` object. The glob arena aliases currently unused heap
+space without advancing the shell break; external ELF loading starts
+immediately after the live matches. The target image therefore does not link
+`malloc()` or `free()`, avoiding persistent heap fragmentation between
+commands.
+
+## Current omissions
+
+The initial shell intentionally has no variable expansion, command
+substitution, environment assignments, `&&`, `||`, background jobs, job
+control, or streamed pipes. Scripts are selected explicitly with
+`sbsh script`; shebang dispatch and a `source` builtin are not yet provided.
+
+## Building and testing
+
+From this directory:
+
+```sh
+make
+make check
+make clean
+```
+
+`make` builds the native test executable plus ARM debug and deploy images.
+The individual profiles are:
+
+```sh
+make -f make/sbsh-posix-x86-debug.make check
+make -f make/sbsh-rambox-debug.make
+make -f make/sbsh-rambox-deploy.make
+```
+
+From the parent `os/sb/apps` directory, the aggregate targets are:
+
+```sh
+make posix-sbsh
+make check-sbsh
+make sb-sbsh
+```
+
+The aggregate build copies only the final executable to `build/posix/sbsh`
+or `build/sb/sbsh.elf`; each profile keeps its intermediate files inside the
+`sbsh` project.

--- a/os/sb/apps/sbsh/execute.c
+++ b/os/sb/apps/sbsh/execute.c
@@ -1,0 +1,832 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#if defined(SBAPP_NATIVE)
+#include <sys/types.h>
+#include <sys/wait.h>
+#else
+#include "sbuser.h"
+#include "paths.h"
+#include "elfexec.h"
+#endif
+
+#include "sbsh.h"
+
+typedef int (*builtin_function_t)(sbsh_state_t *state,
+                                  int argc,
+                                  char *argv[]);
+
+typedef struct {
+  const char            *name;
+  builtin_function_t    function;
+  bool                  pipeline_safe;
+} builtin_t;
+
+typedef struct {
+  int                   saved_input;
+  int                   saved_output;
+} redir_guard_t;
+
+typedef struct {
+  const char            *input_path;
+  const char            *output_path;
+  bool                  append;
+} redir_spec_t;
+
+static int cmd_cd(sbsh_state_t *state, int argc, char *argv[]) {
+
+  (void)state;
+  if (argc != 2) {
+    sbsh_usage("cd <path>");
+    return 2;
+  }
+  if (chdir(argv[1]) != 0) {
+    sbsh_error(argv[1]);
+    sbsh_errorln(": change directory failed");
+    return 1;
+  }
+
+  return 0;
+}
+
+static int cmd_echo(sbsh_state_t *state, int argc, char *argv[]) {
+  int i;
+
+  (void)state;
+  for (i = 1; i < argc; i++) {
+    if (i > 1) {
+      sbsh_write_fd(STDOUT_FILENO, " ");
+    }
+    sbsh_write_fd(STDOUT_FILENO, argv[i]);
+  }
+  sbsh_write_fd(STDOUT_FILENO, SBSH_NEWLINE_STR);
+
+  return 0;
+}
+
+static int cmd_env(sbsh_state_t *state, int argc, char *argv[]) {
+  extern char **environ;
+  char **envp;
+
+  (void)state;
+  (void)argv;
+  if (argc != 1) {
+    sbsh_usage("env");
+    return 2;
+  }
+
+  envp = environ;
+  while (*envp != NULL) {
+    sbsh_writeln_fd(STDOUT_FILENO, *envp++);
+  }
+
+  return 0;
+}
+
+static int parse_exit_status(const char *s, int *statusp) {
+  unsigned value;
+
+  if (*s == '\0') {
+    return -1;
+  }
+  value = 0U;
+  while (*s != '\0') {
+    unsigned digit;
+
+    if ((*s < '0') || (*s > '9')) {
+      return -1;
+    }
+    digit = (unsigned)(*s++ - '0');
+    if ((value > 25U) || ((value == 25U) && (digit > 5U))) {
+      return -1;
+    }
+    value = value * 10U + digit;
+  }
+  *statusp = (int)value;
+
+  return 0;
+}
+
+static int cmd_exit(sbsh_state_t *state, int argc, char *argv[]) {
+  int status;
+
+  if (argc == 1) {
+    status = state->last_status;
+  }
+  else {
+    if ((argc != 2) || (parse_exit_status(argv[1], &status) != 0)) {
+      sbsh_usage("exit [status]");
+      return 2;
+    }
+  }
+
+  _exit(status);
+}
+
+static int cmd_mkdir(sbsh_state_t *state, int argc, char *argv[]) {
+
+  (void)state;
+  if (argc != 2) {
+    sbsh_usage("mkdir <directory>");
+    return 2;
+  }
+  if (mkdir(argv[1], 0777) != 0) {
+    sbsh_error(argv[1]);
+    sbsh_errorln(": creation failed");
+    return 1;
+  }
+
+  return 0;
+}
+
+static int cmd_mv(sbsh_state_t *state, int argc, char *argv[]) {
+
+  (void)state;
+  if (argc != 3) {
+    sbsh_usage("mv <old> <new>");
+    return 2;
+  }
+  if (rename(argv[1], argv[2]) != 0) {
+    sbsh_error(argv[1]);
+    sbsh_errorln(": rename failed");
+    return 1;
+  }
+
+  return 0;
+}
+
+static int cmd_path(sbsh_state_t *state, int argc, char *argv[]) {
+  char *path;
+
+  (void)state;
+  (void)argv;
+  if (argc != 1) {
+    sbsh_usage("path");
+    return 2;
+  }
+
+  path = getenv("PATH");
+  if (path != NULL) {
+    sbsh_writeln_fd(STDOUT_FILENO, path);
+  }
+
+  return 0;
+}
+
+static int cmd_pwd(sbsh_state_t *state, int argc, char *argv[]) {
+
+  (void)argv;
+  if (argc != 1) {
+    sbsh_usage("pwd");
+    return 2;
+  }
+  if (getcwd(state->pathbuf, sizeof state->pathbuf) == NULL) {
+    sbsh_errorln("pwd: getcwd failed");
+    return 1;
+  }
+  sbsh_writeln_fd(STDOUT_FILENO, state->pathbuf);
+
+  return 0;
+}
+
+static int cmd_rm(sbsh_state_t *state, int argc, char *argv[]) {
+
+  (void)state;
+  if (argc != 2) {
+    sbsh_usage("rm <file>");
+    return 2;
+  }
+  if (unlink(argv[1]) != 0) {
+    sbsh_error(argv[1]);
+    sbsh_errorln(": remove failed");
+    return 1;
+  }
+
+  return 0;
+}
+
+static int cmd_rmdir(sbsh_state_t *state, int argc, char *argv[]) {
+
+  (void)state;
+  if (argc != 2) {
+    sbsh_usage("rmdir <directory>");
+    return 2;
+  }
+  if (rmdir(argv[1]) != 0) {
+    sbsh_error(argv[1]);
+    sbsh_errorln(": remove failed");
+    return 1;
+  }
+
+  return 0;
+}
+
+static int cmd_help(sbsh_state_t *state, int argc, char *argv[]);
+
+static const builtin_t builtins[] = {
+  {"cd",      cmd_cd,      false},
+  {"echo",    cmd_echo,    true},
+  {"env",     cmd_env,     true},
+  {"exit",    cmd_exit,    false},
+  {"help",    cmd_help,    true},
+  {"mkdir",   cmd_mkdir,   true},
+  {"mv",      cmd_mv,      true},
+  {"path",    cmd_path,    true},
+  {"pwd",     cmd_pwd,     true},
+  {"rm",      cmd_rm,      true},
+  {"rmdir",   cmd_rmdir,   true},
+  {NULL,      NULL,        false}
+};
+
+static int cmd_help(sbsh_state_t *state, int argc, char *argv[]) {
+  const builtin_t *builtin;
+
+  (void)state;
+  (void)argv;
+  if (argc != 1) {
+    sbsh_usage("help");
+    return 2;
+  }
+
+  sbsh_write_fd(STDOUT_FILENO, "Builtins: ");
+  builtin = builtins;
+  while (builtin->name != NULL) {
+    sbsh_write_fd(STDOUT_FILENO, builtin->name);
+    sbsh_write_fd(STDOUT_FILENO, " ");
+    builtin++;
+  }
+  sbsh_write_fd(STDOUT_FILENO, SBSH_NEWLINE_STR);
+  sbsh_writeln_fd(STDOUT_FILENO,
+                  "Syntax: command [args] [<file] [>file] [>>file]");
+  sbsh_writeln_fd(STDOUT_FILENO,
+                  "        command | command ; command");
+
+  return 0;
+}
+
+static const builtin_t *find_builtin(const char *name) {
+  const builtin_t *builtin;
+
+  builtin = builtins;
+  while (builtin->name != NULL) {
+    if (strcmp(builtin->name, name) == 0) {
+      return builtin;
+    }
+    builtin++;
+  }
+
+  return NULL;
+}
+
+static int shell_dup(int fd) {
+
+#if defined(SBAPP_NATIVE)
+  return dup(fd);
+#else
+  msg_t ret;
+
+  ret = sbDup(fd);
+  if (CH_RET_IS_ERROR(ret)) {
+    errno = CH_DECODE_ERROR(ret);
+    return -1;
+  }
+  return (int)ret;
+#endif
+}
+
+static int shell_dup2(int oldfd, int newfd) {
+
+#if defined(SBAPP_NATIVE)
+  return dup2(oldfd, newfd);
+#else
+  msg_t ret;
+
+  ret = sbDup2(oldfd, newfd);
+  if (CH_RET_IS_ERROR(ret)) {
+    errno = CH_DECODE_ERROR(ret);
+    return -1;
+  }
+  return (int)ret;
+#endif
+}
+
+static void redir_guard_init(redir_guard_t *guard) {
+
+  guard->saved_input = -1;
+  guard->saved_output = -1;
+}
+
+static int redir_assign(redir_guard_t *guard, int source, int target) {
+  int *savedp;
+
+  savedp = target == STDIN_FILENO ?
+           &guard->saved_input : &guard->saved_output;
+  if (*savedp < 0) {
+    *savedp = shell_dup(target);
+    if (*savedp < 0) {
+      return -1;
+    }
+  }
+  if (shell_dup2(source, target) < 0) {
+    return -1;
+  }
+
+  return 0;
+}
+
+static int redir_restore(redir_guard_t *guard) {
+  int result;
+
+  result = 0;
+  if (guard->saved_output >= 0) {
+    if (shell_dup2(guard->saved_output, STDOUT_FILENO) < 0) {
+      result = -1;
+    }
+    (void)close(guard->saved_output);
+    guard->saved_output = -1;
+  }
+  if (guard->saved_input >= 0) {
+    if (shell_dup2(guard->saved_input, STDIN_FILENO) < 0) {
+      result = -1;
+    }
+    (void)close(guard->saved_input);
+    guard->saved_input = -1;
+  }
+
+  return result;
+}
+
+static int inspect_redirections(const sbsh_plan_t *plan,
+                                const sbsh_command_t *command,
+                                redir_spec_t *spec) {
+  unsigned i;
+
+  spec->input_path = NULL;
+  spec->output_path = NULL;
+  spec->append = false;
+  for (i = 0U; i < command->redir_count; i++) {
+    const sbsh_redir_t *redir;
+
+    redir = &plan->redirs[command->redir_first + i];
+    if (redir->type == SBSH_REDIR_INPUT) {
+      if (spec->input_path != NULL) {
+        sbsh_errorln("sbsh: multiple input redirections");
+        return -1;
+      }
+      spec->input_path = redir->path;
+    }
+    else {
+      if (spec->output_path != NULL) {
+        sbsh_errorln("sbsh: multiple output redirections");
+        return -1;
+      }
+      spec->output_path = redir->path;
+      spec->append = (bool)(redir->type == SBSH_REDIR_APPEND);
+    }
+  }
+
+  return 0;
+}
+
+#if defined(SBAPP_NATIVE)
+
+static int run_external(sbsh_state_t *state,
+                        int argc,
+                        char *argv[],
+                        void *load_base) {
+  pid_t pid;
+  pid_t waited;
+  int error;
+  int status;
+
+  (void)state;
+  (void)argc;
+  (void)load_base;
+  pid = fork();
+  if (pid < (pid_t)0) {
+    sbsh_errorln("sbsh: fork failed");
+    return 126;
+  }
+  if (pid == (pid_t)0) {
+    execvp(argv[0], argv);
+    error = errno;
+    sbsh_error("sbsh: ");
+    sbsh_error(argv[0]);
+    sbsh_errorln(error == ENOENT ?
+                 ": command not found" : ": execution failed");
+    _exit(error == ENOENT ? 127 : 126);
+  }
+
+  do {
+    waited = waitpid(pid, &status, 0);
+  } while ((waited < (pid_t)0) && (errno == EINTR));
+  if (waited < (pid_t)0) {
+    sbsh_errorln("sbsh: wait failed");
+    return 126;
+  }
+  if (WIFEXITED(status)) {
+    return WEXITSTATUS(status);
+  }
+  if (WIFSIGNALED(status)) {
+    return 128 + WTERMSIG(status);
+  }
+
+  return 126;
+}
+
+#else
+
+static int run_external(sbsh_state_t *state,
+                        int argc,
+                        char *argv[],
+                        void *load_base) {
+  extern char **environ;
+  char *name;
+  char *path;
+  int ret;
+
+  name = argv[0];
+  if (strchr(name, '/') != NULL) {
+    ret = sbRunElfAt(argc, argv, environ, load_base);
+    if (ret != -1) {
+      return ret;
+    }
+  }
+  else {
+    path = getenv("PATH");
+    if (path == NULL) {
+      path = SBSH_DEFAULT_PATH;
+    }
+
+    while (true) {
+      size_t length;
+
+      length = strcspn(path, ":");
+      if (length == 0U) {
+        errno = ENOENT;
+        break;
+      }
+      if (length >= sizeof state->pathbuf) {
+        errno = ERANGE;
+        break;
+      }
+
+      if (*path == '/') {
+        memcpy(state->pathbuf, path, length);
+        state->pathbuf[length] = '\0';
+        if ((path_append(state->pathbuf,
+                         name,
+                         sizeof state->pathbuf) == 0U) ||
+            (path_add_extension(state->pathbuf,
+                                SBSH_EXECUTABLE_EXTENSION,
+                                sizeof state->pathbuf) == 0U)) {
+          errno = ERANGE;
+          break;
+        }
+
+        argv[0] = state->pathbuf;
+        ret = sbRunElfAt(argc, argv, environ, load_base);
+        argv[0] = name;
+        if (ret != -1) {
+          return ret;
+        }
+        if (errno != ENOENT) {
+          break;
+        }
+      }
+
+      path += length;
+      if (*path == '\0') {
+        errno = ENOENT;
+        break;
+      }
+      path++;
+    }
+  }
+
+  sbsh_error("sbsh: ");
+  sbsh_error(name);
+  sbsh_errorln(errno == ENOENT ?
+               ": command not found" : ": execution failed");
+  return errno == ENOENT ? 127 : 126;
+}
+
+#endif
+
+static int apply_path_redirection(redir_guard_t *guard,
+                                  const char *path,
+                                  int target,
+                                  bool append) {
+  int flags;
+  int fd;
+  int ret;
+
+  if (target == STDIN_FILENO) {
+    flags = O_RDONLY;
+  }
+  else {
+    flags = O_WRONLY | O_CREAT | (append ? O_APPEND : O_TRUNC);
+  }
+  fd = open(path, flags, 0666);
+  if (fd < 0) {
+    sbsh_error("sbsh: ");
+    sbsh_error(path);
+    sbsh_errorln(": open failed");
+    return -1;
+  }
+  ret = redir_assign(guard, fd, target);
+  (void)close(fd);
+  if (ret != 0) {
+    sbsh_errorln("sbsh: descriptor assignment failed");
+    return -1;
+  }
+
+  return 0;
+}
+
+static int execute_command(sbsh_state_t *state,
+                           const sbsh_plan_t *plan,
+                           const sbsh_command_t *command,
+                           int pipeline_input,
+                           int pipeline_output) {
+  const builtin_t *builtin;
+  redir_spec_t spec;
+  redir_guard_t guard;
+  void *load_base;
+  int argc;
+  int status;
+
+  if (inspect_redirections(plan, command, &spec) != 0) {
+    return -1;
+  }
+  if (((pipeline_input >= 0) && (spec.input_path != NULL)) ||
+      ((pipeline_output >= 0) && (spec.output_path != NULL))) {
+    sbsh_errorln("sbsh: pipeline conflicts with explicit redirection");
+    return -1;
+  }
+  if (sbsh_expand_command(state,
+                          plan,
+                          command,
+                          &argc,
+                          &load_base) != 0) {
+    sbsh_errorln("sbsh: argument expansion failed");
+    return -1;
+  }
+
+  redir_guard_init(&guard);
+  if ((pipeline_input >= 0) &&
+      (redir_assign(&guard, pipeline_input, STDIN_FILENO) != 0)) {
+    goto redir_failed;
+  }
+  if ((pipeline_output >= 0) &&
+      (redir_assign(&guard, pipeline_output, STDOUT_FILENO) != 0)) {
+    goto redir_failed;
+  }
+  if ((spec.input_path != NULL) &&
+      (apply_path_redirection(&guard,
+                              spec.input_path,
+                              STDIN_FILENO,
+                              false) != 0)) {
+    goto redir_failed;
+  }
+  if ((spec.output_path != NULL) &&
+      (apply_path_redirection(&guard,
+                              spec.output_path,
+                              STDOUT_FILENO,
+                              spec.append) != 0)) {
+    goto redir_failed;
+  }
+
+  builtin = find_builtin(state->expanded_argv[0]);
+  if (builtin != NULL) {
+    status = builtin->function(state, argc, state->expanded_argv);
+  }
+  else {
+    status = run_external(state,
+                          argc,
+                          state->expanded_argv,
+                          load_base);
+  }
+  if (redir_restore(&guard) != 0) {
+    sbsh_errorln("sbsh: descriptor restoration failed");
+    return -1;
+  }
+
+  return status;
+
+redir_failed:
+  (void)redir_restore(&guard);
+  sbsh_errorln("sbsh: redirection failed");
+  return -1;
+}
+
+static int validate_pipeline(const sbsh_plan_t *plan,
+                             const sbsh_pipeline_t *pipeline) {
+  unsigned i;
+
+  for (i = 0U; i < pipeline->command_count; i++) {
+    const sbsh_command_t *command;
+    const sbsh_word_t *word;
+    const builtin_t *builtin;
+    redir_spec_t spec;
+
+    command = &plan->commands[pipeline->command_first + i];
+    if (inspect_redirections(plan, command, &spec) != 0) {
+      return -1;
+    }
+    if (((i > 0U) && (spec.input_path != NULL)) ||
+        ((i + 1U < pipeline->command_count) &&
+         (spec.output_path != NULL))) {
+      sbsh_errorln("sbsh: pipeline conflicts with explicit redirection");
+      return -1;
+    }
+
+    word = &plan->words[command->word_first];
+    builtin = find_builtin(word->text);
+    if ((builtin != NULL) && !builtin->pipeline_safe) {
+      sbsh_error("sbsh: builtin cannot be used in a pipeline: ");
+      sbsh_errorln(builtin->name);
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+static int make_temp_path(sbsh_state_t *state,
+                          char *path,
+                          size_t size) {
+  static const char hex[] = "0123456789abcdef";
+  const char *directory;
+  size_t length;
+  unsigned attempt;
+
+  directory = getenv("TMPDIR");
+  if ((directory == NULL) || (*directory == '\0')) {
+    directory = SBSH_DEFAULT_TMPDIR;
+  }
+  length = strlen(directory);
+  if ((length + 1U + sizeof ".sbsh-pipe-00000000") > size) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+
+  for (attempt = 0U; attempt < 256U; attempt++) {
+    unsigned value;
+    unsigned i;
+    char *p;
+    int fd;
+
+    memcpy(path, directory, length);
+    p = path + length;
+    if ((length == 0U) || (directory[length - 1U] != '/')) {
+      *p++ = '/';
+    }
+    memcpy(p, ".sbsh-pipe-", sizeof ".sbsh-pipe-" - 1U);
+    p += sizeof ".sbsh-pipe-" - 1U;
+    value = state->temp_counter++;
+    for (i = 0U; i < 8U; i++) {
+      p[7U - i] = hex[value & 15U];
+      value >>= 4;
+    }
+    p += 8;
+    *p = '\0';
+
+    fd = open(path,
+              O_RDWR | O_CREAT | O_EXCL | O_TRUNC | O_CLOEXEC,
+              0600);
+    if (fd >= 0) {
+      return fd;
+    }
+    if (errno != EEXIST) {
+      return -1;
+    }
+  }
+
+  errno = EEXIST;
+  return -1;
+}
+
+static int execute_spooled_pipeline(sbsh_state_t *state,
+                                    const sbsh_plan_t *plan,
+                                    const sbsh_pipeline_t *pipeline) {
+  int input_fd;
+  int input_slot;
+  int status;
+  unsigned i;
+
+  if (validate_pipeline(plan, pipeline) != 0) {
+    return 1;
+  }
+
+  input_fd = -1;
+  input_slot = -1;
+  status = 0;
+  for (i = 0U; i < pipeline->command_count; i++) {
+    const sbsh_command_t *command;
+    int output_fd;
+    int output_slot;
+
+    command = &plan->commands[pipeline->command_first + i];
+    output_fd = -1;
+    output_slot = input_slot == 0 ? 1 : 0;
+    if (i + 1U < pipeline->command_count) {
+      output_fd = make_temp_path(state,
+                                 state->temp_paths[output_slot],
+                                 sizeof state->temp_paths[output_slot]);
+      if (output_fd < 0) {
+        sbsh_errorln("sbsh: cannot create pipeline temporary file");
+        status = 1;
+        goto cleanup;
+      }
+    }
+
+    status = execute_command(state,
+                             plan,
+                             command,
+                             input_fd,
+                             output_fd);
+    if (input_fd >= 0) {
+      (void)close(input_fd);
+      (void)unlink(state->temp_paths[input_slot]);
+      input_fd = -1;
+      input_slot = -1;
+    }
+    if (status < 0) {
+      status = 1;
+      if (output_fd >= 0) {
+        (void)close(output_fd);
+        (void)unlink(state->temp_paths[output_slot]);
+      }
+      goto cleanup;
+    }
+
+    if (output_fd >= 0) {
+      if (lseek(output_fd, (off_t)0, SEEK_SET) < (off_t)0) {
+        sbsh_errorln("sbsh: cannot rewind pipeline temporary file");
+        (void)close(output_fd);
+        (void)unlink(state->temp_paths[output_slot]);
+        status = 1;
+        goto cleanup;
+      }
+      input_fd = output_fd;
+      input_slot = output_slot;
+    }
+  }
+
+cleanup:
+  if (input_fd >= 0) {
+    (void)close(input_fd);
+    (void)unlink(state->temp_paths[input_slot]);
+  }
+  return status;
+}
+
+int sbsh_execute_plan(sbsh_state_t *state, const sbsh_plan_t *plan) {
+  int status;
+  unsigned i;
+
+  status = state->last_status;
+  for (i = 0U; i < plan->pipeline_count; i++) {
+    const sbsh_pipeline_t *pipeline;
+
+    pipeline = &plan->pipelines[i];
+    if (pipeline->command_count == 1U) {
+      const sbsh_command_t *command;
+
+      command = &plan->commands[pipeline->command_first];
+      status = execute_command(state, plan, command, -1, -1);
+      if (status < 0) {
+        status = 1;
+      }
+    }
+    else {
+      status = execute_spooled_pipeline(state, plan, pipeline);
+    }
+    state->last_status = status;
+  }
+
+  return status;
+}

--- a/os/sb/apps/sbsh/glob.c
+++ b/os/sb/apps/sbsh/glob.c
@@ -1,0 +1,348 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <dirent.h>
+
+#if !defined(SBAPP_NATIVE)
+#include "sbuser.h"
+#endif
+
+#include "sbsh.h"
+
+static bool is_dots(const char *name) {
+
+  return (bool)((strcmp(name, ".") == 0) || (strcmp(name, "..") == 0));
+}
+
+static bool is_quoted_glob(const sbsh_plan_t *plan, const char *p) {
+  size_t offset;
+
+  offset = (size_t)(p - plan->text);
+  return (bool)((plan->quoted_glob_mask[offset / 8U] &
+                 (uint8_t)(1U << (offset % 8U))) != 0U);
+}
+
+static bool wildcard_match(const sbsh_plan_t *plan,
+                           const char *pattern,
+                           const char *text) {
+  const char *star;
+  const char *retry;
+
+  star = NULL;
+  retry = NULL;
+  while (*text != '\0') {
+    if ((*pattern == '*') && !is_quoted_glob(plan, pattern)) {
+      star = pattern++;
+      retry = text;
+      continue;
+    }
+    if (((*pattern == '?') && !is_quoted_glob(plan, pattern)) ||
+        (*pattern == *text)) {
+      pattern++;
+      text++;
+      continue;
+    }
+    if (star != NULL) {
+      pattern = star + 1;
+      text = ++retry;
+      continue;
+    }
+    return false;
+  }
+  while ((*pattern == '*') && !is_quoted_glob(plan, pattern)) {
+    pattern++;
+  }
+
+  return (bool)(*pattern == '\0');
+}
+
+static void arena_init(sbsh_state_t *state) {
+
+#if defined(SBAPP_NATIVE)
+  state->arena.base = state->native_arena;
+  state->arena.end = state->native_arena + sizeof state->native_arena;
+#else
+  size_t available;
+
+  /*
+   * The arena aliases currently unused heap memory but does not claim it.
+   * No allocator may be called while expanded arguments are live.
+   */
+  state->arena.base = sbrk(0);
+  available = (size_t)(__sb_parameters.heap_end - state->arena.base);
+  if (available > SBSH_ARENA_LIMIT) {
+    available = SBSH_ARENA_LIMIT;
+  }
+  state->arena.end = state->arena.base + available;
+#endif
+  state->arena.current = state->arena.base;
+}
+
+static char *arena_copy_path(sbsh_state_t *state,
+                             const char *prefix,
+                             size_t prefix_length,
+                             const char *name) {
+  size_t name_length;
+  size_t length;
+  char *result;
+  char *p;
+
+  name_length = strlen(name);
+  length = prefix_length + name_length + 1U;
+  if ((prefix_length > 0U) && (prefix[prefix_length - 1U] != '/')) {
+    length++;
+  }
+  if ((size_t)(state->arena.end - state->arena.current) < length) {
+    errno = ENOMEM;
+    return NULL;
+  }
+
+  result = (char *)state->arena.current;
+  p = result;
+  if (prefix_length > 0U) {
+    memcpy(p, prefix, prefix_length);
+    p += prefix_length;
+    if (prefix[prefix_length - 1U] != '/') {
+      *p++ = '/';
+    }
+  }
+  memcpy(p, name, name_length + 1U);
+  state->arena.current += length;
+
+  return result;
+}
+
+static int add_argument(sbsh_state_t *state, int *argcp, char *argument) {
+
+  if (*argcp >= SBSH_MAX_EXPANDED_WORDS) {
+    errno = E2BIG;
+    return -1;
+  }
+  state->expanded_argv[*argcp] = argument;
+  (*argcp)++;
+
+  return 0;
+}
+
+static int add_match(sbsh_state_t *state,
+                     int *argcp,
+                     const char *pattern,
+                     size_t prefix_length,
+                     const char *name) {
+  char *result;
+
+  result = arena_copy_path(state, pattern, prefix_length, name);
+  if (result == NULL) {
+    return -1;
+  }
+  return add_argument(state, argcp, result);
+}
+
+static int split_pattern(sbsh_state_t *state,
+                         const char *pattern,
+                         const char **lastp,
+                         size_t *prefix_lengthp) {
+  const char *slash;
+  size_t directory_length;
+
+  slash = strrchr(pattern, '/');
+  if (slash == NULL) {
+    strcpy(state->pathbuf, ".");
+    *lastp = pattern;
+    *prefix_lengthp = 0U;
+    return 0;
+  }
+
+  *lastp = slash + 1;
+  if (slash == pattern) {
+    strcpy(state->pathbuf, "/");
+    *prefix_lengthp = 1U;
+    return 0;
+  }
+
+  directory_length = (size_t)(slash - pattern);
+  if (directory_length >= sizeof state->pathbuf) {
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  memcpy(state->pathbuf, pattern, directory_length);
+  state->pathbuf[directory_length] = '\0';
+  *prefix_lengthp = directory_length;
+
+  return 0;
+}
+
+#if defined(SBAPP_NATIVE)
+
+static int expand_pattern(sbsh_state_t *state,
+                          const sbsh_plan_t *plan,
+                          int *argcp,
+                          const char *pattern) {
+  const char *last;
+  size_t prefix_length;
+  DIR *dirp;
+  struct dirent *entry;
+  int matches;
+
+  if (split_pattern(state, pattern, &last, &prefix_length) != 0) {
+    return -1;
+  }
+  if ((strchr(last, '*') == NULL) && (strchr(last, '?') == NULL)) {
+    return 0;
+  }
+
+  dirp = opendir(state->pathbuf);
+  if (dirp == NULL) {
+    if ((errno == ENOENT) || (errno == ENOTDIR)) {
+      return 0;
+    }
+    return -1;
+  }
+
+  matches = 0;
+  while ((entry = readdir(dirp)) != NULL) {
+    if (is_dots(entry->d_name) ||
+        !wildcard_match(plan, last, entry->d_name)) {
+      continue;
+    }
+    if (add_match(state,
+                  argcp,
+                  pattern,
+                  prefix_length,
+                  entry->d_name) != 0) {
+      (void)closedir(dirp);
+      return -1;
+    }
+    matches++;
+  }
+  (void)closedir(dirp);
+
+  return matches;
+}
+
+#else
+
+static int expand_pattern(sbsh_state_t *state,
+                          const sbsh_plan_t *plan,
+                          int *argcp,
+                          const char *pattern) {
+  const char *last;
+  size_t prefix_length;
+  int fd;
+  int matches;
+  msg_t n;
+
+  if (split_pattern(state, pattern, &last, &prefix_length) != 0) {
+    return -1;
+  }
+  if ((strchr(last, '*') == NULL) && (strchr(last, '?') == NULL)) {
+    return 0;
+  }
+
+  fd = open(state->pathbuf, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  if (fd < 0) {
+    if ((errno == ENOENT) || (errno == ENOTDIR)) {
+      return 0;
+    }
+    return -1;
+  }
+
+  matches = 0;
+  while ((n = sbGetdents(fd,
+                         state->pathbuf,
+                         sizeof state->pathbuf)) > (msg_t)0) {
+    size_t offset;
+
+    offset = 0U;
+    while (offset < (size_t)n) {
+      struct dirent *entry;
+
+      entry = (struct dirent *)(void *)(state->pathbuf + offset);
+      if ((entry->d_reclen == 0U) ||
+          (offset + entry->d_reclen > (size_t)n)) {
+        errno = EIO;
+        (void)close(fd);
+        return -1;
+      }
+      if (!is_dots(entry->d_name) &&
+          wildcard_match(plan, last, entry->d_name)) {
+        if (add_match(state,
+                      argcp,
+                      pattern,
+                      prefix_length,
+                      entry->d_name) != 0) {
+          (void)close(fd);
+          return -1;
+        }
+        matches++;
+      }
+      offset += entry->d_reclen;
+    }
+  }
+  (void)close(fd);
+  if (CH_RET_IS_ERROR(n)) {
+    errno = CH_DECODE_ERROR(n);
+    return -1;
+  }
+
+  return matches;
+}
+
+#endif
+
+int sbsh_expand_command(sbsh_state_t *state,
+                        const sbsh_plan_t *plan,
+                        const sbsh_command_t *command,
+                        int *argcp,
+                        void **load_basep) {
+  unsigned i;
+  int argc;
+
+  arena_init(state);
+  argc = 0;
+  for (i = 0U; i < command->word_count; i++) {
+    const sbsh_word_t *word;
+    int matches;
+
+    word = &plan->words[command->word_first + i];
+    if ((i == 0U) || !word->glob) {
+      if (add_argument(state, &argc, word->text) != 0) {
+        return -1;
+      }
+      continue;
+    }
+
+    matches = expand_pattern(state, plan, &argc, word->text);
+    if (matches < 0) {
+      return -1;
+    }
+    if (matches == 0) {
+      if (add_argument(state, &argc, word->text) != 0) {
+        return -1;
+      }
+    }
+  }
+  state->expanded_argv[argc] = NULL;
+  *argcp = argc;
+  *load_basep = (void *)(((uintptr_t)state->arena.current + 3U) &
+                         ~(uintptr_t)3U);
+
+  return 0;
+}

--- a/os/sb/apps/sbsh/main.c
+++ b/os/sb/apps/sbsh/main.c
@@ -1,0 +1,449 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "sbsh.h"
+
+#define CTRL(c) ((char)((c) - 0x40))
+
+typedef struct {
+  int                   fd;
+  int                   pending;
+  unsigned              line;
+} script_source_t;
+
+static sbsh_state_t state;
+
+void sbsh_write_fd(int fd, const char *s) {
+  size_t remaining;
+
+  remaining = strlen(s);
+  while (remaining > 0U) {
+    ssize_t n;
+
+    n = write(fd, s, remaining);
+    if (n > (ssize_t)0) {
+      s += n;
+      remaining -= (size_t)n;
+      continue;
+    }
+    if ((n < (ssize_t)0) && (errno == EINTR)) {
+      continue;
+    }
+    break;
+  }
+}
+
+void sbsh_writeln_fd(int fd, const char *s) {
+
+  sbsh_write_fd(fd, s);
+  sbsh_write_fd(fd, SBSH_NEWLINE_STR);
+}
+
+void sbsh_error(const char *s) {
+
+  sbsh_write_fd(STDERR_FILENO, s);
+}
+
+void sbsh_errorln(const char *s) {
+
+  sbsh_writeln_fd(STDERR_FILENO, s);
+}
+
+void sbsh_usage(const char *s) {
+
+  sbsh_error("usage: ");
+  sbsh_errorln(s);
+}
+
+static void write_unsigned(int fd, unsigned value) {
+  char buffer[11];
+  char *p;
+
+  p = buffer + sizeof buffer;
+  *--p = '\0';
+  do {
+    *--p = (char)('0' + value % 10U);
+    value /= 10U;
+  } while (value != 0U);
+  sbsh_write_fd(fd, p);
+}
+
+static void save_history(sbsh_state_t *shell, const char *line) {
+
+  strcpy(shell->history_buffer[shell->history_head], line);
+  shell->history_head++;
+  if (shell->history_head >= SBSH_HISTORY_DEPTH) {
+    shell->history_head = 0U;
+  }
+}
+
+static size_t history_previous(sbsh_state_t *shell, char *line) {
+  char *p;
+  uint8_t previous;
+  size_t length;
+
+  if (shell->history_current == 0U) {
+    previous = SBSH_HISTORY_DEPTH - 1U;
+  }
+  else {
+    previous = shell->history_current - 1U;
+  }
+  p = shell->history_buffer[previous];
+  length = strlen(p);
+  if (length > 0U) {
+    shell->history_current = previous;
+  }
+  strcpy(line, p);
+
+  return length;
+}
+
+static size_t history_next(sbsh_state_t *shell, char *line) {
+  char *p;
+  uint8_t next;
+  size_t length;
+
+  next = shell->history_current + 1U;
+  if (next >= SBSH_HISTORY_DEPTH) {
+    next = 0U;
+  }
+  p = shell->history_buffer[next];
+  length = strlen(p);
+  if (length > 0U) {
+    shell->history_current = next;
+  }
+  strcpy(line, p);
+
+  return length;
+}
+
+static void reset_interactive_line(sbsh_state_t *shell) {
+
+  sbsh_write_fd(STDOUT_FILENO, "\r");
+  sbsh_write_fd(STDOUT_FILENO, shell->prompt);
+  sbsh_write_fd(STDOUT_FILENO, "\033[K");
+}
+
+static bool read_interactive_line(sbsh_state_t *shell,
+                                  char *line,
+                                  size_t size) {
+  char *p;
+  int sequence;
+
+  p = line;
+  *p = '\0';
+  shell->history_current = shell->history_head;
+  sequence = 0;
+  while (true) {
+    char c;
+    ssize_t n;
+
+    n = read(STDIN_FILENO, &c, 1U);
+    if (n == (ssize_t)0) {
+      return true;
+    }
+    if (n < (ssize_t)0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return true;
+    }
+
+    switch (sequence) {
+    case 0:
+      if (c == 27) {
+        sequence = 1;
+        continue;
+      }
+      break;
+    case 1:
+      if (c == '[') {
+        sequence = 2;
+        continue;
+      }
+      if (c == 27) {
+        continue;
+      }
+      sequence = 0;
+      break;
+    case 2:
+      sequence = 0;
+      if (c == 'A') {
+        size_t length;
+
+        length = history_previous(shell, line);
+        if (length > 0U) {
+          reset_interactive_line(shell);
+          sbsh_write_fd(STDOUT_FILENO, line);
+          p = line + length;
+        }
+        continue;
+      }
+      if (c == 'B') {
+        size_t length;
+
+        length = history_next(shell, line);
+        if (length > 0U) {
+          reset_interactive_line(shell);
+          sbsh_write_fd(STDOUT_FILENO, line);
+          p = line + length;
+        }
+        continue;
+      }
+      continue;
+    default:
+      sequence = 0;
+      break;
+    }
+
+    if ((c == CTRL('D')) && (p == line)) {
+      return true;
+    }
+    if ((c == CTRL('H')) || (c == 127)) {
+      if (p != line) {
+        sbsh_write_fd(STDOUT_FILENO, "\010 \010");
+        *--p = '\0';
+      }
+      continue;
+    }
+    if ((c == '\r') || (c == '\n')) {
+      sbsh_write_fd(STDOUT_FILENO, SBSH_NEWLINE_STR);
+      *p = '\0';
+      if (p != line) {
+        save_history(shell, line);
+      }
+      return false;
+    }
+    if (c < ' ') {
+      continue;
+    }
+    if (p < line + size - 1U) {
+      char out[2];
+
+      *p++ = c;
+      *p = '\0';
+      out[0] = c;
+      out[1] = '\0';
+      sbsh_write_fd(STDOUT_FILENO, out);
+    }
+  }
+}
+
+static int read_script_byte(script_source_t *source, char *cp) {
+
+  if (source->pending >= 0) {
+    *cp = (char)source->pending;
+    source->pending = -1;
+    return 1;
+  }
+
+  while (true) {
+    ssize_t n;
+
+    n = read(source->fd, cp, 1U);
+    if (n >= (ssize_t)0) {
+      return (int)n;
+    }
+    if (errno != EINTR) {
+      return -1;
+    }
+  }
+}
+
+static int read_script_line(script_source_t *source,
+                            char *line,
+                            size_t size) {
+  size_t length;
+  bool overflow;
+
+  length = 0U;
+  overflow = false;
+  while (true) {
+    char c;
+    int ret;
+
+    ret = read_script_byte(source, &c);
+    if (ret < 0) {
+      return -1;
+    }
+    if (ret == 0) {
+      if ((length == 0U) && !overflow) {
+        return 0;
+      }
+      break;
+    }
+
+    if (c == '\r') {
+      ret = read_script_byte(source, &c);
+      if (ret < 0) {
+        return -1;
+      }
+      if ((ret > 0) && (c != '\n')) {
+        source->pending = (unsigned char)c;
+      }
+      break;
+    }
+    if (c == '\n') {
+      break;
+    }
+    if (length + 1U < size) {
+      line[length++] = c;
+    }
+    else {
+      overflow = true;
+    }
+  }
+
+  line[length] = '\0';
+  source->line++;
+  return overflow ? 2 : 1;
+}
+
+static int execute_line(sbsh_state_t *shell,
+                        const char *line,
+                        const char *source_name,
+                        unsigned source_line) {
+  const char *error;
+
+  if (sbsh_parse_line(line, &shell->plan, &error) != 0) {
+    if (source_name != NULL) {
+      sbsh_error(source_name);
+      sbsh_error(":");
+      write_unsigned(STDERR_FILENO, source_line);
+      sbsh_error(": ");
+    }
+    else {
+      sbsh_error("sbsh: ");
+    }
+    sbsh_error("syntax error: ");
+    sbsh_errorln(error);
+    shell->last_status = 2;
+    return -1;
+  }
+
+  return sbsh_execute_plan(shell, &shell->plan);
+}
+
+static int execute_script(sbsh_state_t *shell, const char *path) {
+  script_source_t source;
+  int status;
+
+  source.fd = open(path, O_RDONLY | O_CLOEXEC);
+  if (source.fd < 0) {
+    sbsh_error("sbsh: ");
+    sbsh_error(path);
+    sbsh_errorln(": cannot open script");
+    return 1;
+  }
+  source.pending = -1;
+  source.line = 0U;
+  status = 0;
+  while (true) {
+    int ret;
+
+    ret = read_script_line(&source, shell->line, sizeof shell->line);
+    if (ret == 0) {
+      break;
+    }
+    if (ret < 0) {
+      sbsh_error("sbsh: ");
+      sbsh_error(path);
+      sbsh_errorln(": read failed");
+      status = 1;
+      break;
+    }
+    if (ret == 2) {
+      sbsh_error(path);
+      sbsh_error(":");
+      write_unsigned(STDERR_FILENO, source.line);
+      sbsh_errorln(": line too long");
+      status = 2;
+      break;
+    }
+    ret = execute_line(shell, shell->line, path, source.line);
+    if (ret < 0) {
+      status = 2;
+      break;
+    }
+    status = ret;
+  }
+  (void)close(source.fd);
+
+  return status;
+}
+
+static int execute_command_string(sbsh_state_t *shell, const char *command) {
+  int status;
+  size_t length;
+
+  length = strnlen(command, sizeof shell->line);
+  if (length >= sizeof shell->line) {
+    sbsh_errorln("sbsh: command string is too long");
+    return 2;
+  }
+  memcpy(shell->line, command, length + 1U);
+
+  status = execute_line(shell, shell->line, NULL, 0U);
+  return status < 0 ? 2 : status;
+}
+
+static int run_interactive(sbsh_state_t *shell) {
+
+  sbsh_writeln_fd(STDOUT_FILENO,
+                  SBSH_NEWLINE_STR SBSH_WELCOME_STR);
+  while (true) {
+    sbsh_write_fd(STDOUT_FILENO, shell->prompt);
+    if (read_interactive_line(shell,
+                              shell->line,
+                              sizeof shell->line)) {
+      sbsh_writeln_fd(STDOUT_FILENO, "exit");
+      break;
+    }
+    (void)execute_line(shell, shell->line, NULL, 0U);
+  }
+
+  return shell->last_status;
+}
+
+int main(int argc, char *argv[]) {
+
+  state.prompt = getenv("PROMPT");
+  if (state.prompt == NULL) {
+    state.prompt = SBSH_PROMPT_STR;
+  }
+  state.history_head = 0U;
+  state.last_status = 0;
+
+  if (argc == 1) {
+    return run_interactive(&state);
+  }
+  if ((argc == 3) && (strcmp(argv[1], "-c") == 0)) {
+    return execute_command_string(&state, argv[2]);
+  }
+  if (argc == 2) {
+    return execute_script(&state, argv[1]);
+  }
+
+  sbsh_usage("sbsh [-c command] [script]");
+  return 2;
+}

--- a/os/sb/apps/sbsh/make/sbsh-posix-x86-debug.make
+++ b/os/sb/apps/sbsh/make/sbsh-posix-x86-debug.make
@@ -1,0 +1,12 @@
+PROJECT := sbsh
+CHIBIOS := ../../../..
+
+CONFDIR  := ./cfg/sbsh-posix-x86-debug
+BUILDDIR := ./build/sbsh-posix-x86-debug
+DEPDIR   := ./.dep/sbsh-posix-x86-debug
+
+SBAPP_CSRC := main.c parser.c glob.c execute.c
+SBAPP_UDEFS := -DSBAPP_NATIVE
+SBAPP_TESTS := ./test/sbsh.sh
+
+include ../common/make/app-posix-x86.mk

--- a/os/sb/apps/sbsh/make/sbsh-rambox-debug.make
+++ b/os/sb/apps/sbsh/make/sbsh-rambox-debug.make
@@ -1,0 +1,14 @@
+PROJECT := sbsh
+CHIBIOS := ../../../..
+
+CONFDIR  := ./cfg/sbsh-rambox-debug
+BUILDDIR := ./build/sbsh-rambox-debug
+DEPDIR   := ./.dep/sbsh-rambox-debug
+
+UTILSSELECT := paths
+
+SBAPP_CSRC := main.c parser.c glob.c execute.c
+SBAPP_OPT := -O0 -ggdb -fomit-frame-pointer --specs=nano.specs
+
+include ../common/make/elfexec.mk
+include ../common/make/app-arm.mk

--- a/os/sb/apps/sbsh/make/sbsh-rambox-deploy.make
+++ b/os/sb/apps/sbsh/make/sbsh-rambox-deploy.make
@@ -1,0 +1,13 @@
+PROJECT := sbsh
+CHIBIOS := ../../../..
+
+CONFDIR  := ./cfg/sbsh-rambox-deploy
+BUILDDIR := ./build/sbsh-rambox-deploy
+DEPDIR   := ./.dep/sbsh-rambox-deploy
+
+UTILSSELECT := paths
+
+SBAPP_CSRC := main.c parser.c glob.c execute.c
+
+include ../common/make/elfexec.mk
+include ../common/make/app-arm.mk

--- a/os/sb/apps/sbsh/parser.c
+++ b/os/sb/apps/sbsh/parser.c
@@ -1,0 +1,389 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string.h>
+
+#include "sbsh.h"
+
+typedef enum {
+  TOKEN_EOF,
+  TOKEN_WORD,
+  TOKEN_INPUT,
+  TOKEN_OUTPUT,
+  TOKEN_APPEND,
+  TOKEN_PIPE,
+  TOKEN_SEMICOLON,
+  TOKEN_ERROR
+} token_kind_t;
+
+typedef struct {
+  token_kind_t          kind;
+  char                  *text;
+  bool                  glob;
+} token_t;
+
+typedef struct {
+  const char            *input;
+  char                  *output_base;
+  char                  *output;
+  char                  *output_end;
+  uint8_t               *quoted_glob_mask;
+} lexer_t;
+
+static bool is_space(char c) {
+
+  return (bool)((c == ' ') || (c == '\t'));
+}
+
+static bool is_operator(char c) {
+
+  return (bool)((c == '<') || (c == '>') || (c == '|') || (c == ';'));
+}
+
+static bool lexer_putc(lexer_t *lexer, char c, bool quoted) {
+  size_t offset;
+
+  if (lexer->output >= lexer->output_end) {
+    return false;
+  }
+  offset = (size_t)(lexer->output - lexer->output_base);
+  if (quoted && ((c == '*') || (c == '?'))) {
+    lexer->quoted_glob_mask[offset / 8U] |=
+      (uint8_t)(1U << (offset % 8U));
+  }
+  *lexer->output++ = c;
+
+  return true;
+}
+
+static token_kind_t lexer_word(lexer_t *lexer,
+                               token_t *token,
+                               const char **errorp) {
+  char *start;
+  bool started;
+
+  start = lexer->output;
+  started = false;
+  token->glob = false;
+  while (*lexer->input != '\0') {
+    char c;
+
+    c = *lexer->input;
+    if (is_space(c) || is_operator(c)) {
+      break;
+    }
+
+    if (c == '\'') {
+      started = true;
+      lexer->input++;
+      while ((*lexer->input != '\0') && (*lexer->input != '\'')) {
+        if (!lexer_putc(lexer, *lexer->input++, true)) {
+          *errorp = "expanded command line is too long";
+          return TOKEN_ERROR;
+        }
+      }
+      if (*lexer->input != '\'') {
+        *errorp = "unterminated single quote";
+        return TOKEN_ERROR;
+      }
+      lexer->input++;
+      continue;
+    }
+
+    if (c == '"') {
+      started = true;
+      lexer->input++;
+      while ((*lexer->input != '\0') && (*lexer->input != '"')) {
+        if (*lexer->input == '\\') {
+          lexer->input++;
+          if (*lexer->input == '\0') {
+            *errorp = "trailing escape in double quote";
+            return TOKEN_ERROR;
+          }
+        }
+        if (!lexer_putc(lexer, *lexer->input++, true)) {
+          *errorp = "expanded command line is too long";
+          return TOKEN_ERROR;
+        }
+      }
+      if (*lexer->input != '"') {
+        *errorp = "unterminated double quote";
+        return TOKEN_ERROR;
+      }
+      lexer->input++;
+      continue;
+    }
+
+    if (c == '\\') {
+      started = true;
+      lexer->input++;
+      if (*lexer->input == '\0') {
+        *errorp = "trailing escape";
+        return TOKEN_ERROR;
+      }
+      if (!lexer_putc(lexer, *lexer->input++, true)) {
+        *errorp = "expanded command line is too long";
+        return TOKEN_ERROR;
+      }
+      continue;
+    }
+
+    started = true;
+    if ((c == '*') || (c == '?')) {
+      token->glob = true;
+    }
+    if (!lexer_putc(lexer, c, false)) {
+      *errorp = "expanded command line is too long";
+      return TOKEN_ERROR;
+    }
+    lexer->input++;
+  }
+
+  if (!started) {
+    *errorp = "invalid empty token";
+    return TOKEN_ERROR;
+  }
+  if (!lexer_putc(lexer, '\0', false)) {
+    *errorp = "expanded command line is too long";
+    return TOKEN_ERROR;
+  }
+
+  token->kind = TOKEN_WORD;
+  token->text = start;
+  return TOKEN_WORD;
+}
+
+static token_kind_t lexer_next(lexer_t *lexer,
+                               token_t *token,
+                               const char **errorp) {
+  char c;
+
+  while (is_space(*lexer->input)) {
+    lexer->input++;
+  }
+
+  c = *lexer->input;
+  token->text = NULL;
+  token->glob = false;
+  if ((c == '\0') || (c == '#')) {
+    token->kind = TOKEN_EOF;
+    return TOKEN_EOF;
+  }
+
+  lexer->input++;
+  switch (c) {
+  case '<':
+    token->kind = TOKEN_INPUT;
+    return TOKEN_INPUT;
+  case '>':
+    if (*lexer->input == '>') {
+      lexer->input++;
+      token->kind = TOKEN_APPEND;
+      return TOKEN_APPEND;
+    }
+    token->kind = TOKEN_OUTPUT;
+    return TOKEN_OUTPUT;
+  case '|':
+    token->kind = TOKEN_PIPE;
+    return TOKEN_PIPE;
+  case ';':
+    token->kind = TOKEN_SEMICOLON;
+    return TOKEN_SEMICOLON;
+  default:
+    lexer->input--;
+    return lexer_word(lexer, token, errorp);
+  }
+}
+
+static sbsh_command_t *start_command(sbsh_plan_t *plan,
+                                     sbsh_pipeline_t **pipelinep,
+                                     const char **errorp) {
+  sbsh_pipeline_t *pipeline;
+  sbsh_command_t *command;
+
+  pipeline = *pipelinep;
+  if (pipeline == NULL) {
+    if (plan->pipeline_count >= SBSH_MAX_PIPELINES) {
+      *errorp = "too many command lists";
+      return NULL;
+    }
+    pipeline = &plan->pipelines[plan->pipeline_count++];
+    pipeline->command_first = plan->command_count;
+    pipeline->command_count = 0U;
+    *pipelinep = pipeline;
+  }
+
+  if (plan->command_count >= SBSH_MAX_COMMANDS) {
+    *errorp = "too many commands";
+    return NULL;
+  }
+  command = &plan->commands[plan->command_count++];
+  command->word_first = plan->word_count;
+  command->word_count = 0U;
+  command->redir_first = plan->redir_count;
+  command->redir_count = 0U;
+  pipeline->command_count++;
+
+  return command;
+}
+
+static int add_word(sbsh_plan_t *plan,
+                    sbsh_command_t *command,
+                    const token_t *token,
+                    const char **errorp) {
+
+  if (plan->word_count >= SBSH_MAX_WORDS) {
+    *errorp = "too many arguments";
+    return -1;
+  }
+  plan->words[plan->word_count].text = token->text;
+  plan->words[plan->word_count].glob = token->glob;
+  plan->word_count++;
+  command->word_count++;
+
+  return 0;
+}
+
+static int add_redirection(sbsh_plan_t *plan,
+                           sbsh_command_t *command,
+                           token_kind_t kind,
+                           char *path,
+                           const char **errorp) {
+  sbsh_redir_t *redir;
+
+  if (plan->redir_count >= SBSH_MAX_REDIRECTIONS) {
+    *errorp = "too many redirections";
+    return -1;
+  }
+  redir = &plan->redirs[plan->redir_count++];
+  if (kind == TOKEN_INPUT) {
+    redir->type = SBSH_REDIR_INPUT;
+  }
+  else if (kind == TOKEN_OUTPUT) {
+    redir->type = SBSH_REDIR_OUTPUT;
+  }
+  else {
+    redir->type = SBSH_REDIR_APPEND;
+  }
+  redir->path = path;
+  command->redir_count++;
+
+  return 0;
+}
+
+int sbsh_parse_line(const char *line,
+                    sbsh_plan_t *plan,
+                    const char **errorp) {
+  lexer_t lexer;
+  token_t token;
+  sbsh_pipeline_t *pipeline;
+  sbsh_command_t *command;
+  bool after_pipe;
+  token_kind_t kind;
+
+  memset(plan, 0, sizeof *plan);
+  *errorp = NULL;
+  lexer.input = line;
+  lexer.output_base = plan->text;
+  lexer.output = plan->text;
+  lexer.output_end = plan->text + sizeof plan->text;
+  lexer.quoted_glob_mask = plan->quoted_glob_mask;
+  pipeline = NULL;
+  command = NULL;
+  after_pipe = false;
+
+  while ((kind = lexer_next(&lexer, &token, errorp)) != TOKEN_EOF) {
+    if (kind == TOKEN_ERROR) {
+      return -1;
+    }
+
+    if (kind == TOKEN_WORD) {
+      if (command == NULL) {
+        command = start_command(plan, &pipeline, errorp);
+        if (command == NULL) {
+          return -1;
+        }
+      }
+      if (add_word(plan, command, &token, errorp) != 0) {
+        return -1;
+      }
+      after_pipe = false;
+      continue;
+    }
+
+    if ((kind == TOKEN_INPUT) ||
+        (kind == TOKEN_OUTPUT) ||
+        (kind == TOKEN_APPEND)) {
+      token_kind_t path_kind;
+
+      if (command == NULL) {
+        command = start_command(plan, &pipeline, errorp);
+        if (command == NULL) {
+          return -1;
+        }
+      }
+      path_kind = lexer_next(&lexer, &token, errorp);
+      if (path_kind == TOKEN_ERROR) {
+        return -1;
+      }
+      if (path_kind != TOKEN_WORD) {
+        *errorp = "redirection requires a path";
+        return -1;
+      }
+      if (add_redirection(plan,
+                          command,
+                          kind,
+                          token.text,
+                          errorp) != 0) {
+        return -1;
+      }
+      after_pipe = false;
+      continue;
+    }
+
+    if (kind == TOKEN_PIPE) {
+      if ((command == NULL) || (command->word_count == 0U)) {
+        *errorp = "missing command before pipe";
+        return -1;
+      }
+      command = NULL;
+      after_pipe = true;
+      continue;
+    }
+
+    if (kind == TOKEN_SEMICOLON) {
+      if ((command == NULL) || (command->word_count == 0U)) {
+        *errorp = "missing command before semicolon";
+        return -1;
+      }
+      command = NULL;
+      pipeline = NULL;
+      after_pipe = false;
+      continue;
+    }
+  }
+
+  if (after_pipe) {
+    *errorp = "missing command after pipe";
+    return -1;
+  }
+  if ((command != NULL) && (command->word_count == 0U)) {
+    *errorp = "redirection without a command";
+    return -1;
+  }
+
+  return 0;
+}

--- a/os/sb/apps/sbsh/sbsh.h
+++ b/os/sb/apps/sbsh/sbsh.h
@@ -1,0 +1,132 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef SBSH_H
+#define SBSH_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define SBSH_HISTORY_DEPTH          8
+#define SBSH_MAX_LINE_LENGTH        128
+#define SBSH_MAX_WORDS              32
+#define SBSH_MAX_EXPANDED_WORDS     64
+#define SBSH_MAX_REDIRECTIONS       8
+#define SBSH_MAX_COMMANDS           8
+#define SBSH_MAX_PIPELINES          8
+#define SBSH_PATH_MAX               1024
+#define SBSH_TEMP_PATH_MAX          128
+#define SBSH_ARENA_LIMIT            4096
+#define SBSH_GLOB_MASK_SIZE         ((SBSH_MAX_LINE_LENGTH + 7U) / 8U)
+
+#define SBSH_PROMPT_STR             "sbsh> "
+#define SBSH_NEWLINE_STR            "\r\n"
+#define SBSH_WELCOME_STR            "ChibiOS/SB Shell"
+#define SBSH_DEFAULT_PATH           "/bin"
+#define SBSH_EXECUTABLE_EXTENSION   ".elf"
+#define SBSH_DEFAULT_TMPDIR         "/tmp"
+
+typedef enum {
+  SBSH_REDIR_INPUT,
+  SBSH_REDIR_OUTPUT,
+  SBSH_REDIR_APPEND
+} sbsh_redir_type_t;
+
+typedef struct {
+  char                  *text;
+  bool                  glob;
+} sbsh_word_t;
+
+typedef struct {
+  sbsh_redir_type_t     type;
+  char                  *path;
+} sbsh_redir_t;
+
+typedef struct {
+  uint8_t               word_first;
+  uint8_t               word_count;
+  uint8_t               redir_first;
+  uint8_t               redir_count;
+} sbsh_command_t;
+
+typedef struct {
+  uint8_t               command_first;
+  uint8_t               command_count;
+} sbsh_pipeline_t;
+
+typedef struct {
+  char                  text[SBSH_MAX_LINE_LENGTH];
+  uint8_t               quoted_glob_mask[SBSH_GLOB_MASK_SIZE];
+  sbsh_word_t           words[SBSH_MAX_WORDS];
+  sbsh_redir_t          redirs[SBSH_MAX_REDIRECTIONS];
+  sbsh_command_t        commands[SBSH_MAX_COMMANDS];
+  sbsh_pipeline_t       pipelines[SBSH_MAX_PIPELINES];
+  uint8_t               word_count;
+  uint8_t               redir_count;
+  uint8_t               command_count;
+  uint8_t               pipeline_count;
+} sbsh_plan_t;
+
+typedef struct {
+  uint8_t               *base;
+  uint8_t               *current;
+  uint8_t               *end;
+} sbsh_arena_t;
+
+typedef struct {
+  const char            *prompt;
+  uint8_t               history_head;
+  uint8_t               history_current;
+  char                  history_buffer[SBSH_HISTORY_DEPTH]
+                                     [SBSH_MAX_LINE_LENGTH];
+  char                  line[SBSH_MAX_LINE_LENGTH];
+  _Alignas(uint32_t)
+  char                  pathbuf[SBSH_PATH_MAX];
+  char                  temp_paths[2][SBSH_TEMP_PATH_MAX];
+  char                  *expanded_argv[SBSH_MAX_EXPANDED_WORDS + 1];
+  sbsh_plan_t           plan;
+  sbsh_arena_t          arena;
+  unsigned              temp_counter;
+  int                   last_status;
+#if defined(SBAPP_NATIVE)
+  uint8_t               native_arena[SBSH_ARENA_LIMIT];
+#endif
+} sbsh_state_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void sbsh_write_fd(int fd, const char *s);
+  void sbsh_writeln_fd(int fd, const char *s);
+  void sbsh_error(const char *s);
+  void sbsh_errorln(const char *s);
+  void sbsh_usage(const char *s);
+
+  int sbsh_parse_line(const char *line,
+                      sbsh_plan_t *plan,
+                      const char **errorp);
+  int sbsh_expand_command(sbsh_state_t *state,
+                          const sbsh_plan_t *plan,
+                          const sbsh_command_t *command,
+                          int *argcp,
+                          void **load_basep);
+  int sbsh_execute_plan(sbsh_state_t *state, const sbsh_plan_t *plan);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SBSH_H */

--- a/os/sb/apps/sbsh/test/sbsh.sh
+++ b/os/sb/apps/sbsh/test/sbsh.sh
@@ -1,0 +1,111 @@
+#!/bin/sh
+
+set -eu
+
+test_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$test_dir/../../common/test/testlib.sh"
+
+if [ "$#" -ne 1 ]; then
+  sbtest_fail "usage: $0 <sbsh-executable>"
+fi
+
+case $1 in
+/*) sbsh_exe=$1 ;;
+*)  sbsh_exe=$(pwd)/$1 ;;
+esac
+
+work_dir=$(mktemp -d)
+trap 'rm -rf -- "$work_dir"' EXIT HUP INT TERM
+
+output=$("$sbsh_exe" -c 'echo one; echo "two words"; echo three\ four' |
+         tr -d '\r')
+expected=$(printf 'one\ntwo words\nthree four')
+sbtest_equals "$output" "$expected" "sequential command output"
+
+output=$("$sbsh_exe" -c 'echo a#b; echo before # ignored; echo after' |
+         tr -d '\r')
+expected=$(printf 'a#b\nbefore')
+sbtest_equals "$output" "$expected" "comment parsing"
+
+: >"$work_dir/alpha.txt"
+: >"$work_dir/-option.txt"
+: >"$work_dir/*a.mix"
+: >"$work_dir/za.mix"
+output=$("$sbsh_exe" -c "cd $work_dir; echo alpha*.txt; echo \"*.txt\"; echo *.none; echo \\*.txt; echo -*.txt" |
+         tr -d '\r')
+expected=$(printf 'alpha.txt\n*.txt\n*.none\n*.txt\n-option.txt')
+sbtest_equals "$output" "$expected" "quote-aware glob expansion"
+
+output=$("$sbsh_exe" -c "cd $work_dir; echo \"*\"?.mix" | tr -d '\r')
+sbtest_equals "$output" "*a.mix" "mixed quoted glob expansion"
+
+output=$("$sbsh_exe" -c "cd $work_dir; echo first > output; echo second >> output; /bin/cat < output" |
+         tr -d '\r')
+expected=$(printf 'first\nsecond')
+sbtest_equals "$output" "$expected" "file redirection"
+
+output=$(TMPDIR="$work_dir" "$sbsh_exe" -c \
+         'echo first; echo second | /usr/bin/tr a-z A-Z | /usr/bin/head -n 1' |
+         tr -d '\r')
+expected=$(printf 'first\nSECOND')
+sbtest_equals "$output" "$expected" "serialized pipeline"
+for path in "$work_dir"/.sbsh-pipe-*; do
+  [ ! -e "$path" ] ||
+    sbtest_fail "pipeline temporary file was not removed"
+done
+
+status=0
+TMPDIR="$work_dir" "$sbsh_exe" -c \
+  'echo temporary | /no/such/sbsh-command' >/dev/null 2>&1 ||
+  status=$?
+sbtest_equals "$status" "127" "failed pipeline status"
+for path in "$work_dir"/.sbsh-pipe-*; do
+  [ ! -e "$path" ] ||
+    sbtest_fail "failed pipeline left a temporary file"
+done
+
+printf 'echo script-first\r\n/bin/sh -c "exit 2"\r\necho script-last\r\n' \
+  >"$work_dir/continue.sbsh"
+status=0
+raw_output=$("$sbsh_exe" "$work_dir/continue.sbsh") ||
+  status=$?
+output=$(printf '%s' "$raw_output" | tr -d '\r')
+sbtest_equals "$status" "0" "script final status"
+expected=$(printf 'script-first\nscript-last')
+sbtest_equals "$output" "$expected" "script sequential execution"
+
+printf 'echo before\n|\necho after\n' >"$work_dir/error.sbsh"
+status=0
+raw_output=$("$sbsh_exe" "$work_dir/error.sbsh" 2>&1) ||
+  status=$?
+output=$(printf '%s' "$raw_output" | tr -d '\r')
+sbtest_equals "$status" "2" "script syntax status"
+sbtest_contains "$output" "$work_dir/error.sbsh:2: syntax error" \
+  "script syntax diagnostic lacks source location"
+sbtest_not_contains "$output" "after" \
+  "script continued after a syntax error"
+
+status=0
+raw_output=$("$sbsh_exe" -c 'cd / | echo invalid' 2>&1) ||
+  status=$?
+output=$(printf '%s' "$raw_output" | tr -d '\r')
+sbtest_equals "$status" "1" "stateful pipeline status"
+sbtest_contains "$output" "builtin cannot be used in a pipeline: cd" \
+  "stateful pipeline was not diagnosed"
+
+status=0
+"$sbsh_exe" -c '/bin/sh -c "exit 2"' >/dev/null 2>&1 ||
+  status=$?
+sbtest_equals "$status" "2" "external command status"
+
+status=0
+"$sbsh_exe" -c 'exit 7' >/dev/null 2>&1 ||
+  status=$?
+sbtest_equals "$status" "7" "exit builtin status"
+
+status=0
+"$sbsh_exe" -c 'exit 256' >/dev/null 2>&1 ||
+  status=$?
+sbtest_equals "$status" "2" "invalid exit status"
+
+echo "sbsh checks passed"


### PR DESCRIPTION
## Summary

- add `sbsh` as a separate enhanced shell while leaving `msh` unchanged
- support sequential scripts, quoting, comments, bounded globbing, redirection, and serialized temporary-file pipelines
- avoid persistent heap fragmentation with fixed parser storage and an unclaimed bounded glob arena; extend `elfexec` with an explicit load-base entry point
- add ARM deploy/debug and native POSIX profiles, behavioral tests, aggregate build integration, and project documentation

## Current pipeline model

Pipelines execute stages sequentially through exclusive mode-0600 files under `$TMPDIR` or `/tmp`. This provides useful `|` syntax now and leaves the executor ready for `posix_spawn()` and real pipes later.

## Testing

- `make check` from `os/sb/apps`
- `make sb` from `os/sb/apps`
- native ASan/UBSan behavioral run
- final `make clean`

The deploy image is 12,608 bytes and does not link `malloc` or `free`. Rebuilding legacy `msh` still produces its existing 8,560-byte image.