### PR TITLE
Abstractions: fix arbitrary thread priority changes

### DIFF
--- a/os/common/abstractions/cmsis_os/cmsis_os.c
+++ b/os/common/abstractions/cmsis_os/cmsis_os.c
@@ -66,6 +66,44 @@ __STATIC_INLINE sysinterval_t tmo(uint32_t millisec) {
 }
 
 /**
+ * @brief   Converts a CMSIS priority into an RT priority.
+ *
+ * @param[in] priority      CMSIS priority
+ * @param[out] rtprio       pointer to the RT priority result
+ * @retval true             conversion successful
+ * @retval false            invalid CMSIS priority
+ */
+static bool cmsis_priority_to_rt(osPriority priority, tprio_t *rtprio) {
+
+  if ((priority < osPriorityIdle) || (priority > osPriorityRealtime)) {
+    return false;
+  }
+
+  *rtprio = (tprio_t)((int)NORMALPRIO + (int)priority);
+
+  return true;
+}
+
+/**
+ * @brief   Converts an RT priority into a CMSIS priority.
+ *
+ * @param[in] rtprio        RT priority
+ * @return                  The CMSIS priority.
+ * @retval osPriorityError  the RT priority is outside the CMSIS range
+ */
+static osPriority cmsis_priority_from_rt(tprio_t rtprio) {
+  int priority;
+
+  priority = (int)rtprio - (int)NORMALPRIO;
+  if ((priority < (int)osPriorityIdle) ||
+      (priority > (int)osPriorityRealtime)) {
+    return osPriorityError;
+  }
+
+  return (osPriority)priority;
+}
+
+/**
  * @brief   Virtual timers common callback.
  */
 static void timer_cb(virtual_timer_t *vtp, void const *arg) {
@@ -133,13 +171,19 @@ osStatus osKernelStart(void) {
  */
 osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *argument) {
   size_t size;
+  tprio_t priority;
+
+  if ((thread_def == NULL) ||
+      !cmsis_priority_to_rt(thread_def->tpriority, &priority)) {
+    return NULL;
+  }
 
   size = thread_def->stacksize == 0 ? CMSIS_CFG_DEFAULT_STACK :
                                       thread_def->stacksize;
   return (osThreadId)chThdCreateFromHeap(0,
                                          THD_WORKING_AREA_SIZE(size),
                                          thread_def->name,
-                                         NORMALPRIO+thread_def->tpriority,
+                                         priority,
                                          (tfunc_t)thread_def->pthread,
                                          argument);
 }
@@ -168,67 +212,51 @@ osStatus osThreadTerminate(osThreadId thread_id) {
 
 /**
  * @brief   Changes a thread priority.
- * @note    This can interfere with the priority inheritance mechanism.
  *
  * @param[in] thread_id             a thread identifier
  * @param[in] newprio               new priority level
  * @return                          The function execution status.
  * @retval osOK                     if the function succeeded.
+ * @retval osErrorParameter         if @p thread_id is @p NULL.
+ * @retval osErrorPriority          if @p newprio is invalid.
  */
 osStatus osThreadSetPriority(osThreadId thread_id, osPriority newprio) {
-  thread_t * tp = (thread_t *)thread_id;
+  tprio_t priority;
 
-  chSysLock();
-
-  /* Changing priority.*/
-#if CH_CFG_USE_MUTEXES
-  if ((tp->hdr.pqueue.prio == tp->realprio) ||
-      ((tprio_t)newprio > tp->hdr.pqueue.prio))
-    tp->hdr.pqueue.prio = (tprio_t)newprio;
-  tp->realprio = (tprio_t)newprio;
-#else
-  tp->hdr.pqueue.prio = (tprio_t)newprio;
-#endif
-
-  /* The following states need priority queues reordering.*/
-  switch (tp->state) {
-#if CH_CFG_USE_MUTEXES |                                                    \
-    CH_CFG_USE_CONDVARS |                                                   \
-    (CH_CFG_USE_SEMAPHORES && CH_CFG_USE_SEMAPHORES_PRIORITY) |             \
-    (CH_CFG_USE_MESSAGES && CH_CFG_USE_MESSAGES_PRIORITY)
-#if CH_CFG_USE_MUTEXES
-  case CH_STATE_WTMTX:
-#endif
-#if CH_CFG_USE_CONDVARS
-  case CH_STATE_WTCOND:
-#endif
-#if CH_CFG_USE_SEMAPHORES && CH_CFG_USE_SEMAPHORES_PRIORITY
-  case CH_STATE_WTSEM:
-#endif
-#if CH_CFG_USE_MESSAGES && CH_CFG_USE_MESSAGES_PRIORITY
-  case CH_STATE_SNDMSGQ:
-#endif
-    /* Re-enqueues tp with its new priority on the queue.*/
-    ch_sch_prio_insert((ch_queue_t *)tp->u.wtobjp,
-                       ch_queue_dequeue(&tp->hdr.queue));
-    break;
-#endif
-  case CH_STATE_READY:
-#if CH_DBG_ENABLE_ASSERTS
-    /* Prevents an assertion in chSchReadyI().*/
-    tp->state = CH_STATE_CURRENT;
-#endif
-    /* Re-enqueues tp with its new priority on the ready list.*/
-    chSchReadyI((thread_t *)ch_queue_dequeue(&tp->hdr.queue));
-    break;
+  if (thread_id == NULL) {
+    return osErrorParameter;
+  }
+  if (!cmsis_priority_to_rt(newprio, &priority)) {
+    return osErrorPriority;
   }
 
-  /* Rescheduling.*/
-  chSchRescheduleS();
-
+  chSysLock();
+  (void) __thd_set_priority((thread_t *)thread_id, priority);
   chSysUnlock();
 
   return osOK;
+}
+
+/**
+ * @brief   Returns the current priority of a thread.
+ *
+ * @param[in] thread_id             a thread identifier
+ * @return                          The current thread priority.
+ * @retval osPriorityError          if @p thread_id is @p NULL or its current
+ *                                  priority is outside the CMSIS range.
+ */
+osPriority osThreadGetPriority(osThreadId thread_id) {
+  osPriority priority;
+
+  if (thread_id == NULL) {
+    return osPriorityError;
+  }
+
+  chSysLock();
+  priority = cmsis_priority_from_rt(thread_id->hdr.pqueue.prio);
+  chSysUnlock();
+
+  return priority;
 }
 
 /**

--- a/os/common/abstractions/cmsis_os/cmsis_os.h
+++ b/os/common/abstractions/cmsis_os/cmsis_os.h
@@ -471,6 +471,7 @@ extern "C" {
   osThreadId osThreadCreate(const osThreadDef_t *thread_def, void *argument);
   osStatus osThreadTerminate(osThreadId thread_id);
   osStatus osThreadSetPriority(osThreadId thread_id, osPriority newprio);
+  osPriority osThreadGetPriority(osThreadId thread_id);
   /*osEvent osWait(uint32_t millisec);*/
   osTimerId osTimerCreate(const osTimerDef_t *timer_def,
                           os_timer_type type,
@@ -548,14 +549,6 @@ static inline osStatus osThreadYield(void) {
   chThdYield();
 
   return osOK;
-}
-
-/**
- * @brief   Returns priority of a thread.
- */
-static inline osPriority osThreadGetPriority(osThreadId thread_id) {
-
-  return (osPriority)(NORMALPRIO - thread_id->hdr.pqueue.prio);
 }
 
 /**

--- a/os/common/abstractions/nasa_cfe/osal/src/osapi.c
+++ b/os/common/abstractions/nasa_cfe/osal/src/osapi.c
@@ -2009,10 +2009,6 @@ int32 OS_TaskSetPriority(uint32 task_id, uint32 new_priority) {
     rt_newprio = 2;
   }
 
-  if (chThdGetPriorityX() == rt_newprio) {
-    return OS_SUCCESS;
-  }
-
   /* Check for thread validity.*/
   tp = chRegFindThreadByPointer(tp);
   if (tp == NULL) {
@@ -2021,41 +2017,11 @@ int32 OS_TaskSetPriority(uint32 task_id, uint32 new_priority) {
 
   chSysLock();
 
-  /* Changing priority.*/
-  if ((tp->hdr.pqueue.prio == tp->realprio) ||
-      (rt_newprio > tp->hdr.pqueue.prio)) {
-    tp->hdr.pqueue.prio = rt_newprio;
-  }
-  tp->realprio = rt_newprio;
-
-  /* The following states need priority queues reordering.*/
-  switch (tp->state) {
-  case CH_STATE_WTMTX:
-#if CH_CFG_USE_CONDVARS
-  case CH_STATE_WTCOND:
-#endif
-#if CH_CFG_USE_SEMAPHORES_PRIORITY
-  case CH_STATE_WTSEM:
-#endif
-#if CH_CFG_USE_MESSAGES && CH_CFG_USE_MESSAGES_PRIORITY
-  case CH_STATE_SNDMSGQ:
-#endif
-    /* Re-enqueues tp with its new priority on the queue.*/
-    ch_sch_prio_insert((ch_queue_t *)tp->u.wtobjp,
-                       ch_queue_dequeue(&tp->hdr.queue));
-    break;
-  case CH_STATE_READY:
-#if CH_DBG_ENABLE_ASSERTS
-    /* Prevents an assertion in chSchReadyI().*/
-    tp->state = CH_STATE_CURRENT;
-#endif
-    /* Re-enqueues tp with its new priority on the ready list.*/
-    chSchReadyI((thread_t *)ch_queue_dequeue(&tp->hdr.queue));
-    break;
+  /* Changing the target priority if required.*/
+  if (tp->realprio != rt_newprio) {
+    (void) __thd_set_priority(tp, rt_newprio);
   }
 
-  /* Rescheduling.*/
-  chSchRescheduleS();
   chSysUnlock();
 
   /* Releasing the thread reference.*/

--- a/os/rt/include/chschd.h
+++ b/os/rt/include/chschd.h
@@ -140,6 +140,7 @@ extern "C" {
 #endif
   void chSchObjectInit(os_instance_t *oip,
                        const os_instance_config_t *oicp);
+  void __sch_requeue_behind(thread_t *tp);
   thread_t *chSchReadyI(thread_t *tp);
   void chSchGoSleepS(tstate_t newstate);
   msg_t chSchGoSleepTimeoutS(tstate_t newstate, sysinterval_t timeout);

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -464,6 +464,7 @@ extern "C" {
   msg_t chThdSync(thread_t *tp);
   msg_t chThdWait(thread_t *tp);
 #endif
+  tprio_t __thd_set_priority(thread_t *tp, tprio_t newprio);
   tprio_t chThdSetPriority(tprio_t newprio);
   void chThdTerminate(thread_t *tp);
   msg_t chThdSuspendS(thread_reference_t *trp);

--- a/os/rt/src/chmtx.c
+++ b/os/rt/src/chmtx.c
@@ -266,12 +266,8 @@ void chMtxLockS(mutex_t *mp) {
           break;
 #endif
         case CH_STATE_READY:
-#if CH_DBG_ENABLE_ASSERTS == TRUE
-          /* Prevents an assertion in chSchReadyI().*/
-          tp->state = CH_STATE_CURRENT;
-#endif
           /* Re-enqueues tp with its new priority on the ready list.*/
-          (void) chSchReadyI(threadref(ch_queue_dequeue(&tp->hdr.queue)));
+          __sch_requeue_behind(tp);
           break;
         default:
           /* Nothing to do for other states.*/

--- a/os/rt/src/chschd.c
+++ b/os/rt/src/chschd.c
@@ -267,6 +267,38 @@ void ch_sch_prio_insert(ch_queue_t *qp, ch_queue_t *tp) {
 #endif /* CH_CFG_OPTIMIZE_SPEED */
 
 /**
+ * @brief   Requeues a ready thread behind its new peers.
+ * @details The thread is removed from its ready list and reinserted behind
+ *          all threads with higher or equal priority.
+ * @pre     The thread must be in the @p CH_STATE_READY state.
+ * @post    This function does not reschedule so a call to a rescheduling
+ *          function must be performed before unlocking the kernel.
+ *
+ * @param[in] tp        the thread to be requeued
+ *
+ * @notapi
+ * @iclass
+ */
+void __sch_requeue_behind(thread_t *tp) {
+
+  chDbgCheckClassI();
+  chDbgCheck(tp != NULL);
+  chDbgAssert(tp->state == CH_STATE_READY, "invalid state");
+
+#if CH_CFG_SMP_MODE == TRUE
+  if (tp->owner != currcore) {
+    /* Triggering a reschedule on the owning core.*/
+    chSysNotifyInstance(tp->owner);
+  }
+#endif
+
+  /* Re-insertion in the priority queue, no state change or trace event.*/
+  (void) ch_queue_dequeue(&tp->hdr.queue);
+  (void) ch_pqueue_insert_behind(&tp->owner->rlist.pqueue,
+                                 &tp->hdr.pqueue);
+}
+
+/**
  * @brief   Inserts a thread in the Ready List placing it behind its peers.
  * @details The thread is positioned behind all threads with higher or equal
  *          priority.

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -865,6 +865,112 @@ msg_t chThdWait(thread_t *tp) {
 #endif /* CH_CFG_USE_WAITEXIT */
 
 /**
+ * @brief   Changes the base priority of a thread.
+ * @details The effective priority is recomputed and the thread is repositioned
+ *          in its current priority queue. If the thread is waiting on a mutex
+ *          then priority changes are propagated through the owner chain.
+ * @post    A local reschedule is performed before returning. Remote instances
+ *          affected by a ready or current thread priority change are notified.
+ *
+ * @param[in] tp        pointer to the thread
+ * @param[in] newprio   the new base priority level, from @p LOWPRIO through
+ *                      @p HIGHPRIO
+ * @return              The old base priority level.
+ *
+ * @notapi
+ * @sclass
+ */
+tprio_t __thd_set_priority(thread_t *tp, tprio_t newprio) {
+  thread_t *nexttp;
+  ch_queue_t *qp;
+  tprio_t neweffective;
+  tprio_t oldeffective;
+  tprio_t oldprio;
+
+  chDbgCheckClassS();
+  chDbgCheck((tp != NULL) &&
+             (newprio >= LOWPRIO) && (newprio <= HIGHPRIO));
+
+#if CH_CFG_USE_MUTEXES == TRUE
+  oldprio = tp->realprio;
+  tp->realprio = newprio;
+#else
+  oldprio = tp->hdr.pqueue.prio;
+#endif
+
+  while (true) {
+    oldeffective = tp->hdr.pqueue.prio;
+#if CH_CFG_USE_MUTEXES == TRUE
+    neweffective = __mtx_get_effective_priority(tp);
+#else
+    neweffective = newprio;
+#endif
+    if (neweffective == oldeffective) {
+      break;
+    }
+
+    tp->hdr.pqueue.prio = neweffective;
+    nexttp = NULL;
+    qp = NULL;
+
+    /* The following states need priority queues reordering.*/
+    switch (tp->state) {
+#if CH_CFG_USE_MUTEXES == TRUE
+    case CH_STATE_WTMTX:
+      chDbgAssert((tp->u.wtmtxp != NULL) &&
+                  (tp->u.wtmtxp->owner != NULL),
+                  "mutex not owned");
+      qp = &tp->u.wtmtxp->queue;
+      nexttp = tp->u.wtmtxp->owner;
+      break;
+#endif
+#if CH_CFG_USE_CONDVARS == TRUE
+    case CH_STATE_WTCOND:
+      qp = &((condition_variable_t *)tp->u.wtobjp)->queue;
+      break;
+#endif
+#if (CH_CFG_USE_SEMAPHORES == TRUE) &&                                     \
+    (CH_CFG_USE_SEMAPHORES_PRIORITY == TRUE)
+    case CH_STATE_WTSEM:
+      qp = &tp->u.wtsemp->queue;
+      break;
+#endif
+#if (CH_CFG_USE_MESSAGES == TRUE) &&                                       \
+    (CH_CFG_USE_MESSAGES_PRIORITY == TRUE)
+    case CH_STATE_SNDMSGQ:
+      qp = (ch_queue_t *)tp->u.wtobjp;
+      break;
+#endif
+    case CH_STATE_READY:
+      __sch_requeue_behind(tp);
+      break;
+    case CH_STATE_CURRENT:
+#if CH_CFG_SMP_MODE == TRUE
+      if (tp->owner != currcore) {
+        chSysNotifyInstance(tp->owner);
+      }
+#endif
+      break;
+    default:
+      /* Nothing to do for other states.*/
+      break;
+    }
+
+    if (qp != NULL) {
+      ch_sch_prio_insert(qp, ch_queue_dequeue(&tp->hdr.queue));
+    }
+    if (nexttp == NULL) {
+      break;
+    }
+    tp = nexttp;
+  }
+
+  chSchRescheduleS();
+
+  return oldprio;
+}
+
+/**
  * @brief   Changes the running thread priority level then reschedules if
  *          necessary.
  * @note    The function returns the real thread priority regardless of the
@@ -884,15 +990,7 @@ tprio_t chThdSetPriority(tprio_t newprio) {
   chDbgCheck((newprio >= LOWPRIO) && (newprio <= HIGHPRIO));
 
   chSysLock();
-#if CH_CFG_USE_MUTEXES == TRUE
-  oldprio = currtp->realprio;
-  currtp->realprio = newprio;
-  currtp->hdr.pqueue.prio = __mtx_get_effective_priority(currtp);
-#else
-  oldprio = currtp->hdr.pqueue.prio;
-  currtp->hdr.pqueue.prio = newprio;
-#endif
-  chSchRescheduleS();
+  oldprio = __thd_set_priority(currtp, newprio);
   chSysUnlock();
 
   return oldprio;

--- a/test/nasa_osal/configuration.xml
+++ b/test/nasa_osal/configuration.xml
@@ -88,6 +88,45 @@ static void test_task_delete(void) {
     (void) OS_TaskDelay(1);
   }
   test_emit_token('B');
+}
+
+static void test_task_priority(void) {
+
+  while (!OS_TaskDeleteCheck()) {
+    (void) OS_TaskDelay(1);
+  }
+}
+
+static mutex_t priority_m1;
+static mutex_t priority_m2;
+static thread_reference_t priority_chain_ref;
+static uint32 priority_tid;
+static uint32 priority_tid_l;
+static uint32 priority_tid_m;
+static uint32 priority_tid_h;
+static uint32 priority_tid_c;
+
+static void test_task_priority_l(void) {
+
+  chMtxLock(&priority_m2);
+  chSysLock();
+  (void) chThdSuspendS(&priority_chain_ref);
+  chSysUnlock();
+  chMtxUnlock(&priority_m2);
+}
+
+static void test_task_priority_m(void) {
+
+  chMtxLock(&priority_m1);
+  chMtxLock(&priority_m2);
+  chMtxUnlock(&priority_m2);
+  chMtxUnlock(&priority_m1);
+}
+
+static void test_task_priority_h(void) {
+
+  chMtxLock(&priority_m1);
+  chMtxUnlock(&priority_m1);
 }]]></value>
       </shared_code>
       <cases>
@@ -633,6 +672,251 @@ test_assert(err == OS_SUCCESS, "deletable task creation failed");]]></value>
 err = OS_TaskDelete(tid);
 test_assert(err == OS_SUCCESS, "delete failed");
 test_assert_sequence("ABC", "events order violation");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>OS_TaskSetPriority() validation and conversion</value>
+          </brief>
+          <description>
+            <value>Target validation and OSAL-to-RT priority conversion are
+              tested, including the case where the caller already has the
+              requested priority.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[priority_tid = 0;]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[if (priority_tid != 0) {
+  (void) OS_TaskDelete(priority_tid);
+}]]></value>
+            </teardown_code>
+            <local_variables>
+              <value />
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Invalid priorities and an invalid target are rejected.
+                  The invalid-target request uses the caller's own priority.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+
+err = OS_TaskSetPriority((uint32)-1, 0);
+test_assert(err == OS_ERR_INVALID_PRIORITY, "low priority accepted");
+err = OS_TaskSetPriority((uint32)-1, 256);
+test_assert(err == OS_ERR_INVALID_PRIORITY, "high priority accepted");
+err = OS_TaskSetPriority((uint32)-1, 128);
+test_assert(err == OS_ERR_INVALID_ID, "invalid target accepted");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A lower-priority task is created then changed to the
+                  caller's priority.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+
+err = OS_TaskCreate(&priority_tid,
+                    "priority target",
+                    test_task_priority,
+                    (uint32 *)wa_test1,
+                    sizeof wa_test1,
+                    TASKS_BASE_PRIORITY,
+                    0);
+test_assert(err == OS_SUCCESS, "task creation failed");
+
+err = OS_TaskSetPriority(priority_tid, 128);
+test_assert(err == OS_SUCCESS, "priority change failed");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The task information reports the requested OSAL
+                  priority, then the task is deleted.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+OS_task_prop_t info;
+
+err = OS_TaskGetInfo(priority_tid, &info);
+test_assert(err == OS_SUCCESS, "task info failed");
+test_assert(info.priority == 128, "priority conversion failed");
+
+err = OS_TaskDelete(priority_tid);
+test_assert(err == OS_SUCCESS, "task deletion failed");
+priority_tid = 0;]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>OS_TaskSetPriority() transitive inheritance</value>
+          </brief>
+          <description>
+            <value>Priority changes to mutex waiters are propagated through
+              a two-owner chain while preserving a competing donation.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[priority_tid_l = 0;
+priority_tid_m = 0;
+priority_tid_h = 0;
+priority_tid_c = 0;
+priority_chain_ref = NULL;
+chMtxObjectInit(&priority_m1);
+chMtxObjectInit(&priority_m2);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chThdResume(&priority_chain_ref, MSG_RESET);
+if (priority_tid_l != 0) {
+  (void) OS_TaskWait(priority_tid_l);
+}
+if (priority_tid_m != 0) {
+  (void) OS_TaskWait(priority_tid_m);
+}
+if (priority_tid_h != 0) {
+  (void) OS_TaskWait(priority_tid_h);
+}
+if (priority_tid_c != 0) {
+  (void) OS_TaskWait(priority_tid_c);
+}
+chMtxObjectDispose(&priority_m1);
+chMtxObjectDispose(&priority_m2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value />
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Four OSAL tasks form the chain H and C wait on M,
+                  M waits on L, and L is suspended.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+
+err = OS_TaskCreate(&priority_tid_l, "priority L", test_task_priority_l,
+                    (uint32 *)wa_test1, sizeof wa_test1, 127, 0);
+test_assert(err == OS_SUCCESS, "task L creation failed");
+test_assert(priority_chain_ref == (thread_t *)priority_tid_l,
+            "task L not suspended");
+
+err = OS_TaskCreate(&priority_tid_m, "priority M", test_task_priority_m,
+                    (uint32 *)wa_test2, sizeof wa_test2, 126, 0);
+test_assert(err == OS_SUCCESS, "task M creation failed");
+test_assert(((thread_t *)priority_tid_m)->state == CH_STATE_WTMTX,
+            "task M not waiting");
+
+err = OS_TaskCreate(&priority_tid_h, "priority H", test_task_priority_h,
+                    (uint32 *)wa_test3, sizeof wa_test3, 125, 0);
+test_assert(err == OS_SUCCESS, "task H creation failed");
+test_assert(((thread_t *)priority_tid_h)->state == CH_STATE_WTMTX,
+            "task H not waiting");
+
+err = OS_TaskCreate(&priority_tid_c, "priority C", test_task_priority_h,
+                    (uint32 *)wa_test4, sizeof wa_test4, 124, 0);
+test_assert(err == OS_SUCCESS, "task C creation failed");
+test_assert(((thread_t *)priority_tid_c)->state == CH_STATE_WTMTX,
+            "task C not waiting");
+
+test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 4,
+            "task L not initially boosted");
+test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 4,
+            "task M not initially boosted");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Raising H above C propagates through both owners.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+
+err = OS_TaskSetPriority(priority_tid_h, 123);
+test_assert(err == OS_SUCCESS, "task H raise failed");
+test_assert(((thread_t *)priority_tid_h)->hdr.pqueue.prio == NORMALPRIO + 5,
+            "task H not raised");
+test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 5,
+            "raise not propagated to M");
+test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 5,
+            "raise not propagated to L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Lowering H preserves C's donation, then lowering C
+                  restores M's base priority throughout the chain.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[int32 err;
+
+err = OS_TaskSetPriority(priority_tid_h, 127);
+test_assert(err == OS_SUCCESS, "task H lowering failed");
+test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 4,
+            "competing donation lost at M");
+test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 4,
+            "competing donation lost at L");
+
+err = OS_TaskSetPriority(priority_tid_c, 127);
+test_assert(err == OS_SUCCESS, "task C lowering failed");
+test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 2,
+            "drop not propagated to M");
+test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 2,
+            "drop not propagated to L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>L is resumed and all tasks are reaped.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chThdResume(&priority_chain_ref, MSG_OK);
+(void) OS_TaskWait(priority_tid_l);
+(void) OS_TaskWait(priority_tid_m);
+(void) OS_TaskWait(priority_tid_h);
+(void) OS_TaskWait(priority_tid_c);
+priority_tid_l = 0;
+priority_tid_m = 0;
+priority_tid_h = 0;
+priority_tid_c = 0;]]></value>
               </code>
             </step>
           </steps>

--- a/test/nasa_osal/source/test/nasa_osal_test_sequence_001.c
+++ b/test/nasa_osal/source/test/nasa_osal_test_sequence_001.c
@@ -20,6 +20,8 @@
  * - @subpage nasa_osal_test_001_002
  * - @subpage nasa_osal_test_001_003
  * - @subpage nasa_osal_test_001_004
+ * - @subpage nasa_osal_test_001_005
+ * - @subpage nasa_osal_test_001_006
  * .
  */
 
@@ -62,6 +64,45 @@ static void test_task_delete(void) {
     (void) OS_TaskDelay(1);
   }
   test_emit_token('B');
+}
+
+static void test_task_priority(void) {
+
+  while (!OS_TaskDeleteCheck()) {
+    (void) OS_TaskDelay(1);
+  }
+}
+
+static mutex_t priority_m1;
+static mutex_t priority_m2;
+static thread_reference_t priority_chain_ref;
+static uint32 priority_tid;
+static uint32 priority_tid_l;
+static uint32 priority_tid_m;
+static uint32 priority_tid_h;
+static uint32 priority_tid_c;
+
+static void test_task_priority_l(void) {
+
+  chMtxLock(&priority_m2);
+  chSysLock();
+  (void) chThdSuspendS(&priority_chain_ref);
+  chSysUnlock();
+  chMtxUnlock(&priority_m2);
+}
+
+static void test_task_priority_m(void) {
+
+  chMtxLock(&priority_m1);
+  chMtxLock(&priority_m2);
+  chMtxUnlock(&priority_m2);
+  chMtxUnlock(&priority_m1);
+}
+
+static void test_task_priority_h(void) {
+
+  chMtxLock(&priority_m1);
+  chMtxUnlock(&priority_m1);
 }
 
 /****************************************************************************
@@ -557,6 +598,241 @@ static const testcase_t nasa_osal_test_001_004 = {
   nasa_osal_test_001_004_execute
 };
 
+/**
+ * @page nasa_osal_test_001_005 [1.5] OS_TaskSetPriority() validation and conversion
+ *
+ * <h2>Description</h2>
+ * Target validation and OSAL-to-RT priority conversion are tested,
+ * including the case where the caller already has the requested
+ * priority.
+ *
+ * <h2>Test Steps</h2>
+ * - [1.5.1] Invalid priorities and an invalid target are rejected. The
+ *   invalid-target request uses the caller's own priority.
+ * - [1.5.2] A lower-priority task is created then changed to the
+ *   caller's priority.
+ * - [1.5.3] The task information reports the requested OSAL priority,
+ *   then the task is deleted.
+ * .
+ */
+
+static void nasa_osal_test_001_005_setup(void) {
+  priority_tid = 0;
+}
+
+static void nasa_osal_test_001_005_teardown(void) {
+  if (priority_tid != 0) {
+    (void) OS_TaskDelete(priority_tid);
+  }
+}
+
+static void nasa_osal_test_001_005_execute(void) {
+
+  /* [1.5.1] Invalid priorities and an invalid target are rejected. The
+     invalid-target request uses the caller's own priority.*/
+  test_set_step(1);
+  {
+    int32 err;
+
+    err = OS_TaskSetPriority((uint32)-1, 0);
+    test_assert(err == OS_ERR_INVALID_PRIORITY, "low priority accepted");
+    err = OS_TaskSetPriority((uint32)-1, 256);
+    test_assert(err == OS_ERR_INVALID_PRIORITY, "high priority accepted");
+    err = OS_TaskSetPriority((uint32)-1, 128);
+    test_assert(err == OS_ERR_INVALID_ID, "invalid target accepted");
+  }
+  test_end_step(1);
+
+  /* [1.5.2] A lower-priority task is created then changed to the
+     caller's priority.*/
+  test_set_step(2);
+  {
+    int32 err;
+
+    err = OS_TaskCreate(&priority_tid,
+                        "priority target",
+                        test_task_priority,
+                        (uint32 *)wa_test1,
+                        sizeof wa_test1,
+                        TASKS_BASE_PRIORITY,
+                        0);
+    test_assert(err == OS_SUCCESS, "task creation failed");
+
+    err = OS_TaskSetPriority(priority_tid, 128);
+    test_assert(err == OS_SUCCESS, "priority change failed");
+  }
+  test_end_step(2);
+
+  /* [1.5.3] The task information reports the requested OSAL priority,
+     then the task is deleted.*/
+  test_set_step(3);
+  {
+    int32 err;
+    OS_task_prop_t info;
+
+    err = OS_TaskGetInfo(priority_tid, &info);
+    test_assert(err == OS_SUCCESS, "task info failed");
+    test_assert(info.priority == 128, "priority conversion failed");
+
+    err = OS_TaskDelete(priority_tid);
+    test_assert(err == OS_SUCCESS, "task deletion failed");
+    priority_tid = 0;
+  }
+  test_end_step(3);
+}
+
+static const testcase_t nasa_osal_test_001_005 = {
+  "OS_TaskSetPriority() validation and conversion",
+  nasa_osal_test_001_005_setup,
+  nasa_osal_test_001_005_teardown,
+  nasa_osal_test_001_005_execute
+};
+
+/**
+ * @page nasa_osal_test_001_006 [1.6] OS_TaskSetPriority() transitive inheritance
+ *
+ * <h2>Description</h2>
+ * Priority changes to mutex waiters are propagated through a two-owner
+ * chain while preserving a competing donation.
+ *
+ * <h2>Test Steps</h2>
+ * - [1.6.1] Four OSAL tasks form the chain H and C wait on M, M waits
+ *   on L, and L is suspended.
+ * - [1.6.2] Raising H above C propagates through both owners.
+ * - [1.6.3] Lowering H preserves C's donation, then lowering C
+ *   restores M's base priority throughout the chain.
+ * - [1.6.4] L is resumed and all tasks are reaped.
+ * .
+ */
+
+static void nasa_osal_test_001_006_setup(void) {
+  priority_tid_l = 0;
+  priority_tid_m = 0;
+  priority_tid_h = 0;
+  priority_tid_c = 0;
+  priority_chain_ref = NULL;
+  chMtxObjectInit(&priority_m1);
+  chMtxObjectInit(&priority_m2);
+}
+
+static void nasa_osal_test_001_006_teardown(void) {
+  chThdResume(&priority_chain_ref, MSG_RESET);
+  if (priority_tid_l != 0) {
+    (void) OS_TaskWait(priority_tid_l);
+  }
+  if (priority_tid_m != 0) {
+    (void) OS_TaskWait(priority_tid_m);
+  }
+  if (priority_tid_h != 0) {
+    (void) OS_TaskWait(priority_tid_h);
+  }
+  if (priority_tid_c != 0) {
+    (void) OS_TaskWait(priority_tid_c);
+  }
+  chMtxObjectDispose(&priority_m1);
+  chMtxObjectDispose(&priority_m2);
+}
+
+static void nasa_osal_test_001_006_execute(void) {
+
+  /* [1.6.1] Four OSAL tasks form the chain H and C wait on M, M waits
+     on L, and L is suspended.*/
+  test_set_step(1);
+  {
+    int32 err;
+
+    err = OS_TaskCreate(&priority_tid_l, "priority L", test_task_priority_l,
+                        (uint32 *)wa_test1, sizeof wa_test1, 127, 0);
+    test_assert(err == OS_SUCCESS, "task L creation failed");
+    test_assert(priority_chain_ref == (thread_t *)priority_tid_l,
+                "task L not suspended");
+
+    err = OS_TaskCreate(&priority_tid_m, "priority M", test_task_priority_m,
+                        (uint32 *)wa_test2, sizeof wa_test2, 126, 0);
+    test_assert(err == OS_SUCCESS, "task M creation failed");
+    test_assert(((thread_t *)priority_tid_m)->state == CH_STATE_WTMTX,
+                "task M not waiting");
+
+    err = OS_TaskCreate(&priority_tid_h, "priority H", test_task_priority_h,
+                        (uint32 *)wa_test3, sizeof wa_test3, 125, 0);
+    test_assert(err == OS_SUCCESS, "task H creation failed");
+    test_assert(((thread_t *)priority_tid_h)->state == CH_STATE_WTMTX,
+                "task H not waiting");
+
+    err = OS_TaskCreate(&priority_tid_c, "priority C", test_task_priority_h,
+                        (uint32 *)wa_test4, sizeof wa_test4, 124, 0);
+    test_assert(err == OS_SUCCESS, "task C creation failed");
+    test_assert(((thread_t *)priority_tid_c)->state == CH_STATE_WTMTX,
+                "task C not waiting");
+
+    test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 4,
+                "task L not initially boosted");
+    test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 4,
+                "task M not initially boosted");
+  }
+  test_end_step(1);
+
+  /* [1.6.2] Raising H above C propagates through both owners.*/
+  test_set_step(2);
+  {
+    int32 err;
+
+    err = OS_TaskSetPriority(priority_tid_h, 123);
+    test_assert(err == OS_SUCCESS, "task H raise failed");
+    test_assert(((thread_t *)priority_tid_h)->hdr.pqueue.prio == NORMALPRIO + 5,
+                "task H not raised");
+    test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 5,
+                "raise not propagated to M");
+    test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 5,
+                "raise not propagated to L");
+  }
+  test_end_step(2);
+
+  /* [1.6.3] Lowering H preserves C's donation, then lowering C
+     restores M's base priority throughout the chain.*/
+  test_set_step(3);
+  {
+    int32 err;
+
+    err = OS_TaskSetPriority(priority_tid_h, 127);
+    test_assert(err == OS_SUCCESS, "task H lowering failed");
+    test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 4,
+                "competing donation lost at M");
+    test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 4,
+                "competing donation lost at L");
+
+    err = OS_TaskSetPriority(priority_tid_c, 127);
+    test_assert(err == OS_SUCCESS, "task C lowering failed");
+    test_assert(((thread_t *)priority_tid_m)->hdr.pqueue.prio == NORMALPRIO + 2,
+                "drop not propagated to M");
+    test_assert(((thread_t *)priority_tid_l)->hdr.pqueue.prio == NORMALPRIO + 2,
+                "drop not propagated to L");
+  }
+  test_end_step(3);
+
+  /* [1.6.4] L is resumed and all tasks are reaped.*/
+  test_set_step(4);
+  {
+    chThdResume(&priority_chain_ref, MSG_OK);
+    (void) OS_TaskWait(priority_tid_l);
+    (void) OS_TaskWait(priority_tid_m);
+    (void) OS_TaskWait(priority_tid_h);
+    (void) OS_TaskWait(priority_tid_c);
+    priority_tid_l = 0;
+    priority_tid_m = 0;
+    priority_tid_h = 0;
+    priority_tid_c = 0;
+  }
+  test_end_step(4);
+}
+
+static const testcase_t nasa_osal_test_001_006 = {
+  "OS_TaskSetPriority() transitive inheritance",
+  nasa_osal_test_001_006_setup,
+  nasa_osal_test_001_006_teardown,
+  nasa_osal_test_001_006_execute
+};
+
 /****************************************************************************
  * Exported data.
  ****************************************************************************/
@@ -569,6 +845,8 @@ const testcase_t * const nasa_osal_test_sequence_001_array[] = {
   &nasa_osal_test_001_002,
   &nasa_osal_test_001_003,
   &nasa_osal_test_001_004,
+  &nasa_osal_test_001_005,
+  &nasa_osal_test_001_006,
   NULL
 };
 

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1713,6 +1713,69 @@ test_assert_sequence("R", "invalid sequence");]]></value>
             </step>
           </steps>
         </case>
+        <case>
+          <brief>
+            <value>Arbitrary ready thread priority change.</value>
+          </brief>
+          <description>
+            <value>A ready thread priority is raised above the current
+              thread. The ready list must be reordered without a state
+              transition and the operation must reschedule internally.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[bool switched;
+tprio_t oldprio, prio;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Two lower-priority threads are placed in the ready
+                  list.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[prio = chThdGetPriorityX();
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio - 1, thread, "A");
+threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio - 2, thread, "B");
+test_assert(threads[0]->state == CH_STATE_READY, "thread A not ready");
+test_assert(threads[1]->state == CH_STATE_READY, "thread B not ready");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Thread B is raised above the current thread. It must
+                  run before the locked operation returns.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[1], prio + 1);
+switched = threads[1]->state == CH_STATE_FINAL;
+chSysUnlock();
+
+test_assert(oldprio == prio - 2, "wrong old priority");
+test_assert(switched, "thread B not scheduled internally");
+test_wait_threads();
+test_assert_sequence("BA", "ready list not reordered");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
       </cases>
     </sequence>
     <sequence>
@@ -2660,6 +2723,34 @@ static THD_FUNCTION(thread5, p) {
 static THD_FUNCTION(thread11M, p) {
 
   test_emit_token(*(char *)p);
+}
+
+static thread_reference_t priority_chain_ref;
+
+static THD_FUNCTION(thread13L, p) {
+
+  (void)p;
+  chMtxLock(&m2);
+  chSysLock();
+  (void) chThdSuspendS(&priority_chain_ref);
+  chSysUnlock();
+  chMtxUnlock(&m2);
+}
+
+static THD_FUNCTION(thread13M, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxLock(&m2);
+  chMtxUnlock(&m2);
+  chMtxUnlock(&m1);
+}
+
+static THD_FUNCTION(thread13H, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxUnlock(&m1);
 }
 
 #if CH_CFG_USE_CONDVARS || defined(__DOXYGEN__)
@@ -3939,6 +4030,145 @@ test_assert(chThdGetPriorityX() == prio + 1, "signaller not queued");]]></value>
                 <value><![CDATA[test_assert(msg == MSG_OK, "condition signal lost");
 test_assert(m1.owner == chThdGetSelfX(), "mutex not reacquired");
 chMtxUnlock(&m1);
+test_wait_threads();]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Transitive arbitrary priority change.</value>
+          </brief>
+          <description>
+            <value>The base priority of a thread waiting at the end of a
+              two-mutex dependency chain is changed. Both increases and
+              decreases must propagate through all owners while preserving
+              another waiter's donation.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[priority_chain_ref = NULL;
+chMtxObjectInit(&m1);
+chMtxObjectInit(&m2);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chThdResume(&priority_chain_ref, MSG_RESET);
+test_wait_threads();
+chMtxObjectDispose(&m1);
+chMtxObjectDispose(&m2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[tprio_t oldprio, prio;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Four threads form the chain H and C wait on M, M waits
+                  on L, and L is suspended while owning the final mutex.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[prio = chThdGetPriorityX();
+threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1,
+                               thread13L, NULL);
+test_assert(priority_chain_ref == threads[0], "thread L not suspended");
+threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio + 2,
+                               thread13M, NULL);
+test_assert(threads[1]->state == CH_STATE_WTMTX, "thread M not waiting");
+threads[2] = chThdCreateStatic(wa[2], WA_SIZE, prio + 3,
+                               thread13H, NULL);
+test_assert(threads[2]->state == CH_STATE_WTMTX, "thread H not waiting");
+threads[3] = chThdCreateStatic(wa[3], WA_SIZE, prio + 4,
+                               thread13H, NULL);
+test_assert(threads[3]->state == CH_STATE_WTMTX, "thread C not waiting");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+            "thread L not initially boosted");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+            "thread M not initially boosted");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Raising H propagates the new effective priority through
+                  M to L.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[2], prio + 5);
+chSysUnlock();
+
+test_assert(oldprio == prio + 3, "wrong old raised priority");
+test_assert(threads[2]->hdr.pqueue.prio == prio + 5,
+            "thread H not raised");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 5,
+            "raise not propagated to M");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 5,
+            "raise not propagated to L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Lowering H below C reorders M1's wait queue and
+                  preserves C's donation throughout the chain.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[2], prio + 1);
+chSysUnlock();
+
+test_assert(oldprio == prio + 5, "wrong old lowered priority");
+test_assert(threads[2]->hdr.pqueue.prio == prio + 1,
+            "thread H not lowered");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+            "competing donation lost at M");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+            "competing donation lost at L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Lowering C below M's base priority removes the final
+                  donation throughout the chain.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+oldprio = __thd_set_priority(threads[3], prio + 1);
+chSysUnlock();
+
+test_assert(oldprio == prio + 4, "wrong old competing priority");
+test_assert(threads[3]->hdr.pqueue.prio == prio + 1,
+            "thread C not lowered");
+test_assert(threads[1]->hdr.pqueue.prio == prio + 2,
+            "drop not propagated to M");
+test_assert(threads[0]->hdr.pqueue.prio == prio + 2,
+            "drop not propagated to L");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>L is resumed and the complete chain is allowed to
+                  unwind.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chThdResume(&priority_chain_ref, MSG_OK);
 test_wait_threads();]]></value>
               </code>
             </step>

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -37,6 +37,7 @@
  * - @subpage rt_test_005_005
  * - @subpage rt_test_005_006
  * - @subpage rt_test_005_007
+ * - @subpage rt_test_005_008
  * .
  */
 
@@ -698,6 +699,64 @@ static const testcase_t rt_test_005_007 = {
 };
 #endif /* CH_CFG_USE_REGISTRY == TRUE */
 
+/**
+ * @page rt_test_005_008 [5.8] Arbitrary ready thread priority change
+ *
+ * <h2>Description</h2>
+ * A ready thread priority is raised above the current thread. The
+ * ready list must be reordered without a state transition and the
+ * operation must reschedule internally.
+ *
+ * <h2>Test Steps</h2>
+ * - [5.8.1] Two lower-priority threads are placed in the ready list.
+ * - [5.8.2] Thread B is raised above the current thread. It must run
+ *   before the locked operation returns.
+ * .
+ */
+
+static void rt_test_005_008_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_005_008_execute(void) {
+  bool switched;
+  tprio_t oldprio, prio;
+
+  /* [5.8.1] Two lower-priority threads are placed in the ready list.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio - 1, thread, "A");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio - 2, thread, "B");
+    test_assert(threads[0]->state == CH_STATE_READY, "thread A not ready");
+    test_assert(threads[1]->state == CH_STATE_READY, "thread B not ready");
+  }
+  test_end_step(1);
+
+  /* [5.8.2] Thread B is raised above the current thread. It must run
+     before the locked operation returns.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[1], prio + 1);
+    switched = threads[1]->state == CH_STATE_FINAL;
+    chSysUnlock();
+
+    test_assert(oldprio == prio - 2, "wrong old priority");
+    test_assert(switched, "thread B not scheduled internally");
+    test_wait_threads();
+    test_assert_sequence("BA", "ready list not reordered");
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_005_008 = {
+  "Arbitrary ready thread priority change",
+  NULL,
+  rt_test_005_008_teardown,
+  rt_test_005_008_execute
+};
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -717,6 +776,7 @@ const testcase_t * const rt_test_sequence_005_array[] = {
 #if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
   &rt_test_005_007,
 #endif
+  &rt_test_005_008,
   NULL
 };
 

--- a/test/rt/source/test/rt_test_sequence_008.c
+++ b/test/rt/source/test/rt_test_sequence_008.c
@@ -48,6 +48,7 @@
  * - @subpage rt_test_008_010
  * - @subpage rt_test_008_011
  * - @subpage rt_test_008_012
+ * - @subpage rt_test_008_013
  * .
  */
 
@@ -209,6 +210,34 @@ static THD_FUNCTION(thread5, p) {
 static THD_FUNCTION(thread11M, p) {
 
   test_emit_token(*(char *)p);
+}
+
+static thread_reference_t priority_chain_ref;
+
+static THD_FUNCTION(thread13L, p) {
+
+  (void)p;
+  chMtxLock(&m2);
+  chSysLock();
+  (void) chThdSuspendS(&priority_chain_ref);
+  chSysUnlock();
+  chMtxUnlock(&m2);
+}
+
+static THD_FUNCTION(thread13M, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxLock(&m2);
+  chMtxUnlock(&m2);
+  chMtxUnlock(&m1);
+}
+
+static THD_FUNCTION(thread13H, p) {
+
+  (void)p;
+  chMtxLock(&m1);
+  chMtxUnlock(&m1);
 }
 
 #if CH_CFG_USE_CONDVARS || defined(__DOXYGEN__)
@@ -1449,6 +1478,139 @@ static const testcase_t rt_test_008_012 = {
 };
 #endif /* (CH_CFG_USE_CONDVARS == TRUE) && (CH_CFG_USE_CONDVARS_TIMEOUT == TRUE) */
 
+/**
+ * @page rt_test_008_013 [8.13] Transitive arbitrary priority change
+ *
+ * <h2>Description</h2>
+ * The base priority of a thread waiting at the end of a two-mutex
+ * dependency chain is changed. Both increases and decreases must
+ * propagate through all owners while preserving another waiter's
+ * donation.
+ *
+ * <h2>Test Steps</h2>
+ * - [8.13.1] Four threads form the chain H and C wait on M, M waits on
+ *   L, and L is suspended while owning the final mutex.
+ * - [8.13.2] Raising H propagates the new effective priority through M
+ *   to L.
+ * - [8.13.3] Lowering H below C reorders M1's wait queue and preserves
+ *   C's donation throughout the chain.
+ * - [8.13.4] Lowering C below M's base priority removes the final
+ *   donation throughout the chain.
+ * - [8.13.5] L is resumed and the complete chain is allowed to unwind.
+ * .
+ */
+
+static void rt_test_008_013_setup(void) {
+  priority_chain_ref = NULL;
+  chMtxObjectInit(&m1);
+  chMtxObjectInit(&m2);
+}
+
+static void rt_test_008_013_teardown(void) {
+  chThdResume(&priority_chain_ref, MSG_RESET);
+  test_wait_threads();
+  chMtxObjectDispose(&m1);
+  chMtxObjectDispose(&m2);
+}
+
+static void rt_test_008_013_execute(void) {
+  tprio_t oldprio, prio;
+
+  /* [8.13.1] Four threads form the chain H and C wait on M, M waits on
+     L, and L is suspended while owning the final mutex.*/
+  test_set_step(1);
+  {
+    prio = chThdGetPriorityX();
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1,
+                                   thread13L, NULL);
+    test_assert(priority_chain_ref == threads[0], "thread L not suspended");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, prio + 2,
+                                   thread13M, NULL);
+    test_assert(threads[1]->state == CH_STATE_WTMTX, "thread M not waiting");
+    threads[2] = chThdCreateStatic(wa[2], WA_SIZE, prio + 3,
+                                   thread13H, NULL);
+    test_assert(threads[2]->state == CH_STATE_WTMTX, "thread H not waiting");
+    threads[3] = chThdCreateStatic(wa[3], WA_SIZE, prio + 4,
+                                   thread13H, NULL);
+    test_assert(threads[3]->state == CH_STATE_WTMTX, "thread C not waiting");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+                "thread L not initially boosted");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+                "thread M not initially boosted");
+  }
+  test_end_step(1);
+
+  /* [8.13.2] Raising H propagates the new effective priority through M
+     to L.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[2], prio + 5);
+    chSysUnlock();
+
+    test_assert(oldprio == prio + 3, "wrong old raised priority");
+    test_assert(threads[2]->hdr.pqueue.prio == prio + 5,
+                "thread H not raised");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 5,
+                "raise not propagated to M");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 5,
+                "raise not propagated to L");
+  }
+  test_end_step(2);
+
+  /* [8.13.3] Lowering H below C reorders M1's wait queue and preserves
+     C's donation throughout the chain.*/
+  test_set_step(3);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[2], prio + 1);
+    chSysUnlock();
+
+    test_assert(oldprio == prio + 5, "wrong old lowered priority");
+    test_assert(threads[2]->hdr.pqueue.prio == prio + 1,
+                "thread H not lowered");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 4,
+                "competing donation lost at M");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 4,
+                "competing donation lost at L");
+  }
+  test_end_step(3);
+
+  /* [8.13.4] Lowering C below M's base priority removes the final
+     donation throughout the chain.*/
+  test_set_step(4);
+  {
+    chSysLock();
+    oldprio = __thd_set_priority(threads[3], prio + 1);
+    chSysUnlock();
+
+    test_assert(oldprio == prio + 4, "wrong old competing priority");
+    test_assert(threads[3]->hdr.pqueue.prio == prio + 1,
+                "thread C not lowered");
+    test_assert(threads[1]->hdr.pqueue.prio == prio + 2,
+                "drop not propagated to M");
+    test_assert(threads[0]->hdr.pqueue.prio == prio + 2,
+                "drop not propagated to L");
+  }
+  test_end_step(4);
+
+  /* [8.13.5] L is resumed and the complete chain is allowed to
+     unwind.*/
+  test_set_step(5);
+  {
+    chThdResume(&priority_chain_ref, MSG_OK);
+    test_wait_threads();
+  }
+  test_end_step(5);
+}
+
+static const testcase_t rt_test_008_013 = {
+  "Transitive arbitrary priority change",
+  rt_test_008_013_setup,
+  rt_test_008_013_teardown,
+  rt_test_008_013_execute
+};
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -1485,6 +1647,7 @@ const testcase_t * const rt_test_sequence_008_array[] = {
 #if ((CH_CFG_USE_CONDVARS == TRUE) && (CH_CFG_USE_CONDVARS_TIMEOUT == TRUE)) || defined(__DOXYGEN__)
   &rt_test_008_012,
 #endif
+  &rt_test_008_013,
   NULL
 };
 


### PR DESCRIPTION
## Summary

- route CMSIS-RTOS and NASA OSAL arbitrary-thread priority changes through the RT helper from #162
- make CMSIS priority conversion consistent across create, set, and get operations, with parameter validation
- validate the NASA OSAL target thread before deciding whether a priority change is unnecessary
- add NASA OSAL regressions for target validation, conversion, and transitive priority inheritance

This PR is stacked on #162 and should be retargeted to `master` after #162 is merged.

## Validation

- validated and regenerated `test/nasa_osal/configuration.xml`
- built `demos/STM32/CMSIS-STM32F407-DISCOVERY`
- built `demos/STM32/NASA-OSAL-STM32F407-DISCOVERY`
- built `demos/STM32/NASA-OSAL-STM32F746G-DISCOVERY`
- ran `git diff --check` and style checks on touched C/header files