### PR TITLE
XHAL: remove redundant MMC SPI module switch

### DIFF
--- a/os/xhal/lib/complex/mmc-spi/hal_mmc_spi.c
+++ b/os/xhal/lib/complex/mmc-spi/hal_mmc_spi.c
@@ -30,8 +30,6 @@
 
 #include "hal_mmc_spi.h"
 
-#if (MMC_SPI_USE_MODULE == TRUE) || defined(__DOXYGEN__)
-
 /*===========================================================================*/
 /* Driver local definitions.                                                 */
 /*===========================================================================*/
@@ -994,7 +992,5 @@ done:
 
   return result;
 }
-
-#endif /* MMC_SPI_USE_MODULE == TRUE */
 
 /** @} */

--- a/os/xhal/lib/complex/mmc-spi/hal_mmc_spi.h
+++ b/os/xhal/lib/complex/mmc-spi/hal_mmc_spi.h
@@ -27,12 +27,6 @@
 
 #include "hal.h"
 
-#if !defined(MMC_SPI_USE_MODULE) || defined(__DOXYGEN__)
-#define MMC_SPI_USE_MODULE               TRUE
-#endif
-
-#if (MMC_SPI_USE_MODULE == TRUE) || defined(__DOXYGEN__)
-
 /*===========================================================================*/
 /* Driver constants.                                                         */
 /*===========================================================================*/
@@ -331,8 +325,6 @@ static inline hal_mmc_spi_driver_c *mmcSpiObjectInit(hal_mmc_spi_driver_c *self,
 
   return self;
 }
-
-#endif /* MMC_SPI_USE_MODULE == TRUE */
 
 #endif /* HAL_MMC_SPI_H */
 


### PR DESCRIPTION
## Summary

- Remove the redundant MMC_SPI_USE_MODULE default and compilation guards.
- Enable the complex driver solely by including its make fragment in a project.

## Related

- Issue(s): none
- Notes for reviewers: this is intentionally isolated from the POSIX TTY work.

## Target Branch Check

- [x] This PR targets master, the current upstream default branch.

## Scope

- [x] Change is focused and does not bundle unrelated work.
- [x] I reviewed impact on other ports and configurations where relevant.

## Mechanical Checks

- [x] Style check passed on both changed files.
- [x] Relevant ARM target compiled and linked.

## Testing

- [x] testxhal/MMC-SPI completed successfully for STM32G474RE NUCLEO64.
- Any other tests run on a device? No.

## Compatibility and Risk

- [x] No runtime API or ABI change.
- The redundant build-time module switch is intentionally removed; including hal_mmc_spi.mk now unconditionally enables this module.