### PR TITLE
RT: enforce thread identity and lifecycle invariants

### DIFF
--- a/os/rt/include/chobjects.h
+++ b/os/rt/include/chobjects.h
@@ -211,6 +211,7 @@ struct ch_thread {
 #if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
   /**
    * @brief   References to this thread.
+   * @note    The maximum value is @p THREAD_MAX_REFERENCES.
    */
   trefs_t                       refs;
   /**

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -33,6 +33,14 @@
 /* Module constants.                                                         */
 /*===========================================================================*/
 
+#if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Maximum number of references to a thread.
+ */
+#define THREAD_MAX_REFERENCES                                               \
+  ((trefs_t)-1)
+#endif
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/

--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -144,6 +144,8 @@ ROMCONST chdebug_t ch_debug = {
  * @details Returns the most ancient thread in the system, usually this is
  *          the main thread unless it terminated. A reference is added to the
  *          returned thread in order to make sure its status is not lost.
+ * @pre     The returned thread must have fewer than
+ *          @p THREAD_MAX_REFERENCES references.
  * @note    This function cannot return @p NULL because there is always at
  *          least one thread in the system.
  *
@@ -158,7 +160,7 @@ thread_t *chRegFirstThread(void) {
   chSysLock();
   p = (uint8_t *)REG_HEADER(currcore)->next;
   tp = __CH_OWNEROF(p, thread_t, rqueue);
-  chDbgAssert(tp->refs < (trefs_t)255, "too many references");
+  chDbgAssert(tp->refs < THREAD_MAX_REFERENCES, "too many references");
 
   tp->refs++;
   chSysUnlock();
@@ -170,6 +172,8 @@ thread_t *chRegFirstThread(void) {
  * @brief   Returns the thread next to the specified one.
  * @details The reference counter of the specified thread is decremented and
  *          the reference counter of the returned thread is incremented.
+ * @pre     If there is a next thread then it must have fewer than
+ *          @p THREAD_MAX_REFERENCES references.
  *
  * @param[in] tp        pointer to the thread
  * @return              A reference to the next thread.
@@ -192,7 +196,7 @@ thread_t *chRegNextThread(thread_t *tp) {
     uint8_t *p = (uint8_t *)nqp;
     ntp = __CH_OWNEROF(p, thread_t, rqueue);
 
-    chDbgAssert(ntp->refs < (trefs_t)255, "too many references");
+    chDbgAssert(ntp->refs < THREAD_MAX_REFERENCES, "too many references");
 
     ntp->refs++;
   }
@@ -207,6 +211,9 @@ thread_t *chRegNextThread(thread_t *tp) {
  * @note    The reference counter of the found thread is increased by one so
  *          it cannot be disposed incidentally after the pointer has been
  *          returned.
+ * @pre     The name must not be @p NULL.
+ * @pre     Each thread inspected by the registry scan must have fewer than
+ *          @p THREAD_MAX_REFERENCES references.
  *
  * @param[in] name      the thread name
  * @return              A pointer to the found thread.
@@ -215,12 +222,16 @@ thread_t *chRegNextThread(thread_t *tp) {
  * @api
  */
 thread_t *chRegFindThreadByName(const char *name) {
+  const char *tname;
   thread_t *ctp;
+
+  chDbgCheck(name != NULL);
 
   /* Scanning registry.*/
   ctp = chRegFirstThread();
   do {
-    if (strcmp(chRegGetThreadNameX(ctp), name) == 0) {
+    tname = chRegGetThreadNameX(ctp);
+    if ((tname != NULL) && (strcmp(tname, name) == 0)) {
       return ctp;
     }
     ctp = chRegNextThread(ctp);
@@ -234,6 +245,8 @@ thread_t *chRegFindThreadByName(const char *name) {
  * @note    The reference counter of the found thread is increased by one so
  *          it cannot be disposed incidentally after the pointer has been
  *          returned.
+ * @pre     Each thread inspected by the registry scan must have fewer than
+ *          @p THREAD_MAX_REFERENCES references.
  *
  * @param[in] tp        pointer to the thread
  * @return              A pointer to the found thread.
@@ -261,6 +274,8 @@ thread_t *chRegFindThreadByPointer(thread_t *tp) {
  * @note    The reference counter of the found thread is increased by one so
  *          it cannot be disposed incidentally after the pointer has been
  *          returned.
+ * @pre     Each thread inspected by the registry scan must have fewer than
+ *          @p THREAD_MAX_REFERENCES references.
  *
  * @param[in] wa        pointer to a static working area
  * @return              A pointer to the found thread.

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -188,6 +188,7 @@ thread_t *chThdObjectInit(thread_t *tp,
 
 /**
  * @brief   Disposes a thread.
+ * @pre     The thread must be in the @p CH_STATE_FINAL state.
  * @note    Objects disposing does not involve freeing memory but just
  *          performing checks that make sure that the object is in a
  *          state compatible with operations stop.
@@ -204,6 +205,7 @@ thread_t *chThdObjectInit(thread_t *tp,
 void chThdObjectDispose(thread_t *tp) {
 
   chDbgCheck(tp != NULL);
+  chSftAssert(1, tp->state == CH_STATE_FINAL, "not terminated");
 
 #if CH_CFG_USE_WAITEXIT == TRUE
   chSftCheckListX(&tp->waiting);
@@ -625,6 +627,8 @@ thread_t *chThdStart(thread_t *tp) {
  * @brief   Adds a reference to a thread object.
  * @pre     The configuration option @p CH_CFG_USE_REGISTRY must be enabled in
  *          order to use this function.
+ * @pre     The thread must have fewer than @p THREAD_MAX_REFERENCES
+ *          references.
  *
  * @param[in] tp        pointer to the thread
  * @return              The same thread pointer passed as parameter
@@ -635,7 +639,7 @@ thread_t *chThdStart(thread_t *tp) {
 thread_t *chThdAddRef(thread_t *tp) {
 
   chSysLock();
-  chDbgAssert(tp->refs < (trefs_t)255, "too many references");
+  chDbgAssert(tp->refs < THREAD_MAX_REFERENCES, "too many references");
   tp->refs++;
   chSysUnlock();
 

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1657,7 +1657,8 @@ test_assert(chRegGetThreadNameX(tp) == oldname, "name not restored");]]></value>
             <step>
               <description>
                 <value>A static thread is created then retrieved by name,
-                  pointer and working area.</value>
+                  pointer and working area while an unnamed thread is in the
+                  registry.</value>
               </description>
               <tags>
                 <value />
@@ -1666,6 +1667,14 @@ test_assert(chRegGetThreadNameX(tp) == oldname, "name not restored");]]></value>
                 <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread, "R");
 test_assert(threads[0] != NULL, "thread creation failed");
 chRegSetThreadNameX(threads[0], "registry-worker");
+
+chRegSetThreadName(NULL);
+tp = chRegFindThreadByName("registry-worker");
+test_assert(tp == threads[0], "unnamed thread stopped name lookup");
+chThdRelease(tp);
+tp = chRegFindThreadByName("registry-missing");
+test_assert(tp == NULL, "unexpected thread found");
+chRegSetThreadName(oldname);
 
 tp = chThdAddRef(threads[0]);
 test_assert(tp == threads[0], "wrong referenced thread");
@@ -7075,6 +7084,59 @@ test_assert(b, "recursive lock failed");
 test_assert(m1.cnt == MUTEX_MAX_RECURSION,
             "wrong recursion counter");
 chMtxUnlockAll();]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Thread reference boundary.</value>
+          </brief>
+          <description>
+            <value>The last valid thread reference is added without
+              overflowing the reference counter.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_USE_REGISTRY == TRUE]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value />
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_descriptor_t td;
+thread_t *tp;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>@p chThdAddRef() reaches @p
+                  THREAD_MAX_REFERENCES without overflowing the counter,
+                  then the final object is disposed.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[td.name   = "reference-boundary";
+td.wbase  = TEST_THREAD_STACK_BASE(0);
+td.wend   = TEST_THREAD_STACK_END(0);
+td.prio   = LOWPRIO;
+td.funcp  = test_thread;
+td.arg    = NULL;
+td.owner  = NULL;
+tp = chThdObjectInit(TEST_THREAD_OBJECT(0), &td);
+tp->refs = THREAD_MAX_REFERENCES - (trefs_t)1;
+test_assert(chThdAddRef(tp) == tp, "wrong thread reference");
+test_assert(tp->refs == THREAD_MAX_REFERENCES,
+            "wrong reference counter");
+tp->refs = (trefs_t)0;
+tp->state = CH_STATE_FINAL;
+chThdObjectDispose(tp);]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -612,7 +612,7 @@ static const testcase_t rt_test_005_006 = {
  * - [5.7.1] The current thread registry name is changed and then
  *   restored.
  * - [5.7.2] A static thread is created then retrieved by name, pointer
- *   and working area.
+ *   and working area while an unnamed thread is in the registry.
  * - [5.7.3] The registry is scanned forward until the end and the
  *   created thread is found in the scan.
  * .
@@ -642,12 +642,20 @@ static void rt_test_005_007_execute(void) {
   test_end_step(1);
 
   /* [5.7.2] A static thread is created then retrieved by name, pointer
-     and working area.*/
+     and working area while an unnamed thread is in the registry.*/
   test_set_step(2);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread, "R");
     test_assert(threads[0] != NULL, "thread creation failed");
     chRegSetThreadNameX(threads[0], "registry-worker");
+
+    chRegSetThreadName(NULL);
+    tp = chRegFindThreadByName("registry-worker");
+    test_assert(tp == threads[0], "unnamed thread stopped name lookup");
+    chThdRelease(tp);
+    tp = chRegFindThreadByName("registry-missing");
+    test_assert(tp == NULL, "unexpected thread found");
+    chRegSetThreadName(oldname);
 
     tp = chThdAddRef(threads[0]);
     test_assert(tp == threads[0], "wrong referenced thread");

--- a/test/rt/source/test/rt_test_sequence_013.c
+++ b/test/rt/source/test/rt_test_sequence_013.c
@@ -31,6 +31,7 @@
  * <h2>Test Cases</h2>
  * - @subpage rt_test_013_001
  * - @subpage rt_test_013_002
+ * - @subpage rt_test_013_003
  * .
  */
 
@@ -209,6 +210,61 @@ static const testcase_t rt_test_013_002 = {
 };
 #endif /* CH_CFG_USE_MUTEXES_RECURSIVE == TRUE */
 
+#if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_013_003 [13.3] Thread reference boundary
+ *
+ * <h2>Description</h2>
+ * The last valid thread reference is added without overflowing the
+ * reference counter.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_USE_REGISTRY == TRUE
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [13.3.1] @p chThdAddRef() reaches @p THREAD_MAX_REFERENCES without
+ *   overflowing the counter, then the final object is disposed.
+ * .
+ */
+
+static void rt_test_013_003_execute(void) {
+  thread_descriptor_t td;
+  thread_t *tp;
+
+  /* [13.3.1] @p chThdAddRef() reaches @p THREAD_MAX_REFERENCES without
+     overflowing the counter, then the final object is disposed.*/
+  test_set_step(1);
+  {
+    td.name   = "reference-boundary";
+    td.wbase  = TEST_THREAD_STACK_BASE(0);
+    td.wend   = TEST_THREAD_STACK_END(0);
+    td.prio   = LOWPRIO;
+    td.funcp  = test_thread;
+    td.arg    = NULL;
+    td.owner  = NULL;
+    tp = chThdObjectInit(TEST_THREAD_OBJECT(0), &td);
+    tp->refs = THREAD_MAX_REFERENCES - (trefs_t)1;
+    test_assert(chThdAddRef(tp) == tp, "wrong thread reference");
+    test_assert(tp->refs == THREAD_MAX_REFERENCES,
+                "wrong reference counter");
+    tp->refs = (trefs_t)0;
+    tp->state = CH_STATE_FINAL;
+    chThdObjectDispose(tp);
+  }
+  test_end_step(1);
+}
+
+static const testcase_t rt_test_013_003 = {
+  "Thread reference boundary",
+  NULL,
+  NULL,
+  rt_test_013_003_execute
+};
+#endif /* CH_CFG_USE_REGISTRY == TRUE */
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -220,6 +276,9 @@ const testcase_t * const rt_test_sequence_013_array[] = {
   &rt_test_013_001,
 #if (CH_CFG_USE_MUTEXES_RECURSIVE == TRUE) || defined(__DOXYGEN__)
   &rt_test_013_002,
+#endif
+#if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
+  &rt_test_013_003,
 #endif
   NULL
 };


### PR DESCRIPTION
## Summary

- make registry name lookup skip valid unnamed threads and reject a null search key through the standard parameter-check contract
- require externally stored thread objects to be in CH_STATE_FINAL before disposal
- define the type-derived THREAD_MAX_REFERENCES limit and use it in all reference increment paths
- add focused generated tests for lookup across an unnamed registry entry and the last valid reference increment

This is Class A of the RT data-model correctness review. No review Markdown files are included.

## Related

- Issue(s): none
- Notes for reviewers: reference exhaustion remains a documented precondition enforced by assertions, consistent with the existing recursive-mutex counter policy. The final-state disposal check is also active at hardening level one and above.

## Target Branch Check

- [x] This PR targets master — all changes land on master first (upstream-first policy);
      stable-* branches only receive maintainer-selected backports of commits already
      merged on master

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed .c/.h files
- [x] Build check passed (POSIX simulator compile and ARMv7-M RT port build)

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? No hardware tests; SIMX86_64 RT and OSLIB suites passed with checks, assertions, and state checking enabled. Registry-disabled execution and SIMIA32 compilation also passed. Targeted assertion reproducers covered READY and SUSPENDED disposal, null-name lookup, and reference-limit exhaustion.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

The reference counter remains assertion-guarded in non-hardened builds; the new public limit and API preconditions make the existing policy explicit. There is no structure layout or ABI change.