### PR TITLE
I2Cv4: support devices without SMBus flags

### DIFF
--- a/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
@@ -60,8 +60,8 @@
 /*===========================================================================*/
 
 /* Devices without SMBus support (STM32U0xx) do not define the SMBus
-   related flags, defining them as zero makes the related error paths
-   compile out.*/
+   related flags; defining them as zero allows the related error paths
+   to be compiled out.*/
 #if !defined(I2C_ISR_PECERR)
 #define I2C_ISR_PECERR      0U
 #endif

--- a/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
@@ -59,6 +59,21 @@
 /* Driver constants.                                                         */
 /*===========================================================================*/
 
+/* Devices without SMBus support (STM32U0xx) do not define the SMBus
+   related flags, defining them as zero makes the related error paths
+   compile out.*/
+#if !defined(I2C_ISR_PECERR)
+#define I2C_ISR_PECERR      0U
+#endif
+
+#if !defined(I2C_ISR_TIMEOUT)
+#define I2C_ISR_TIMEOUT     0U
+#endif
+
+#if !defined(I2C_ISR_ALERT)
+#define I2C_ISR_ALERT       0U
+#endif
+
 #define I2C_ERROR_MASK                                                      \
   ((uint32_t)(I2C_ISR_BERR | I2C_ISR_ARLO | I2C_ISR_OVR | I2C_ISR_PECERR |  \
               I2C_ISR_TIMEOUT | I2C_ISR_ALERT))

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,11 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: STM32 I2Cv4 did not build on devices without SMBus support
+       (STM32U0xx), whose headers do not define the I2C_ISR_PECERR/TIMEOUT/
+       ALERT flags referenced by the error mask. These flags now default to
+       zero when undefined, compiling out the SMBus error paths (github
+       PR #172).
 - FIX: STM32H7xx HAL initialization reset the SYSCFG block, clearing the
        overdrive enable (SYSCFG_PWRCR ODEN) set during clock initialization
        and dropping the core out of overdrive while the PLL kept running above


### PR DESCRIPTION
The STM32U0xx I2C peripheral does not have SMBus support and its CMSIS headers do not define I2C_ISR_PECERR, I2C_ISR_TIMEOUT and I2C_ISR_ALERT, so hal_i2c_lld.c fails to compile for U0. Defining the missing flags as 0 makes the SMBus error decode paths compile out; no behaviour change for devices that have the flags.

Hardware validated on STM32U083 (NUCLEO-U083RC-hosted bring-up of a U073 target): I2C1 at 400 kHz (TIMINGR-configured, 56 MHz kernel clock) driving an IS31FL3741A LED controller — transactions ACK and the full register init sequence completes.