### PR TITLE
RT: harden virtual timer callback and tickless boundaries

### DIFF
--- a/os/rt/VIRTUAL-TIMERS-REVIEW.md
+++ b/os/rt/VIRTUAL-TIMERS-REVIEW.md
@@ -89,7 +89,7 @@ change with a focused regression test.
    periodic constant-return path remains unchanged. The tree currently has only
    two call sites and both use the no-suffix API from thread context.
 
-5. **VT-5 — make the read-only timer-state query saturating**
+5. **VT-5 — make the read-only timer-state query saturating (implemented)**
 
    Use `lastdelta`, saturate deadline addition at `TIME_INFINITE`, and saturate
    elapsed-time subtraction at zero. This changes only a query result and does
@@ -116,7 +116,7 @@ alarm retry increment boundary, is stated explicitly.
 | VT-2 | Confirmed concurrency defect | periodic and tickless, especially SMP | Callback function and argument are loaded after the kernel lock is dropped |
 | VT-3 | Confirmed | tickless | A callback-created list base makes automatic reload late |
 | VT-4 | Confirmed, high | tickless | Continuous timers with no future reload margin can keep the timer ISR from returning |
-| VT-5 | Confirmed arithmetic defect | tickless | `chVTGetTimersStateI()` can wrap instead of reporting a bounded interval |
+| VT-5 | Fixed arithmetic defect | tickless | `chVTGetTimersStateI()` can wrap instead of reporting a bounded interval |
 | VT-6 | Confirmed contract defect | tickless | Near-full-range delays can expire early when the list is nonempty |
 | VT-7 | Confirmed, high | SMP | Timer operations use the caller's instance without recording the timer's owner |
 | VT-8 | Confirmed documentation defect | all | `chVTObjectInit()` incorrectly says `chVTSetI()` needs no initialization |
@@ -279,11 +279,11 @@ The expression also uses the static `CH_CFG_ST_TIMEDELTA`. Since commit
 runtime. The query can therefore disagree with the alarm policy even when no
 arithmetic wraps.
 
-**Proposed fix:** calculate the tolerated deadline with saturating addition,
-subtract elapsed with saturation at zero, and use `vtlp->lastdelta`. Preserve
-the documented tolerance by saturating at `TIME_INFINITE` rather than wrapping.
-Add boundary tests at zero, just before and after the logical deadline, and with
-first deltas near and equal to `TIME_INFINITE`.
+**Implemented fix:** calculate the tolerated deadline with saturating addition,
+subtract elapsed with saturation at zero, and use `vtlp->lastdelta`. The
+documented tolerance saturates at `TIME_INFINITE` rather than wrapping. Added
+focused tickless tests for a first delta equal to `TIME_INFINITE` and for a
+query held past the tolerated deadline.
 
 ### VT-6 — near-full-range tickless timers can expire early
 
@@ -487,7 +487,6 @@ checked. Neither suite covers:
 - continuous rearm followed by reset in the same callback;
 - a sole continuous callback that starts another timer;
 - two continuous callbacks that overrun their periods;
-- `chVTGetTimersStateI()` boundary arithmetic;
 - near-full-range tickless overflow reporting and saturation on an aged,
   nonempty list;
 - callback-target replacement during the unlocked dispatch window;
@@ -541,3 +540,17 @@ the long-duration VT storm.
    `git diff --check` passed. The full periodic simulator RT and OSLIB suites
    passed, including the new cases, and the STM32F407 tickless test-suite demo
    built successfully. Generated build artifacts were cleaned.
+
+5. **VT-5 — saturating tickless timer-state query**
+
+   `chVTGetTimersStateI()` now uses the adaptive `lastdelta` value, saturates
+   tolerated-deadline addition at `TIME_INFINITE`, and saturates elapsed-time
+   subtraction at zero. Normal representable query results are unchanged.
+
+   Added generated tickless tests for maximum-interval addition and an overdue
+   query, updating both `configuration.xml` and its checked-in generated source.
+   XML validation, regeneration, and `git diff --check` passed. The full
+   periodic simulator RT and OSLIB suites passed, and the STM32F407 tickless
+   test-suite demo containing the new conditional test built successfully.
+   Generated build artifacts were cleaned; execution of the new tickless-only
+   test still requires a supported tickless hardware target.

--- a/os/rt/VIRTUAL-TIMERS-REVIEW.md
+++ b/os/rt/VIRTUAL-TIMERS-REVIEW.md
@@ -1,0 +1,527 @@
+# RT Virtual Timers — Correctness Review
+
+**Status:** second cross-check complete. Nine behavioral defects and two
+documentation defects are confirmed. The normal one-shot callback-rearm pattern
+is correct and is not a finding. The report retains stable IDs while further
+cross-checks continue.
+
+| | |
+|---|---|
+| Date | 2026-08-03 |
+| Branch / commit | `chibios-kernel-dev` @ `a874f3591c` |
+| Main scope | `chvt.c`, `chvt.h`, delta-list helpers, periodic and tickless operation, continuous reload, callback-time mutation, SMP instance ownership |
+| Also read | VT storm test, standard RT VT tests, timer port contracts, SMP RP2 alarm binding, VT/reload history from 2015 through 2024 |
+| Verification | Source invariants, history, tree-wide use audit, and fixed-width arithmetic traces; no source build was required for this review-only pass |
+
+## Proposed PR classes
+
+The classes below are proposed change boundaries, not yet a merge order. The
+three Class A defects share the callback/reload state machine and should be
+fixed together so that one correction does not conceal another.
+
+1. **Class A — callback rearming and continuous reload**
+
+   Defects: VT-1, VT-3, and VT-4.
+
+   Scope: recognize callback-side rearming, calculate tickless reload insertion
+   against the current list base, bound the skipped-deadline recovery path, and
+   add periodic and tickless callback-mutation tests.
+
+2. **Class B — tickless range, configuration, and query APIs**
+
+   Defects: VT-5, VT-6, VT-10, and VT-11.
+
+   Scope: make next-event reporting saturating and adaptive-delta-aware, report
+   unrepresentable near-full-range tickless delays through RFCU and saturate
+   them to the furthest representable deadline, make the current-delta getter
+   obey its no-suffix locking contract, and reject unrepresentable static delta
+   settings.
+
+3. **Class C — SMP ownership and callback dispatch**
+
+   Defects: VT-2 and VT-7.
+
+   Scope: define and assert same-instance timer affinity without enabling
+   remote timer manipulation, and preserve the expired callback and argument
+   before dropping the kernel lock.
+
+4. **Class D — API documentation**
+
+   Defects: VT-8 and VT-9.
+
+   Scope: correct the initialization, continuous-callback, and reload-setter
+   contracts. This class should follow the callback-state decision in Class A.
+
+## Safe changes to take first
+
+Here, "safe" means that the change does not alter normal deadline ordering,
+continuous-timer phase calculations, delta-list coordinates, or physical alarm
+ownership. Keep the changes independently reviewable and pair each behavioral
+change with a focused regression test.
+
+1. **VT-8 and VT-9 — documentation only (implemented)**
+
+   Correct the initialization, continuous restart, and callback-only reload
+   setter documentation. There is no source behavior change.
+
+2. **VT-2 — snapshot callback dispatch under the lock (implemented)**
+
+   Copy both `func` and `par` to automatic locals before dropping the kernel
+   lock, then invoke the saved values. This restores the earlier dispatch
+   invariant without changing timer insertion, removal, reload, or alarm
+   programming.
+
+3. **VT-1 — suppress duplicate automatic insertion**
+
+   After the callback, enter the automatic reload path only when `reload` is
+   nonzero and the timer is still disarmed. This is the narrow corruption fix:
+   an armed timer is an explicit callback-side replacement and must never be
+   inserted again. Test normal continuous reload, continuous-to-one-shot rearm,
+   and continuous-to-continuous rearm in periodic and tickless modes.
+
+   Do not yet change reset's treatment of `reload`. The continuous-rearm-then-
+   reset override case remains open until its API semantics are fixed together
+   with the rest of the callback/reload state machine.
+
+4. **VT-10 — lock the no-suffix current-delta getter**
+
+   Acquire the system lock around the mutable tickless `lastdelta` read. The
+   periodic constant-return path remains unchanged. The tree currently has only
+   two call sites and both use the no-suffix API from thread context.
+
+5. **VT-5 — make the read-only timer-state query saturating**
+
+   Use `lastdelta`, saturate deadline addition at `TIME_INFINITE`, and saturate
+   elapsed-time subtraction at zero. This changes only a query result and does
+   not modify the timer list or alarm.
+
+6. **VT-6 — report and saturate unrepresentable enqueue intervals**
+
+   As a second-stage bounded change, add the selected RFCU overflow event and
+   saturate to `TIME_INFINITE` in both insertion paths. Representable delays are
+   unchanged. Land this after the query fixes because it deliberately changes
+   exceptional-path behavior and can invoke an application runtime-fault hook.
+
+Defer VT-3 and VT-4 because they change tickless reload scheduling and ISR exit
+behavior. Defer the remaining VT-1 reset semantics and the VT-7 diagnostic owner
+lifetime until the callback state transitions are specified and tested as a
+whole. Defer VT-11 until the exact maximum legal static delta, including the
+alarm retry increment boundary, is stated explicitly.
+
+## Findings summary
+
+| ID | Classification | Modes | Summary |
+|---|---|---|---|
+| VT-1 | Confirmed, high | periodic and tickless | Continuous callback-side rearming inserts the same timer twice |
+| VT-2 | Confirmed concurrency defect | periodic and tickless, especially SMP | Callback function and argument are loaded after the kernel lock is dropped |
+| VT-3 | Confirmed | tickless | A callback-created list base makes automatic reload late |
+| VT-4 | Confirmed, high | tickless | Continuous timers with no future reload margin can keep the timer ISR from returning |
+| VT-5 | Confirmed arithmetic defect | tickless | `chVTGetTimersStateI()` can wrap instead of reporting a bounded interval |
+| VT-6 | Confirmed contract defect | tickless | Near-full-range delays can expire early when the list is nonempty |
+| VT-7 | Confirmed, high | SMP | Timer operations use the caller's instance without recording the timer's owner |
+| VT-8 | Confirmed documentation defect | all | `chVTObjectInit()` incorrectly says `chVTSetI()` needs no initialization |
+| VT-9 | Confirmed documentation defect | all | Continuous callback and reload-setter documentation contradicts behavior |
+| VT-10 | Confirmed API atomicity defect | tickless | `chVTGetCurrentDelta()` reads mutable state without locking |
+| VT-11 | Confirmed configuration defect | tickless | `CH_CFG_ST_TIMEDELTA` can narrow to an invalid runtime value |
+
+## Confirmed behavioral defects
+
+### VT-1 — continuous callback-side rearming inserts an armed node again
+
+Both ticker implementations unlink the expired timer and set
+`vtp->dlist.next` to null before invoking its callback (`chvt.c:535-541` and
+`chvt.c:578-594`). This is what makes callback-side timer reuse possible. The
+tree already relies on that behavior for variable one-shot intervals: the VT
+storm sweepers and several drivers call `chVTSetI(vtp, new_delay, ...)` from the
+callback.
+
+After a continuous callback returns, however, both ticker implementations test
+only `vtp->reload` and unconditionally insert the timer (`chvt.c:543-546` and
+`chvt.c:596-647`). If the callback called `chVTSetContinuousI(vtp, ...)`, that
+call already inserted the same delta-list node and left `reload` nonzero. The
+automatic path inserts it a second time.
+
+The equal-deadline case is particularly direct. `ch_dlist_insert()` reaches the
+already-linked node as its insertion point, so the duplicate check inside the
+strict `<` scan does not fire (`chlists.h:626-639`). Inserting the node before
+itself turns its links into a self-loop and disconnects the list header.
+
+Rearming with `chVTSetI()` is correct: it sets `reload` to zero, so the automatic
+reload is suppressed. Changing the next period with
+`chVTSetReloadIntervalX()` is also correct while the timer remains disarmed in
+its callback. The primary defective case is rearming the object while leaving
+it continuous. There is a related override case: a callback can continuously
+rearm the object and then reset that newly armed timer. Reset unlinks it but
+leaves `reload` nonzero, so the original expiration's automatic path starts it
+yet again. The explicit final reset does not win.
+
+**Proposed fix:** after the callback, automatically reload only if `reload` is
+nonzero **and the timer is still disarmed**. An armed timer represents an
+explicit callback-side replacement and must be left untouched. Explicit reset
+must also cancel a pending automatic reload: the small
+representation-compatible solution is to clear `reload` when an armed timer is
+reset. If preserving the reload value across reset is an intended contract,
+add a callback-generation or override marker instead. Add tests for the
+relevant transitions:
+
+- one-shot callback to one-shot rearm;
+- continuous callback to one-shot rearm with a variable delay;
+- continuous callback to continuous rearm with a new delay;
+- continuous rearm followed by reset in the same callback;
+- one-shot callback converted to continuous with
+  `chVTSetReloadIntervalX()`.
+
+Run the same state-transition tests in periodic and tickless configurations.
+
+### VT-2 — callback function and argument are fetched after unlocking
+
+The ticker marks the timer disarmed and then drops the kernel lock before
+evaluating `vtp->func(vtp, vtp->par)` (`chvt.c:535-540` and
+`chvt.c:578-592`). A higher-priority interrupt, or another core after the global
+lock is released, can legally observe the disarmed state and rearm the object.
+`chVTDoSetI()` and `chVTDoSetContinuousI()` overwrite both `func` and `par`.
+The pending expiration can consequently invoke the newly installed callback
+immediately and lose the callback that actually expired.
+
+Earlier VT code saved the callback in a local before dropping the lock. That
+local disappeared when armed state moved from `func != NULL` to the delta-list
+null sentinel; the need to preserve the dispatch target did not disappear with
+it.
+
+**Implemented fix:** copy both `func` and `par` to locals while the timer is still
+protected by the kernel lock, then invoke the saved values after unlocking.
+Combine this with the ownership decision in VT-7; preserving the callback alone
+does not define cross-instance object lifetime.
+
+### VT-3 — callback-created tickless base shifts the next continuous deadline
+
+The tickless ticker correctly records the expired logical deadline in local
+`lasttime` before invoking the callback. It also explicitly notes that the
+callback can modify `vtlp->lasttime` (`chvt.c:574-589`). The automatic reload
+path nevertheless calculates `delta` with `nowdelta` measured from the old,
+local expiration deadline (`chvt.c:600-646`).
+
+The failing sequence is:
+
+1. A continuous timer is the sole timer and expires at time 100.
+2. Its callback adds another timer at time 103. Because the list was empty,
+   `vt_insert_first()` changes the list base to 103.
+3. The callback returns at time 105; the continuous reload is 20.
+4. The code correctly calculates 15 ticks remaining to the phase deadline at
+   120, but stores delta 20 (`5 + 15`) in the list now based at 103.
+5. The continuous timer therefore expires at 123, three ticks late.
+
+The error is the distance between the old expiration base and the base created
+inside the callback. The same issue occurs if a callback empties a previously
+nonempty list and then starts it again.
+
+**Proposed fix:** use elapsed time from the expired deadline only to calculate
+the phase-preserving remaining `delay`. Immediately before insertion, calculate
+a separate base delta from the **current** `vtlp->lasttime` to the captured
+`now`. Alternatively, factor an enqueue helper that accepts the already-read
+`now` and always translates a delay relative to that time into the current
+list's coordinate system.
+
+### VT-4 — zero remaining reload time can make the tickless ISR unbounded
+
+When callback execution has already exceeded a continuous timer's reload, the
+default RFCU path records `CH_RFCU_VT_SKIPPED_DEADLINE` and assigns zero to
+`delay` (`chvt.c:605-619`). Equality reaches the same zero delay through the
+normal subtraction path, without recording a fault. If another timer remains
+in the list, the continuous timer is inserted at the current logical time
+(`chvt.c:628-646`). The outer `while` immediately sees it as due and calls it
+again before leaving `chVTDoTickI()`.
+
+One overdue timer can cause a long catch-up burst while another future timer
+keeps the list nonempty. Two continuous timers whose callbacks consume at least
+their reload are sufficient for an unbounded alternating sequence: each timer
+is reinserted already due, and the list never reaches the empty-list path that
+returns after programming a physical minimum delay. With strictly overdue
+callbacks and debug assertions enabled, the explicit assertion halts first;
+with normal release assertions disabled, the RFCU recovery path continues into
+this loop. Exact-deadline equality follows the unbounded path even with the
+assertion enabled because the asserted `<=` condition still holds.
+
+The comment says recovery proceeds with a minimum delay, but zero is only
+raised to the physical minimum in the empty-list special case. It is not a
+minimum delay in the nonempty case.
+
+**Proposed fix:** when `nowdelta >= reload`, schedule the timer no earlier than
+`now + vtlp->lastdelta`, reprogram the alarm, and leave the current timer
+handler invocation. This gives due timers another interrupt opportunity without
+repeatedly invoking the same callback in one ISR. Add tests with two continuous
+timers whose callbacks advance simulated time exactly to and then past their
+reload; verify bounded callbacks per interrupt and the RFCU record for the
+strictly skipped case.
+
+### VT-5 — `chVTGetTimersStateI()` wraps at both ends of its arithmetic
+
+In tickless mode the function calculates:
+
+```
+(first_delta + CH_CFG_ST_TIMEDELTA) - elapsed
+```
+
+without saturation (`chvt.h:238-244`). Two independent wrap cases follow:
+
+- A first delta of `TIME_INFINITE`, which the VT APIs explicitly accept as a
+  normal interval, plus a configured delta of two becomes one in 32-bit
+  arithmetic. With zero elapsed time the function reports one tick rather than
+  the full-range interval.
+- If interrupt or lock latency makes `elapsed` greater than the tolerated
+  deadline, subtraction wraps to a very large interval rather than reporting
+  zero.
+
+The expression also uses the static `CH_CFG_ST_TIMEDELTA`. Since commit
+`ac16028605`, the effective safe delta is `vtlp->lastdelta` and can increase at
+runtime. The query can therefore disagree with the alarm policy even when no
+arithmetic wraps.
+
+**Proposed fix:** calculate the tolerated deadline with saturating addition,
+subtract elapsed with saturation at zero, and use `vtlp->lastdelta`. Preserve
+the documented tolerance by saturating at `TIME_INFINITE` rather than wrapping.
+Add boundary tests at zero, just before and after the logical deadline, and with
+first deltas near and equal to `TIME_INFINITE`.
+
+### VT-6 — near-full-range tickless timers can expire early
+
+When a tickless list is nonempty, `vt_enqueue()` expresses a new delay relative
+to the older list base by adding the elapsed `nowdelta` (`chvt.c:236-245`). If
+that addition wraps, it stores `delay` itself as a delta from the old base. The
+source comment accurately states the consequence: the timer triggers
+`nowdelta` ticks early.
+
+For a 32-bit example with list base 100, current time 200, and requested delay
+`TIME_INFINITE`, the stored delta from the base is 4294967295. Relative to the
+current time, the actual remaining interval is 4294967195: exactly 100 ticks
+short. The callback contract says that `TIME_INFINITE` is allowed as a normal
+time specification and does not document early expiry.
+
+This is not the physical-timer chunking case. `VT_MAX_DELAY` correctly limits a
+single hardware alarm when `sysinterval_t` is wider than `systime_t`; VT-6 is
+the logical list-coordinate overflow before alarm programming.
+
+**Selected solution:** detect the unsigned addition overflow, report it through
+a dedicated RFCU fault such as `CH_RFCU_VT_INTERVAL_OVERFLOW`, and saturate the
+list-relative delta to `TIME_INFINITE`, the furthest deadline representable
+from the current list base. If the application runtime-fault hook returns, this
+provides the least-early representable fallback; strict applications can halt
+from the hook. When VT RFCU collection is disabled, use a debug assertion as
+the fallback, consistently with the other VT runtime-fault paths.
+
+Apply the same detection to both ordinary enqueue and automatic continuous
+reload insertion. Document that a tickless delay is exact only while adding
+the age of the current list base is representable; otherwise the RFCU event is
+raised and the deadline is saturated. Tests must insert the boundary timer
+after the list base has aged, not only into an empty list, and verify the fault
+mask, hook invocation, saturated fallback deadline, and disabled-RFCU assertion
+path.
+
+### VT-7 — SMP timer operations have no owner but manipulate the current list
+
+Each `os_instance_t` owns a separate `vtlist`, and the SMP RP2 tickless port
+binds a separate hardware alarm to each core. `virtual_timer_t` contains no
+instance owner (`chobjects.h:72-89`). Set, reset, remaining-time query, and tick
+all select `currcore->vtlist`; alarm operations likewise select
+`currcore->core_id` (`chvt.c:333-394`, `chvt.c:479-520`, and
+`chcoresmp_timer.h:54-95`). No public timer API documents same-instance
+affinity.
+
+An armed timer can therefore be passed to `chVTReset()` or `chVTSet()` by a
+thread on another core while correctly serialized by the global kernel lock.
+The intrusive node still points into the original list, so unlinking can partly
+operate on that list, but all header identity and alarm decisions use the
+caller's list.
+
+The smallest destructive case is the last timer on the original core. In
+periodic mode, reset adds its delta to the original list header and then
+restores the **caller's** header to `TIME_INFINITE`, leaving the original header
+corrupted. In tickless mode it additionally fails to stop the original core's
+alarm. `chVTGetRemainingIntervalI()` simply scans the wrong list and reaches
+its "timer not in list" assertion. Re-setting an armed timer on another core
+first performs the wrong reset and then migrates the damaged object.
+
+**Preferred solution:** define timer affinity as same-instance-only and add an
+`os_instance_t *owner` field to `virtual_timer_t` only when
+`CH_DBG_ENABLE_ASSERTS` is enabled. The field is diagnostic state only: no
+functional decision may depend on it. This gives constant-time detection with
+no timer-size or execution overhead when assertions are disabled.
+
+Initialize the diagnostic owner to null, set it to `currcore` when arming, and
+assert `owner == currcore` before reset, replacement, remaining-time query, or
+other owner-sensitive mutation. Clear it after an explicit reset. Keep it set
+while the expiration callback is executing so that another core cannot claim
+the temporarily disarmed object; after the callback, clear it if the timer
+remains disarmed and retain or restore it if the timer is explicitly or
+automatically rearmed. All owner-field accesses must be under the same
+`CH_DBG_ENABLE_ASSERTS` conditional as the field itself.
+
+Do not operate on the owning instance's list or alarm from a foreign core.
+Document that an armed or callback-active timer may only be manipulated from
+its owner instance; a fully disarmed timer has no affinity and may subsequently
+be armed on another instance. Add assertion-enabled SMP tests that arm on core
+zero and attempt query, reset, re-set, and callback-window rearm from core one,
+plus a test that resets on the owner before safely arming the disarmed object on
+the other core.
+
+### VT-10 — `chVTGetCurrentDelta()` does not implement no-suffix locking
+
+`chVTGetCurrentDelta()` has the ordinary no-suffix API name but directly reads
+`currcore->vtlist.lastdelta` without acquiring the system lock
+(`chvt.h:510-525`). `lastdelta` is mutable: the tickless alarm compensation
+paths increase it from interrupt context (`chvt.c:198-203`, with the analogous
+update in `vt_set_alarm()`). It is not declared volatile or atomic.
+
+This is observably unsafe in a supported data model where
+`CH_CFG_INTERVALS_SIZE` is 64 and the target CPU has 32-bit natural accesses. A
+thread-context read can be interrupted between the words of a concurrent
+64-bit update and return a value that was never stored. SMP adds a second
+unlocked writer/read interleaving. The nearby `chVTGetSystemTime()` and
+`chVTGetTimeStamp()` no-suffix APIs acquire the lock; only their X/I-class
+forms assume the caller supplies the required context.
+
+**Proposed fix:** make `chVTGetCurrentDelta()` acquire and release the system
+lock around the mutable tickless read. If a locked-context form is needed, add
+an explicitly named I- or X-class helper and document its atomicity contract.
+The periodic constant-return path requires no lock. Add a compile/run test with
+64-bit intervals on a 32-bit port configuration.
+
+### VT-11 — `CH_CFG_ST_TIMEDELTA` can narrow to zero or one
+
+The configuration check rejects negative values and the literal value one, but
+does not verify that `CH_CFG_ST_TIMEDELTA` fits the configured system-time and
+interval types (`chvt.h:42-44`). Initialization then explicitly casts the
+option to `sysinterval_t` (`chvt.h:541-543`).
+
+For example, with 16-bit intervals, a configured value of 65536 passes the
+preprocessor check and becomes zero at runtime. A value of 65537 becomes one,
+even though one is explicitly invalid. The preprocessor still selects all
+tickless code because it tests the original positive macro, so the compiled
+mode and the runtime minimum delta disagree. When intervals are wider than
+`systime_t`, a value that fits only the interval type can also reach
+`chTimeAddX()` as a physical alarm delay that does not fit system time.
+
+**Proposed fix:** reject any nonzero delta that is not representable as both a
+runtime `sysinterval_t` margin and a physical `systime_t` alarm distance, and
+exclude reserved or sentinel boundary values needed by the retry increment.
+Add accepted tests at zero, two, and the chosen maximum plus rejected tests at
+one and immediately above each representable boundary.
+
+## Documentation defects
+
+### VT-8 — the object-initialization note names the wrong setter
+
+`chVTObjectInit()` says explicit initialization is unnecessary because
+`chVTSetI()` initializes the object (`chvt.c:268-273`). `chVTSetI()` first calls
+`chVTResetI()`, which reads `dlist.next` to decide whether the timer is armed
+(`chvt.h:297-300` and `chvt.h:342-346`). Calling it on an uninitialized automatic
+object therefore reads an indeterminate pointer and can attempt to unlink an
+invalid list node. The setter's own precondition correctly requires prior
+initialization.
+
+The note appears to mean `chVTDoSetI()`, whose precondition is that the object is
+not armed and whose implementation overwrites all fields needed before
+insertion.
+
+**Proposed fix:** name `chVTDoSetI()` in the note and state explicitly that the
+ordinary `chVTSetI()`/`chVTSet()` forms require an initialized object because
+they support replacing an armed timer.
+
+### VT-9 — continuous and reload-setter contracts contradict the implementation
+
+The public inline documentation for `chVTSetContinuousI()` and
+`chVTSetContinuous()` says the timer is disabled after the callback and can be
+disposed or reused (`chvt.h:391-393` and `chvt.h:419-421`). The implementation
+and the lower-level continuous setter correctly say it is restarted. The public
+text is copied from the one-shot API and is false for a callback that makes no
+state change.
+
+`chVTSetReloadIntervalX()` also says it does nothing outside a timer callback,
+but the inline implementation writes `reload` unconditionally
+(`chvt.h:448-463`). The API is intended exclusively for use from the callback
+of the timer passed as `vtp`; the copy/paste error is the claim that calls from
+other contexts "do nothing." Such calls are outside the supported contract, so
+their incidental implementation effect must not be documented as API behavior.
+
+**Selected solution:** documentation changes only. Document the actual
+continuous restart behavior and the supported callback overrides: zero reload
+stops, one-shot rearm replaces the automatic reload, continuous rearm replaces
+it once VT-1 is fixed, and changing `reload` changes the next phase interval.
+State clearly that `chVTSetReloadIntervalX()` may only be called from the
+callback of `vtp`. Within that callback, zero suppresses automatic reload and a
+nonzero value selects the next reload interval, including turning a one-shot
+callback into a continuous timer. Its X-class suffix describes the locking
+context in which the callback can invoke it; it does not permit use outside the
+callback. Remove the false "does nothing" statement, but do not add runtime
+context enforcement or otherwise change behavior for VT-9.
+
+## Behaviors checked and not classified as defects
+
+- Variable one-shot rearming from the callback is valid and works in both
+  ticker implementations because `chVTSetI()` clears `reload`.
+- Calling `chVTSetReloadIntervalX(vtp, 0)` in the active callback correctly
+  stops a continuous timer.
+- Equal-deadline timers are represented by a zero delta following the first
+  timer and are consumed in the same ticker invocation. No FIFO ordering is
+  promised for equal deadlines.
+- Normal reset preserves the delta-list cumulative deadline by transferring the
+  removed node's delta to its successor. Restoring the header after removing the
+  last timer is intentional in same-instance operation.
+- `chVTGetRemainingIntervalI()` saturates an overdue tickless timer at zero.
+- Hardware-alarm chunking through `VT_MAX_DELAY` prevents a wide interval from
+  being passed directly to a narrower `systime_t` alarm. It does not solve VT-6,
+  which occurs in the logical list coordinates.
+- A sole continuous timer that misses its deadline takes the empty-list path,
+  programs a physical minimum delay, and returns. VT-4 requires another timer
+  to keep the list nonempty.
+
+## Test gaps exposed by the review
+
+The standard continuous-timer test only increments a counter. The VT storm test
+has extensive one-shot self-rearming and a continuous timer, but its continuous
+callback does not mutate timer state and its full-range wrapper deadline is not
+checked. Neither suite covers:
+
+- continuous self-rearm from a callback;
+- a sole continuous callback that starts another timer;
+- two continuous callbacks that overrun their periods;
+- `chVTGetTimersStateI()` boundary arithmetic;
+- near-full-range tickless overflow reporting and saturation on an aged,
+  nonempty list;
+- callback-target replacement during the unlocked dispatch window;
+- timer operations from a different SMP instance;
+- 64-bit `chVTGetCurrentDelta()` reads on a 32-bit target;
+- rejected `CH_CFG_ST_TIMEDELTA` narrowing configurations.
+
+These should become focused regression tests rather than being folded only into
+the long-duration VT storm.
+
+## Implemented fixes
+
+1. **VT-8 — object initialization documentation**
+
+   Corrected `chVTObjectInit()` documentation to name `chVTDoSetI()` and
+   `chVTDoSetContinuousI()` as the forms that initialize a disarmed object
+   during insertion. Documented that the replacing `chVTSet*()` forms require
+   an initialized object because they first inspect and possibly reset it.
+
+2. **VT-9 — continuous timer and reload-setter documentation**
+
+   Corrected `chVTSetContinuousI()` and `chVTSetContinuous()` to state that the
+   timer is restarted after its callback. Documented that
+   `chVTSetReloadIntervalX()` may only be called from the callback of the timer
+   passed as `vtp`, that zero suppresses automatic reload, and that a nonzero
+   reload turns a one-shot callback into a continuous timer. No runtime behavior
+   was changed.
+
+3. **VT-2 — protected callback dispatch snapshot**
+
+   In both periodic and tickless ticker paths, copied the expired timer's
+   callback function and argument to automatic locals while holding the kernel
+   lock, then invoked those saved values after unlocking. A concurrent rearm can
+   no longer replace the dispatch target or argument of the expiration already
+   being processed.
+
+   Verification completed with `git diff --check`, the full periodic simulator
+   RT and OSLIB test suites, and an STM32G474 tickless VT storm build. All checks
+   passed and generated build artifacts were cleaned.

--- a/os/rt/VIRTUAL-TIMERS-REVIEW.md
+++ b/os/rt/VIRTUAL-TIMERS-REVIEW.md
@@ -71,7 +71,7 @@ change with a focused regression test.
    invariant without changing timer insertion, removal, reload, or alarm
    programming.
 
-3. **VT-1 — suppress duplicate automatic insertion**
+3. **VT-1 — suppress duplicate automatic insertion (implemented)**
 
    After the callback, enter the automatic reload path only when `reload` is
    nonzero and the timer is still disarmed. This is the narrow corruption fix:
@@ -112,7 +112,7 @@ alarm retry increment boundary, is stated explicitly.
 
 | ID | Classification | Modes | Summary |
 |---|---|---|---|
-| VT-1 | Confirmed, high | periodic and tickless | Continuous callback-side rearming inserts the same timer twice |
+| VT-1 | Partially fixed, high | periodic and tickless | Continuous callback-side rearming inserts the same timer twice |
 | VT-2 | Confirmed concurrency defect | periodic and tickless, especially SMP | Callback function and argument are loaded after the kernel lock is dropped |
 | VT-3 | Confirmed | tickless | A callback-created list base makes automatic reload late |
 | VT-4 | Confirmed, high | tickless | Continuous timers with no future reload margin can keep the timer ISR from returning |
@@ -155,14 +155,16 @@ rearm the object and then reset that newly armed timer. Reset unlinks it but
 leaves `reload` nonzero, so the original expiration's automatic path starts it
 yet again. The explicit final reset does not win.
 
-**Proposed fix:** after the callback, automatically reload only if `reload` is
-nonzero **and the timer is still disarmed**. An armed timer represents an
-explicit callback-side replacement and must be left untouched. Explicit reset
-must also cancel a pending automatic reload: the small
-representation-compatible solution is to clear `reload` when an armed timer is
-reset. If preserving the reload value across reset is an intended contract,
-add a callback-generation or override marker instead. Add tests for the
-relevant transitions:
+**Implemented corruption fix:** after the callback, automatically reload only
+if `reload` is nonzero **and the timer is still disarmed**. An armed timer
+represents an explicit callback-side replacement and is left untouched. This
+prevents duplicate insertion in both periodic and tickless operation.
+
+**Remaining VT-1 decision:** explicit reset must also cancel a pending
+automatic reload. The small representation-compatible solution is to clear
+`reload` when an armed timer is reset. If preserving the reload value across
+reset is an intended contract, add a callback-generation or override marker
+instead. The relevant state transitions are:
 
 - one-shot callback to one-shot rearm;
 - continuous callback to one-shot rearm with a variable delay;
@@ -482,7 +484,7 @@ has extensive one-shot self-rearming and a continuous timer, but its continuous
 callback does not mutate timer state and its full-range wrapper deadline is not
 checked. Neither suite covers:
 
-- continuous self-rearm from a callback;
+- continuous rearm followed by reset in the same callback;
 - a sole continuous callback that starts another timer;
 - two continuous callbacks that overrun their periods;
 - `chVTGetTimersStateI()` boundary arithmetic;
@@ -525,3 +527,17 @@ the long-duration VT storm.
    Verification completed with `git diff --check`, the full periodic simulator
    RT and OSLIB test suites, and an STM32G474 tickless VT storm build. All checks
    passed and generated build artifacts were cleaned.
+
+4. **VT-1 — duplicate automatic reload insertion guard**
+
+   In both ticker paths, automatic reload now requires a nonzero reload value
+   and a timer that is still disarmed after its callback. An explicit
+   callback-side replacement is therefore left in place and is not inserted a
+   second time.
+
+   Added generated RT tests for continuous-to-continuous self-rearm and
+   continuous-to-one-shot replacement, updating both `configuration.xml` and
+   its checked-in generated source. XML validation, regeneration, and
+   `git diff --check` passed. The full periodic simulator RT and OSLIB suites
+   passed, including the new cases, and the STM32F407 tickless test-suite demo
+   built successfully. Generated build artifacts were cleaned.

--- a/os/rt/VIRTUAL-TIMERS-REVIEW.md
+++ b/os/rt/VIRTUAL-TIMERS-REVIEW.md
@@ -95,7 +95,7 @@ change with a focused regression test.
    elapsed-time subtraction at zero. This changes only a query result and does
    not modify the timer list or alarm.
 
-6. **VT-6 — report and saturate unrepresentable enqueue intervals**
+6. **VT-6 — report and saturate unrepresentable enqueue intervals (implemented)**
 
    As a second-stage bounded change, add the selected RFCU overflow event and
    saturate to `TIME_INFINITE` in both insertion paths. Representable delays are
@@ -117,7 +117,7 @@ alarm retry increment boundary, is stated explicitly.
 | VT-3 | Confirmed | tickless | A callback-created list base makes automatic reload late |
 | VT-4 | Confirmed, high | tickless | Continuous timers with no future reload margin can keep the timer ISR from returning |
 | VT-5 | Fixed arithmetic defect | tickless | `chVTGetTimersStateI()` can wrap instead of reporting a bounded interval |
-| VT-6 | Confirmed contract defect | tickless | Near-full-range delays can expire early when the list is nonempty |
+| VT-6 | Fixed contract defect | tickless | Near-full-range delays could expire early when the list was nonempty |
 | VT-7 | Confirmed, high | SMP | Timer operations use the caller's instance without recording the timer's owner |
 | VT-8 | Confirmed documentation defect | all | `chVTObjectInit()` incorrectly says `chVTSetI()` needs no initialization |
 | VT-9 | Confirmed documentation defect | all | Continuous callback and reload-setter documentation contradicts behavior |
@@ -303,21 +303,22 @@ This is not the physical-timer chunking case. `VT_MAX_DELAY` correctly limits a
 single hardware alarm when `sysinterval_t` is wider than `systime_t`; VT-6 is
 the logical list-coordinate overflow before alarm programming.
 
-**Selected solution:** detect the unsigned addition overflow, report it through
-a dedicated RFCU fault such as `CH_RFCU_VT_INTERVAL_OVERFLOW`, and saturate the
+**Implemented fix:** detect the unsigned addition overflow, report it through
+the dedicated `CH_RFCU_VT_INTERVAL_OVERFLOW` fault, and saturate the
 list-relative delta to `TIME_INFINITE`, the furthest deadline representable
 from the current list base. If the application runtime-fault hook returns, this
 provides the least-early representable fallback; strict applications can halt
-from the hook. When VT RFCU collection is disabled, use a debug assertion as
-the fallback, consistently with the other VT runtime-fault paths.
+from the hook. When VT RFCU collection is disabled, a debug assertion is used
+as the fallback, consistently with the other VT runtime-fault paths.
 
-Apply the same detection to both ordinary enqueue and automatic continuous
-reload insertion. Document that a tickless delay is exact only while adding
-the age of the current list base is representable; otherwise the RFCU event is
-raised and the deadline is saturated. Tests must insert the boundary timer
-after the list base has aged, not only into an empty list, and verify the fault
-mask, hook invocation, saturated fallback deadline, and disabled-RFCU assertion
-path.
+The shared checked-add helper is used by both ordinary enqueue and automatic
+continuous reload insertion. The timer APIs now document that a tickless delay
+is exact only while adding the age of the current list base is representable;
+otherwise the RFCU event is raised and the deadline is saturated. A focused
+generated test inserts the boundary timer after the list base has aged and
+checks both the fault mask and saturated fallback coordinate. An
+RFCU-disabled, assertions-enabled build verifies the diagnostic fallback is
+compiled.
 
 ### VT-7 — SMP timer operations have no owner but manipulate the current list
 
@@ -471,8 +472,8 @@ context enforcement or otherwise change behavior for VT-9.
   last timer is intentional in same-instance operation.
 - `chVTGetRemainingIntervalI()` saturates an overdue tickless timer at zero.
 - Hardware-alarm chunking through `VT_MAX_DELAY` prevents a wide interval from
-  being passed directly to a narrower `systime_t` alarm. It does not solve VT-6,
-  which occurs in the logical list coordinates.
+  being passed directly to a narrower `systime_t` alarm. This is distinct from
+  VT-6's now-handled logical list-coordinate overflow.
 - A sole continuous timer that misses its deadline takes the empty-list path,
   programs a physical minimum delay, and returns. VT-4 requires another timer
   to keep the list nonempty.
@@ -487,8 +488,7 @@ checked. Neither suite covers:
 - continuous rearm followed by reset in the same callback;
 - a sole continuous callback that starts another timer;
 - two continuous callbacks that overrun their periods;
-- near-full-range tickless overflow reporting and saturation on an aged,
-  nonempty list;
+- runtime execution of VT-6's RFCU-disabled assertion fallback;
 - callback-target replacement during the unlocked dispatch window;
 - timer operations from a different SMP instance;
 - 64-bit `chVTGetCurrentDelta()` reads on a 32-bit target;
@@ -554,3 +554,21 @@ the long-duration VT storm.
    test-suite demo containing the new conditional test built successfully.
    Generated build artifacts were cleaned; execution of the new tickless-only
    test still requires a supported tickless hardware target.
+
+6. **VT-6 — reported and saturated tickless interval overflow**
+
+   Added `CH_RFCU_VT_INTERVAL_OVERFLOW` and a shared checked-add helper for
+   conversion from a current-time delay to a tickless delta-list coordinate.
+   Both ordinary insertion and automatic continuous reload use the helper.
+   Overflow invokes the RFCU path and saturates at `TIME_INFINITE`; when VT
+   RFCU collection is disabled, the same condition uses a debug assertion.
+
+   Added API documentation for the exceptional tickless range contract, a
+   generated RT test using an aged nonempty list, and VT storm recognition of
+   the new fault bit. XML validation, regeneration, and `git diff --check`
+   passed. The full periodic simulator RT and OSLIB suites passed, the normal
+   STM32F407 tickless test-suite image and STM32G474 VT storm image built, and
+   an RFCU-disabled/assertions-enabled STM32F407 variant built without
+   warnings. Runtime execution of the focused tickless-only test still
+   requires a supported hardware target. Generated build artifacts were
+   cleaned.

--- a/os/rt/VIRTUAL-TIMERS-REVIEW.md
+++ b/os/rt/VIRTUAL-TIMERS-REVIEW.md
@@ -83,7 +83,7 @@ change with a focused regression test.
    reset override case remains open until its API semantics are fixed together
    with the rest of the callback/reload state machine.
 
-4. **VT-10 — lock the no-suffix current-delta getter**
+4. **VT-10 — lock the no-suffix current-delta getter (implemented)**
 
    Acquire the system lock around the mutable tickless `lastdelta` read. The
    periodic constant-return path remains unchanged. The tree currently has only
@@ -121,7 +121,7 @@ alarm retry increment boundary, is stated explicitly.
 | VT-7 | Confirmed, high | SMP | Timer operations use the caller's instance without recording the timer's owner |
 | VT-8 | Confirmed documentation defect | all | `chVTObjectInit()` incorrectly says `chVTSetI()` needs no initialization |
 | VT-9 | Confirmed documentation defect | all | Continuous callback and reload-setter documentation contradicts behavior |
-| VT-10 | Confirmed API atomicity defect | tickless | `chVTGetCurrentDelta()` reads mutable state without locking |
+| VT-10 | Fixed API atomicity defect | tickless | `chVTGetCurrentDelta()` read mutable state without locking |
 | VT-11 | Confirmed configuration defect | tickless | `CH_CFG_ST_TIMEDELTA` can narrow to an invalid runtime value |
 
 ## Confirmed behavioral defects
@@ -383,11 +383,15 @@ unlocked writer/read interleaving. The nearby `chVTGetSystemTime()` and
 `chVTGetTimeStamp()` no-suffix APIs acquire the lock; only their X/I-class
 forms assume the caller supplies the required context.
 
-**Proposed fix:** make `chVTGetCurrentDelta()` acquire and release the system
-lock around the mutable tickless read. If a locked-context form is needed, add
-an explicitly named I- or X-class helper and document its atomicity contract.
-The periodic constant-return path requires no lock. Add a compile/run test with
-64-bit intervals on a 32-bit port configuration.
+**Implemented fix:** `chVTGetCurrentDelta()` now acquires and releases the
+system lock around the mutable tickless `lastdelta` read. The periodic
+constant-return path remains lock-free. The tree has no locked-context caller,
+so no additional I- or X-class API was introduced.
+
+A generated tickless test exercises the thread-context getter and verifies the
+adaptive delta is not below its configured minimum. The test is also compiled
+with 64-bit intervals for a 32-bit Cortex-M4 target, covering the data model in
+which the original unlocked read could tear.
 
 ### VT-11 — `CH_CFG_ST_TIMEDELTA` can narrow to zero or one
 
@@ -491,7 +495,8 @@ checked. Neither suite covers:
 - runtime execution of VT-6's RFCU-disabled assertion fallback;
 - callback-target replacement during the unlocked dispatch window;
 - timer operations from a different SMP instance;
-- 64-bit `chVTGetCurrentDelta()` reads on a 32-bit target;
+- runtime execution of the 64-bit current-delta getter test on a 32-bit
+  tickless target;
 - rejected `CH_CFG_ST_TIMEDELTA` narrowing configurations.
 
 These should become focused regression tests rather than being folded only into
@@ -572,3 +577,19 @@ the long-duration VT storm.
    warnings. Runtime execution of the focused tickless-only test still
    requires a supported hardware target. Generated build artifacts were
    cleaned.
+
+7. **VT-10 — atomic current-delta getter**
+
+   `chVTGetCurrentDelta()` now locks around the mutable tickless `lastdelta`
+   read, preventing interrupt or SMP interleaving and torn wide reads. The
+   periodic compile-time-constant branch remains unchanged and lock-free. No
+   locked-context form was added because both tree call sites are ordinary
+   thread-context calls.
+
+   Added a generated tickless getter test, updating both `configuration.xml`
+   and its checked-in generated source. XML validation, regeneration, and
+   `git diff --check` passed. The full periodic simulator RT and OSLIB suites
+   passed, the STM32G474 tickless VT storm built, and the STM32F407 tickless
+   test-suite image built with 64-bit intervals on its 32-bit Cortex-M4 target.
+   Runtime execution of the new tickless-only test still requires a supported
+   hardware target. Generated build artifacts were cleaned.

--- a/os/rt/include/chrfcu.h
+++ b/os/rt/include/chrfcu.h
@@ -37,6 +37,7 @@
  */
 #define CH_RFCU_VT_INSUFFICIENT_DELTA       1U
 #define CH_RFCU_VT_SKIPPED_DEADLINE         2U
+#define CH_RFCU_VT_INTERVAL_OVERFLOW        4U
 /** @} */
 
 /**

--- a/os/rt/include/chvt.h
+++ b/os/rt/include/chvt.h
@@ -212,7 +212,7 @@ static inline bool chVTIsSystemTimeWithin(systime_t start, systime_t end) {
 /**
  * @brief   Returns the time interval until the next timer event.
  * @note    The return value is not perfectly accurate and can report values
- *          in excess of @p CH_CFG_ST_TIMEDELTA ticks.
+ *          in excess of the current tickless delta setting.
  * @note    The interval returned by this function is only meaningful if
  *          more timers are not added to the list until the returned time.
  *
@@ -239,8 +239,27 @@ static inline bool chVTGetTimersStateI(sysinterval_t *timep) {
 #if CH_CFG_ST_TIMEDELTA == 0
     *timep = dlp->next->delta;
 #else
-    *timep = (dlp->next->delta + (sysinterval_t)CH_CFG_ST_TIMEDELTA) -
-             chTimeDiffX(vtlp->lasttime, chVTGetSystemTimeX());
+    sysinterval_t delta;
+    sysinterval_t nowdelta;
+
+    /* Tolerated deadline with saturation at the maximum interval.*/
+    if (dlp->next->delta > TIME_INFINITE - vtlp->lastdelta) {
+      delta = TIME_INFINITE;
+    }
+    else {
+      delta = dlp->next->delta + vtlp->lastdelta;
+    }
+
+    /* Remaining interval with saturation at zero.*/
+    nowdelta = chTimeDiffX(vtlp->lasttime, chVTGetSystemTimeX());
+    if (nowdelta >= delta) {
+      delta = (sysinterval_t)0;
+    }
+    else {
+      delta -= nowdelta;
+    }
+
+    *timep = delta;
 #endif
   }
 

--- a/os/rt/include/chvt.h
+++ b/os/rt/include/chvt.h
@@ -343,6 +343,12 @@ static inline void chVTReset(virtual_timer_t *vtp) {
  *          using the new parameters.
  * @pre     The timer must have been initialized using @p chVTObjectInit()
  *          or @p chVTDoSetI().
+ * @note    In tickless mode, a delay that cannot be represented relative to
+ *          the current timer-list base reports
+ *          @p CH_RFCU_VT_INTERVAL_OVERFLOW and saturates the deadline at
+ *          @p TIME_INFINITE from that base.
+ *          If VT RFCU collection is disabled, a debug assertion is used
+ *          instead.
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
  * @param[in] delay     the number of ticks before the operation times out, the
@@ -371,6 +377,12 @@ static inline void chVTSetI(virtual_timer_t *vtp, sysinterval_t delay,
  *          using the new parameters.
  * @pre     The timer must have been initialized using @p chVTObjectInit()
  *          or @p chVTDoSetI().
+ * @note    In tickless mode, a delay that cannot be represented relative to
+ *          the current timer-list base reports
+ *          @p CH_RFCU_VT_INTERVAL_OVERFLOW and saturates the deadline at
+ *          @p TIME_INFINITE from that base.
+ *          If VT RFCU collection is disabled, a debug assertion is used
+ *          instead.
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
  * @param[in] delay     the number of ticks before the operation times out, the
@@ -400,6 +412,12 @@ static inline void chVTSet(virtual_timer_t *vtp, sysinterval_t delay,
  *          using the new parameters.
  * @pre     The timer must have been initialized using @p chVTObjectInit()
  *          or @p chVTDoSetI().
+ * @note    In tickless mode, a delay that cannot be represented relative to
+ *          the current timer-list base reports
+ *          @p CH_RFCU_VT_INTERVAL_OVERFLOW and saturates the deadline at
+ *          @p TIME_INFINITE from that base.
+ *          If VT RFCU collection is disabled, a debug assertion is used
+ *          instead.
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
  * @param[in] delay     the number of ticks before the operation times out, the
@@ -427,6 +445,12 @@ static inline void chVTSetContinuousI(virtual_timer_t *vtp, sysinterval_t delay,
  *          using the new parameters.
  * @pre     The timer must have been initialized using @p chVTObjectInit()
  *          or @p chVTDoSetI().
+ * @note    In tickless mode, a delay that cannot be represented relative to
+ *          the current timer-list base reports
+ *          @p CH_RFCU_VT_INTERVAL_OVERFLOW and saturates the deadline at
+ *          @p TIME_INFINITE from that base.
+ *          If VT RFCU collection is disabled, a debug assertion is used
+ *          instead.
  *
  * @param[in] vtp       pointer to a @p virtual_timer_t object
  * @param[in] delay     the number of ticks before the operation times out, the

--- a/os/rt/include/chvt.h
+++ b/os/rt/include/chvt.h
@@ -556,15 +556,21 @@ static inline void chVTResetTimeStamp(void) {
  *          condition is also reported in the RFCU.
  *
  * @return              The current delta setting.
+ *
+ * @api
  */
 static inline sysinterval_t chVTGetCurrentDelta(void) {
 
 #if CH_CFG_ST_TIMEDELTA == 0
   return (sysinterval_t)CH_CFG_ST_TIMEDELTA;
 #else
-  virtual_timers_list_t *vtlp = &currcore->vtlist;
+  sysinterval_t delta;
 
-  return vtlp->lastdelta;
+  chSysLock();
+  delta = currcore->vtlist.lastdelta;
+  chSysUnlock();
+
+  return delta;
 #endif
 }
 

--- a/os/rt/include/chvt.h
+++ b/os/rt/include/chvt.h
@@ -389,8 +389,7 @@ static inline void chVTSet(virtual_timer_t *vtp, sysinterval_t delay,
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
  * @param[in] vtfunc    the timer callback function. After invoking the
- *                      callback the timer is disabled and the structure can
- *                      be disposed or reused.
+ *                      callback the timer is restarted.
  * @param[in] par       a parameter that will be passed to the callback
  *                      function
  *
@@ -417,8 +416,7 @@ static inline void chVTSetContinuousI(virtual_timer_t *vtp, sysinterval_t delay,
  *                        normal time specification.
  *                      - @a TIME_IMMEDIATE this value is not allowed.
  * @param[in] vtfunc    the timer callback function. After invoking the
- *                      callback the timer is disabled and the structure can
- *                      be disposed or reused.
+ *                      callback the timer is restarted.
  * @param[in] par       a parameter that will be passed to the callback
  *                      function
  *
@@ -447,8 +445,10 @@ static inline sysinterval_t chVTGetReloadIntervalX(virtual_timer_t *vtp) {
 
 /**
  * @brief   Changes a timer reload time interval.
- * @note    This function is meant to be called from a timer callback, it
- *          does nothing in any other context.
+ * @pre     This function must only be called from the callback invoked for
+ *          @p vtp.
+ * @note    A zero reload value suppresses automatic reload when the callback
+ *          returns.
  * @note    Calling this function from a one-shot timer callback turns it
  *          into a continuous timer.
  *

--- a/os/rt/src/chvt.c
+++ b/os/rt/src/chvt.c
@@ -548,8 +548,9 @@ void chVTDoTickI(void) {
       func(vtp, par);
       chSysLockFromISR();
 
-      /* If a reload is defined the timer needs to be restarted.*/
-      if (vtp->reload > (sysinterval_t)0) {
+      /* If a reload is defined and the callback left the timer disarmed then
+         it needs to be restarted.*/
+      if ((vtp->reload > (sysinterval_t)0) && !chVTIsArmedI(vtp)) {
         ch_dlist_insert(&vtlp->dlist, &vtp->dlist, vtp->reload);
       }
     }
@@ -607,8 +608,9 @@ void chVTDoTickI(void) {
 
     chSysLockFromISR();
 
-    /* If a reload is defined the timer needs to be restarted.*/
-    if (unlikely(vtp->reload > (sysinterval_t)0)) {
+    /* If a reload is defined and the callback left the timer disarmed then
+       it needs to be restarted.*/
+    if (unlikely((vtp->reload > (sysinterval_t)0) && !chVTIsArmedI(vtp))) {
       sysinterval_t delta, delay;
 
       /* Refreshing the now delta after spending time in the callback for

--- a/os/rt/src/chvt.c
+++ b/os/rt/src/chvt.c
@@ -206,6 +206,31 @@ static void vt_insert_first(virtual_timers_list_t *vtlp,
   chDbgAssert(currdelta <= CH_CFG_ST_TIMEDELTA, "insufficient delta");
 #endif
 }
+
+/**
+ * @brief   Converts a delay to a delta-list coordinate.
+ * @note    An RFCU fault is registered if the addition is not representable,
+ *          the result is saturated to the furthest representable deadline.
+ *
+ * @param[in] nowdelta  delta between the list base and current time
+ * @param[in] delay     delay over current time
+ * @return              The delta from the list base.
+ */
+static sysinterval_t vt_add_delta(sysinterval_t nowdelta,
+                                  sysinterval_t delay) {
+
+  if (unlikely(delay > (TIME_INFINITE - nowdelta))) {
+#if !defined(CH_VT_RFCU_DISABLED)
+    chRFCUCollectFaultsI(CH_RFCU_VT_INTERVAL_OVERFLOW);
+#else
+    chDbgAssert(false, "interval overflow");
+#endif
+
+    return TIME_INFINITE;
+  }
+
+  return nowdelta + delay;
+}
 #endif /* CH_CFG_ST_TIMEDELTA > 0 */
 
 /**
@@ -233,17 +258,9 @@ static void vt_enqueue(virtual_timers_list_t *vtlp,
       return;
     }
 
-    /* Delay as delta from 'lasttime'. Note, it can overflow and the value
-       becomes lower than 'deltanow'.*/
+    /* Delay as delta from 'lasttime'.*/
     nowdelta = chTimeDiffX(vtlp->lasttime, now);
-    delta    = nowdelta + delay;
-
-    /* Scenario where a very large delay exceeded the numeric range, the
-       delta is shortened to make it fit the numeric range, the timer
-       will be triggered "deltanow" cycles earlier.*/
-    if (delta < nowdelta) {
-      delta = delay;
-    }
+    delta    = vt_add_delta(nowdelta, delay);
 
     /* Checking if this timer would become the first in the delta list, this
        requires changing the current alarm setting.*/
@@ -317,6 +334,12 @@ void chVTObjectDispose(virtual_timer_t *vtp) {
  *          specified as parameter.
  * @pre     The timer must not be already armed before calling this function.
  * @note    The callback function is invoked from interrupt context.
+ * @note    In tickless mode, a delay that cannot be represented relative to
+ *          the current timer-list base reports
+ *          @p CH_RFCU_VT_INTERVAL_OVERFLOW and saturates the deadline at
+ *          @p TIME_INFINITE from that base.
+ *          If VT RFCU collection is disabled, a debug assertion is used
+ *          instead.
  *
  * @param[out] vtp      pointer to a @p virtual_timer_t object
  * @param[in] delay     the number of ticks before the operation times out, the
@@ -354,6 +377,12 @@ void chVTDoSetI(virtual_timer_t *vtp, sysinterval_t delay,
  *          specified as parameter.
  * @pre     The timer must not be already armed before calling this function.
  * @note    The callback function is invoked from interrupt context.
+ * @note    In tickless mode, a delay that cannot be represented relative to
+ *          the current timer-list base reports
+ *          @p CH_RFCU_VT_INTERVAL_OVERFLOW and saturates the deadline at
+ *          @p TIME_INFINITE from that base.
+ *          If VT RFCU collection is disabled, a debug assertion is used
+ *          instead.
  *
  * @param[out] vtp      pointer to a @p virtual_timer_t object
  * @param[in] delay     the number of ticks before the operation times out, the
@@ -649,14 +678,8 @@ void chVTDoTickI(void) {
         return;
       }
 
-      /* Delay as delta from 'lasttime'. Note, it can overflow and the value
-         becomes lower than 'nowdelta'. In that case the delta is shortened
-         to make it fit the numeric range and the timer will be triggered
-         "nowdelta" cycles earlier.*/
-      delta = nowdelta + delay;
-      if (delta < nowdelta) {
-        delta = delay;
-      }
+      /* Delay as delta from 'lasttime'.*/
+      delta = vt_add_delta(nowdelta, delay);
 
       /* Insert into delta list. */
       ch_dlist_insert(&vtlp->dlist, &vtp->dlist, delta);

--- a/os/rt/src/chvt.c
+++ b/os/rt/src/chvt.c
@@ -267,10 +267,12 @@ static void vt_enqueue(virtual_timers_list_t *vtlp,
 
 /**
  * @brief   Initializes a @p virtual_timer_t object.
- * @note    Initializing a timer object is not strictly required because
- *          the function @p chVTSetI() initializes the object too. This
- *          function is only useful if you need to perform a @p chVTIsArmed()
- *          check before calling @p chVTSetI().
+ * @note    Explicit initialization is not required before calling
+ *          @p chVTDoSetI() or @p chVTDoSetContinuousI() because those
+ *          functions initialize a disarmed object before inserting it.
+ * @note    The replacing forms @p chVTSetI(), @p chVTSet(),
+ *          @p chVTSetContinuousI(), and @p chVTSetContinuous() require an
+ *          initialized object because they first check and reset it if armed.
  *
  * @param[out] vtp      pointer to a @p virtual_timer_t object
  *
@@ -528,16 +530,22 @@ void chVTDoTickI(void) {
     --vtlp->dlist.next->delta;
     while (vtlp->dlist.next->delta == (sysinterval_t)0) {
       virtual_timer_t *vtp;
+      vtfunc_t func;
+      void *par;
 
       /* Triggered timer.*/
       vtp = (virtual_timer_t *)vtlp->dlist.next;
+
+      /* Preserving callback information while still protected.*/
+      func = vtp->func;
+      par  = vtp->par;
 
       /* Removing the element from the delta list, marking it as not armed.*/
       (void) ch_dlist_dequeue(&vtp->dlist);
       vtp->dlist.next = NULL;
 
       chSysUnlockFromISR();
-      vtp->func(vtp, vtp->par);
+      func(vtp, par);
       chSysLockFromISR();
 
       /* If a reload is defined the timer needs to be restarted.*/
@@ -548,6 +556,8 @@ void chVTDoTickI(void) {
   }
 #else /* CH_CFG_ST_TIMEDELTA > 0 */
   virtual_timer_t *vtp;
+  vtfunc_t func;
+  void *par;
   sysinterval_t nowdelta;
   systime_t now;
 
@@ -575,6 +585,10 @@ void chVTDoTickI(void) {
     lasttime = chTimeAddX(vtlp->lasttime, vtp->dlist.delta);
     vtlp->lasttime = lasttime;
 
+    /* Preserving callback information while still protected.*/
+    func = vtp->func;
+    par  = vtp->par;
+
     /* Removing the timer from the list, marking it as not armed.*/
     (void) ch_dlist_dequeue(&vtp->dlist);
     vtp->dlist.next = NULL;
@@ -589,7 +603,7 @@ void chVTDoTickI(void) {
        modified within the callback if some timer function is called.*/
     chSysUnlockFromISR();
 
-    vtp->func(vtp, vtp->par);
+    func(vtp, par);
 
     chSysLockFromISR();
 

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1069,6 +1069,44 @@ test_assert(listdelta == TIME_INFINITE,
             </step>
           </steps>
         </case>
+        <case>
+          <brief>
+            <value>Current tickless delta getter.</value>
+          </brief>
+          <description>
+            <value>The thread-context current-delta API is exercised.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_ST_TIMEDELTA > 0]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value />
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[sysinterval_t delta;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The current adaptive delta is read from thread context
+                  and checked against its configured minimum.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[delta = chVTGetCurrentDelta();
+test_assert(delta >= (sysinterval_t)CH_CFG_ST_TIMEDELTA,
+            "invalid current delta");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
       </cases>
     </sequence>
     <sequence>

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -696,6 +696,16 @@ chSysEnable();]]></value>
 
 #if CH_CFG_USE_TM || defined(__DOXYGEN__)
 static time_measurement_t tm1, tm2;
+#endif
+
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+static virtual_timer_t timers_state_vt;
+
+static void timers_state_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)vtp;
+  (void)param;
+}
 #endif]]></value>
       </shared_code>
       <cases>
@@ -915,6 +925,79 @@ test_assert(tm2.n == (ucnt_t)1, "invalid counter");
 test_assert(tm2.last > (rtcnt_t)0, "invalid last");
 test_assert(tm2.best == tm2.last, "invalid best");
 test_assert(tm2.worst == tm2.last, "invalid worst");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Tickless timers state boundaries.</value>
+          </brief>
+          <description>
+            <value>The saturating boundary behavior of @p
+              chVTGetTimersStateI() is tested.</value>
+          </description>
+          <condition>
+            <value><![CDATA[CH_CFG_ST_TIMEDELTA > 0]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chVTObjectInit(&timers_state_vt);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chVTReset(&timers_state_vt);
+chVTObjectDispose(&timers_state_vt);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[sysinterval_t interval;
+bool pending;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>A maximum-interval timer is queried. Addition of the
+                  current tickless delta must saturate instead of wrapping to
+                  a short interval.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+chVTDoSetI(&timers_state_vt, TIME_INFINITE, timers_state_cb, NULL);
+pending = chVTGetTimersStateI(&interval);
+chVTDoResetI(&timers_state_vt);
+chSysUnlock();
+
+test_assert(pending, "timer not reported");
+test_assert(interval > (TIME_MAX_INTERVAL / (sysinterval_t)2),
+            "interval addition wrapped");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Timer processing is held past the tolerated deadline.
+                  The reported remaining interval must saturate at zero
+                  instead of wrapping.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+chVTDoSetI(&timers_state_vt, currcore->vtlist.lastdelta,
+           timers_state_cb, NULL);
+do {
+  interval = chTimeDiffX(currcore->vtlist.lasttime, chVTGetSystemTimeX());
+} while (interval <= (timers_state_vt.dlist.delta +
+                      currcore->vtlist.lastdelta));
+pending = chVTGetTimersStateI(&interval);
+chVTDoResetI(&timers_state_vt);
+chSysUnlock();
+
+test_assert(pending, "timer not reported");
+test_assert(interval == (sysinterval_t)0, "interval subtraction wrapped");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -700,6 +700,10 @@ static time_measurement_t tm1, tm2;
 
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
 static virtual_timer_t timers_state_vt;
+#if !defined(CH_VT_RFCU_DISABLED) || defined(__DOXYGEN__)
+static virtual_timer_t timers_overflow_anchor;
+static virtual_timer_t timers_overflow_vt;
+#endif
 
 static void timers_state_cb(virtual_timer_t *vtp, void *param) {
 
@@ -998,6 +1002,69 @@ chSysUnlock();
 
 test_assert(pending, "timer not reported");
 test_assert(interval == (sysinterval_t)0, "interval subtraction wrapped");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Tickless timer interval overflow.</value>
+          </brief>
+          <description>
+            <value>Overflow while converting a delay to an aged timer-list
+              coordinate is reported and saturated.</value>
+          </description>
+          <condition>
+            <value><![CDATA[(CH_CFG_ST_TIMEDELTA > 0) && !defined(CH_VT_RFCU_DISABLED)]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chVTObjectInit(&timers_overflow_anchor);
+chVTObjectInit(&timers_overflow_vt);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chVTReset(&timers_overflow_vt);
+chVTReset(&timers_overflow_anchor);
+chVTObjectDispose(&timers_overflow_vt);
+chVTObjectDispose(&timers_overflow_anchor);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[rfcu_mask_t mask;
+sysinterval_t delay, listdelta, nowdelta;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>A timer is inserted after a nonempty list base has
+                  aged enough to make its requested delay unrepresentable.
+                  The overflow fault and saturated list coordinate are
+                  verified.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSysLock();
+(void) chRFCUGetAndClearFaultsI(CH_RFCU_ALL_FAULTS);
+chVTDoSetI(&timers_overflow_anchor, TIME_INFINITE,
+           timers_state_cb, NULL);
+do {
+  nowdelta = chTimeDiffX(currcore->vtlist.lasttime,
+                         chVTGetSystemTimeX());
+} while (nowdelta < (sysinterval_t)2);
+delay = TIME_INFINITE - nowdelta + (sysinterval_t)1;
+chVTDoSetI(&timers_overflow_vt, delay, timers_state_cb, NULL);
+mask = chRFCUGetAndClearFaultsI(CH_RFCU_ALL_FAULTS);
+listdelta = timers_overflow_vt.dlist.delta;
+chVTDoResetI(&timers_overflow_vt);
+chVTDoResetI(&timers_overflow_anchor);
+chSysUnlock();
+
+test_assert((mask & CH_RFCU_VT_INTERVAL_OVERFLOW) != (rfcu_mask_t)0,
+            "overflow fault not reported");
+test_assert(listdelta == TIME_INFINITE,
+            "list coordinate not saturated");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -5622,6 +5622,36 @@ static void vt_continuous_cb(virtual_timer_t *vtp, void *param) {
   vt_counter++;
 }
 
+static void vt_continuous_rearm_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)param;
+
+  vt_counter++;
+  if (vt_counter == 1U) {
+    chSysLockFromISR();
+    chVTSetContinuousI(vtp, TIME_MS2I(10), vt_continuous_rearm_cb, NULL);
+    chSysUnlockFromISR();
+  }
+}
+
+static void vt_oneshot_count_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)vtp;
+  (void)param;
+
+  vt_counter++;
+}
+
+static void vt_continuous_to_oneshot_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)param;
+
+  vt_counter++;
+  chSysLockFromISR();
+  chVTSetI(vtp, TIME_MS2I(10), vt_oneshot_count_cb, NULL);
+  chSysUnlockFromISR();
+}
+
 #if CH_CFG_USE_MESSAGES
 static THD_FUNCTION(bmk_thread1, p) {
   thread_t *tp;
@@ -6396,7 +6426,9 @@ test_assert(chVTIsArmed(&vt2) == false, "timer still armed");]]></value>
           </brief>
           <description>
             <value>A continuous virtual timer is armed, allowed to fire
-              multiple times, then reset and checked for inactivity.</value>
+              multiple times, then reset and checked for inactivity. Callback
+              replacement with continuous and one-shot timers is also
+              verified.</value>
           </description>
           <condition>
             <value />
@@ -6468,6 +6500,51 @@ test_assert(!armed, "timer still armed");
 count = vt_counter;
 chThdSleepMilliseconds(30);
 test_assert(vt_counter == count, "timer still running");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The callback continuously rearms its own timer once.
+                  The explicit replacement is verified to remain armed and to
+                  fire repeatedly without duplicate insertion.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[vt_counter = 0;
+chVTSetContinuous(&vt2, TIME_MS2I(10), vt_continuous_rearm_cb, NULL);
+chThdSleepMilliseconds(50);
+chSysLock();
+armed = chVTIsArmedI(&vt2);
+chVTResetI(&vt2);
+chSysUnlock();
+count = vt_counter;
+
+test_assert(armed, "replacement timer not armed");
+test_assert(count >= 2U, "replacement timer not reloaded");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>The continuous callback replaces its timer with a
+                  one-shot timer. The one-shot is verified to fire exactly
+                  once and remain disarmed.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[vt_counter = 0;
+chVTSetContinuous(&vt2, TIME_MS2I(10), vt_continuous_to_oneshot_cb, NULL);
+chThdSleepMilliseconds(50);
+chSysLock();
+armed = chVTIsArmedI(&vt2);
+chSysUnlock();
+count = vt_counter;
+
+test_assert(!armed, "one-shot replacement still armed");
+test_assert(count == 2U, "one-shot replacement count");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -33,6 +33,7 @@
  * - @subpage rt_test_003_001
  * - @subpage rt_test_003_002
  * - @subpage rt_test_003_003
+ * - @subpage rt_test_003_004
  * .
  */
 
@@ -44,6 +45,16 @@
 
 #if CH_CFG_USE_TM || defined(__DOXYGEN__)
 static time_measurement_t tm1, tm2;
+#endif
+
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+static virtual_timer_t timers_state_vt;
+
+static void timers_state_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)vtp;
+  (void)param;
+}
 #endif
 
 /*===========================================================================*/
@@ -247,6 +258,90 @@ static const testcase_t rt_test_003_003 = {
 };
 #endif /* CH_CFG_USE_TM == TRUE */
 
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_003_004 [3.4] Tickless timers state boundaries
+ *
+ * <h2>Description</h2>
+ * The saturating boundary behavior of @p chVTGetTimersStateI() is
+ * tested.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_ST_TIMEDELTA > 0
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [3.4.1] A maximum-interval timer is queried. Addition of the
+ *   current tickless delta must saturate instead of wrapping to a
+ *   short interval.
+ * - [3.4.2] Timer processing is held past the tolerated deadline. The
+ *   reported remaining interval must saturate at zero instead of
+ *   wrapping.
+ * .
+ */
+
+static void rt_test_003_004_setup(void) {
+  chVTObjectInit(&timers_state_vt);
+}
+
+static void rt_test_003_004_teardown(void) {
+  chVTReset(&timers_state_vt);
+  chVTObjectDispose(&timers_state_vt);
+}
+
+static void rt_test_003_004_execute(void) {
+  sysinterval_t interval;
+  bool pending;
+
+  /* [3.4.1] A maximum-interval timer is queried. Addition of the
+     current tickless delta must saturate instead of wrapping to a
+     short interval.*/
+  test_set_step(1);
+  {
+    chSysLock();
+    chVTDoSetI(&timers_state_vt, TIME_INFINITE, timers_state_cb, NULL);
+    pending = chVTGetTimersStateI(&interval);
+    chVTDoResetI(&timers_state_vt);
+    chSysUnlock();
+
+    test_assert(pending, "timer not reported");
+    test_assert(interval > (TIME_MAX_INTERVAL / (sysinterval_t)2),
+                "interval addition wrapped");
+  }
+  test_end_step(1);
+
+  /* [3.4.2] Timer processing is held past the tolerated deadline. The
+     reported remaining interval must saturate at zero instead of
+     wrapping.*/
+  test_set_step(2);
+  {
+    chSysLock();
+    chVTDoSetI(&timers_state_vt, currcore->vtlist.lastdelta,
+               timers_state_cb, NULL);
+    do {
+      interval = chTimeDiffX(currcore->vtlist.lasttime, chVTGetSystemTimeX());
+    } while (interval <= (timers_state_vt.dlist.delta +
+                          currcore->vtlist.lastdelta));
+    pending = chVTGetTimersStateI(&interval);
+    chVTDoResetI(&timers_state_vt);
+    chSysUnlock();
+
+    test_assert(pending, "timer not reported");
+    test_assert(interval == (sysinterval_t)0, "interval subtraction wrapped");
+  }
+  test_end_step(2);
+}
+
+static const testcase_t rt_test_003_004 = {
+  "Tickless timers state boundaries",
+  rt_test_003_004_setup,
+  rt_test_003_004_teardown,
+  rt_test_003_004_execute
+};
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -259,6 +354,9 @@ const testcase_t * const rt_test_sequence_003_array[] = {
   &rt_test_003_002,
 #if (CH_CFG_USE_TM == TRUE) || defined(__DOXYGEN__)
   &rt_test_003_003,
+#endif
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+  &rt_test_003_004,
 #endif
   NULL
 };

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -35,6 +35,7 @@
  * - @subpage rt_test_003_003
  * - @subpage rt_test_003_004
  * - @subpage rt_test_003_005
+ * - @subpage rt_test_003_006
  * .
  */
 
@@ -421,6 +422,47 @@ static const testcase_t rt_test_003_005 = {
 };
 #endif /* (CH_CFG_ST_TIMEDELTA > 0) && !defined(CH_VT_RFCU_DISABLED) */
 
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_003_006 [3.6] Current tickless delta getter
+ *
+ * <h2>Description</h2>
+ * The thread-context current-delta API is exercised.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - CH_CFG_ST_TIMEDELTA > 0
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [3.6.1] The current adaptive delta is read from thread context and
+ *   checked against its configured minimum.
+ * .
+ */
+
+static void rt_test_003_006_execute(void) {
+  sysinterval_t delta;
+
+  /* [3.6.1] The current adaptive delta is read from thread context and
+     checked against its configured minimum.*/
+  test_set_step(1);
+  {
+    delta = chVTGetCurrentDelta();
+    test_assert(delta >= (sysinterval_t)CH_CFG_ST_TIMEDELTA,
+                "invalid current delta");
+  }
+  test_end_step(1);
+}
+
+static const testcase_t rt_test_003_006 = {
+  "Current tickless delta getter",
+  NULL,
+  NULL,
+  rt_test_003_006_execute
+};
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -439,6 +481,9 @@ const testcase_t * const rt_test_sequence_003_array[] = {
 #endif
 #if ((CH_CFG_ST_TIMEDELTA > 0) && !defined(CH_VT_RFCU_DISABLED)) || defined(__DOXYGEN__)
   &rt_test_003_005,
+#endif
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+  &rt_test_003_006,
 #endif
   NULL
 };

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -34,6 +34,7 @@
  * - @subpage rt_test_003_002
  * - @subpage rt_test_003_003
  * - @subpage rt_test_003_004
+ * - @subpage rt_test_003_005
  * .
  */
 
@@ -49,6 +50,10 @@ static time_measurement_t tm1, tm2;
 
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
 static virtual_timer_t timers_state_vt;
+#if !defined(CH_VT_RFCU_DISABLED) || defined(__DOXYGEN__)
+static virtual_timer_t timers_overflow_anchor;
+static virtual_timer_t timers_overflow_vt;
+#endif
 
 static void timers_state_cb(virtual_timer_t *vtp, void *param) {
 
@@ -342,6 +347,80 @@ static const testcase_t rt_test_003_004 = {
 };
 #endif /* CH_CFG_ST_TIMEDELTA > 0 */
 
+#if ((CH_CFG_ST_TIMEDELTA > 0) && !defined(CH_VT_RFCU_DISABLED)) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_003_005 [3.5] Tickless timer interval overflow
+ *
+ * <h2>Description</h2>
+ * Overflow while converting a delay to an aged timer-list coordinate
+ * is reported and saturated.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - (CH_CFG_ST_TIMEDELTA > 0) && !defined(CH_VT_RFCU_DISABLED)
+ * .
+ *
+ * <h2>Test Steps</h2>
+ * - [3.5.1] A timer is inserted after a nonempty list base has aged
+ *   enough to make its requested delay unrepresentable. The overflow
+ *   fault and saturated list coordinate are verified.
+ * .
+ */
+
+static void rt_test_003_005_setup(void) {
+  chVTObjectInit(&timers_overflow_anchor);
+  chVTObjectInit(&timers_overflow_vt);
+}
+
+static void rt_test_003_005_teardown(void) {
+  chVTReset(&timers_overflow_vt);
+  chVTReset(&timers_overflow_anchor);
+  chVTObjectDispose(&timers_overflow_vt);
+  chVTObjectDispose(&timers_overflow_anchor);
+}
+
+static void rt_test_003_005_execute(void) {
+  rfcu_mask_t mask;
+  sysinterval_t delay, listdelta, nowdelta;
+
+  /* [3.5.1] A timer is inserted after a nonempty list base has aged
+     enough to make its requested delay unrepresentable. The overflow
+     fault and saturated list coordinate are verified.*/
+  test_set_step(1);
+  {
+    chSysLock();
+    (void) chRFCUGetAndClearFaultsI(CH_RFCU_ALL_FAULTS);
+    chVTDoSetI(&timers_overflow_anchor, TIME_INFINITE,
+               timers_state_cb, NULL);
+    do {
+      nowdelta = chTimeDiffX(currcore->vtlist.lasttime,
+                             chVTGetSystemTimeX());
+    } while (nowdelta < (sysinterval_t)2);
+    delay = TIME_INFINITE - nowdelta + (sysinterval_t)1;
+    chVTDoSetI(&timers_overflow_vt, delay, timers_state_cb, NULL);
+    mask = chRFCUGetAndClearFaultsI(CH_RFCU_ALL_FAULTS);
+    listdelta = timers_overflow_vt.dlist.delta;
+    chVTDoResetI(&timers_overflow_vt);
+    chVTDoResetI(&timers_overflow_anchor);
+    chSysUnlock();
+
+    test_assert((mask & CH_RFCU_VT_INTERVAL_OVERFLOW) != (rfcu_mask_t)0,
+                "overflow fault not reported");
+    test_assert(listdelta == TIME_INFINITE,
+                "list coordinate not saturated");
+  }
+  test_end_step(1);
+}
+
+static const testcase_t rt_test_003_005 = {
+  "Tickless timer interval overflow",
+  rt_test_003_005_setup,
+  rt_test_003_005_teardown,
+  rt_test_003_005_execute
+};
+#endif /* (CH_CFG_ST_TIMEDELTA > 0) && !defined(CH_VT_RFCU_DISABLED) */
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -357,6 +436,9 @@ const testcase_t * const rt_test_sequence_003_array[] = {
 #endif
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
   &rt_test_003_004,
+#endif
+#if ((CH_CFG_ST_TIMEDELTA > 0) && !defined(CH_VT_RFCU_DISABLED)) || defined(__DOXYGEN__)
+  &rt_test_003_005,
 #endif
   NULL
 };

--- a/test/rt/source/test/rt_test_sequence_012.c
+++ b/test/rt/source/test/rt_test_sequence_012.c
@@ -80,6 +80,36 @@ static void vt_continuous_cb(virtual_timer_t *vtp, void *param) {
   vt_counter++;
 }
 
+static void vt_continuous_rearm_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)param;
+
+  vt_counter++;
+  if (vt_counter == 1U) {
+    chSysLockFromISR();
+    chVTSetContinuousI(vtp, TIME_MS2I(10), vt_continuous_rearm_cb, NULL);
+    chSysUnlockFromISR();
+  }
+}
+
+static void vt_oneshot_count_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)vtp;
+  (void)param;
+
+  vt_counter++;
+}
+
+static void vt_continuous_to_oneshot_cb(virtual_timer_t *vtp, void *param) {
+
+  (void)param;
+
+  vt_counter++;
+  chSysLockFromISR();
+  chVTSetI(vtp, TIME_MS2I(10), vt_oneshot_count_cb, NULL);
+  chSysUnlockFromISR();
+}
+
 #if CH_CFG_USE_MESSAGES
 static THD_FUNCTION(bmk_thread1, p) {
   thread_t *tp;
@@ -790,13 +820,20 @@ static const testcase_t rt_test_012_009 = {
  *
  * <h2>Description</h2>
  * A continuous virtual timer is armed, allowed to fire multiple times,
- * then reset and checked for inactivity.
+ * then reset and checked for inactivity. Callback replacement with
+ * continuous and one-shot timers is also verified.
  *
  * <h2>Test Steps</h2>
  * - [12.10.1] The continuous timer is armed and its remaining interval
  *   is queried.
  * - [12.10.2] The timer is allowed to reload and fire multiple times.
  * - [12.10.3] The timer is reset and verified not to fire again.
+ * - [12.10.4] The callback continuously rearms its own timer once. The
+ *   explicit replacement is verified to remain armed and to fire
+ *   repeatedly without duplicate insertion.
+ * - [12.10.5] The continuous callback replaces its timer with a
+ *   one-shot timer. The one-shot is verified to fire exactly once and
+ *   remain disarmed.
  * .
  */
 
@@ -854,6 +891,43 @@ static void rt_test_012_010_execute(void) {
     test_assert(vt_counter == count, "timer still running");
   }
   test_end_step(3);
+
+  /* [12.10.4] The callback continuously rearms its own timer once. The
+     explicit replacement is verified to remain armed and to fire
+     repeatedly without duplicate insertion.*/
+  test_set_step(4);
+  {
+    vt_counter = 0;
+    chVTSetContinuous(&vt2, TIME_MS2I(10), vt_continuous_rearm_cb, NULL);
+    chThdSleepMilliseconds(50);
+    chSysLock();
+    armed = chVTIsArmedI(&vt2);
+    chVTResetI(&vt2);
+    chSysUnlock();
+    count = vt_counter;
+
+    test_assert(armed, "replacement timer not armed");
+    test_assert(count >= 2U, "replacement timer not reloaded");
+  }
+  test_end_step(4);
+
+  /* [12.10.5] The continuous callback replaces its timer with a
+     one-shot timer. The one-shot is verified to fire exactly once and
+     remain disarmed.*/
+  test_set_step(5);
+  {
+    vt_counter = 0;
+    chVTSetContinuous(&vt2, TIME_MS2I(10), vt_continuous_to_oneshot_cb, NULL);
+    chThdSleepMilliseconds(50);
+    chSysLock();
+    armed = chVTIsArmedI(&vt2);
+    chSysUnlock();
+    count = vt_counter;
+
+    test_assert(!armed, "one-shot replacement still armed");
+    test_assert(count == 2U, "one-shot replacement count");
+  }
+  test_end_step(5);
 }
 
 static const testcase_t rt_test_012_010 = {

--- a/testrt/VT_STORM/source/vt_storm.c
+++ b/testrt/VT_STORM/source/vt_storm.c
@@ -284,12 +284,18 @@ void vt_storm_execute(const vt_storm_config_t *cfg) {
 
       /* Check for relevant RFCU events.*/
       mask = chRFCUGetAndClearFaultsI(CH_RFCU_VT_INSUFFICIENT_DELTA |
-                                      CH_RFCU_VT_SKIPPED_DEADLINE);
+                                      CH_RFCU_VT_SKIPPED_DEADLINE |
+                                      CH_RFCU_VT_INTERVAL_OVERFLOW);
       chSysUnlock();
 
       if (saturated) {
         chprintf(cfg->out, "#");
         break;
+      }
+      else if ((mask & CH_RFCU_VT_INTERVAL_OVERFLOW) != (rfcu_mask_t)0) {
+        palToggleLine(config->line);
+        chprintf(cfg->out, "o");
+        warning = true;
       }
       else if (mask == CH_RFCU_VT_INSUFFICIENT_DELTA) {
         palToggleLine(config->line);


### PR DESCRIPTION
## Summary

- preserve the expired virtual timer callback and argument before releasing the kernel lock
- prevent automatic continuous reload from inserting a timer already rearmed by its callback
- correct virtual timer initialization, continuous reload, and callback-only reload-setter documentation
- saturate tickless timer-state queries and report unrepresentable enqueue coordinates through the new CH_RFCU_VT_INTERVAL_OVERFLOW fault
- make the no-suffix current-delta getter atomic in tickless mode
- add focused generated RT tests, VT storm fault handling, and the virtual-timer correctness review

## Related

- Issue(s): none
- Notes for reviewers: The PR intentionally contains the bounded VT-1, VT-2, VT-5, VT-6, VT-8, VT-9, and VT-10 changes. Broader callback scheduling, SMP ownership, and configuration-boundary findings remain deferred and documented in VIRTUAL-TIMERS-REVIEW.md.

## Target Branch Check

- [x] This PR targets master — all changes land on master first (upstream-first policy);
      stable-* branches only receive maintainer-selected backports of commits already
      merged on master

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed .c/.h files
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? No device runtime was performed. Tickless-only cases were compiled for STM32F407; the full periodic RT and OSLIB suites ran on the POSIX simulator.

Additional checks:

- STM32F407 tickless test-suite build with 64-bit intervals on Cortex-M4
- STM32F407 RFCU-disabled and assertions-enabled build
- STM32G474 tickless VT storm build
- XML validation and FMPP regeneration
- git diff --check

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

The virtual_timer_t layout is unchanged. Representable timer delays retain their existing behavior. An unrepresentable tickless list coordinate now raises a runtime fault and saturates at TIME_INFINITE instead of silently expiring early. Applications with a halting runtime-fault hook may therefore stop on a condition that was previously silent. Runtime execution of the focused tickless-only tests still requires supported hardware.