### PR TITLE
RT: enforce queue layout invariants

### DIFF
--- a/os/rt/include/chearly.h
+++ b/os/rt/include/chearly.h
@@ -154,11 +154,7 @@ typedef struct ch_os_instance os_instance_t;
  * @param[in] m         field name in the structured type
  * @return              The offset of the field in the structured type.
  */
-#define __CH_OFFSETOF(st, m)                                                \
-  /*lint -save -e9005 -e9033 -e413 [11.8, 10.8, 1.3] Normal pointers
-    arithmetic, it is safe.*/                                               \
-  ((size_t)((char *)(void *)&((st *)0)->m - (char *)0))                     \
-  /*lint -restore*/
+#define __CH_OFFSETOF(st, m) offsetof(st, m)
 
 /**
  * @brief Get the address of structured type from a member

--- a/os/rt/include/chlists.h
+++ b/os/rt/include/chlists.h
@@ -79,7 +79,10 @@ typedef struct ch_priority_queue ch_priority_queue_t;
 /**
  * @brief   Structure representing a generic priority-ordered bidirectional
  *          linked list header and element.
- * @note    Link fields are void pointers in order to avoid aliasing issues.
+ * @note    The link fields must have the same layout as those in
+ *          @p ch_queue_t and @p prio must follow them. Thread queue elements
+ *          overlay the two structures and priority inheritance reads
+ *          @p prio while an element is linked through @p ch_queue_t.
  */
 struct ch_priority_queue {
   ch_priority_queue_t   *next;      /**< @brief Next in the queue.          */

--- a/os/rt/include/chobjects.h
+++ b/os/rt/include/chobjects.h
@@ -288,16 +288,24 @@ struct ch_thread {
     thread_reference_t          *wttrp;
 #if (CH_CFG_USE_SEMAPHORES == TRUE) || defined(__DOXYGEN__)
     /**
-     * @brief   Pointer to a generic semaphore object.
+     * @brief   Pointer to a semaphore object.
      * @note    This field is used to get a pointer to a synchronization
      *          object and is valid when the thread is in @p CH_STATE_WTSEM
      *          state.
      */
     struct ch_semaphore         *wtsemp;
 #endif
+#if (CH_CFG_USE_CONDVARS == TRUE) || defined(__DOXYGEN__)
+    /**
+     * @brief   Pointer to a condition variable object.
+     * @note    This field is valid when the thread is in @p CH_STATE_WTCOND
+     *          state.
+     */
+    struct condition_variable   *wtcondp;
+#endif
 #if (CH_CFG_USE_MUTEXES == TRUE) || defined(__DOXYGEN__)
     /**
-     * @brief   Pointer to a generic mutex object.
+     * @brief   Pointer to a mutex object.
      * @note    This field is used to get a pointer to a synchronization
      *          object and is valid when the thread is in @p CH_STATE_WTMTX
      *          state.

--- a/os/rt/include/chobjects.h
+++ b/os/rt/include/chobjects.h
@@ -166,6 +166,10 @@ typedef void (*thread_dispose_t)(thread_t *tp);
 struct ch_thread {
   /**
    * @brief   Shared list headers.
+   * @note    This union must remain the first field in @p thread_t because
+   *          queue and list pointers are converted by @p threadref().
+   * @note    The @p pqueue priority field must not overlap the @p queue link
+   *          fields because the priority remains valid in all queued states.
    */
   union {
     /**

--- a/os/rt/src/chcond.c
+++ b/os/rt/src/chcond.c
@@ -253,7 +253,7 @@ msg_t chCondWaitS(condition_variable_t *cp) {
 
   /* Start waiting on the condition variable, on exit the mutex is taken
      again.*/
-  currtp->u.wtobjp = cp;
+  currtp->u.wtcondp = cp;
   ch_sch_prio_insert(&cp->queue, &currtp->hdr.queue);
   chSchGoSleepS(CH_STATE_WTCOND);
   msg = currtp->u.rdymsg;
@@ -348,7 +348,7 @@ msg_t chCondWaitTimeoutS(condition_variable_t *cp, sysinterval_t timeout) {
 
   /* Start waiting on the condition variable, on exit the mutex is taken
      again.*/
-  currtp->u.wtobjp = cp;
+  currtp->u.wtcondp = cp;
   ch_sch_prio_insert(&cp->queue, &currtp->hdr.queue);
   msg = chSchGoSleepTimeoutS(CH_STATE_WTCOND, timeout);
   if (msg != MSG_TIMEOUT) {

--- a/os/rt/src/chmtx.c
+++ b/os/rt/src/chmtx.c
@@ -242,18 +242,19 @@ void chMtxLockS(mutex_t *mp) {
           tp = tp->u.wtmtxp->owner;
           /*lint -e{9042} [16.1] Continues the while.*/
           continue;
-#if (CH_CFG_USE_CONDVARS == TRUE) ||                                        \
-    ((CH_CFG_USE_SEMAPHORES == TRUE) &&                                     \
-     (CH_CFG_USE_SEMAPHORES_PRIORITY == TRUE))
 #if CH_CFG_USE_CONDVARS == TRUE
         case CH_STATE_WTCOND:
+          /* Re-enqueues tp on the condition variable queue.*/
+          ch_sch_prio_insert(
+              &((condition_variable_t *)tp->u.wtobjp)->queue,
+              ch_queue_dequeue(&tp->hdr.queue));
+          break;
 #endif
 #if (CH_CFG_USE_SEMAPHORES == TRUE) &&                                      \
     (CH_CFG_USE_SEMAPHORES_PRIORITY == TRUE)
         case CH_STATE_WTSEM:
-#endif
-          /* Re-enqueues tp with its new priority on the queue.*/
-          ch_sch_prio_insert(&tp->u.wtmtxp->queue,
+          /* Re-enqueues tp on the semaphore queue.*/
+          ch_sch_prio_insert(&tp->u.wtsemp->queue,
                              ch_queue_dequeue(&tp->hdr.queue));
           break;
 #endif

--- a/os/rt/src/chmtx.c
+++ b/os/rt/src/chmtx.c
@@ -245,9 +245,8 @@ void chMtxLockS(mutex_t *mp) {
 #if CH_CFG_USE_CONDVARS == TRUE
         case CH_STATE_WTCOND:
           /* Re-enqueues tp on the condition variable queue.*/
-          ch_sch_prio_insert(
-              &((condition_variable_t *)tp->u.wtobjp)->queue,
-              ch_queue_dequeue(&tp->hdr.queue));
+          ch_sch_prio_insert(&tp->u.wtcondp->queue,
+                             ch_queue_dequeue(&tp->hdr.queue));
           break;
 #endif
 #if (CH_CFG_USE_SEMAPHORES == TRUE) &&                                      \

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -953,7 +953,7 @@ tprio_t __thd_set_priority(thread_t *tp, tprio_t newprio) {
 #endif
 #if CH_CFG_USE_CONDVARS == TRUE
     case CH_STATE_WTCOND:
-      qp = &((condition_variable_t *)tp->u.wtobjp)->queue;
+      qp = &tp->u.wtcondp->queue;
       break;
 #endif
 #if (CH_CFG_USE_SEMAPHORES == TRUE) &&                                     \

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -72,6 +72,29 @@
 /* Module local types.                                                       */
 /*===========================================================================*/
 
+/* Layout invariants required by generic queue owner conversions. */
+typedef char ch_kernel_layout_is_valid_t[
+  ((offsetof(thread_t, hdr) == (size_t)0) &&
+    (offsetof(virtual_timer_t, dlist) == (size_t)0) &&
+    (offsetof(virtual_timers_list_t, dlist) == (size_t)0) &&
+#if CH_CFG_USE_MUTEXES == TRUE
+    (offsetof(mutex_t, queue) == (size_t)0) &&
+#endif
+#if CH_CFG_USE_SEMAPHORES == TRUE
+    (offsetof(semaphore_t, queue) == (size_t)0) &&
+#endif
+#if CH_CFG_USE_CONDVARS == TRUE
+    (offsetof(condition_variable_t, queue) == (size_t)0) &&
+#endif
+    (offsetof(threads_queue_t, queue) == (size_t)0) &&
+    (offsetof(registry_t, queue) == (size_t)0) &&
+    (offsetof(ready_list_t, pqueue) == (size_t)0) &&
+    (offsetof(ch_priority_queue_t, next) ==
+     offsetof(ch_queue_t, next)) &&
+    (offsetof(ch_priority_queue_t, prev) ==
+     offsetof(ch_queue_t, prev)) &&
+    (offsetof(ch_priority_queue_t, prio) >= sizeof (ch_queue_t))) ? 1 : -1];
+
 /*===========================================================================*/
 /* Module local variables.                                                   */
 /*===========================================================================*/


### PR DESCRIPTION
## Summary
- use state-correct condition-variable and semaphore pointers during mutex priority-inheritance requeueing
- document the load-bearing queue overlay requirements
- enforce queue-owner and priority-field layout invariants at compile time with a local C99 typedef
- implement the existing offset helper with standard offsetof()

## Validation
- full SIMX86_64 RT and OSLIB suites: SUCCESS
- semaphore-priority SIMX86_64 RT and OSLIB suites: SUCCESS
- strict C99 compilation of affected translation units: passed
- mutex/condition-variable-disabled configuration: passed
- ARMv7-M test build: passed
- RP2040 ARMv6-M SMP demo build: passed
- deliberate priority-field reordering: rejected at compile time
- stylecheck.py and git diff --check: passed

PC-lint was not run because wine/lint-nt is not installed in the environment. The local typedef has a unique name; the project's lint configuration already waives unused typedefs (MISRA C:2012 Rule 2.3).