### PR TITLE
PR template: target branch is master, not main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,9 @@
 
 <!-- put a x instead of the space in the [ ] to check the box [x] -->
 
-- [ ] This PR targets `main` — all changes land on `main` first (upstream-first policy);
+- [ ] This PR targets `master` — all changes land on `master` first (upstream-first policy);
       `stable-*` branches only receive maintainer-selected backports of commits already
-      merged on `main`
+      merged on `master`
 
 ## Scope
 


### PR DESCRIPTION
## Summary

The Target Branch Check in the PR template names `main`, but this repository's default and integration branch is `master` — `main` exists only as the stale `archive/main` ref. Every PR opened through the template therefore asserts it targets a branch that doesn't exist while GitHub actually targets `master` (see #152 for a recent example). REVIEW.md already states the policy correctly ("backports of commits already merged on `master`"); this brings the template in line with it.

## Related

- Issue(s): none; discrepancy noticed while reviewing #152
- Notes for reviewers: wording-only change to the template text; no policy change intended

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant (docs-only, no code affected)

## Mechanical Checks

- [ ] Style check passed on changed `.c`/`.h` files (N/A — no `.c`/`.h` files changed)
- [ ] Build check passed (N/A — Markdown template only)

## Testing

- [ ] Test run successfully locally (N/A — Markdown template only)
- Any other tests run on a device? N/A

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
