### PR TITLE
RT: correct mutex and condition-variable contracts

### DIFF
--- a/os/rt/src/chcond.c
+++ b/os/rt/src/chcond.c
@@ -195,6 +195,8 @@ void chCondBroadcastI(condition_variable_t *cp) {
  *          variable, and finally acquires the mutex again. All the sequence
  *          is performed atomically.
  * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+ * @pre     In recursive mode, the mutex being released must have a lock
+ *          depth of one.
  *
  * @param[in] cp        pointer to a @p condition_variable_t object
  * @return              A message specifying how the invoking thread has been
@@ -221,6 +223,8 @@ msg_t chCondWait(condition_variable_t *cp) {
  *          variable, and finally acquires the mutex again. All the sequence
  *          is performed atomically.
  * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+ * @pre     In recursive mode, the mutex being released must have a lock
+ *          depth of one.
  *
  * @param[in] cp        pointer to a @p condition_variable_t object
  * @return              A message specifying how the invoking thread has been
@@ -240,6 +244,9 @@ msg_t chCondWaitS(condition_variable_t *cp) {
   chDbgCheckClassS();
   chDbgCheck(cp != NULL);
   chDbgAssert(mp != NULL, "not owning a mutex");
+#if CH_CFG_USE_MUTEXES_RECURSIVE == TRUE
+  chDbgAssert(mp->cnt == (cnt_t)1, "recursively locked mutex");
+#endif
 
   /* Releasing "current" mutex.*/
   (void) __mtx_unlock_no_reschedule(mp);
@@ -262,6 +269,8 @@ msg_t chCondWaitS(condition_variable_t *cp) {
  *          variable, and finally acquires the mutex again. All the sequence
  *          is performed atomically.
  * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+ * @pre     In recursive mode, the mutex being released must have a lock
+ *          depth of one.
  * @pre     The configuration option @p CH_CFG_USE_CONDVARS_TIMEOUT must be enabled
  *          in order to use this function.
  * @post    Exiting the function because a timeout does not re-acquire the
@@ -299,6 +308,8 @@ msg_t chCondWaitTimeout(condition_variable_t *cp, sysinterval_t timeout) {
  *          variable, and finally acquires the mutex again. All the sequence
  *          is performed atomically.
  * @pre     The invoking thread <b>must</b> have at least one owned mutex.
+ * @pre     In recursive mode, the mutex being released must have a lock
+ *          depth of one.
  * @pre     The configuration option @p CH_CFG_USE_CONDVARS_TIMEOUT must be enabled
  *          in order to use this function.
  * @post    Exiting the function because a timeout does not re-acquire the
@@ -328,6 +339,9 @@ msg_t chCondWaitTimeoutS(condition_variable_t *cp, sysinterval_t timeout) {
   chDbgCheckClassS();
   chDbgCheck((cp != NULL) && (timeout != TIME_IMMEDIATE));
   chDbgAssert(mp != NULL, "not owning a mutex");
+#if CH_CFG_USE_MUTEXES_RECURSIVE == TRUE
+  chDbgAssert(mp->cnt == (cnt_t)1, "recursively locked mutex");
+#endif
 
   /* Releasing "current" mutex.*/
   (void) __mtx_unlock_no_reschedule(mp);

--- a/os/rt/src/chmtx.c
+++ b/os/rt/src/chmtx.c
@@ -39,11 +39,10 @@
  *          .
  *          <h2>Constraints</h2>
  *          In ChibiOS/RT the Unlock operations must always be performed
- *          in lock-reverse order. This restriction both improves the
- *          performance and is required for an efficient implementation
- *          of the priority inheritance mechanism.<br>
- *          Operating under this restriction also ensures that deadlocks
- *          are no possible.
+ *          in lock-reverse order. This restriction supports the owned-mutex
+ *          stack and efficient priority inheritance recomputation.<br>
+ *          Applications must also use a consistent global lock-acquisition
+ *          order in order to prevent lock-order deadlocks.
  *
  *          <h2>Recursive mode</h2>
  *          By default mutexes are not recursive, this mean that it is not
@@ -508,8 +507,7 @@ void chMtxUnlockS(mutex_t *mp) {
  * @brief   Unlocks all mutexes owned by the invoking thread.
  * @post    The stack of owned mutexes is emptied and all the found
  *          mutexes are unlocked.
- * @post    This function does not reschedule so a call to a rescheduling
- *          function must be performed before unlocking the kernel.
+ * @post    The function reschedules internally if required.
  * @note    This function is <b>MUCH MORE</b> efficient than releasing the
  *          mutexes one by one and not just because the call overhead,
  *          this function does not have any overhead related to the priority
@@ -519,6 +517,8 @@ void chMtxUnlockS(mutex_t *mp) {
  */
 void chMtxUnlockAllS(void) {
   thread_t *currtp = chThdGetSelfX();
+
+  chDbgCheckClassS();
 
   if (currtp->mtxlist != NULL) {
     do {

--- a/os/various/cpp_wrappers/ch.hpp
+++ b/os/various/cpp_wrappers/ch.hpp
@@ -2177,6 +2177,8 @@ namespace chibios_rt {
   protected:
     /**
      * @brief   Waits on the condition variable releasing the mutex lock.
+     * @pre     In recursive mode, the controlling mutex must have a lock
+     *          depth of one.
      *
      * @param[in] var       the condition variable index
      * @return              A message specifying how the invoking thread has
@@ -2197,6 +2199,8 @@ namespace chibios_rt {
 
     /**
      * @brief   Waits on the condition variable releasing the mutex lock.
+     * @pre     In recursive mode, the controlling mutex must have a lock
+     *          depth of one.
      *
      * @param[in] var       the condition variable index
      * @return              A message specifying how the invoking thread has
@@ -2218,6 +2222,8 @@ namespace chibios_rt {
 #if (CH_CFG_USE_CONDVARS_TIMEOUT == TRUE) || defined(__DOXYGEN__)
     /**
      * @brief   Waits on the CondVar while releasing the controlling mutex.
+     * @pre     In recursive mode, the controlling mutex must have a lock
+     *          depth of one.
      *
      * @param[in] var       the condition variable index
      * @param[in] timeout   the number of ticks before the operation fails
@@ -2240,6 +2246,8 @@ namespace chibios_rt {
 
     /**
      * @brief   Waits on the CondVar while releasing the controlling mutex.
+     * @pre     In recursive mode, the controlling mutex must have a lock
+     *          depth of one.
      *
      * @param[in] var       the condition variable index
      * @param[in] timeout   the number of ticks before the operation fails


### PR DESCRIPTION
## Summary

- require recursive condition waits to release a mutex held at depth one, with matching assertions in both S-class wait paths
- add the missing S-class check to `chMtxUnlockAllS()` and document its internal rescheduling
- replace the incorrect deadlock-freedom claim with the owned-mutex-stack rationale and the application lock-order requirement
- mirror the condition-wait contract in the C++ monitor wrapper

This implements Class C (findings 4, 6, and 9) from `os/rt/MUTEX-CONFIRMED-DEFECTS.md`.

## Validation

- POSIX RT and OSLIB suites, normal mutex configuration, state checks/assertions enabled
- POSIX RT and OSLIB suites with `CH_CFG_USE_MUTEXES_RECURSIVE=TRUE`, state checks/assertions enabled
- `demos/STM32/RT-STM32F407-DISCOVERY-G++`
- stylecheck on the modified RT C sources
