### PR TITLE
STM32 EFL: take flash addresses from CMSIS

### DIFF
--- a/os/hal/ports/STM32/STM32F4xx/hal_efl_lld.h
+++ b/os/hal/ports/STM32/STM32F4xx/hal_efl_lld.h
@@ -55,7 +55,7 @@
     defined(STM32F40_41xxx) || defined(__DOXYGEN__)
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF7A22
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*
@@ -74,7 +74,7 @@
     defined(__DOXYGEN__)
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF7A22
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*
@@ -95,7 +95,7 @@
       defined(__DOXYGEN__)
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF7A22
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*

--- a/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.h
+++ b/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.h
@@ -56,7 +56,7 @@
     defined(__DOXYGEN__)
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF75E0
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*

--- a/os/hal/ports/STM32/STM32G4xx/hal_efl_lld.h
+++ b/os/hal/ports/STM32/STM32G4xx/hal_efl_lld.h
@@ -64,7 +64,7 @@
 #endif
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF75E0
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*===========================================================================*/

--- a/os/hal/ports/STM32/STM32L4xx+/hal_efl_lld.h
+++ b/os/hal/ports/STM32/STM32L4xx+/hal_efl_lld.h
@@ -56,7 +56,7 @@
     defined(STM32L4S7xx) || defined(STM32L4S9xx) || defined(__DOXYGEN__)
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF75E0
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*

--- a/os/hal/ports/STM32/STM32L4xx/hal_efl_lld.c
+++ b/os/hal/ports/STM32/STM32L4xx/hal_efl_lld.c
@@ -68,7 +68,7 @@ static const flash_descriptor_t efl_lld_descriptor = {
                       STM32_FLASH_SECTORS_PER_BANK,
  .sectors           = NULL,
  .sectors_size      = STM32_FLASH_SECTOR_SIZE,
- .address           = (uint8_t *)0x08000000U,
+ .address           = (uint8_t *)FLASH_BASE,
  .size              = STM32_FLASH_NUMBER_OF_BANKS *
                       STM32_FLASH_SECTORS_PER_BANK *
                       STM32_FLASH_SECTOR_SIZE

--- a/os/hal/ports/STM32/STM32WLxx/hal_efl_lld.c
+++ b/os/hal/ports/STM32/STM32WLxx/hal_efl_lld.c
@@ -68,7 +68,7 @@ static const flash_descriptor_t efl_lld_descriptor = {
                       STM32_FLASH_SECTORS_PER_BANK,
  .sectors           = NULL,
  .sectors_size      = STM32_FLASH_SECTOR_SIZE,
- .address           = (uint8_t *)0x08000000U,
+ .address           = (uint8_t *)FLASH_BASE,
  .size              = STM32_FLASH_NUMBER_OF_BANKS *
                       STM32_FLASH_SECTORS_PER_BANK *
                       STM32_FLASH_SECTOR_SIZE


### PR DESCRIPTION
Replaces hard coded flash addresses in the EFL drivers with the CMSIS macros, matching what the F7 driver already does (and what the new STM32U0xx driver in #164 does, where the size register address genuinely differs between devices: U031 vs U073/U083).

Commit 1 — flash size register: G0, F4, L4+ and G4 take `STM32_FLASH_SIZE_REGISTER` from `FLASHSIZE_BASE` instead of hard coded literals. Verified per device: every part the four drivers gate on defines `FLASHSIZE_BASE` in its vendored CMSIS header with a value identical to the removed literal (G0 x4, L4+ x8 and G4 x9 at 0x1FFF75E0, all F4 headers at 0x1FFF7A22), so the change is behavior neutral today; it removes the risk of a silently wrong address if a driver gate ever widens.

Commit 2 — flash base address: the L4 and WL descriptors were the only two EFL drivers hard coding `0x08000000`; they now use `FLASH_BASE` like every other family.

Notes:
- The G4 driver never calls `stm32_flash_get_size()`, but the static inline still compiles, so its define is updated for consistency.
- The byte identical EFL copies under `STM32G0xx_OLD`, `STM32G4xx_OLD` and `STM32G4xx_TEST` are deliberately untouched.
- Build checked via QMK wear-leveling EFL targets (HAL_USE_EFL active) for G0B1, F401, G431 and L432; L4+ and WL have no build target here and are covered by the header verification plus the identical patterns already shipping in other families.

Independent of #164; no merge ordering constraint between the two.