### PR TITLE
NASA OSAL: fix mutex deletion lifecycle

### DIFF
--- a/os/common/abstractions/nasa_cfe/osal/src/osapi.c
+++ b/os/common/abstractions/nasa_cfe/osal/src/osapi.c
@@ -1591,6 +1591,9 @@ int32 OS_MutSemCreate(uint32 *sem_id, const char *sem_name, uint32 options) {
  *
  * @param[in] sem_id            mutex id variable
  * @return                      An error code.
+ * @retval OS_SUCCESS           if the mutex has been deleted
+ * @retval OS_ERR_INVALID_ID    if @p sem_id is not a valid mutex
+ * @retval OS_SEM_FAILURE       if the mutex is owned or contended
  *
  * @api
  */
@@ -1605,15 +1608,24 @@ int32 OS_MutSemDelete(uint32 sem_id) {
 
   chSysLock();
 
-  /* Resetting the mutex, no threads in queue.*/
-  chMtxUnlockAllS();
+  /* If the mutex is not in use then error.*/
+  if (mp->queue.prev == NULL) {
+    chSysUnlock();
+    return OS_ERR_INVALID_ID;
+  }
+
+  /* An owned or contended mutex cannot be deleted.*/
+  if ((chMtxGetOwnerI(mp) != NULL) || chMtxQueueNotEmptyS(mp)) {
+    chSysUnlock();
+    return OS_SEM_FAILURE;
+  }
+
+  /* Disposing the target mutex.*/
+  chMtxObjectDispose(mp);
 
   /* Flagging it as unused and returning it to the pool.*/
   mp->queue.prev = NULL;
   chPoolFreeI(&osal.mutexes_pool, (void *)mp);
-
-  /* Required because some thread could have been made ready.*/
-  chSchRescheduleS();
 
   chSysUnlock();
 

--- a/test/nasa_osal/configuration.xml
+++ b/test/nasa_osal/configuration.xml
@@ -2499,7 +2499,7 @@ test_assert(err == OS_ERR_INVALID_ID, "wrong semaphore id not detected");]]></va
               </tags>
               <code>
                 <value><![CDATA[int32 err;
-uint32 msid1; /*, msid2;*/
+uint32 msid1;
 
 err = OS_MutSemCreate(&msid1, "my semaphore", 0);
 test_assert(err == OS_SUCCESS, "semaphore creation failed");
@@ -2661,6 +2661,111 @@ test_assert(err == OS_INVALID_POINTER, "NULL not detected");]]></value>
 
 err = OS_MutSemGetIdByName(&msid, "very very long semaphore name");
 test_assert(err == OS_ERR_NAME_TOO_LONG, "name limit not detected");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>OS_MutSemDelete() lifecycle</value>
+          </brief>
+          <description>
+            <value>Mutex deletion is restricted to the specified idle
+              mutex and preserves unrelated mutex ownership.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value />
+            </teardown_code>
+            <local_variables>
+              <value />
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Deleting an idle mutex leaves an unrelated owned
+                  mutex locked by the invoking task.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+uint32 guard, target;
+
+err = OS_MutSemCreate(&guard, "guard", 0);
+test_assert(err == OS_SUCCESS, "guard creation failed");
+err = OS_MutSemCreate(&target, "target", 0);
+test_assert(err == OS_SUCCESS, "target creation failed");
+err = OS_MutSemTake(guard);
+test_assert(err == OS_SUCCESS, "guard take failed");
+
+err = OS_MutSemDelete(target);
+test_assert(err == OS_SUCCESS, "idle target deletion failed");
+err = OS_MutSemGive(guard);
+test_assert(err == OS_SUCCESS, "unrelated mutex was released");
+err = OS_MutSemDelete(guard);
+test_assert(err == OS_SUCCESS, "guard deletion failed");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Deleting an owned mutex fails without changing
+                  the ownership of it or other mutexes.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+uint32 guard, target;
+
+err = OS_MutSemCreate(&guard, "guard", 0);
+test_assert(err == OS_SUCCESS, "guard creation failed");
+err = OS_MutSemCreate(&target, "target", 0);
+test_assert(err == OS_SUCCESS, "target creation failed");
+err = OS_MutSemTake(guard);
+test_assert(err == OS_SUCCESS, "guard take failed");
+err = OS_MutSemTake(target);
+test_assert(err == OS_SUCCESS, "target take failed");
+
+err = OS_MutSemDelete(target);
+test_assert(err == OS_SEM_FAILURE, "owned target deletion accepted");
+err = OS_MutSemGive(target);
+test_assert(err == OS_SUCCESS, "target ownership changed");
+err = OS_MutSemGive(guard);
+test_assert(err == OS_SUCCESS, "guard ownership changed");
+err = OS_MutSemDelete(target);
+test_assert(err == OS_SUCCESS, "target deletion failed");
+err = OS_MutSemDelete(guard);
+test_assert(err == OS_SUCCESS, "guard deletion failed");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Deleting an already deleted mutex reports an
+                  invalid identifier.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+uint32 target;
+
+err = OS_MutSemCreate(&target, "target", 0);
+test_assert(err == OS_SUCCESS, "target creation failed");
+err = OS_MutSemDelete(target);
+test_assert(err == OS_SUCCESS, "target deletion failed");
+err = OS_MutSemDelete(target);
+test_assert(err == OS_ERR_INVALID_ID, "deleted target accepted");]]></value>
               </code>
             </step>
           </steps>

--- a/test/nasa_osal/source/test/nasa_osal_test_sequence_006.c
+++ b/test/nasa_osal/source/test/nasa_osal_test_sequence_006.c
@@ -20,20 +20,21 @@
  * - @subpage nasa_osal_test_006_002
  * - @subpage nasa_osal_test_006_003
  * - @subpage nasa_osal_test_006_004
+ * - @subpage nasa_osal_test_006_005
  * .
  */
 
-/****************************************************************************
- * Shared code.
- ****************************************************************************/
+/*===========================================================================*/
+/* Shared code.                                                              */
+/*===========================================================================*/
 
 #include "osapi.h"
 
 uint32 msid;
 
-/****************************************************************************
- * Test cases.
- ****************************************************************************/
+/*===========================================================================*/
+/* Test cases.                                                               */
+/*===========================================================================*/
 
 /**
  * @page nasa_osal_test_006_001 [6.1] OS_MutSemCreate() and OS_MutSemDelete() errors
@@ -117,7 +118,7 @@ static void nasa_osal_test_006_001_execute(void) {
   test_set_step(5);
   {
     int32 err;
-    uint32 msid1; /*, msid2;*/
+    uint32 msid1;
 
     err = OS_MutSemCreate(&msid1, "my semaphore", 0);
     test_assert(err == OS_SUCCESS, "semaphore creation failed");
@@ -265,9 +266,104 @@ static const testcase_t nasa_osal_test_006_004 = {
   nasa_osal_test_006_004_execute
 };
 
-/****************************************************************************
- * Exported data.
- ****************************************************************************/
+/**
+ * @page nasa_osal_test_006_005 [6.5] OS_MutSemDelete() lifecycle
+ *
+ * <h2>Description</h2>
+ * Mutex deletion is restricted to the specified idle mutex and
+ * preserves unrelated mutex ownership.
+ *
+ * <h2>Test Steps</h2>
+ * - [6.5.1] Deleting an idle mutex leaves an unrelated owned mutex
+ *   locked by the invoking task.
+ * - [6.5.2] Deleting an owned mutex fails without changing the
+ *   ownership of it or other mutexes.
+ * - [6.5.3] Deleting an already deleted mutex reports an invalid
+ *   identifier.
+ * .
+ */
+
+static void nasa_osal_test_006_005_execute(void) {
+
+  /* [6.5.1] Deleting an idle mutex leaves an unrelated owned mutex
+     locked by the invoking task.*/
+  test_set_step(1);
+  {
+    int32 err;
+    uint32 guard, target;
+
+    err = OS_MutSemCreate(&guard, "guard", 0);
+    test_assert(err == OS_SUCCESS, "guard creation failed");
+    err = OS_MutSemCreate(&target, "target", 0);
+    test_assert(err == OS_SUCCESS, "target creation failed");
+    err = OS_MutSemTake(guard);
+    test_assert(err == OS_SUCCESS, "guard take failed");
+
+    err = OS_MutSemDelete(target);
+    test_assert(err == OS_SUCCESS, "idle target deletion failed");
+    err = OS_MutSemGive(guard);
+    test_assert(err == OS_SUCCESS, "unrelated mutex was released");
+    err = OS_MutSemDelete(guard);
+    test_assert(err == OS_SUCCESS, "guard deletion failed");
+  }
+  test_end_step(1);
+
+  /* [6.5.2] Deleting an owned mutex fails without changing the
+     ownership of it or other mutexes.*/
+  test_set_step(2);
+  {
+    int32 err;
+    uint32 guard, target;
+
+    err = OS_MutSemCreate(&guard, "guard", 0);
+    test_assert(err == OS_SUCCESS, "guard creation failed");
+    err = OS_MutSemCreate(&target, "target", 0);
+    test_assert(err == OS_SUCCESS, "target creation failed");
+    err = OS_MutSemTake(guard);
+    test_assert(err == OS_SUCCESS, "guard take failed");
+    err = OS_MutSemTake(target);
+    test_assert(err == OS_SUCCESS, "target take failed");
+
+    err = OS_MutSemDelete(target);
+    test_assert(err == OS_SEM_FAILURE, "owned target deletion accepted");
+    err = OS_MutSemGive(target);
+    test_assert(err == OS_SUCCESS, "target ownership changed");
+    err = OS_MutSemGive(guard);
+    test_assert(err == OS_SUCCESS, "guard ownership changed");
+    err = OS_MutSemDelete(target);
+    test_assert(err == OS_SUCCESS, "target deletion failed");
+    err = OS_MutSemDelete(guard);
+    test_assert(err == OS_SUCCESS, "guard deletion failed");
+  }
+  test_end_step(2);
+
+  /* [6.5.3] Deleting an already deleted mutex reports an invalid
+     identifier.*/
+  test_set_step(3);
+  {
+    int32 err;
+    uint32 target;
+
+    err = OS_MutSemCreate(&target, "target", 0);
+    test_assert(err == OS_SUCCESS, "target creation failed");
+    err = OS_MutSemDelete(target);
+    test_assert(err == OS_SUCCESS, "target deletion failed");
+    err = OS_MutSemDelete(target);
+    test_assert(err == OS_ERR_INVALID_ID, "deleted target accepted");
+  }
+  test_end_step(3);
+}
+
+static const testcase_t nasa_osal_test_006_005 = {
+  "OS_MutSemDelete() lifecycle",
+  NULL,
+  NULL,
+  nasa_osal_test_006_005_execute
+};
+
+/*===========================================================================*/
+/* Exported data.                                                            */
+/*===========================================================================*/
 
 /**
  * @brief   Array of test cases.
@@ -277,6 +373,7 @@ const testcase_t * const nasa_osal_test_sequence_006_array[] = {
   &nasa_osal_test_006_002,
   &nasa_osal_test_006_003,
   &nasa_osal_test_006_004,
+  &nasa_osal_test_006_005,
   NULL
 };
 


### PR DESCRIPTION
## Summary

- make `OS_MutSemDelete()` operate only on the requested mutex instead of unlocking every mutex owned by the caller
- reject unused IDs with `OS_ERR_INVALID_ID` and owned or contended mutexes with `OS_SEM_FAILURE`
- dispose an idle target before returning it to the mutex pool
- remove the now-unnecessary reschedule from the deletion path
- add generated NASA OSAL regression coverage for unrelated ownership preservation, busy deletion, and repeated deletion

This implements Class D (finding 10) from `os/rt/MUTEX-CONFIRMED-DEFECTS.md`.

## Validation

- validated `test/nasa_osal/configuration.xml` and regenerated sequence 006
- built `demos/STM32/NASA-OSAL-STM32F407-DISCOVERY` with system-state checking, parameter checks, and assertions enabled
- stylecheck has no findings on changed lines
