### PR TITLE
RT: reject unrepresentable debugger layouts

### DIFF
--- a/os/rt/include/chregistry.h
+++ b/os/rt/include/chregistry.h
@@ -47,6 +47,9 @@
 
 /**
  * @brief   ChibiOS/RT memory signature record.
+ * @note    The legacy names @p off_newer, @p off_older and @p off_stklimit
+ *          are retained for debugger compatibility. They contain the offsets
+ *          of @p rqueue.next, @p rqueue.prev and @p wabase respectively.
  */
 typedef struct {
   char      identifier[4];          /**< @brief Always set to "main".       */

--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -58,6 +58,51 @@
 /* Module local types.                                                       */
 /*===========================================================================*/
 
+/* The debugger layout record uses eight-bit sizes and offsets. */
+typedef char chdebug_layout_fits_uint8_t[
+  ((sizeof (chdebug_t) <= (size_t)UINT8_MAX) &&
+    (sizeof (void *) <= (size_t)UINT8_MAX) &&
+    (sizeof (systime_t) <= (size_t)UINT8_MAX) &&
+    (sizeof (sysinterval_t) <= (size_t)UINT8_MAX) &&
+    (sizeof (thread_t) <= (size_t)UINT8_MAX) &&
+    (sizeof (struct port_intctx) <= (size_t)UINT8_MAX) &&
+    (PORT_CORES_NUMBER <= (unsigned)UINT8_MAX) &&
+    (offsetof(thread_t, hdr.pqueue.prio) <= (size_t)UINT8_MAX) &&
+    (offsetof(thread_t, ctx) <= (size_t)UINT8_MAX) &&
+    (offsetof(thread_t, rqueue.next) <= (size_t)UINT8_MAX) &&
+    (offsetof(thread_t, rqueue.prev) <= (size_t)UINT8_MAX) &&
+    (offsetof(thread_t, name) <= (size_t)UINT8_MAX) &&
+#if (CH_DBG_ENABLE_STACK_CHECK == TRUE) || (CH_CFG_USE_DYNAMIC == TRUE)
+    (offsetof(thread_t, wabase) <= (size_t)UINT8_MAX) &&
+#endif
+    (offsetof(thread_t, state) <= (size_t)UINT8_MAX) &&
+    (offsetof(thread_t, flags) <= (size_t)UINT8_MAX) &&
+    (offsetof(thread_t, refs) <= (size_t)UINT8_MAX) &&
+#if CH_CFG_TIME_QUANTUM > 0
+    (offsetof(thread_t, ticks) <= (size_t)UINT8_MAX) &&
+#endif
+#if CH_DBG_THREADS_PROFILING == TRUE
+    (offsetof(thread_t, time) <= (size_t)UINT8_MAX) &&
+#endif
+    (offsetof(ch_system_t, state) <= (size_t)UINT8_MAX) &&
+    (offsetof(ch_system_t, instances[0]) <= (size_t)UINT8_MAX) &&
+#if (CH_CFG_USE_REGISTRY == TRUE) && (CH_CFG_SMP_MODE == TRUE)
+    (offsetof(ch_system_t, reglist) <= (size_t)UINT8_MAX) &&
+#endif
+#if CH_CFG_SMP_MODE == TRUE
+    (offsetof(ch_system_t, rfcu) <= (size_t)UINT8_MAX) &&
+#endif
+    (offsetof(os_instance_t, rlist.current) <= (size_t)UINT8_MAX) &&
+    (offsetof(os_instance_t, rlist) <= (size_t)UINT8_MAX) &&
+    (offsetof(os_instance_t, vtlist) <= (size_t)UINT8_MAX) &&
+#if (CH_CFG_USE_REGISTRY == TRUE) && (CH_CFG_SMP_MODE == FALSE)
+    (offsetof(os_instance_t, reglist) <= (size_t)UINT8_MAX) &&
+#endif
+#if CH_CFG_SMP_MODE == FALSE
+    (offsetof(os_instance_t, rfcu) <= (size_t)UINT8_MAX) &&
+#endif
+    (offsetof(os_instance_t, core_id) <= (size_t)UINT8_MAX)) ? 1 : -1];
+
 /*===========================================================================*/
 /* Module local variables.                                                   */
 /*===========================================================================*/


### PR DESCRIPTION
## Summary
- reject debugger metadata layouts whose sizes or offsets do not fit the exported eight-bit fields
- keep the C99 compile-time check local to chregistry.c
- document the legacy debugger field-name mappings

## Validation
- full SIMX86_64 RT and OSLIB test suites: SUCCESS
- strict C99 compilation of chregistry.c: passed
- ARMv7-M test build: passed
- RP2040 SMP demo build: passed
- 64-byte thread extension: accepted
- 256-byte thread extension: rejected at compile time
- stylecheck.py and git diff --check: passed

PC-lint was not run because wine/lint-nt is not installed in the environment. The local typedef has a unique name; the project's existing lint configuration waives unused typedefs (MISRA C:2012 Rule 2.3).