### PR TITLE
rt: fix tickless continuous reload safety

### DIFF
--- a/.github/workflows/review-mechanical-checks.yml
+++ b/.github/workflows/review-mechanical-checks.yml
@@ -126,6 +126,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          sh test/rt/testbuild/check_vt_config.sh
           # Compile only: no execution of produced binaries.
           make -C test/rt/testbuild -f Makefile_x86 all
           make -C test/rt/testbuild -f Makefile_x86 clean

--- a/.github/workflows/review-mechanical-checks.yml
+++ b/.github/workflows/review-mechanical-checks.yml
@@ -127,6 +127,7 @@ jobs:
         run: |
           set -euo pipefail
           sh test/rt/testbuild/check_vt_config.sh
+          sh test/rt/testbuild/check_vt_tickless.sh
           # Compile only: no execution of produced binaries.
           make -C test/rt/testbuild -f Makefile_x86 all
           make -C test/rt/testbuild -f Makefile_x86 clean

--- a/os/rt/VIRTUAL-TIMERS-REVIEW.md
+++ b/os/rt/VIRTUAL-TIMERS-REVIEW.md
@@ -102,11 +102,12 @@ change with a focused regression test.
    unchanged. Land this after the query fixes because it deliberately changes
    exceptional-path behavior and can invoke an application runtime-fault hook.
 
-Defer VT-3 and VT-4 because they change tickless reload scheduling and ISR exit
-behavior. Defer the remaining VT-1 reset semantics and the VT-7 diagnostic owner
-lifetime until the callback state transitions are specified and tested as a
-whole. VT-11 is now bounded by the existing physical-alarm maximum, which
-reserves the low half of the counter range for alarm retry increments.
+VT-3 and VT-4 are now implemented together with deterministic tickless
+scheduling tests. Defer the remaining VT-1 reset semantics and the VT-7
+diagnostic owner lifetime until the callback state transitions are specified
+and tested as a whole. VT-11 is now bounded by the existing physical-alarm
+maximum, which reserves the low half of the counter range for alarm retry
+increments.
 
 ## Findings summary
 
@@ -114,8 +115,8 @@ reserves the low half of the counter range for alarm retry increments.
 |---|---|---|---|
 | VT-1 | Partially fixed, high | periodic and tickless | Continuous callback-side rearming inserts the same timer twice |
 | VT-2 | Confirmed concurrency defect | periodic and tickless, especially SMP | Callback function and argument are loaded after the kernel lock is dropped |
-| VT-3 | Confirmed | tickless | A callback-created list base makes automatic reload late |
-| VT-4 | Confirmed, high | tickless | Continuous timers with no future reload margin can keep the timer ISR from returning |
+| VT-3 | Fixed scheduling defect | tickless | A callback-created list base made automatic reload late |
+| VT-4 | Fixed boundedness defect | tickless | Continuous timers with no future reload margin could keep the timer ISR from returning |
 | VT-5 | Fixed arithmetic defect | tickless | `chVTGetTimersStateI()` can wrap instead of reporting a bounded interval |
 | VT-6 | Fixed contract defect | tickless | Near-full-range delays could expire early when the list was nonempty |
 | VT-7 | Confirmed, high | SMP | Timer operations use the caller's instance without recording the timer's owner |
@@ -217,12 +218,13 @@ The error is the distance between the old expiration base and the base created
 inside the callback. The same issue occurs if a callback empties a previously
 nonempty list and then starts it again.
 
-**Proposed fix:** use elapsed time from the expired deadline only to calculate
-the phase-preserving remaining `delay`. Immediately before insertion, calculate
-a separate base delta from the **current** `vtlp->lasttime` to the captured
-`now`. Alternatively, factor an enqueue helper that accepts the already-read
-`now` and always translates a delay relative to that time into the current
-list's coordinate system.
+**Implemented fix:** elapsed time from the expired deadline is now used only to
+calculate the phase-preserving remaining `delay`. Immediately before insertion,
+a separate `basedelta` is calculated from the current `vtlp->lasttime` to the
+captured `now` (`chvt.c:637-684`). Timer operations performed during the
+unlocked callback window, either by the callback or by a preempting ISR, can
+therefore replace the list base without shifting the automatic reload's
+absolute phase deadline.
 
 ### VT-4 — zero remaining reload time can make the tickless ISR unbounded
 
@@ -248,13 +250,23 @@ The comment says recovery proceeds with a minimum delay, but zero is only
 raised to the physical minimum in the empty-list special case. It is not a
 minimum delay in the nonempty case.
 
-**Proposed fix:** when `nowdelta >= reload`, schedule the timer no earlier than
-`now + vtlp->lastdelta`, reprogram the alarm, and leave the current timer
-handler invocation. This gives due timers another interrupt opportunity without
-repeatedly invoking the same callback in one ISR. Add tests with two continuous
-timers whose callbacks advance simulated time exactly to and then past their
-reload; verify bounded callbacks per interrupt and the RFCU record for the
-strictly skipped case.
+**Implemented fix:** when elapsed callback time reaches or exceeds `reload`, the
+timer is scheduled at `now + vtlp->lastdelta`, the physical alarm is
+reprogrammed, and the current timer handler invocation returns
+(`chvt.c:645-690`). Exact equality is deferred without reporting a fault;
+strictly skipped deadlines retain the existing RFCU or assertion reporting.
+This gives all due timers another interrupt opportunity without invoking a
+continuous callback repeatedly in one ISR.
+
+A deterministic host-side tickless harness compiles the real `chvt.c` against a
+controlled clock and alarm. Two equal-deadline continuous timers advance the
+clock exactly to and then past their reload boundary. Both cases verify one
+callback in the initial handler and a minimum-delta alarm, then advance to that
+alarm and verify the deferred timer is dispatched in the next handler. Only the
+strictly skipped case verifies `CH_RFCU_VT_SKIPPED_DEADLINE`. A sole-timer
+overrun also verifies empty-list rearming through `port_timer_start_alarm()`.
+The same harness verifies that a sole continuous timer whose callback creates a
+new list base retains its original absolute phase deadline.
 
 ### VT-5 — `chVTGetTimersStateI()` wraps at both ends of its arithmetic
 
@@ -496,12 +508,10 @@ context enforcement or otherwise change behavior for VT-9.
 
 The standard continuous-timer test only increments a counter. The VT storm test
 has extensive one-shot self-rearming and a continuous timer, but its continuous
-callback does not mutate timer state and its full-range wrapper deadline is not
+callback does not mutate timer state and its long-range wrapper deadline is not
 checked. Neither suite covers:
 
 - continuous rearm followed by reset in the same callback;
-- a sole continuous callback that starts another timer;
-- two continuous callbacks that overrun their periods;
 - runtime execution of VT-6's RFCU-disabled assertion fallback;
 - callback-target replacement during the unlocked dispatch window;
 - timer operations from a different SMP instance;
@@ -587,6 +597,22 @@ the long-duration VT storm.
    requires a supported hardware target. Generated build artifacts were
    cleaned.
 
+   An STM32H563 hardware run showed that repeatedly rearming the VT storm
+   wrapper at `TIME_INFINITE` on an aged list intentionally raised this fault
+   on every sweep, masking other storm markers. The wrapper now uses half the
+   interval range and is initially armed on the empty list. A hardware rerun
+   exposed the expected adaptive-delta startup events and then settled to dots
+   without further interval-overflow markers.
+
+   VT storm reporting now accumulates all relevant RFCU bits before handling
+   watchdog saturation, records the lowest tested delay for each fault class,
+   and reports each accumulated class by name. Combined per-sweep masks use a
+   distinct marker instead of being reported as interval overflow alone. On
+   STM32H563, the first iteration attributed the expected adaptive-delta event
+   to 160297 ticks while separately reporting saturation at 233 ticks; the next
+   complete iteration reported no warnings. The copied IRQ storm Doxygen
+   identity in `vt_storm.c` was also corrected.
+
 7. **VT-10 — atomic current-delta getter**
 
    `chVTGetCurrentDelta()` now locks around the mutable tickless `lastdelta`
@@ -616,3 +642,32 @@ the long-duration VT storm.
    the full periodic simulator RT and OSLIB suites, and a 32-bit system-time,
    64-bit interval tickless build at the maximum accepted delta all passed.
    Generated build artifacts were cleaned.
+
+9. **VT-3 — callback-safe automatic reload coordinates**
+
+   Split the tickless reload arithmetic into elapsed time from the expired
+   phase deadline and a separately calculated offset from the current list
+   base. A callback that starts or rebuilds the timer list no longer shifts the
+   continuous timer's automatic reload deadline.
+
+   A deterministic mock-clock test makes a sole continuous callback advance
+   time, create a new timer-list base, advance time again, and return. It checks
+   the resulting delta-list coordinate and exact physical alarm deadline.
+
+10. **VT-4 — bounded reached and skipped continuous reloads**
+
+   Automatic reloads whose phase deadline has been reached or skipped are now
+   deferred by the adaptive minimum delta. After inserting the timer, the
+   ticker reprograms the alarm and returns, bounding callback dispatch in the
+   current interrupt. Strict skips still report
+   `CH_RFCU_VT_SKIPPED_DEADLINE`; equality remains non-faulting.
+
+   The deterministic harness uses two equal-deadline continuous timers and
+   advances its clock to exact equality and then strict overrun. It verifies a
+   single callback in the initial handler, minimum-delta alarm programming,
+   deferred dispatch in the next handler, and RFCU reporting only for the
+   strict case. A sole-timer overrun verifies the empty-list alarm-start path.
+   The harness is wired into the mechanical CI workflow. C/H style checks and
+   `git diff --check` passed, the full periodic simulator RT and OSLIB suites
+   passed, and normal plus RFCU-disabled/assertions-enabled STM32F407 tickless
+   images built without warnings. Generated build artifacts were cleaned.

--- a/os/rt/VIRTUAL-TIMERS-REVIEW.md
+++ b/os/rt/VIRTUAL-TIMERS-REVIEW.md
@@ -105,8 +105,8 @@ change with a focused regression test.
 Defer VT-3 and VT-4 because they change tickless reload scheduling and ISR exit
 behavior. Defer the remaining VT-1 reset semantics and the VT-7 diagnostic owner
 lifetime until the callback state transitions are specified and tested as a
-whole. Defer VT-11 until the exact maximum legal static delta, including the
-alarm retry increment boundary, is stated explicitly.
+whole. VT-11 is now bounded by the existing physical-alarm maximum, which
+reserves the low half of the counter range for alarm retry increments.
 
 ## Findings summary
 
@@ -122,7 +122,7 @@ alarm retry increment boundary, is stated explicitly.
 | VT-8 | Confirmed documentation defect | all | `chVTObjectInit()` incorrectly says `chVTSetI()` needs no initialization |
 | VT-9 | Confirmed documentation defect | all | Continuous callback and reload-setter documentation contradicts behavior |
 | VT-10 | Fixed API atomicity defect | tickless | `chVTGetCurrentDelta()` read mutable state without locking |
-| VT-11 | Confirmed configuration defect | tickless | `CH_CFG_ST_TIMEDELTA` can narrow to an invalid runtime value |
+| VT-11 | Fixed configuration defect | tickless | `CH_CFG_ST_TIMEDELTA` could narrow to an invalid runtime value |
 
 ## Confirmed behavioral defects
 
@@ -393,12 +393,12 @@ adaptive delta is not below its configured minimum. The test is also compiled
 with 64-bit intervals for a 32-bit Cortex-M4 target, covering the data model in
 which the original unlocked read could tear.
 
-### VT-11 — `CH_CFG_ST_TIMEDELTA` can narrow to zero or one
+### VT-11 — `CH_CFG_ST_TIMEDELTA` could narrow to zero or one
 
-The configuration check rejects negative values and the literal value one, but
-does not verify that `CH_CFG_ST_TIMEDELTA` fits the configured system-time and
-interval types (`chvt.h:42-44`). Initialization then explicitly casts the
-option to `sysinterval_t` (`chvt.h:541-543`).
+The former configuration check rejected negative values and the literal value
+one, but did not verify that `CH_CFG_ST_TIMEDELTA` fit the configured
+system-time and interval types. Initialization explicitly casts the option to
+`sysinterval_t` (`chvt.h:600-607`).
 
 For example, with 16-bit intervals, a configured value of 65536 passes the
 preprocessor check and becomes zero at runtime. A value of 65537 becomes one,
@@ -408,11 +408,21 @@ mode and the runtime minimum delta disagree. When intervals are wider than
 `systime_t`, a value that fits only the interval type can also reach
 `chTimeAddX()` as a physical alarm delay that does not fit system time.
 
-**Proposed fix:** reject any nonzero delta that is not representable as both a
-runtime `sysinterval_t` margin and a physical `systime_t` alarm distance, and
-exclude reserved or sentinel boundary values needed by the retry increment.
-Add accepted tests at zero, two, and the chosen maximum plus rejected tests at
-one and immediately above each representable boundary.
+**Implemented fix:** `VT_MAX_DELAY`, previously local to the wide-interval
+alarm-chunking code, is now a shared derived constant and the configuration
+check rejects larger deltas. Its exact values are `0xFF00`, `0xFFFF0000`, and
+`0xFFFFFFFF00000000` for 16-, 32-, and 64-bit system time respectively. These
+values fit every supported `sysinterval_t` because interval width cannot be
+narrower than system time, while the cleared low half leaves respectively 255,
+65535, or 4294967295 increments before the adaptive retry delta reaches the
+physical counter maximum. This is why the same-width limit is deliberately
+lower than `TIME_MAX_INTERVAL` as well.
+
+A focused preprocessing matrix accepts periodic zero, tickless two, and the
+maximum for same-width and wider-interval configurations. It rejects negative
+and one, the value immediately above each maximum, 16- and 32-bit values that
+would narrow to zero or one, and wider-interval values that fit
+`sysinterval_t` but exceed the physical alarm limit.
 
 ## Documentation defects
 
@@ -496,8 +506,7 @@ checked. Neither suite covers:
 - callback-target replacement during the unlocked dispatch window;
 - timer operations from a different SMP instance;
 - runtime execution of the 64-bit current-delta getter test on a 32-bit
-  tickless target;
-- rejected `CH_CFG_ST_TIMEDELTA` narrowing configurations.
+  tickless target.
 
 These should become focused regression tests rather than being folded only into
 the long-duration VT storm.
@@ -593,3 +602,17 @@ the long-duration VT storm.
    test-suite image built with 64-bit intervals on its 32-bit Cortex-M4 target.
    Runtime execution of the new tickless-only test still requires a supported
    hardware target. Generated build artifacts were cleaned.
+
+8. **VT-11 — bounded static tickless delta**
+
+   Moved the established physical alarm cap into the shared VT header and
+   rejected `CH_CFG_ST_TIMEDELTA` values above it before they can narrow during
+   initialization or bypass wide-interval alarm chunking. The same cap applies
+   when interval and system-time widths match, preserving the retry increment
+   headroom instead of accepting a value adjacent to the type sentinel.
+
+   Added a focused accepted/rejected preprocessing matrix and wired it into the
+   mechanical CI workflow. The matrix, `git diff --check`, C/H style checks,
+   the full periodic simulator RT and OSLIB suites, and a 32-bit system-time,
+   64-bit interval tickless build at the maximum accepted delta all passed.
+   Generated build artifacts were cleaned.

--- a/os/rt/include/chvt.h
+++ b/os/rt/include/chvt.h
@@ -31,6 +31,19 @@
 /* Module constants.                                                         */
 /*===========================================================================*/
 
+/**
+ * @brief   Maximum delay directly programmable in tickless mode.
+ * @details The unused low half of the physical counter range provides
+ *          headroom for alarm setup retries to increase the minimum delta.
+ */
+#if (CH_CFG_ST_RESOLUTION == 64) || defined(__DOXYGEN__)
+#define VT_MAX_DELAY                        0xFFFFFFFF00000000ULL
+#elif CH_CFG_ST_RESOLUTION == 32
+#define VT_MAX_DELAY                        0xFFFF0000U
+#elif CH_CFG_ST_RESOLUTION == 16
+#define VT_MAX_DELAY                        0xFF00U
+#endif
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -42,6 +55,8 @@
 #if (CH_CFG_ST_TIMEDELTA < 0) || (CH_CFG_ST_TIMEDELTA == 1)
 #error "invalid CH_CFG_ST_TIMEDELTA specified, must "                       \
        "be zero or greater than one"
+#elif CH_CFG_ST_TIMEDELTA > VT_MAX_DELAY
+#error "invalid CH_CFG_ST_TIMEDELTA specified, exceeds VT_MAX_DELAY"
 #endif
 
 #if (CH_CFG_ST_TIMEDELTA > 0) && (CH_CFG_TIME_QUANTUM > 0)

--- a/os/rt/src/chvt.c
+++ b/os/rt/src/chvt.c
@@ -33,12 +33,6 @@
 /* Module local definitions.                                                 */
 /*===========================================================================*/
 
-#if CH_CFG_INTERVALS_SIZE > CH_CFG_ST_RESOLUTION
-#define VT_MAX_DELAY                                                        \
-  (((sysinterval_t)TIME_MAX_SYSTIME) &                                      \
-   ~(sysinterval_t)(((sysinterval_t)1 << (CH_CFG_ST_RESOLUTION / 2)) - (sysinterval_t)1))
-#endif
-
 /*===========================================================================*/
 /* Module exported variables.                                                */
 /*===========================================================================*/

--- a/os/rt/src/chvt.c
+++ b/os/rt/src/chvt.c
@@ -634,35 +634,38 @@ void chVTDoTickI(void) {
     /* If a reload is defined and the callback left the timer disarmed then
        it needs to be restarted.*/
     if (unlikely((vtp->reload > (sysinterval_t)0) && !chVTIsArmedI(vtp))) {
-      sysinterval_t delta, delay;
+      sysinterval_t basedelta, delay, delta, elapsed;
+      bool postponed;
 
-      /* Refreshing the now delta after spending time in the callback for
+      /* Refreshing the elapsed time after spending time in the callback for
          a more accurate detection of too fast reloads.*/
       now = chVTGetSystemTimeX();
-      nowdelta = chTimeDiffX(lasttime, now);
+      elapsed = chTimeDiffX(lasttime, now);
 
 #if !defined(CH_VT_RFCU_DISABLED)
       /* Checking if the required reload is feasible.*/
-      if (nowdelta > vtp->reload) {
+      if (elapsed > vtp->reload) {
         /* System time is already past the deadline, logging the fault and
            proceeding with a minimum delay.*/
 
         chDbgAssert(false, "skipped deadline");
         chRFCUCollectFaultsI(CH_RFCU_VT_SKIPPED_DEADLINE);
+      }
+#else /* defined(CH_VT_RFCU_DISABLED) */
+      /* Assertions as fallback.*/
+      chDbgAssert(elapsed <= vtp->reload, "skipped deadline");
+#endif /* defined(CH_VT_RFCU_DISABLED) */
 
-        delay = (sysinterval_t)0;
+      /* A reached or skipped phase deadline is deferred by the physical
+         minimum delta. The ticker returns after insertion so the callback
+         cannot be invoked repeatedly from the same interrupt.*/
+      postponed = elapsed >= vtp->reload;
+      if (postponed) {
+        delay = vtlp->lastdelta;
       }
       else {
-        /* Enqueuing the timer again using the calculated delta.*/
-        delay = vtp->reload - nowdelta;
+        delay = vtp->reload - elapsed;
       }
-#else
-      /* Assertions as fallback.*/
-      chDbgAssert(nowdelta <= vtp->reload, "skipped deadline");
-
-      /* Enqueuing the timer again using the calculated delta.*/
-      delay = vtp->reload - nowdelta;
-#endif
 
       /* Special case where the timers list is empty.*/
       if (ch_dlist_isempty(&vtlp->dlist)) {
@@ -672,11 +675,20 @@ void chVTDoTickI(void) {
         return;
       }
 
-      /* Delay as delta from 'lasttime'.*/
-      delta = vt_add_delta(nowdelta, delay);
+      /* Delay as delta from the current list base, which could have been
+         replaced by timer operations performed within the callback.*/
+      basedelta = chTimeDiffX(vtlp->lasttime, now);
+      delta = vt_add_delta(basedelta, delay);
 
       /* Insert into delta list. */
       ch_dlist_insert(&vtlp->dlist, &vtp->dlist, delta);
+
+      /* Deferred reloads give all due timers another interrupt opportunity.*/
+      if (postponed) {
+        vt_set_alarm(vtlp, now, delay);
+
+        return;
+      }
     }
   }
 

--- a/test/rt/testbuild/check_vt_config.sh
+++ b/test/rt/testbuild/check_vt_config.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -eu
+
+test_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root_dir=$(CDPATH= cd -- "$test_dir/../../.." && pwd)
+cc=${CC:-cc}
+
+preprocess_vt_config() {
+  resolution=$1
+  intervals=$2
+  delta=$3
+
+  "$cc" -E -x c -include chvt.h \
+    -I "$root_dir/os/rt/include" \
+    -DTRUE=1 \
+    -DFALSE=0 \
+    -DCH_CFG_ST_RESOLUTION="$resolution" \
+    -DCH_CFG_INTERVALS_SIZE="$intervals" \
+    -DCH_CFG_ST_TIMEDELTA="$delta" \
+    -DCH_CFG_TIME_QUANTUM=0 \
+    -DCH_DBG_THREADS_PROFILING=0 \
+    /dev/null >/dev/null
+}
+
+expect_pass() {
+  label=$1
+  shift
+
+  if ! preprocess_vt_config "$@"; then
+    echo "unexpected rejected configuration: $label" >&2
+    exit 1
+  fi
+}
+
+expect_fail() {
+  label=$1
+  shift
+
+  if preprocess_vt_config "$@" 2>/dev/null; then
+    echo "unexpected accepted configuration: $label" >&2
+    exit 1
+  fi
+}
+
+expect_pass "periodic mode"                  16 16 0
+expect_pass "minimum tickless delta"         16 16 2
+expect_pass "16-bit maximum"                 16 16 0xFF00U
+expect_pass "16/32-bit maximum"              16 32 0xFF00U
+expect_pass "32-bit maximum"                 32 32 0xFFFF0000U
+expect_pass "32/64-bit maximum"              32 64 0xFFFF0000ULL
+expect_pass "64-bit maximum"                 64 64 0xFFFFFFFF00000000ULL
+
+expect_fail "negative delta"                 32 32 -1
+expect_fail "reserved delta one"             32 32 1
+expect_fail "above 16-bit maximum"            16 16 0xFF01U
+expect_fail "16-bit narrowing to zero"        16 16 0x10000U
+expect_fail "16-bit narrowing to one"         16 16 0x10001U
+expect_fail "above 16/32-bit physical maximum" 16 32 0xFF01U
+expect_fail "above 32-bit maximum"            32 32 0xFFFF0001U
+expect_fail "32-bit narrowing to zero"        32 32 0x100000000ULL
+expect_fail "32-bit narrowing to one"         32 32 0x100000001ULL
+expect_fail "above 32/64-bit physical maximum" 32 64 0xFFFF0001ULL
+expect_fail "above 64-bit maximum"            64 64 0xFFFFFFFF00000001ULL
+
+echo "VT configuration boundary checks passed"

--- a/test/rt/testbuild/check_vt_tickless.sh
+++ b/test/rt/testbuild/check_vt_tickless.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+test_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root_dir=$(CDPATH= cd -- "$test_dir/../../.." && pwd)
+mock_dir="$test_dir/vt_tickless_mock"
+build_dir=$(mktemp -d)
+cc=${CC:-cc}
+
+trap 'rm -rf "$build_dir"' EXIT HUP INT TERM
+
+"$cc" -std=c99 -Wall -Wextra -Werror -pedantic \
+  -I "$mock_dir" \
+  -I "$root_dir/os/rt/include" \
+  "$root_dir/os/rt/src/chvt.c" \
+  "$mock_dir/main.c" \
+  -o "$build_dir/vt_tickless_mock"
+
+"$build_dir/vt_tickless_mock"

--- a/test/rt/testbuild/vt_tickless_mock/ch.h
+++ b/test/rt/testbuild/vt_tickless_mock/ch.h
@@ -1,0 +1,148 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef CH_H
+#define CH_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define TRUE                                    1
+#define FALSE                                   0
+
+#define CH_CFG_HARDENING_LEVEL                  0
+#define CH_CFG_INTERVALS_SIZE                   32
+#define CH_CFG_ST_RESOLUTION                    32
+#define CH_CFG_ST_TIMEDELTA                     2
+#define CH_CFG_USE_TIMESTAMP                    FALSE
+
+#define CH_RFCU_VT_INSUFFICIENT_DELTA           1U
+#define CH_RFCU_VT_SKIPPED_DEADLINE             2U
+#define CH_RFCU_VT_INTERVAL_OVERFLOW            4U
+
+#define likely(c)                               __builtin_expect(!!(c), 1)
+#define unlikely(c)                             __builtin_expect(!!(c), 0)
+
+#define chDbgAssert(c, msg)                     ((void)0)
+#define chDbgCheck(c)                           assert(c)
+#define chDbgCheckClassI()                      ((void)0)
+#define chSftAssert(level, c, msg)               ((void)0)
+#define chSftValidateDataPointerX(level, p)      ((void)0)
+
+typedef uint32_t sysinterval_t;
+typedef uint32_t systime_t;
+typedef int32_t tprio_t;
+
+#define TIME_IMMEDIATE                          ((sysinterval_t)0)
+#define TIME_INFINITE                           ((sysinterval_t)-1)
+
+#include "chlists.h"
+
+typedef struct ch_virtual_timer virtual_timer_t;
+typedef void (*vtfunc_t)(virtual_timer_t *vtp, void *par);
+
+struct ch_virtual_timer {
+  ch_delta_list_t dlist;
+  vtfunc_t func;
+  void *par;
+  sysinterval_t reload;
+};
+
+typedef struct {
+  ch_delta_list_t dlist;
+  systime_t lasttime;
+  sysinterval_t lastdelta;
+} virtual_timers_list_t;
+
+typedef struct {
+  virtual_timers_list_t vtlist;
+} os_instance_t;
+
+extern os_instance_t test_instance;
+extern systime_t test_time;
+extern systime_t test_alarm;
+extern bool test_alarm_active;
+extern unsigned test_alarm_programs;
+extern unsigned test_alarm_starts;
+extern unsigned test_alarm_sets;
+
+#define currcore                                (&test_instance)
+
+static inline systime_t chTimeAddX(systime_t systime,
+                                   sysinterval_t interval) {
+
+  return systime + interval;
+}
+
+static inline sysinterval_t chTimeDiffX(systime_t start, systime_t end) {
+
+  return end - start;
+}
+
+static inline systime_t chVTGetSystemTimeX(void) {
+
+  return test_time;
+}
+
+static inline bool chVTIsArmedI(const virtual_timer_t *vtp) {
+
+  return vtp->dlist.next != NULL;
+}
+
+static inline void chVTSetReloadIntervalX(virtual_timer_t *vtp,
+                                          sysinterval_t reload) {
+
+  vtp->reload = reload;
+}
+
+static inline void chSysLockFromISR(void) {
+}
+
+static inline void chSysUnlockFromISR(void) {
+}
+
+static inline void port_timer_start_alarm(systime_t time) {
+
+  test_alarm = time;
+  test_alarm_active = true;
+  test_alarm_programs++;
+  test_alarm_starts++;
+}
+
+static inline void port_timer_stop_alarm(void) {
+
+  test_alarm_active = false;
+}
+
+static inline void port_timer_set_alarm(systime_t time) {
+
+  test_alarm = time;
+  test_alarm_active = true;
+  test_alarm_programs++;
+  test_alarm_sets++;
+}
+
+void chRFCUCollectFaultsI(uint32_t mask);
+void chVTObjectInit(virtual_timer_t *vtp);
+void chVTDoSetI(virtual_timer_t *vtp, sysinterval_t delay,
+                vtfunc_t vtfunc, void *par);
+void chVTDoSetContinuousI(virtual_timer_t *vtp, sysinterval_t delay,
+                          vtfunc_t vtfunc, void *par);
+void chVTDoTickI(void);
+
+#endif /* CH_H */

--- a/test/rt/testbuild/vt_tickless_mock/main.c
+++ b/test/rt/testbuild/vt_tickless_mock/main.c
@@ -1,0 +1,251 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ch.h"
+
+os_instance_t test_instance;
+systime_t test_time;
+systime_t test_alarm;
+bool test_alarm_active;
+unsigned test_alarm_programs;
+unsigned test_alarm_starts;
+unsigned test_alarm_sets;
+
+static uint32_t test_faults;
+
+static void fail(const char *msg) {
+
+  fprintf(stderr, "VT tickless mock failure: %s\n", msg);
+  exit(1);
+}
+
+static void expect(bool condition, const char *msg) {
+
+  if (!condition) {
+    fail(msg);
+  }
+}
+
+void chRFCUCollectFaultsI(uint32_t mask) {
+
+  test_faults |= mask;
+}
+
+static void reset_fixture(void) {
+
+  memset(&test_instance, 0, sizeof test_instance);
+  ch_dlist_init(&test_instance.vtlist.dlist);
+  test_instance.vtlist.lastdelta = (sysinterval_t)CH_CFG_ST_TIMEDELTA;
+  test_time = (systime_t)0;
+  test_alarm = (systime_t)0;
+  test_alarm_active = false;
+  test_alarm_programs = 0U;
+  test_alarm_starts = 0U;
+  test_alarm_sets = 0U;
+  test_faults = 0U;
+}
+
+static void empty_cb(virtual_timer_t *vtp, void *par) {
+
+  (void)vtp;
+  (void)par;
+}
+
+typedef struct {
+  virtual_timer_t *anchor;
+  unsigned callbacks;
+} base_change_context_t;
+
+static void base_change_cb(virtual_timer_t *vtp, void *par) {
+  base_change_context_t *ctx = par;
+
+  (void)vtp;
+  ctx->callbacks++;
+  if (ctx->callbacks == 1U) {
+    test_time = (systime_t)23;
+    chSysLockFromISR();
+    chVTDoSetI(ctx->anchor, (sysinterval_t)100, empty_cb, NULL);
+    chSysUnlockFromISR();
+    test_time = (systime_t)25;
+  }
+}
+
+static void test_callback_replaced_base(void) {
+  base_change_context_t ctx;
+  virtual_timer_t anchor, continuous;
+
+  reset_fixture();
+  chVTObjectInit(&anchor);
+  chVTObjectInit(&continuous);
+  ctx.anchor = &anchor;
+  ctx.callbacks = 0U;
+
+  chVTDoSetContinuousI(&continuous, (sysinterval_t)20,
+                       base_change_cb, &ctx);
+  test_alarm_programs = 0U;
+  test_alarm_starts = 0U;
+  test_alarm_sets = 0U;
+  test_time = (systime_t)20;
+  chVTDoTickI();
+
+  expect(ctx.callbacks == 1U, "base-change callback count");
+  expect(test_instance.vtlist.lasttime == (systime_t)25,
+         "base-change list time");
+  expect(test_instance.vtlist.dlist.next == &continuous.dlist,
+         "base-change timer order");
+  expect(continuous.dlist.delta == (sysinterval_t)15,
+         "base-change phase deadline shifted");
+  expect(test_alarm_active, "base-change alarm stopped");
+  expect(test_alarm == (systime_t)40, "base-change alarm deadline");
+  expect(test_alarm_programs == 2U, "base-change alarm programming count");
+}
+
+typedef struct {
+  virtual_timer_t *first;
+  virtual_timer_t *second;
+  systime_t callback_time;
+  unsigned first_callbacks;
+  unsigned second_callbacks;
+} overrun_context_t;
+
+static void overrun_cb(virtual_timer_t *vtp, void *par) {
+  overrun_context_t *ctx = par;
+
+  if (vtp == ctx->first) {
+    ctx->first_callbacks++;
+    if (ctx->first_callbacks == 1U) {
+      test_time = ctx->callback_time;
+    }
+    else {
+      chVTSetReloadIntervalX(vtp, (sysinterval_t)0);
+    }
+  }
+  else {
+    expect(vtp == ctx->second, "unexpected overrun timer");
+    ctx->second_callbacks++;
+    chVTSetReloadIntervalX(vtp, (sysinterval_t)0);
+  }
+}
+
+static void test_empty_list_overrun(void) {
+  overrun_context_t ctx;
+  virtual_timer_t continuous;
+
+  reset_fixture();
+  chVTObjectInit(&continuous);
+  ctx.first = &continuous;
+  ctx.second = NULL;
+  ctx.callback_time = (systime_t)20;
+  ctx.first_callbacks = 0U;
+  ctx.second_callbacks = 0U;
+
+  chVTDoSetContinuousI(&continuous, (sysinterval_t)10,
+                       overrun_cb, &ctx);
+  test_alarm_programs = 0U;
+  test_alarm_starts = 0U;
+  test_alarm_sets = 0U;
+  test_time = (systime_t)10;
+  chVTDoTickI();
+
+  expect(ctx.first_callbacks == 1U, "empty-list callback count");
+  expect(ctx.second_callbacks == 0U, "empty-list unexpected callback");
+  expect(chVTIsArmedI(&continuous), "empty-list timer disarmed");
+  expect(test_instance.vtlist.lasttime == (systime_t)20,
+         "empty-list base time");
+  expect(continuous.dlist.delta == (sysinterval_t)CH_CFG_ST_TIMEDELTA,
+         "empty-list postponed delta");
+  expect(test_alarm_active, "empty-list alarm stopped");
+  expect(test_alarm == (systime_t)22, "empty-list alarm deadline");
+  expect(test_alarm_programs == 1U, "empty-list alarm programming count");
+  expect(test_alarm_starts == 1U, "empty-list alarm not started");
+  expect(test_alarm_sets == 0U, "empty-list alarm unexpectedly set");
+  expect((test_faults & CH_RFCU_VT_SKIPPED_DEADLINE) == 0U,
+         "empty-list exact deadline reported as skipped");
+}
+
+static void run_overrun_test(systime_t callback_time,
+                             bool skipped,
+                             systime_t expected_alarm) {
+  overrun_context_t ctx;
+  virtual_timer_t first, second;
+
+  reset_fixture();
+  chVTObjectInit(&first);
+  chVTObjectInit(&second);
+  ctx.first = &first;
+  ctx.second = &second;
+  ctx.callback_time = callback_time;
+  ctx.first_callbacks = 0U;
+  ctx.second_callbacks = 0U;
+
+  /* Equal deadlines are inserted before existing equal deadlines, arm the
+     deferred timer first so "first" is the deliberate overrunner.*/
+  chVTDoSetContinuousI(&second, (sysinterval_t)10, overrun_cb, &ctx);
+  chVTDoSetContinuousI(&first, (sysinterval_t)10, overrun_cb, &ctx);
+  test_alarm_programs = 0U;
+  test_alarm_starts = 0U;
+  test_alarm_sets = 0U;
+  test_time = (systime_t)10;
+  chVTDoTickI();
+
+  expect(ctx.first_callbacks == 1U,
+         "first overrun callback count");
+  expect(ctx.second_callbacks == 0U,
+         "second timer dispatched in first interrupt");
+  expect(chVTIsArmedI(&first), "first continuous timer disarmed");
+  expect(chVTIsArmedI(&second), "second continuous timer disarmed");
+  expect(test_alarm_active, "overrun alarm stopped");
+  expect(test_alarm == expected_alarm, "overrun alarm deadline");
+  expect(test_alarm_programs == 1U, "overrun alarm programming count");
+  expect(test_alarm_starts == 0U, "overrun alarm unexpectedly started");
+  expect(test_alarm_sets == 1U, "overrun alarm not set");
+  if (skipped) {
+    expect((test_faults & CH_RFCU_VT_SKIPPED_DEADLINE) != 0U,
+           "skipped deadline not reported");
+  }
+  else {
+    expect((test_faults & CH_RFCU_VT_SKIPPED_DEADLINE) == 0U,
+           "exact deadline reported as skipped");
+  }
+
+  test_time = test_alarm;
+  chVTDoTickI();
+
+  expect(ctx.first_callbacks == 2U,
+         "deferred first timer not dispatched");
+  expect(ctx.second_callbacks == 1U,
+         "deferred second timer not dispatched");
+  expect(!chVTIsArmedI(&first), "deferred first timer still armed");
+  expect(!chVTIsArmedI(&second), "deferred second timer still armed");
+  expect(!test_alarm_active, "deferred alarm still active");
+  expect(test_alarm_programs == 1U,
+         "deferred dispatch reprogrammed alarm");
+}
+
+int main(void) {
+
+  test_callback_replaced_base();
+  test_empty_list_overrun();
+  run_overrun_test((systime_t)20, false, (systime_t)22);
+  run_overrun_test((systime_t)21, true, (systime_t)23);
+  puts("VT tickless scheduling mock checks passed");
+
+  return 0;
+}

--- a/testrt/VT_STORM/source/vt_storm.c
+++ b/testrt/VT_STORM/source/vt_storm.c
@@ -15,10 +15,10 @@
 */
 
 /**
- * @file    irq_storm.c
- * @brief   IRQ Storm stress test code.
+ * @file    vt_storm.c
+ * @brief   VT Storm stress test code.
  *
- * @addtogroup IRQ_STORM
+ * @addtogroup VT_STORM
  * @{
  */
 
@@ -34,6 +34,9 @@
 /*===========================================================================*/
 /* Module local definitions.                                                 */
 /*===========================================================================*/
+
+/* Long interval leaving headroom for the age of the timer-list base.*/
+#define VT_STORM_WRAPPER_INTERVAL           (TIME_INFINITE / 2U)
 
 /*===========================================================================*/
 /* Module exported variables.                                                */
@@ -106,7 +109,7 @@ static void sweeper0_cb(virtual_timer_t *vtp, void *p) {
 
   chSysLockFromISR();
   rnddly();
-  chVTSetI(&wrapper, (sysinterval_t)-1, wrapper_cb, NULL);
+  chVTSetI(&wrapper, VT_STORM_WRAPPER_INTERVAL, wrapper_cb, NULL);
   chVTSetI(vtp, delay, sweeper0_cb, NULL);
   chSysUnlockFromISR();
 }
@@ -232,7 +235,10 @@ void vt_storm_execute(const vt_storm_config_t *cfg) {
   }
 
   for (i = 1; i <= VT_STORM_CFG_ITERATIONS; i++) {
-    bool warning;
+    rfcu_mask_t faults;
+    sysinterval_t insufficient_delay;
+    sysinterval_t skipped_delay;
+    sysinterval_t overflow_delay;
 
     chprintf(cfg->out, "Iteration %d\r\n", i);
     chThdSleep(TIME_MS2I(10));
@@ -245,20 +251,23 @@ void vt_storm_execute(const vt_storm_config_t *cfg) {
       delay = (sysinterval_t)VT_STORM_CFG_MIN_DELAY;
     }
     saturated = false;
-    warning   = false;
+    faults = (rfcu_mask_t)0;
+    insufficient_delay = (sysinterval_t)0;
+    skipped_delay = (sysinterval_t)0;
+    overflow_delay = (sysinterval_t)0;
     do {
       rfcu_mask_t mask;
       sysinterval_t decrease;
 
-      /* Starting sweepers.*/
+      /* Starting the long-range wrapper first on an empty list.*/
       chSysLock();
+      chVTSetI(&wrapper, VT_STORM_WRAPPER_INTERVAL, wrapper_cb, NULL);
       chVTSetI(&watchdog, TIME_MS2I(501), watchdog_cb, NULL);
       chVTSetI(&sweeper0, delay, sweeper0_cb, NULL);
       chVTSetI(&sweeperm1, delay - 1, sweeperm1_cb, NULL);
       chVTSetI(&sweeperp1, delay + 1, sweeperp1_cb, NULL);
       chVTSetI(&sweeperm3, delay - 3, sweeperm3_cb, NULL);
       chVTSetI(&sweeperp3, delay + 3, sweeperp3_cb, NULL);
-      chVTSetI(&wrapper, (sysinterval_t)-1, wrapper_cb, NULL);
       chVTSetContinuousI(&continuous, periodic, continuous_cb, NULL);
       chVTSetI(&guard0, TIME_MS2I(250) + (CH_CFG_TIME_QUANTUM / 2), guard_cb, NULL);
       chVTSetI(&guard1, TIME_MS2I(250) + (CH_CFG_TIME_QUANTUM - 1), guard_cb, NULL);
@@ -288,29 +297,36 @@ void vt_storm_execute(const vt_storm_config_t *cfg) {
                                       CH_RFCU_VT_INTERVAL_OVERFLOW);
       chSysUnlock();
 
+      faults |= mask;
+      if ((mask & CH_RFCU_VT_INSUFFICIENT_DELTA) != (rfcu_mask_t)0) {
+        insufficient_delay = delay;
+      }
+      if ((mask & CH_RFCU_VT_SKIPPED_DEADLINE) != (rfcu_mask_t)0) {
+        skipped_delay = delay;
+      }
+      if ((mask & CH_RFCU_VT_INTERVAL_OVERFLOW) != (rfcu_mask_t)0) {
+        overflow_delay = delay;
+      }
+
       if (saturated) {
         chprintf(cfg->out, "#");
         break;
       }
-      else if ((mask & CH_RFCU_VT_INTERVAL_OVERFLOW) != (rfcu_mask_t)0) {
-        palToggleLine(config->line);
-        chprintf(cfg->out, "o");
-        warning = true;
-      }
       else if (mask == CH_RFCU_VT_INSUFFICIENT_DELTA) {
         palToggleLine(config->line);
         chprintf(cfg->out, "x");
-        warning = true;
       }
       else if (mask == CH_RFCU_VT_SKIPPED_DEADLINE) {
         palToggleLine(config->line);
         chprintf(cfg->out, "+");
-        warning = true;
       }
-      else if (mask == (CH_RFCU_VT_INSUFFICIENT_DELTA | CH_RFCU_VT_SKIPPED_DEADLINE)) {
+      else if (mask == CH_RFCU_VT_INTERVAL_OVERFLOW) {
+        palToggleLine(config->line);
+        chprintf(cfg->out, "o");
+      }
+      else if (mask != (rfcu_mask_t)0) {
         palToggleLine(config->line);
         chprintf(cfg->out, "*");
-        warning = true;
       }
       else {
         palToggleLine(config->line);
@@ -326,9 +342,20 @@ void vt_storm_execute(const vt_storm_config_t *cfg) {
       delay = delay - decrease;
     } while (delay >= (sysinterval_t)VT_STORM_CFG_MIN_DELAY);
 
-    if (warning) {
-      chprintf(cfg->out, "\r\nRFCU warning detected at %u uS %u ticks",
-               TIME_I2US(delay), delay);
+    if (faults != (rfcu_mask_t)0) {
+      chprintf(cfg->out, "\r\nRFCU warnings:");
+      if ((faults & CH_RFCU_VT_INSUFFICIENT_DELTA) != (rfcu_mask_t)0) {
+        chprintf(cfg->out, "\r\n  Insufficient delta at %u uS %u ticks",
+                 TIME_I2US(insufficient_delay), insufficient_delay);
+      }
+      if ((faults & CH_RFCU_VT_SKIPPED_DEADLINE) != (rfcu_mask_t)0) {
+        chprintf(cfg->out, "\r\n  Skipped deadline at %u uS %u ticks",
+                 TIME_I2US(skipped_delay), skipped_delay);
+      }
+      if ((faults & CH_RFCU_VT_INTERVAL_OVERFLOW) != (rfcu_mask_t)0) {
+        chprintf(cfg->out, "\r\n  Interval overflow at %u uS %u ticks",
+                 TIME_I2US(overflow_delay), overflow_delay);
+      }
       chprintf(cfg->out, "\r\nRecalculated delta is %u ticks", chVTGetCurrentDelta());
     }
     else {


### PR DESCRIPTION
## Summary

- validate CH_CFG_ST_TIMEDELTA without narrowing and include the Doxygen configuration check
- calculate continuous reloads from the current tickless list base
- defer reached or skipped continuous reloads by the adaptive minimum delta and return from the current timer interrupt
- add deterministic host regressions for callback-time base replacement, empty-list postponement, bounded dispatch, and next-interrupt delivery
- make VT_STORM long-range scheduling representable and preserve every RFCU fault class in its iteration summary

## Validation

- sh test/rt/testbuild/check_vt_config.sh
- sh test/rt/testbuild/check_vt_tickless.sh
- git diff --check
- periodic simulator RT and OSLIB suites
- normal and RFCU-disabled/assertions-enabled STM32F407 tickless builds
- STM32H563 hardware VT_STORM run: expected adaptive startup from 2 to 8 ticks, settled iterations with no RFCU warnings, repeatable saturation at 233 ticks and 454020 continuous callbacks

## Performance note

An identical-harness comparison on STM32H563 measured the unmodified master VTs saturating at 219 ticks versus 233 ticks here. This is a 280 ns shift, approximately a 6 percent reduction in the extreme mixed-timer stress ceiling. Linked text increased by 168 bytes. Assembly inspection identifies the LTO-inlined chVTDoTickI timer ISR as the main contributor. Optimization is intentionally deferred until the correctness fixes are complete.
