### PR TITLE
SDU: re-arm bulk OUT receive on USB wakeup

### DIFF
--- a/os/hal/src/hal_serial_usb.c
+++ b/os/hal/src/hal_serial_usb.c
@@ -347,8 +347,9 @@ void sduSuspendHookI(SerialUSBDriver *sdup) {
 
 /**
  * @brief   USB device wakeup handler.
- * @details Generates a @p CHN_CONNECT event and resumes normal queues
- *          operations.
+ * @details Generates a @p CHN_CONNECT event, resumes normal queues
+ *          operations and restarts the bulk OUT receive operation which
+ *          is terminated on suspend by the USB driver.
  *
  * @note    If this function is not called from an ISR then an explicit call
  *          to @p osalOsRescheduleS() is necessary afterward.
@@ -362,6 +363,15 @@ void sduWakeupHookI(SerialUSBDriver *sdup) {
   chnAddFlagsI(sdup, CHN_CONNECTED);
   bqResumeX(&sdup->ibqueue);
   bqResumeX(&sdup->obqueue);
+
+  /* Re-arming the bulk OUT receive transaction. The generic USB driver
+     declares all pending transactions terminated on suspend and some
+     LLDs (notably STM32 OTG) also disable all endpoints in hardware,
+     destroying the previously armed OUT transfer, without this call the
+     host-to-device direction would remain inactive after wakeup. On ports
+     retaining endpoint state across suspend this is harmless, the receive
+     operation is re-armed using the same buffer.*/
+  (void) sdu_start_receive(sdup);
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,12 @@ See .devcontainer/README.md for included tools and usage.
 *****************************************************************************
 
 *** Next ***
+- FIX: Serial over USB input remained inactive after an USB suspend/wakeup
+       cycle on STM32 OTG devices. The generic USB driver terminates all
+       pending transactions on suspend and the OTG LLD also disables the
+       endpoints in hardware, so the bulk OUT receive armed before suspend
+       was lost. Now sduWakeupHookI() restarts the receive operation, as
+       the XHAL driver already did (github PR #180).
 - FIX: STM32 I2Cv4 did not build on devices without SMBus support
        (STM32U0xx), whose headers do not define the I2C_ISR_PECERR/TIMEOUT/
        ALERT flags referenced by the error mask. These flags now default to


### PR DESCRIPTION
## Problem

After a USB suspend/wakeup cycle (e.g. Windows host sleep), a Serial over USB console on an STM32 OTG device keeps transmitting (IN) but no longer accepts host input (OUT), permanently.

## Root cause

A mismatch between the generic USB layer and the OTG LLD suspend handling:

- `_usb_suspend()` declares all pending transactions terminated (`transmitting`/`receiving` cleared) — `os/hal/src/hal_usb.c`.
- The OTGv1 LLD additionally disables every enabled endpoint in hardware on suspend (`otg_disable_ep()`), destroying the armed bulk OUT transfer. On wakeup `otg_enable_ep()` only restores endpoint interrupt masks — it cannot re-create the transfer, since buffer ownership returned to the class driver.
- `sduWakeupHookI()` only resumed the queues and never re-armed the receive, so no OUT callback could ever fire again. IN self-heals because any new write submits a fresh IN transaction; OUT has no equivalent trigger.

USBv1/USBv2 mask the bug by retaining endpoint hardware state across suspend, but relying on that contradicts the generic layer's declared semantics.

## Fix

`sduWakeupHookI()` now calls `sdu_start_receive()`, mirroring `sduConfigureHookI()` and the XHAL serial-usb driver (`__sdu_wakehook_impl()`), which already implements exactly this. The call is fully guarded inside `sdu_start_receive()` (USB active, SDU ready, no receive pending, buffer available) and is harmless on USBv1/USBv2 where it re-arms with the same buffer.

Verified against a field report: adding the re-arm to the wakeup hook restored input after host sleep on OTG hardware.

A backport PR to `stable-21.11.x` follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)