### PR TITLE
STM32 EFL/I2Cv4: complete XHAL twins and G4xx_TEST for #165/#172

### DIFF
--- a/os/hal/ports/STM32/STM32G4xx_TEST/hal_efl_lld.h
+++ b/os/hal/ports/STM32/STM32G4xx_TEST/hal_efl_lld.h
@@ -64,7 +64,7 @@
 #endif
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF75E0
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*===========================================================================*/

--- a/os/xhal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
+++ b/os/xhal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
@@ -59,6 +59,21 @@
 /* Driver constants.                                                         */
 /*===========================================================================*/
 
+/* Devices without SMBus support (STM32U0xx) do not define the SMBus
+   related flags; defining them as zero allows the related error paths
+   to be compiled out.*/
+#if !defined(I2C_ISR_PECERR)
+#define I2C_ISR_PECERR      0U
+#endif
+
+#if !defined(I2C_ISR_TIMEOUT)
+#define I2C_ISR_TIMEOUT     0U
+#endif
+
+#if !defined(I2C_ISR_ALERT)
+#define I2C_ISR_ALERT       0U
+#endif
+
 #define I2C_ERROR_MASK                                                      \
   ((uint32_t)(I2C_ISR_BERR | I2C_ISR_ARLO | I2C_ISR_OVR | I2C_ISR_PECERR |  \
               I2C_ISR_TIMEOUT | I2C_ISR_ALERT))

--- a/os/xhal/ports/STM32/STM32G0xx/hal_efl_lld.h
+++ b/os/xhal/ports/STM32/STM32G0xx/hal_efl_lld.h
@@ -56,7 +56,7 @@
     defined(__DOXYGEN__)
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF75E0
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*

--- a/os/xhal/ports/STM32/STM32L4xx+/hal_efl_lld.h
+++ b/os/xhal/ports/STM32/STM32L4xx+/hal_efl_lld.h
@@ -56,7 +56,7 @@
     defined(STM32L4S7xx) || defined(STM32L4S9xx) || defined(__DOXYGEN__)
 
 /* Flash size register. */
-#define STM32_FLASH_SIZE_REGISTER           0x1FFF75E0
+#define STM32_FLASH_SIZE_REGISTER           FLASHSIZE_BASE
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*

--- a/os/xhal/ports/STM32/STM32WLxx/hal_efl_lld.c
+++ b/os/xhal/ports/STM32/STM32WLxx/hal_efl_lld.c
@@ -62,7 +62,7 @@ static const flash_descriptor_t efl_lld_desc = {
                       STM32_FLASH_SECTORS_PER_BANK,
  .sectors           = NULL,
  .sectors_size      = STM32_FLASH_SECTOR_SIZE,
- .address           = (uint8_t *)0x08000000U,
+ .address           = (uint8_t *)FLASH_BASE,
  .size              = STM32_FLASH_NUMBER_OF_BANKS *
                       STM32_FLASH_SECTORS_PER_BANK *
                       STM32_FLASH_SECTOR_SIZE


### PR DESCRIPTION
Companion to #165 (STM32 EFL flash addresses from CMSIS) and #172 (I2Cv4 SMBus-flag guards), both of which touched only the `os/hal` copies. This completes the `os/xhal` twins and the `STM32G4xx_TEST` port so the fixes are consistent across the tree.

### EFL (behavior-neutral symbol substitution)
- `os/xhal/…/STM32G0xx/hal_efl_lld.h`, `os/xhal/…/STM32L4xx+/hal_efl_lld.h` — `STM32_FLASH_SIZE_REGISTER` → `FLASHSIZE_BASE`
- `os/xhal/…/STM32WLxx/hal_efl_lld.c` — `.address` `0x08000000U` → `FLASH_BASE`
- `os/hal/…/STM32G4xx_TEST/hal_efl_lld.h` — `STM32_FLASH_SIZE_REGISTER` → `FLASHSIZE_BASE`

Verified the CMSIS symbols equal the replaced literals (`FLASHSIZE_BASE` = 0x1FFF75E0 on G0/L4+/G4, `FLASH_BASE` = 0x08000000).

### I2Cv4 (build fix, XHAL side of #172)
- `os/xhal/…/LLD/I2Cv4/hal_i2c_lld.c` — the same `#if !defined(I2C_ISR_PECERR/TIMEOUT/ALERT)` guards.

Without them the XHAL I2Cv4 driver fails to build on STM32U0xx (no SMBus) exactly like the HAL copy did — reproduced: building the RT-XHAL-STM32-MULTI `stm32u083rc_nucleo64` demo with I2C enabled fails on current master (`'I2C_ISR_TIMEOUT' undeclared`, `hal_i2c_lld.c:458`) and builds clean with this PR (ARM GCC 14.3.1).

### Gates
- `stylecheck.py` clean on all five files.
- Build: XHAL I2Cv4 on `stm32u083rc_nucleo64` — reproduced the break on master, clean with this PR.
- EFL changes are symbol-identical to the already-built #165 HAL changes (L476/WL55).

No changelog: EFL is behavior-neutral; the I2Cv4 twin is the XHAL side of the fix already described by #172.

---
🤖 chibios-sheriff — first-layer review (advisory). This is an automated first-layer patch; a human maintainer decides on merge. The sheriff does not review or merge its own PRs.
