### PR TITLE
RT: validate thread and mutex invariants

### DIFF
--- a/os/rt/include/chmtx.h
+++ b/os/rt/include/chmtx.h
@@ -33,6 +33,14 @@
 /* Module constants.                                                         */
 /*===========================================================================*/
 
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Maximum recursive mutex lock depth.
+ */
+#define MUTEX_MAX_RECURSION                                                 \
+  ((cnt_t)(((ucnt_t)-1) / (ucnt_t)2))
+#endif
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -61,7 +69,8 @@ struct ch_mutex {
   mutex_t               *next;      /**< @brief Next @p mutex_t into an
                                                 owner-list or @p NULL.      */
 #if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
-  cnt_t                 cnt;        /**< @brief Mutex recursion counter.    */
+  cnt_t                 cnt;        /**< @brief Mutex recursion counter, up
+                                                to @p MUTEX_MAX_RECURSION.  */
 #endif
 };
 

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -67,7 +67,8 @@ typedef struct {
    */
   stkline_t                     *wend;
   /**
-   * @brief   Thread priority.
+   * @brief   Thread priority, from @p LOWPRIO through @p HIGHPRIO for
+   *          user threads.
    */
   tprio_t                       prio;
   /**
@@ -435,6 +436,8 @@ extern "C" {
 #if CH_DBG_FILL_THREADS == TRUE
   void __thd_stackfill(uint8_t *startp, uint8_t *endp);
 #endif
+  thread_t *__thd_spawn_suspended(thread_t *tp,
+                                  const thread_descriptor_t *tdp);
   thread_t *chThdObjectInit(thread_t *tp, const thread_descriptor_t *tdp);
   void chThdObjectDispose(thread_t *tp);
   thread_t *chThdSpawnSuspendedI(thread_t *tp,

--- a/os/rt/src/chdynamic.c
+++ b/os/rt/src/chdynamic.c
@@ -82,7 +82,8 @@ static void thd_poolfree(thread_t *tp) {
  *                      default heap
  * @param[in] size      size of the working area to be allocated
  * @param[in] name      thread name
- * @param[in] prio      the priority level for the new thread
+ * @param[in] prio      the priority level for the new thread, from
+ *                      @p LOWPRIO through @p HIGHPRIO
  * @param[in] pf        the thread function
  * @param[in] arg       an argument to be passed to the thread function. It
  *                      can be @p NULL.
@@ -145,7 +146,8 @@ thread_t *chThdCreateFromHeap(memory_heap_t *heapp, size_t size,
  *
  * @param[in] mp        pointer to the memory pool object
  * @param[in] name      thread name
- * @param[in] prio      the priority level for the new thread
+ * @param[in] prio      the priority level for the new thread, from
+ *                      @p LOWPRIO through @p HIGHPRIO
  * @param[in] pf        the thread function
  * @param[in] arg       an argument to be passed to the thread function. It
  *                      can be @p NULL.

--- a/os/rt/src/chinstances.c
+++ b/os/rt/src/chinstances.c
@@ -186,7 +186,8 @@ void chInstanceObjectInit(os_instance_t *oip,
     /* This thread has the lowest priority in the system, its role is just to
        serve interrupts in its context while keeping the lowest energy saving
        mode compatible with the system status.*/
-    (void) chThdSpawnRunningI(&oip->idlethread, &idle_thd_desc);
+    (void) chSchReadyI(__thd_spawn_suspended(&oip->idlethread,
+                                             &idle_thd_desc));
   }
 #endif /* CH_CFG_NO_IDLE_THREAD == FALSE */
 }

--- a/os/rt/src/chmtx.c
+++ b/os/rt/src/chmtx.c
@@ -176,6 +176,8 @@ void chMtxObjectDispose(mutex_t *mp) {
 
 /**
  * @brief   Locks the specified mutex.
+ * @pre     In recursive mode, a mutex already owned by the invoking thread
+ *          must have a lock depth lower than @p MUTEX_MAX_RECURSION.
  * @post    The mutex is locked and inserted in the per-thread stack of owned
  *          mutexes.
  *
@@ -192,6 +194,8 @@ void chMtxLock(mutex_t *mp) {
 
 /**
  * @brief   Locks the specified mutex.
+ * @pre     In recursive mode, a mutex already owned by the invoking thread
+ *          must have a lock depth lower than @p MUTEX_MAX_RECURSION.
  * @post    The mutex is locked and inserted in the per-thread stack of owned
  *          mutexes.
  *
@@ -214,6 +218,7 @@ void chMtxLockS(mutex_t *mp) {
     /* If the mutex is already owned by this thread, the counter is increased
        and there is no need of more actions.*/
     if (mp->owner == currtp) {
+      chDbgAssert(mp->cnt < MUTEX_MAX_RECURSION, "counter overflow");
       mp->cnt++;
     }
     else {
@@ -294,7 +299,7 @@ void chMtxLockS(mutex_t *mp) {
 #if CH_CFG_USE_MUTEXES_RECURSIVE == TRUE
     chDbgAssert(mp->cnt == (cnt_t)0, "counter is not zero");
 
-    mp->cnt++;
+    mp->cnt = (cnt_t)1;
 #endif
     /* It was not owned, inserted in the owned mutexes list.*/
     mp->owner = currtp;
@@ -307,6 +312,8 @@ void chMtxLockS(mutex_t *mp) {
  * @brief   Tries to lock a mutex.
  * @details This function attempts to lock a mutex, if the mutex is already
  *          locked by another thread then the function exits without waiting.
+ * @pre     In recursive mode, a mutex already owned by the invoking thread
+ *          must have a lock depth lower than @p MUTEX_MAX_RECURSION.
  * @post    The mutex is locked and inserted in the per-thread stack of owned
  *          mutexes.
  * @note    This function does not have any overhead related to the
@@ -334,6 +341,8 @@ bool chMtxTryLock(mutex_t *mp) {
  * @brief   Tries to lock a mutex.
  * @details This function attempts to lock a mutex, if the mutex is already
  *          taken by another thread then the function exits without waiting.
+ * @pre     In recursive mode, a mutex already owned by the invoking thread
+ *          must have a lock depth lower than @p MUTEX_MAX_RECURSION.
  * @post    The mutex is locked and inserted in the per-thread stack of owned
  *          mutexes.
  * @note    This function does not have any overhead related to the
@@ -359,6 +368,7 @@ bool chMtxTryLockS(mutex_t *mp) {
     chDbgAssert(mp->cnt >= (cnt_t)1, "counter is not positive");
 
     if (mp->owner == currtp) {
+      chDbgAssert(mp->cnt < MUTEX_MAX_RECURSION, "counter overflow");
       mp->cnt++;
       return true;
     }
@@ -369,7 +379,7 @@ bool chMtxTryLockS(mutex_t *mp) {
 
   chDbgAssert(mp->cnt == (cnt_t)0, "counter is not zero");
 
-  mp->cnt++;
+  mp->cnt = (cnt_t)1;
 #endif
   mp->owner = currtp;
   mp->next = currtp->mtxlist;
@@ -382,6 +392,7 @@ bool chMtxTryLockS(mutex_t *mp) {
  * @details This internal operation exists in order to support atomic
  *          release-and-wait sequences. Public S-class APIs must reschedule
  *          before returning.
+ * @pre     The invoking thread <b>must</b> own the specified mutex.
  *
  * @param[in] mp        pointer to a @p mutex_t object
  * @return              The wakeup status.
@@ -398,7 +409,7 @@ bool __mtx_unlock_no_reschedule(mutex_t *mp) {
   chDbgCheck(mp != NULL);
 
   chDbgAssert(currtp->mtxlist != NULL, "owned mutexes list empty");
-  chDbgAssert(currtp->mtxlist->owner == currtp, "ownership failure");
+  chDbgAssert(mp->owner == currtp, "ownership failure");
 #if CH_CFG_USE_MUTEXES_RECURSIVE == TRUE
   chDbgAssert(mp->cnt >= (cnt_t)1, "counter is not positive");
 
@@ -451,7 +462,7 @@ bool __mtx_unlock_no_reschedule(mutex_t *mp) {
  * @brief   Unlocks the specified mutex.
  * @note    Mutexes must be unlocked in reverse lock order. Violating this
  *          rules will result in a panic if assertions are enabled.
- * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+ * @pre     The invoking thread <b>must</b> own the specified mutex.
  * @post    The mutex is unlocked and removed from the per-thread stack of
  *          owned mutexes.
  *
@@ -474,7 +485,7 @@ void chMtxUnlock(mutex_t *mp) {
  * @brief   Unlocks the specified mutex.
  * @note    Mutexes must be unlocked in reverse lock order. Violating this
  *          rules will result in a panic if assertions are enabled.
- * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+ * @pre     The invoking thread <b>must</b> own the specified mutex.
  * @post    The mutex is unlocked and removed from the per-thread stack of
  *          owned mutexes.
  * @post    The function reschedules internally if required.

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -231,6 +231,39 @@ void chThdObjectDispose(thread_t *tp) {
 }
 
 /**
+ * @brief   Spawns a suspended thread without parameter validation.
+ * @details This internal operation also supports creation of the idle thread
+ *          at the reserved @p IDLEPRIO priority.
+ *
+ * @param[out] tp       pointer to a @p thread_t object
+ * @param[in] tdp       pointer to a @p thread_descriptor_t object
+ * @return              Reference to the @p thread_t object.
+ *
+ * @notapi
+ */
+thread_t *__thd_spawn_suspended(thread_t *tp,
+                                const thread_descriptor_t *tdp) {
+
+#if CH_CFG_USE_REGISTRY == TRUE
+  chDbgAssert(!chRegIsWorkingAreaInUseI(tdp->wbase),
+              "working area in use");
+#endif
+
+  /* Thread object initialization.*/
+  tp = chThdObjectInit(tp, tdp);
+
+  /* Setting up the port-dependent part of the working area.*/
+  port_setup_context(&tp->ctx, tp->wabase, tp->waend, tdp->funcp, tdp->arg);
+
+  /* Registry-related fields.*/
+#if CH_CFG_USE_REGISTRY == TRUE
+  REG_INSERT(tp->owner, tp);
+#endif
+
+  return tp;
+}
+
+/**
  * @brief   Spawns a suspended thread.
  * @details The spawned thread is in the @p CH_STATE_WTSTART state and can
  *          be subsequently started using @p chThdStart(), @p chThdStartI() or
@@ -262,23 +295,12 @@ thread_t *chThdSpawnSuspendedI(thread_t *tp,
              (tdp->wend > tdp->wbase) &&
              (((size_t)tdp->wend - (size_t)tdp->wbase) >= THD_STACK_SIZE(0)));
 
-#if CH_CFG_USE_REGISTRY == TRUE
-  chDbgAssert(!chRegIsWorkingAreaInUseI(tdp->wbase),
-              "working area in use");
-#endif
+  /* Other checks.*/
+  chDbgCheck((tdp->prio >= LOWPRIO) &&
+             (tdp->prio <= HIGHPRIO) &&
+             (tdp->funcp != NULL));
 
-  /* Thread object initialization.*/
-  tp = chThdObjectInit(tp, tdp);
-
-  /* Setting up the port-dependent part of the working area.*/
-  port_setup_context(&tp->ctx, tp->wabase, tp->waend, tdp->funcp, tdp->arg);
-
-  /* Registry-related fields.*/
-#if CH_CFG_USE_REGISTRY == TRUE
-  REG_INSERT(tp->owner, tp);
-#endif
-
-  return tp;
+  return __thd_spawn_suspended(tp, tdp);
 }
 
 /**
@@ -389,7 +411,9 @@ thread_t *chThdCreateSuspendedI(const thread_descriptor_t *tdp) {
              (((size_t)tdp->wend - (size_t)tdp->wbase) >= THD_WORKING_AREA_SIZE(0)));
 
   /* Other checks.*/
-  chDbgCheck((tdp->prio <= HIGHPRIO) && (tdp->funcp != NULL));
+  chDbgCheck((tdp->prio >= LOWPRIO) &&
+             (tdp->prio <= HIGHPRIO) &&
+             (tdp->funcp != NULL));
 
   /* Stack area addresses.
      The thread structure is laid out in the upper part of the thread
@@ -512,7 +536,8 @@ thread_t *chThdCreate(const thread_descriptor_t *tdp) {
  *
  * @param[out] wbase    working area base address
  * @param[in] wsize     working area size
- * @param[in] prio      priority level for the new thread
+ * @param[in] prio      priority level for the new thread, from @p LOWPRIO
+ *                      through @p HIGHPRIO
  * @param[in] func      thread function
  * @param[in] arg       an argument passed to the thread function. It can be
  *                      @p NULL.
@@ -531,7 +556,9 @@ thread_t *chThdCreateStatic(stkline_t *wbase, size_t wsize,
              (wsize >= THD_WORKING_AREA_SIZE(0)));
 
   /* Other checks.*/
-  chDbgCheck((prio <= HIGHPRIO) && (func != NULL));
+  chDbgCheck((prio >= LOWPRIO) &&
+             (prio <= HIGHPRIO) &&
+             (func != NULL));
 
   /* Working area end address.*/
   wend = (uint8_t *)wbase + wsize;
@@ -670,6 +697,8 @@ void chThdRelease(thread_t *tp) {
  *          this function never returns. The compiler has no way to
  *          know this so do not assume that the compiler would remove
  *          the dead code.
+ * @pre     If mutexes are enabled then the invoking thread must not own
+ *          any mutex.
  *
  * @param[in] msg       thread exit code
  *
@@ -694,6 +723,8 @@ void chThdExit(msg_t msg) {
  *          this function never returns. The compiler has no way to
  *          know this so do not assume that the compiler would remove
  *          the dead code.
+ * @pre     If mutexes are enabled then the invoking thread must not own
+ *          any mutex.
  *
  * @param[in] msg       thread exit code
  *
@@ -701,6 +732,10 @@ void chThdExit(msg_t msg) {
  */
 void chThdExitS(msg_t msg) {
   thread_t *currtp = chThdGetSelfX();
+
+#if CH_CFG_USE_MUTEXES == TRUE
+  chDbgAssert(currtp->mtxlist == NULL, "owning mutexes");
+#endif
 
   /* Storing exit message.*/
   currtp->u.exitcode = msg;
@@ -836,7 +871,8 @@ msg_t chThdWait(thread_t *tp) {
  *          current priority that could be higher than the real priority
  *          because the priority inheritance mechanism.
  *
- * @param[in] newprio   the new priority level of the running thread
+ * @param[in] newprio   the new priority level of the running thread, from
+ *                      @p LOWPRIO through @p HIGHPRIO
  * @return              The old priority level.
  *
  * @api
@@ -845,7 +881,7 @@ tprio_t chThdSetPriority(tprio_t newprio) {
   thread_t *currtp = chThdGetSelfX();
   tprio_t oldprio;
 
-  chDbgCheck(newprio <= HIGHPRIO);
+  chDbgCheck((newprio >= LOWPRIO) && (newprio <= HIGHPRIO));
 
   chSysLock();
 #if CH_CFG_USE_MUTEXES == TRUE

--- a/os/various/cpp_wrappers/ch.hpp
+++ b/os/various/cpp_wrappers/ch.hpp
@@ -944,7 +944,8 @@ namespace chibios_rt {
     /**
      * @brief   Creates and starts a system thread.
      *
-     * @param[in] prio          thread priority
+     * @param[in] prio          thread priority, from @p LOWPRIO through
+     *                          @p HIGHPRIO
      * @return                  A reference to the created thread with
      *                          reference counter set to one.
      *
@@ -985,7 +986,8 @@ namespace chibios_rt {
      *          current priority that could be higher than the real priority
      *          because the priority inheritance mechanism.
      *
-     * @param[in] newprio   the new priority level of the running thread
+     * @param[in] newprio   the new priority level of the running thread, from
+     *                      @p LOWPRIO through @p HIGHPRIO
      * @return              The old priority level.
      *
      * @api
@@ -1017,6 +1019,8 @@ namespace chibios_rt {
      *          this function never returns. The compiler has no way to
      *          know this so do not assume that the compiler would remove
      *          the dead code.
+     * @pre     If mutexes are enabled then the invoking thread must not own
+     *          any mutex.
      *
      * @param[in] msg       thread exit code
      *
@@ -1036,6 +1040,8 @@ namespace chibios_rt {
      *          this function never returns. The compiler has no way to
      *          know this so do not assume that the compiler would remove
      *          the dead code.
+     * @pre     If mutexes are enabled then the invoking thread must not own
+     *          any mutex.
      *
      * @param[in] msg       thread exit code
      *
@@ -1346,7 +1352,8 @@ namespace chibios_rt {
     /**
      * @brief   Starts a static thread.
      *
-     * @param[in] prio          thread priority
+     * @param[in] prio          thread priority, from @p LOWPRIO through
+     *                          @p HIGHPRIO
      * @return                  A reference to the created thread with
      *                          reference counter set to one.
      *
@@ -2000,6 +2007,9 @@ namespace chibios_rt {
      * @details This function attempts to lock a mutex, if the mutex is already
      *          locked by another thread then the function exits without
      *          waiting.
+     * @pre     In recursive mode, a mutex already owned by the invoking
+     *          thread must have a lock depth lower than
+     *          @p MUTEX_MAX_RECURSION.
      * @post    The mutex is locked and inserted in the per-thread stack of
      *          owned mutexes.
      * @note    This function does not have any overhead related to the
@@ -2022,6 +2032,9 @@ namespace chibios_rt {
      * @details This function attempts to lock a mutex, if the mutex is already
      *          taken by another thread then the function exits without
      *          waiting.
+     * @pre     In recursive mode, a mutex already owned by the invoking
+     *          thread must have a lock depth lower than
+     *          @p MUTEX_MAX_RECURSION.
      * @post    The mutex is locked and inserted in the per-thread stack of
      *          owned mutexes.
      * @note    This function does not have any overhead related to the
@@ -2041,6 +2054,9 @@ namespace chibios_rt {
 
     /**
      * @brief   Locks the specified mutex.
+     * @pre     In recursive mode, a mutex already owned by the invoking
+     *          thread must have a lock depth lower than
+     *          @p MUTEX_MAX_RECURSION.
      * @post    The mutex is locked and inserted in the per-thread stack of
      *          owned mutexes.
      *
@@ -2053,6 +2069,9 @@ namespace chibios_rt {
 
     /**
      * @brief   Locks the specified mutex.
+     * @pre     In recursive mode, a mutex already owned by the invoking
+     *          thread must have a lock depth lower than
+     *          @p MUTEX_MAX_RECURSION.
      * @post    The mutex is locked and inserted in the per-thread stack of
      *          owned mutexes.
      *
@@ -2065,7 +2084,7 @@ namespace chibios_rt {
 
     /**
      * @brief   Unlocks the next owned mutex in reverse lock order.
-     * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+     * @pre     The invoking thread <b>must</b> own this mutex.
      * @post    The mutex is unlocked and removed from the per-thread stack of
      *          owned mutexes.
      *
@@ -2078,7 +2097,7 @@ namespace chibios_rt {
 
     /**
      * @brief   Unlocks the next owned mutex in reverse lock order.
-     * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+     * @pre     The invoking thread <b>must</b> own this mutex.
      * @post    The mutex is unlocked and removed from the per-thread stack of
      *          owned mutexes.
      * @post    The function reschedules internally if required.
@@ -2092,7 +2111,7 @@ namespace chibios_rt {
 
     /**
      * @brief   Unlocks the next owned mutex in reverse lock order.
-     * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+     * @pre     The invoking thread <b>must</b> own this mutex.
      * @post    The mutex is unlocked and removed from the per-thread stack of
      *          owned mutexes.
      *
@@ -2107,7 +2126,7 @@ namespace chibios_rt {
 
     /**
      * @brief   Unlocks the next owned mutex in reverse lock order.
-     * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+     * @pre     The invoking thread <b>must</b> own this mutex.
      * @post    The mutex is unlocked and removed from the per-thread stack of
      *          owned mutexes.
      * @post    The function reschedules internally if required.
@@ -3040,7 +3059,8 @@ namespace chibios_rt {
     /**
      * @brief   Starts a dynamic thread from the pool.
      *
-     * @param[in] prio          thread priority
+     * @param[in] prio          thread priority, from @p LOWPRIO through
+     *                          @p HIGHPRIO
      * @return                  A reference to the created thread with
      *                          reference counter set to one.
      *

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -6664,5 +6664,192 @@ test_println(" bytes");
         </case>
       </cases>
     </sequence>
+    <sequence>
+      <type index="0">
+        <value>Internal Tests</value>
+      </type>
+      <brief>
+        <value>Kernel invariant boundaries.</value>
+      </brief>
+      <description>
+        <value>This sequence tests the valid boundaries of kernel
+          invariants.</value>
+      </description>
+      <condition>
+        <value />
+      </condition>
+      <shared_code>
+        <value><![CDATA[static THD_FUNCTION(test_thread, arg) {
+
+  (void)arg;
+}
+
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
+static mutex_t m1;
+#endif]]></value>
+      </shared_code>
+      <cases>
+        <case>
+          <brief>
+            <value>User thread priority boundaries.</value>
+          </brief>
+          <description>
+            <value>The lowest and highest user priorities are exercised
+              through the priority setter and all three thread creation
+              implementations.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_descriptor_t td;
+tprio_t oldprio, prio;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The current thread priority is changed to @p
+                  LOWPRIO and then restored.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[prio = chThdGetPriorityX();
+oldprio = chThdSetPriority(LOWPRIO);
+test_assert(oldprio == prio, "wrong old priority");
+test_assert(chThdGetPriorityX() == LOWPRIO, "wrong low priority");
+oldprio = chThdSetPriority(prio);
+test_assert(oldprio == LOWPRIO, "wrong restored priority");
+test_assert(chThdGetPriorityX() == prio, "priority not restored");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A static thread is created at @p LOWPRIO.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, LOWPRIO,
+                               test_thread, NULL);
+test_wait_threads();]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A thread is created from a descriptor at @p
+                  LOWPRIO.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[td.name   = "priority-low";
+td.wbase  = TEST_THREAD_WA_BASE(0);
+td.wend   = TEST_THREAD_WA_END(0);
+td.prio   = LOWPRIO;
+td.funcp  = test_thread;
+td.arg    = NULL;
+td.owner  = NULL;
+threads[0] = chThdCreate(&td);
+test_wait_threads();]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A thread object is spawned from a descriptor at
+                  @p HIGHPRIO.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[td.name   = "priority-high";
+td.wbase  = TEST_THREAD_STACK_BASE(0);
+td.wend   = TEST_THREAD_STACK_END(0);
+td.prio   = HIGHPRIO;
+td.funcp  = test_thread;
+td.arg    = NULL;
+td.owner  = NULL;
+threads[0] = chThdSpawnRunning(TEST_THREAD_OBJECT(0), &td);
+test_wait_threads();
+chThdObjectDispose(TEST_THREAD_OBJECT(0));]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Recursive mutex depth boundary.</value>
+          </brief>
+          <description>
+            <value>The last valid recursive acquisition is tested
+              through both lock paths.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_USE_MUTEXES_RECURSIVE == TRUE]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chMtxObjectInit(&m1);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chMtxObjectDispose(&m1);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[bool b;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>@p chMtxLock() reaches @p MUTEX_MAX_RECURSION
+                  without overflowing the counter.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chMtxLock(&m1);
+m1.cnt = MUTEX_MAX_RECURSION - (cnt_t)1;
+chMtxLock(&m1);
+test_assert(m1.cnt == MUTEX_MAX_RECURSION,
+            "wrong recursion counter");
+chMtxUnlockAll();]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>@p chMtxTryLock() reaches @p MUTEX_MAX_RECURSION
+                  without overflowing the counter.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[b = chMtxTryLock(&m1);
+test_assert(b, "already locked");
+m1.cnt = MUTEX_MAX_RECURSION - (cnt_t)1;
+b = chMtxTryLock(&m1);
+test_assert(b, "recursive lock failed");
+test_assert(m1.cnt == MUTEX_MAX_RECURSION,
+            "wrong recursion counter");
+chMtxUnlockAll();]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+      </cases>
+    </sequence>
   </sequences>
 </instance>

--- a/test/rt/rt_test.mk
+++ b/test/rt/rt_test.mk
@@ -11,7 +11,8 @@ TESTSRC += ${CHIBIOS}/test/rt/source/test/rt_test_root.c \
            ${CHIBIOS}/test/rt/source/test/rt_test_sequence_009.c \
            ${CHIBIOS}/test/rt/source/test/rt_test_sequence_010.c \
            ${CHIBIOS}/test/rt/source/test/rt_test_sequence_011.c \
-           ${CHIBIOS}/test/rt/source/test/rt_test_sequence_012.c
+           ${CHIBIOS}/test/rt/source/test/rt_test_sequence_012.c \
+           ${CHIBIOS}/test/rt/source/test/rt_test_sequence_013.c
 
 # Required include directories
 TESTINC += ${CHIBIOS}/test/rt/source/test

--- a/test/rt/source/test/rt_test_root.c
+++ b/test/rt/source/test/rt_test_root.c
@@ -33,6 +33,7 @@
  * - @subpage rt_test_sequence_010
  * - @subpage rt_test_sequence_011
  * - @subpage rt_test_sequence_012
+ * - @subpage rt_test_sequence_013
  * .
  */
 
@@ -78,6 +79,7 @@ const testsequence_t * const rt_test_suite_array[] = {
   &rt_test_sequence_011,
 #endif
   &rt_test_sequence_012,
+  &rt_test_sequence_013,
   NULL
 };
 

--- a/test/rt/source/test/rt_test_root.h
+++ b/test/rt/source/test/rt_test_root.h
@@ -36,6 +36,7 @@
 #include "rt_test_sequence_010.h"
 #include "rt_test_sequence_011.h"
 #include "rt_test_sequence_012.h"
+#include "rt_test_sequence_013.h"
 
 #if !defined(__DOXYGEN__)
 

--- a/test/rt/source/test/rt_test_sequence_013.c
+++ b/test/rt/source/test/rt_test_sequence_013.c
@@ -1,0 +1,233 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "hal.h"
+#include "rt_test_root.h"
+
+/**
+ * @file    rt_test_sequence_013.c
+ * @brief   Test Sequence 013 code.
+ *
+ * @page rt_test_sequence_013 [13] Kernel invariant boundaries
+ *
+ * File: @ref rt_test_sequence_013.c
+ *
+ * <h2>Description</h2>
+ * This sequence tests the valid boundaries of kernel invariants.
+ *
+ * <h2>Test Cases</h2>
+ * - @subpage rt_test_013_001
+ * - @subpage rt_test_013_002
+ * .
+ */
+
+/*===========================================================================*/
+/* Shared code.                                                              */
+/*===========================================================================*/
+
+static THD_FUNCTION(test_thread, arg) {
+
+  (void)arg;
+}
+
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
+static mutex_t m1;
+#endif
+
+/*===========================================================================*/
+/* Test cases.                                                               */
+/*===========================================================================*/
+
+/**
+ * @page rt_test_013_001 [13.1] User thread priority boundaries
+ *
+ * <h2>Description</h2>
+ * The lowest and highest user priorities are exercised through the
+ * priority setter and all three thread creation implementations.
+ *
+ * <h2>Test Steps</h2>
+ * - [13.1.1] The current thread priority is changed to @p LOWPRIO and
+ *   then restored.
+ * - [13.1.2] A static thread is created at @p LOWPRIO.
+ * - [13.1.3] A thread is created from a descriptor at @p LOWPRIO.
+ * - [13.1.4] A thread object is spawned from a descriptor at @p
+ *   HIGHPRIO.
+ * .
+ */
+
+static void rt_test_013_001_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_013_001_execute(void) {
+  thread_descriptor_t td;
+  tprio_t oldprio, prio;
+
+  /* [13.1.1] The current thread priority is changed to @p LOWPRIO and
+     then restored.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+    oldprio = chThdSetPriority(LOWPRIO);
+    test_assert(oldprio == prio, "wrong old priority");
+    test_assert(chThdGetPriorityX() == LOWPRIO, "wrong low priority");
+    oldprio = chThdSetPriority(prio);
+    test_assert(oldprio == LOWPRIO, "wrong restored priority");
+    test_assert(chThdGetPriorityX() == prio, "priority not restored");
+  }
+  test_end_step(1);
+
+  /* [13.1.2] A static thread is created at @p LOWPRIO.*/
+  test_set_step(2);
+  {
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, LOWPRIO,
+                                   test_thread, NULL);
+    test_wait_threads();
+  }
+  test_end_step(2);
+
+  /* [13.1.3] A thread is created from a descriptor at @p LOWPRIO.*/
+  test_set_step(3);
+  {
+    td.name   = "priority-low";
+    td.wbase  = TEST_THREAD_WA_BASE(0);
+    td.wend   = TEST_THREAD_WA_END(0);
+    td.prio   = LOWPRIO;
+    td.funcp  = test_thread;
+    td.arg    = NULL;
+    td.owner  = NULL;
+    threads[0] = chThdCreate(&td);
+    test_wait_threads();
+  }
+  test_end_step(3);
+
+  /* [13.1.4] A thread object is spawned from a descriptor at @p
+     HIGHPRIO.*/
+  test_set_step(4);
+  {
+    td.name   = "priority-high";
+    td.wbase  = TEST_THREAD_STACK_BASE(0);
+    td.wend   = TEST_THREAD_STACK_END(0);
+    td.prio   = HIGHPRIO;
+    td.funcp  = test_thread;
+    td.arg    = NULL;
+    td.owner  = NULL;
+    threads[0] = chThdSpawnRunning(TEST_THREAD_OBJECT(0), &td);
+    test_wait_threads();
+    chThdObjectDispose(TEST_THREAD_OBJECT(0));
+  }
+  test_end_step(4);
+}
+
+static const testcase_t rt_test_013_001 = {
+  "User thread priority boundaries",
+  NULL,
+  rt_test_013_001_teardown,
+  rt_test_013_001_execute
+};
+
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_013_002 [13.2] Recursive mutex depth boundary
+ *
+ * <h2>Description</h2>
+ * The last valid recursive acquisition is tested through both lock
+ * paths.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_MUTEXES_RECURSIVE == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [13.2.1] @p chMtxLock() reaches @p MUTEX_MAX_RECURSION without
+ *   overflowing the counter.
+ * - [13.2.2] @p chMtxTryLock() reaches @p MUTEX_MAX_RECURSION without
+ *   overflowing the counter.
+ * .
+ */
+
+static void rt_test_013_002_setup(void) {
+  chMtxObjectInit(&m1);
+}
+
+static void rt_test_013_002_teardown(void) {
+  chMtxObjectDispose(&m1);
+}
+
+static void rt_test_013_002_execute(void) {
+  bool b;
+
+  /* [13.2.1] @p chMtxLock() reaches @p MUTEX_MAX_RECURSION without
+     overflowing the counter.*/
+  test_set_step(1);
+  {
+    chMtxLock(&m1);
+    m1.cnt = MUTEX_MAX_RECURSION - (cnt_t)1;
+    chMtxLock(&m1);
+    test_assert(m1.cnt == MUTEX_MAX_RECURSION,
+                "wrong recursion counter");
+    chMtxUnlockAll();
+  }
+  test_end_step(1);
+
+  /* [13.2.2] @p chMtxTryLock() reaches @p MUTEX_MAX_RECURSION without
+     overflowing the counter.*/
+  test_set_step(2);
+  {
+    b = chMtxTryLock(&m1);
+    test_assert(b, "already locked");
+    m1.cnt = MUTEX_MAX_RECURSION - (cnt_t)1;
+    b = chMtxTryLock(&m1);
+    test_assert(b, "recursive lock failed");
+    test_assert(m1.cnt == MUTEX_MAX_RECURSION,
+                "wrong recursion counter");
+    chMtxUnlockAll();
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_013_002 = {
+  "Recursive mutex depth boundary",
+  rt_test_013_002_setup,
+  rt_test_013_002_teardown,
+  rt_test_013_002_execute
+};
+#endif /* CH_CFG_USE_MUTEXES_RECURSIVE == TRUE */
+
+/*===========================================================================*/
+/* Exported data.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Array of test cases.
+ */
+const testcase_t * const rt_test_sequence_013_array[] = {
+  &rt_test_013_001,
+#if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
+  &rt_test_013_002,
+#endif
+  NULL
+};
+
+/**
+ * @brief   Kernel invariant boundaries.
+ */
+const testsequence_t rt_test_sequence_013 = {
+  "Kernel invariant boundaries",
+  rt_test_sequence_013_array
+};

--- a/test/rt/source/test/rt_test_sequence_013.h
+++ b/test/rt/source/test/rt_test_sequence_013.h
@@ -1,0 +1,27 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt_test_sequence_013.h
+ * @brief   Test Sequence 013 header.
+ */
+
+#ifndef RT_TEST_SEQUENCE_013_H
+#define RT_TEST_SEQUENCE_013_H
+
+extern const testsequence_t rt_test_sequence_013;
+
+#endif /* RT_TEST_SEQUENCE_013_H */


### PR DESCRIPTION
## Summary

- constrain user-created and user-adjusted thread priorities to LOWPRIO through HIGHPRIO while preserving the IDLEPRIO kernel bootstrap path
- verify that the invoking thread owns the exact mutex passed to unlock before recursive state is changed
- reject thread exit while the thread still owns mutexes
- define and enforce the maximum recursive mutex lock depth without changing valid lock behavior
- add a focused RT test sequence for valid priority and recursion boundaries

This is the Class B correctness group from the RT mutex review. It is independent of the Class A priority-inheritance scheduling PR.

## Validation

- POSIX simulator RT and OSLIB suites, normal mutex configuration, checks/assertions/state checking enabled
- POSIX simulator RT and OSLIB suites, recursive mutex configuration, checks/assertions/state checking enabled
- Cortex-M4 G++ demo build with recursive mutexes and checks/assertions enabled
- targeted simulator assertion reproducers for NOPRIO, IDLEPRIO, foreign recursive unlock, exit while owning a mutex, and recursion-limit exhaustion
- recursion-limit constant verified for 8-, 16-, and 32-bit cnt_t
- stylecheck on changed C/H files and git diff --check