### PR TITLE
RT: add arbitrary thread priority helper

### DIFF
--- a/os/rt/include/chschd.h
+++ b/os/rt/include/chschd.h
@@ -140,6 +140,7 @@ extern "C" {
 #endif
   void chSchObjectInit(os_instance_t *oip,
                        const os_instance_config_t *oicp);
+  void __sch_requeue_behind(thread_t *tp);
   thread_t *chSchReadyI(thread_t *tp);
   void chSchGoSleepS(tstate_t newstate);
   msg_t chSchGoSleepTimeoutS(tstate_t newstate, sysinterval_t timeout);

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -464,6 +464,7 @@ extern "C" {
   msg_t chThdSync(thread_t *tp);
   msg_t chThdWait(thread_t *tp);
 #endif
+  tprio_t __thd_set_priority(thread_t *tp, tprio_t newprio);
   tprio_t chThdSetPriority(tprio_t newprio);
   void chThdTerminate(thread_t *tp);
   msg_t chThdSuspendS(thread_reference_t *trp);

--- a/os/rt/src/chmtx.c
+++ b/os/rt/src/chmtx.c
@@ -266,12 +266,8 @@ void chMtxLockS(mutex_t *mp) {
           break;
 #endif
         case CH_STATE_READY:
-#if CH_DBG_ENABLE_ASSERTS == TRUE
-          /* Prevents an assertion in chSchReadyI().*/
-          tp->state = CH_STATE_CURRENT;
-#endif
           /* Re-enqueues tp with its new priority on the ready list.*/
-          (void) chSchReadyI(threadref(ch_queue_dequeue(&tp->hdr.queue)));
+          __sch_requeue_behind(tp);
           break;
         default:
           /* Nothing to do for other states.*/

--- a/os/rt/src/chschd.c
+++ b/os/rt/src/chschd.c
@@ -267,6 +267,38 @@ void ch_sch_prio_insert(ch_queue_t *qp, ch_queue_t *tp) {
 #endif /* CH_CFG_OPTIMIZE_SPEED */
 
 /**
+ * @brief   Requeues a ready thread behind its new peers.
+ * @details The thread is removed from its ready list and reinserted behind
+ *          all threads with higher or equal priority.
+ * @pre     The thread must be in the @p CH_STATE_READY state.
+ * @post    This function does not reschedule so a call to a rescheduling
+ *          function must be performed before unlocking the kernel.
+ *
+ * @param[in] tp        the thread to be requeued
+ *
+ * @notapi
+ * @iclass
+ */
+void __sch_requeue_behind(thread_t *tp) {
+
+  chDbgCheckClassI();
+  chDbgCheck(tp != NULL);
+  chDbgAssert(tp->state == CH_STATE_READY, "invalid state");
+
+#if CH_CFG_SMP_MODE == TRUE
+  if (tp->owner != currcore) {
+    /* Triggering a reschedule on the owning core.*/
+    chSysNotifyInstance(tp->owner);
+  }
+#endif
+
+  /* Re-insertion in the priority queue, no state change or trace event.*/
+  (void) ch_queue_dequeue(&tp->hdr.queue);
+  (void) ch_pqueue_insert_behind(&tp->owner->rlist.pqueue,
+                                 &tp->hdr.pqueue);
+}
+
+/**
  * @brief   Inserts a thread in the Ready List placing it behind its peers.
  * @details The thread is positioned behind all threads with higher or equal
  *          priority.

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -865,6 +865,112 @@ msg_t chThdWait(thread_t *tp) {
 #endif /* CH_CFG_USE_WAITEXIT */
 
 /**
+ * @brief   Changes the base priority of a thread.
+ * @details The effective priority is recomputed and the thread is repositioned
+ *          in its current priority queue. If the thread is waiting on a mutex
+ *          then priority changes are propagated through the owner chain.
+ * @post    A local reschedule is performed before returning. Remote instances
+ *          affected by a ready or current thread priority change are notified.
+ *
+ * @param[in] tp        pointer to the thread
+ * @param[in] newprio   the new base priority level, from @p LOWPRIO through
+ *                      @p HIGHPRIO
+ * @return              The old base priority level.
+ *
+ * @notapi
+ * @sclass
+ */
+tprio_t __thd_set_priority(thread_t *tp, tprio_t newprio) {
+  thread_t *nexttp;
+  ch_queue_t *qp;
+  tprio_t neweffective;
+  tprio_t oldeffective;
+  tprio_t oldprio;
+
+  chDbgCheckClassS();
+  chDbgCheck((tp != NULL) &&
+             (newprio >= LOWPRIO) && (newprio <= HIGHPRIO));
+
+#if CH_CFG_USE_MUTEXES == TRUE
+  oldprio = tp->realprio;
+  tp->realprio = newprio;
+#else
+  oldprio = tp->hdr.pqueue.prio;
+#endif
+
+  while (true) {
+    oldeffective = tp->hdr.pqueue.prio;
+#if CH_CFG_USE_MUTEXES == TRUE
+    neweffective = __mtx_get_effective_priority(tp);
+#else
+    neweffective = newprio;
+#endif
+    if (neweffective == oldeffective) {
+      break;
+    }
+
+    tp->hdr.pqueue.prio = neweffective;
+    nexttp = NULL;
+    qp = NULL;
+
+    /* The following states need priority queues reordering.*/
+    switch (tp->state) {
+#if CH_CFG_USE_MUTEXES == TRUE
+    case CH_STATE_WTMTX:
+      chDbgAssert((tp->u.wtmtxp != NULL) &&
+                  (tp->u.wtmtxp->owner != NULL),
+                  "mutex not owned");
+      qp = &tp->u.wtmtxp->queue;
+      nexttp = tp->u.wtmtxp->owner;
+      break;
+#endif
+#if CH_CFG_USE_CONDVARS == TRUE
+    case CH_STATE_WTCOND:
+      qp = &((condition_variable_t *)tp->u.wtobjp)->queue;
+      break;
+#endif
+#if (CH_CFG_USE_SEMAPHORES == TRUE) &&                                     \
+    (CH_CFG_USE_SEMAPHORES_PRIORITY == TRUE)
+    case CH_STATE_WTSEM:
+      qp = &tp->u.wtsemp->queue;
+      break;
+#endif
+#if (CH_CFG_USE_MESSAGES == TRUE) &&                                       \
+    (CH_CFG_USE_MESSAGES_PRIORITY == TRUE)
+    case CH_STATE_SNDMSGQ:
+      qp = (ch_queue_t *)tp->u.wtobjp;
+      break;
+#endif
+    case CH_STATE_READY:
+      __sch_requeue_behind(tp);
+      break;
+    case CH_STATE_CURRENT:
+#if CH_CFG_SMP_MODE == TRUE
+      if (tp->owner != currcore) {
+        chSysNotifyInstance(tp->owner);
+      }
+#endif
+      break;
+    default:
+      /* Nothing to do for other states.*/
+      break;
+    }
+
+    if (qp != NULL) {
+      ch_sch_prio_insert(qp, ch_queue_dequeue(&tp->hdr.queue));
+    }
+    if (nexttp == NULL) {
+      break;
+    }
+    tp = nexttp;
+  }
+
+  chSchRescheduleS();
+
+  return oldprio;
+}
+
+/**
  * @brief   Changes the running thread priority level then reschedules if
  *          necessary.
  * @note    The function returns the real thread priority regardless of the
@@ -884,15 +990,7 @@ tprio_t chThdSetPriority(tprio_t newprio) {
   chDbgCheck((newprio >= LOWPRIO) && (newprio <= HIGHPRIO));
 
   chSysLock();
-#if CH_CFG_USE_MUTEXES == TRUE
-  oldprio = currtp->realprio;
-  currtp->realprio = newprio;
-  currtp->hdr.pqueue.prio = __mtx_get_effective_priority(currtp);
-#else
-  oldprio = currtp->hdr.pqueue.prio;
-  currtp->hdr.pqueue.prio = newprio;
-#endif
-  chSchRescheduleS();
+  oldprio = __thd_set_priority(currtp, newprio);
   chSysUnlock();
 
   return oldprio;

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1713,6 +1713,69 @@ test_assert_sequence("R", "invalid sequence");]]></value>
             </step>
           </steps>
         </case>
+        <case>
+          <brief>
+            <value>Arbitrary ready thread priority change.</value>
+          </brief>
+          <description>
+            <value>A ready thread priority is raised above the current
+              thread. The ready list must be reordered without a state
+              transition and the operation must reschedule internally.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[bool switched;
+tprio_t oldprio, prio;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Two lower-priority threads are placed in the ready
+                  list.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[prio = chThdGetPriorityX();
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio - 1, thread, "A");
+threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio - 2, thread, "B");
+test_assert(threads[0]->state == CH_STATE_READY, "thread A not ready");
+test_assert(threads[1]->state == CH_STATE_READY, "thread B not ready");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Thread B is raised above the current thread. It must
+                  run before the locked operation returns.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[1], prio + 1);
+switched = threads[1]->state == CH_STATE_FINAL;
+chSysUnlock();
+
+test_assert(oldprio == prio - 2, "wrong old priority");
+test_assert(switched, "thread B not scheduled internally");
+test_wait_threads();
+test_assert_sequence("BA", "ready list not reordered");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
       </cases>
     </sequence>
     <sequence>
@@ -2660,6 +2723,34 @@ static THD_FUNCTION(thread5, p) {
 static THD_FUNCTION(thread11M, p) {
 
   test_emit_token(*(char *)p);
+}
+
+static thread_reference_t priority_chain_ref;
+
+static THD_FUNCTION(thread13L, p) {
+
+  (void)p;
+  chMtxLock(&m2);
+  chSysLock();
+  (void) chThdSuspendS(&priority_chain_ref);
+  chSysUnlock();
+  chMtxUnlock(&m2);
+}
+
+static THD_FUNCTION(thread13M, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxLock(&m2);
+  chMtxUnlock(&m2);
+  chMtxUnlock(&m1);
+}
+
+static THD_FUNCTION(thread13H, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxUnlock(&m1);
 }
 
 #if CH_CFG_USE_CONDVARS || defined(__DOXYGEN__)
@@ -3939,6 +4030,145 @@ test_assert(chThdGetPriorityX() == prio + 1, "signaller not queued");]]></value>
                 <value><![CDATA[test_assert(msg == MSG_OK, "condition signal lost");
 test_assert(m1.owner == chThdGetSelfX(), "mutex not reacquired");
 chMtxUnlock(&m1);
+test_wait_threads();]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Transitive arbitrary priority change.</value>
+          </brief>
+          <description>
+            <value>The base priority of a thread waiting at the end of a
+              two-mutex dependency chain is changed. Both increases and
+              decreases must propagate through all owners while preserving
+              another waiter's donation.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[priority_chain_ref = NULL;
+chMtxObjectInit(&m1);
+chMtxObjectInit(&m2);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chThdResume(&priority_chain_ref, MSG_RESET);
+test_wait_threads();
+chMtxObjectDispose(&m1);
+chMtxObjectDispose(&m2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[tprio_t oldprio, prio;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Four threads form the chain H and C wait on M, M waits
+                  on L, and L is suspended while owning the final mutex.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[prio = chThdGetPriorityX();
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1,
+                               thread13L, NULL);
+test_assert(priority_chain_ref == threads[0], "thread L not suspended");
+threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio + 2,
+                               thread13M, NULL);
+test_assert(threads[1]->state == CH_STATE_WTMTX, "thread M not waiting");
+threads[2] = chThdCreateStatic(wa[2], WA_SIZE, prio + 3,
+                               thread13H, NULL);
+test_assert(threads[2]->state == CH_STATE_WTMTX, "thread H not waiting");
+threads[3] = chThdCreateStatic(wa[3], WA_SIZE, prio + 4,
+                               thread13H, NULL);
+test_assert(threads[3]->state == CH_STATE_WTMTX, "thread C not waiting");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+            "thread L not initially boosted");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+            "thread M not initially boosted");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Raising H propagates the new effective priority through
+                  M to L.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[2], prio + 5);
+chSysUnlock();
+
+test_assert(oldprio == prio + 3, "wrong old raised priority");
+test_assert(threads[2]->hdr.pqueue.prio == prio + 5,
+            "thread H not raised");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 5,
+            "raise not propagated to M");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 5,
+            "raise not propagated to L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Lowering H below C reorders M1's wait queue and
+                  preserves C's donation throughout the chain.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[2], prio + 1);
+chSysUnlock();
+
+test_assert(oldprio == prio + 5, "wrong old lowered priority");
+test_assert(threads[2]->hdr.pqueue.prio == prio + 1,
+            "thread H not lowered");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+            "competing donation lost at M");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+            "competing donation lost at L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Lowering C below M's base priority removes the final
+                  donation throughout the chain.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[3], prio + 1);
+chSysUnlock();
+
+test_assert(oldprio == prio + 4, "wrong old competing priority");
+test_assert(threads[3]->hdr.pqueue.prio == prio + 1,
+            "thread C not lowered");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 2,
+            "drop not propagated to M");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 2,
+            "drop not propagated to L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>L is resumed and the complete chain is allowed to
+                  unwind.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chThdResume(&priority_chain_ref, MSG_OK);
 test_wait_threads();]]></value>
               </code>
             </step>

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -37,6 +37,7 @@
  * - @subpage rt_test_005_005
  * - @subpage rt_test_005_006
  * - @subpage rt_test_005_007
+ * - @subpage rt_test_005_008
  * .
  */
 
@@ -698,6 +699,64 @@ static const testcase_t rt_test_005_007 = {
 };
 #endif /* CH_CFG_USE_REGISTRY == TRUE */
 
+/**
+ * @page rt_test_005_008 [5.8] Arbitrary ready thread priority change
+ *
+ * <h2>Description</h2>
+ * A ready thread priority is raised above the current thread. The
+ * ready list must be reordered without a state transition and the
+ * operation must reschedule internally.
+ *
+ * <h2>Test Steps</h2>
+ * - [5.8.1] Two lower-priority threads are placed in the ready list.
+ * - [5.8.2] Thread B is raised above the current thread. It must run
+ *   before the locked operation returns.
+ * .
+ */
+
+static void rt_test_005_008_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_005_008_execute(void) {
+  bool switched;
+  tprio_t oldprio, prio;
+
+  /* [5.8.1] Two lower-priority threads are placed in the ready list.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio - 1, thread, "A");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio - 2, thread, "B");
+    test_assert(threads[0]->state == CH_STATE_READY, "thread A not ready");
+    test_assert(threads[1]->state == CH_STATE_READY, "thread B not ready");
+  }
+  test_end_step(1);
+
+  /* [5.8.2] Thread B is raised above the current thread. It must run
+     before the locked operation returns.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[1], prio + 1);
+    switched = threads[1]->state == CH_STATE_FINAL;
+    chSysUnlock();
+
+    test_assert(oldprio == prio - 2, "wrong old priority");
+    test_assert(switched, "thread B not scheduled internally");
+    test_wait_threads();
+    test_assert_sequence("BA", "ready list not reordered");
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_005_008 = {
+  "Arbitrary ready thread priority change",
+  NULL,
+  rt_test_005_008_teardown,
+  rt_test_005_008_execute
+};
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -717,6 +776,7 @@ const testcase_t * const rt_test_sequence_005_array[] = {
 #if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
   &rt_test_005_007,
 #endif
+  &rt_test_005_008,
   NULL
 };
 

--- a/test/rt/source/test/rt_test_sequence_008.c
+++ b/test/rt/source/test/rt_test_sequence_008.c
@@ -48,6 +48,7 @@
  * - @subpage rt_test_008_010
  * - @subpage rt_test_008_011
  * - @subpage rt_test_008_012
+ * - @subpage rt_test_008_013
  * .
  */
 
@@ -209,6 +210,34 @@ static THD_FUNCTION(thread5, p) {
 static THD_FUNCTION(thread11M, p) {
 
   test_emit_token(*(char *)p);
+}
+
+static thread_reference_t priority_chain_ref;
+
+static THD_FUNCTION(thread13L, p) {
+
+  (void)p;
+  chMtxLock(&m2);
+  chSysLock();
+  (void) chThdSuspendS(&priority_chain_ref);
+  chSysUnlock();
+  chMtxUnlock(&m2);
+}
+
+static THD_FUNCTION(thread13M, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxLock(&m2);
+  chMtxUnlock(&m2);
+  chMtxUnlock(&m1);
+}
+
+static THD_FUNCTION(thread13H, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxUnlock(&m1);
 }
 
 #if CH_CFG_USE_CONDVARS || defined(__DOXYGEN__)
@@ -1449,6 +1478,139 @@ static const testcase_t rt_test_008_012 = {
 };
 #endif /* (CH_CFG_USE_CONDVARS == TRUE) && (CH_CFG_USE_CONDVARS_TIMEOUT == TRUE) */
 
+/**
+ * @page rt_test_008_013 [8.13] Transitive arbitrary priority change
+ *
+ * <h2>Description</h2>
+ * The base priority of a thread waiting at the end of a two-mutex
+ * dependency chain is changed. Both increases and decreases must
+ * propagate through all owners while preserving another waiter's
+ * donation.
+ *
+ * <h2>Test Steps</h2>
+ * - [8.13.1] Four threads form the chain H and C wait on M, M waits on
+ *   L, and L is suspended while owning the final mutex.
+ * - [8.13.2] Raising H propagates the new effective priority through M
+ *   to L.
+ * - [8.13.3] Lowering H below C reorders M1's wait queue and preserves
+ *   C's donation throughout the chain.
+ * - [8.13.4] Lowering C below M's base priority removes the final
+ *   donation throughout the chain.
+ * - [8.13.5] L is resumed and the complete chain is allowed to unwind.
+ * .
+ */
+
+static void rt_test_008_013_setup(void) {
+  priority_chain_ref = NULL;
+  chMtxObjectInit(&m1);
+  chMtxObjectInit(&m2);
+}
+
+static void rt_test_008_013_teardown(void) {
+  chThdResume(&priority_chain_ref, MSG_RESET);
+  test_wait_threads();
+  chMtxObjectDispose(&m1);
+  chMtxObjectDispose(&m2);
+}
+
+static void rt_test_008_013_execute(void) {
+  tprio_t oldprio, prio;
+
+  /* [8.13.1] Four threads form the chain H and C wait on M, M waits on
+     L, and L is suspended while owning the final mutex.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1,
+                                   thread13L, NULL);
+    test_assert(priority_chain_ref == threads[0], "thread L not suspended");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio + 2,
+                                   thread13M, NULL);
+    test_assert(threads[1]->state == CH_STATE_WTMTX, "thread M not waiting");
+    threads[2] = chThdCreateStatic(wa[2], WA_SIZE, prio + 3,
+                                   thread13H, NULL);
+    test_assert(threads[2]->state == CH_STATE_WTMTX, "thread H not waiting");
+    threads[3] = chThdCreateStatic(wa[3], WA_SIZE, prio + 4,
+                                   thread13H, NULL);
+    test_assert(threads[3]->state == CH_STATE_WTMTX, "thread C not waiting");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+                "thread L not initially boosted");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+                "thread M not initially boosted");
+  }
+  test_end_step(1);
+
+  /* [8.13.2] Raising H propagates the new effective priority through M
+     to L.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[2], prio + 5);
+    chSysUnlock();
+
+    test_assert(oldprio == prio + 3, "wrong old raised priority");
+    test_assert(threads[2]->hdr.pqueue.prio == prio + 5,
+                "thread H not raised");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 5,
+                "raise not propagated to M");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 5,
+                "raise not propagated to L");
+  }
+  test_end_step(2);
+
+  /* [8.13.3] Lowering H below C reorders M1's wait queue and preserves
+     C's donation throughout the chain.*/
+  test_set_step(3);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[2], prio + 1);
+    chSysUnlock();
+
+    test_assert(oldprio == prio + 5, "wrong old lowered priority");
+    test_assert(threads[2]->hdr.pqueue.prio == prio + 1,
+                "thread H not lowered");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+                "competing donation lost at M");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+                "competing donation lost at L");
+  }
+  test_end_step(3);
+
+  /* [8.13.4] Lowering C below M's base priority removes the final
+     donation throughout the chain.*/
+  test_set_step(4);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[3], prio + 1);
+    chSysUnlock();
+
+    test_assert(oldprio == prio + 4, "wrong old competing priority");
+    test_assert(threads[3]->hdr.pqueue.prio == prio + 1,
+                "thread C not lowered");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 2,
+                "drop not propagated to M");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 2,
+                "drop not propagated to L");
+  }
+  test_end_step(4);
+
+  /* [8.13.5] L is resumed and the complete chain is allowed to
+     unwind.*/
+  test_set_step(5);
+  {
+    chThdResume(&priority_chain_ref, MSG_OK);
+    test_wait_threads();
+  }
+  test_end_step(5);
+}
+
+static const testcase_t rt_test_008_013 = {
+  "Transitive arbitrary priority change",
+  rt_test_008_013_setup,
+  rt_test_008_013_teardown,
+  rt_test_008_013_execute
+};
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -1485,6 +1647,7 @@ const testcase_t * const rt_test_sequence_008_array[] = {
 #if ((CH_CFG_USE_CONDVARS == TRUE) && (CH_CFG_USE_CONDVARS_TIMEOUT == TRUE)) || defined(__DOXYGEN__)
   &rt_test_008_012,
 #endif
+  &rt_test_008_013,
   NULL
 };
 


### PR DESCRIPTION
Summary:
- add an internal S-class operation for changing any thread base priority
- recompute effective priority and propagate raises and drops through mutex-owner chains
- requeue READY threads without fake state transitions or duplicate trace events
- notify remote SMP instances when READY or CURRENT scheduling decisions may change
- route chThdSetPriority() through the common operation
- add generated regressions for READY-list and transitive PI reprioritization

Validation:
- RT simulator default configuration
- RT simulator mutex-disabled configuration
- RT simulator recursive-mutex configuration
- RT simulator unoptimized scheduler configuration
- RT simulator full checks/assertions/trace configuration
- semaphore-priority and message-priority configurations compile
- RP2040 SMP ARM build
- XML validation, regeneration, stylecheck, and git diff checks