### PR TITLE
SDU: re-arm bulk OUT receive on USB wakeup (21.11.x backport)

### DIFF
--- a/os/hal/src/hal_serial_usb.c
+++ b/os/hal/src/hal_serial_usb.c
@@ -338,8 +338,9 @@ void sduSuspendHookI(SerialUSBDriver *sdup) {
 
 /**
  * @brief   USB device wakeup handler.
- * @details Generates a @p CHN_CONNECT event and resumes normal queues
- *          operations.
+ * @details Generates a @p CHN_CONNECT event, resumes normal queues
+ *          operations and restarts the bulk OUT receive operation which
+ *          is terminated on suspend by the USB driver.
  *
  * @note    If this function is not called from an ISR then an explicit call
  *          to @p osalOsRescheduleS() is necessary afterward.
@@ -353,6 +354,15 @@ void sduWakeupHookI(SerialUSBDriver *sdup) {
   chnAddFlagsI(sdup, CHN_CONNECTED);
   bqResumeX(&sdup->ibqueue);
   bqResumeX(&sdup->obqueue);
+
+  /* Re-arming the bulk OUT receive transaction. The generic USB driver
+     declares all pending transactions terminated on suspend and some
+     LLDs (notably STM32 OTG) also disable all endpoints in hardware,
+     destroying the previously armed OUT transfer, without this call the
+     host-to-device direction would remain inactive after wakeup. On ports
+     retaining endpoint state across suspend this is harmless, the receive
+     operation is re-armed using the same buffer.*/
+  (void) sdu_start_receive(sdup);
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,12 @@
 *****************************************************************************
 
 *** 21.11.6 ***
+- FIX: Serial over USB input remained inactive after an USB suspend/wakeup
+       cycle on STM32 OTG devices. The generic USB driver terminates all
+       pending transactions on suspend and the OTG LLD also disables the
+       endpoints in hardware, so the bulk OUT receive armed before suspend
+       was lost. Now sduWakeupHookI() restarts the receive operation
+       (backport of github PR #180).
 - FIX: STM32H7xx HAL initialization reset the SYSCFG block, clearing the
        overdrive enable (SYSCFG_PWRCR ODEN) set during clock initialization
        and dropping the core out of overdrive while the PLL kept running above


### PR DESCRIPTION
Backport of #180 to `stable-21.11.x` (targeted for 21.11.6).

After a USB suspend/wakeup cycle (e.g. Windows host sleep), a Serial over USB console on an STM32 OTG device keeps transmitting (IN) but no longer accepts host input (OUT). `_usb_suspend()` terminates all pending transactions and the OTG LLD disables the endpoints in hardware, destroying the armed bulk OUT transfer; `sduWakeupHookI()` never re-armed it. The hook now calls `sdu_start_receive()`, mirroring `sduConfigureHookI()`. The call is fully guarded and harmless on USBv1/USBv2 which retain endpoint state across suspend.

Identical code change as #180; readme entry adapted to the 21.11.6 section (the XHAL driver referenced there does not exist on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)