### PR TITLE
RT: correct thread lifecycle interfaces

### DIFF
--- a/demos/various/RT-ARMCM4-USELIB/rt/ch.h
+++ b/demos/various/RT-ARMCM4-USELIB/rt/ch.h
@@ -1235,10 +1235,6 @@ typedef struct {
 #define chThdSleepSeconds(sec) chThdSleep(TIME_S2I(sec))
 #define chThdSleepMilliseconds(msec) chThdSleep(TIME_MS2I(msec))
 #define chThdSleepMicroseconds(usec) chThdSleep(TIME_US2I(usec))
-   thread_t *__thd_object_init(os_instance_t *oip,
-                               thread_t *tp,
-                               const char *name,
-                               tprio_t prio);
   thread_t *__thd_spawn_suspended(thread_t *tp,
                                   const thread_descriptor_t *tdp);
   thread_t *chThdObjectInit(thread_t *tp, const thread_descriptor_t *tdp);

--- a/os/common/ports/SIMIA32/chcore.c
+++ b/os/common/ports/SIMIA32/chcore.c
@@ -111,7 +111,7 @@ static void __dummy(thread_t *ntp, thread_t *otp) {
  *          invoked.
  */
 __attribute__((cdecl, noreturn))
-void _port_thread_start(msg_t (*pf)(void *), void *p) {
+void _port_thread_start(void (*pf)(void *), void *p) {
 
   chSysUnlock();
   pf(p);

--- a/os/common/ports/SIMIA32/chcore.h
+++ b/os/common/ports/SIMIA32/chcore.h
@@ -263,7 +263,7 @@ extern "C" {
 #endif
   /*lint -save -e950 [Dir-2.1] Non-ANSI keywords are fine in the port layer.*/
   __attribute__((fastcall)) void port_switch(thread_t *ntp, thread_t *otp);
-  __attribute__((cdecl, noreturn)) void _port_thread_start(msg_t (*pf)(void *p),
+  __attribute__((cdecl, noreturn)) void _port_thread_start(void (*pf)(void *p),
                                                            void *p);
   /*lint -restore*/
   rtcnt_t port_rt_get_counter_value(void);

--- a/os/common/ports/SIMX86_64/chcore.c
+++ b/os/common/ports/SIMX86_64/chcore.c
@@ -105,7 +105,7 @@ static void __dummy(thread_t *ntp, thread_t *otp) {
  *          invoked.
  */
 __attribute__((noreturn))
-void _port_thread_start(msg_t (*pf)(void *), void *p) {
+void _port_thread_start(void (*pf)(void *), void *p) {
 
   chSysUnlock();
   pf(p);

--- a/os/common/ports/SIMX86_64/chcore.h
+++ b/os/common/ports/SIMX86_64/chcore.h
@@ -264,7 +264,7 @@ extern "C" {
 #endif
   /*lint -save -e950 [Dir-2.1] Non-ANSI keywords are fine in the port layer.*/
   void port_switch(thread_t *ntp, thread_t *otp);
-  __attribute__((noreturn)) void _port_thread_start(msg_t (*pf)(void *p),
+  __attribute__((noreturn)) void _port_thread_start(void (*pf)(void *p),
                                                     void *p);
   /*lint -restore*/
   rtcnt_t port_rt_get_counter_value(void);

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -437,10 +437,6 @@ typedef struct {
 #ifdef __cplusplus
 extern "C" {
 #endif
-   thread_t *__thd_object_init(os_instance_t *oip,
-                               thread_t *tp,
-                               const char *name,
-                               tprio_t prio);
 #if CH_DBG_FILL_THREADS == TRUE
   void __thd_stackfill(uint8_t *startp, uint8_t *endp);
 #endif

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -262,7 +262,7 @@ void chThdObjectDispose(thread_t *tp) {
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @notapi
  */
@@ -293,17 +293,18 @@ thread_t *__thd_spawn_suspended(thread_t *tp,
  * @details The spawned thread is in the @p CH_STATE_WTSTART state and can
  *          be subsequently started using @p chThdStart(), @p chThdStartI() or
  *           @p chSchWakeupS() depending on the execution context.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  * @note    Threads created using this function do not honor the
  *          @p CH_DBG_FILL_THREADS debug option because it would stay
  *          in a critical section for too long while filling.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @api
  */
@@ -333,14 +334,15 @@ thread_t *chThdSpawnSuspendedI(thread_t *tp,
  * @details The spawned thread is in the @p CH_STATE_WTSTART state and can
  *          be subsequently started using @p chThdStart(), @p chThdStartI() or
  *           @p chSchWakeupS() depending on the execution context.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @api
  */
@@ -359,17 +361,18 @@ thread_t *chThdSpawnSuspended(thread_t *tp,
 /**
  * @brief   Spawns a running thread.
  * @details The spawned thread is run immediately.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  * @note    Threads created using this function do not honor the
  *          @p CH_DBG_FILL_THREADS debug option because it would keep
  *          the kernel locked for too much time.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @iclass
  */
@@ -381,14 +384,15 @@ thread_t *chThdSpawnRunningI(thread_t *tp, const thread_descriptor_t *tdp) {
 /**
  * @brief   Spawns a running thread.
  * @details The spawned thread is run immediately.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @iclass
  */
@@ -408,10 +412,11 @@ thread_t *chThdSpawnRunning(thread_t *tp, const thread_descriptor_t *tdp) {
  * @brief   Creates a non-running thread.
  * @details The created thread is in the @p CH_STATE_WTSTART state and can
  *          be subsequently started.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  * @post    The initialized thread can be subsequently started by invoking
  *          @p chThdStart(), @p chThdStartI() or @p chSchWakeupS()
  *          depending on the execution context.
@@ -420,7 +425,7 @@ thread_t *chThdSpawnRunning(thread_t *tp, const thread_descriptor_t *tdp) {
  *          in a critical section for too long while filling.
  *
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @iclass
  */
@@ -472,16 +477,17 @@ thread_t *chThdCreateSuspendedI(const thread_descriptor_t *tdp) {
  * @brief   Creates a non-running thread.
  * @details The new thread is initialized but not inserted in the ready list,
  *          the initial state is @p CH_STATE_WTSTART.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  * @post    The initialized thread can be subsequently started by invoking
  *          @p chThdStart(), @p chThdStartI() or @p chSchWakeupS()
  *          depending on the execution context.
  *
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @api
  */
@@ -502,10 +508,11 @@ thread_t *chThdCreateSuspended(const thread_descriptor_t *tdp) {
 /**
  * @brief   Creates a new thread.
  * @details The new thread is initialized and made ready to execute.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  * @note    A thread can terminate by calling @p chThdExit() or by simply
  *          returning from its main function.
  * @note    Threads created using this function do not honor the
@@ -513,7 +520,7 @@ thread_t *chThdCreateSuspended(const thread_descriptor_t *tdp) {
  *          the kernel locked for too much time.
  *
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @iclass
  */
@@ -525,13 +532,14 @@ thread_t *chThdCreateI(const thread_descriptor_t *tdp) {
 /**
  * @brief   Creates a new thread.
  * @details The new thread is initialized and made ready to execute.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  *
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
- * @return              Reference to the @p thread_t object.
+ * @return              Pointer to the @p thread_t object.
  *
  * @iclass
  */
@@ -552,10 +560,11 @@ thread_t *chThdCreate(const thread_descriptor_t *tdp) {
 
 /**
  * @brief   Creates a new thread.
- * @post    The created thread has a reference counter set to one, it is
- *          the caller's responsibility to call @p chThdRelease() or @p chThdWait()
- *          in order to release the reference. The thread persists in the
- *          registry until its reference counter reaches zero.
+ * @post    If @p CH_CFG_USE_REGISTRY is @p TRUE then the created thread has
+ *          a reference counter set to one. It is the caller's responsibility
+ *          to eventually release that reference using @p chThdRelease() or,
+ *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
+ *          persists in the registry until its reference counter reaches zero.
  * @note    A thread can terminate by calling @p chThdExit() or by simply
  *          returning from its main function.
  *
@@ -809,8 +818,9 @@ void chThdExitS(msg_t msg) {
 /**
  * @brief   Blocks the execution of the invoking thread until the specified
  *          thread terminates then the exit code is returned.
- * @details The thread reference counter is not affected by this function,
- *          the caller is responsible for eventually releasing its reference.
+ * @details This function does not modify thread reference ownership. If
+ *          @p CH_CFG_USE_REGISTRY is @p TRUE then the caller remains
+ *          responsible for eventually releasing its reference.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
  * @post    Enabling @p chThdSyncS() requires 2-4 (depending on the
@@ -843,8 +853,9 @@ msg_t chThdSyncS(thread_t *tp) {
 /**
  * @brief   Blocks the execution of the invoking thread until the specified
  *          thread terminates then the exit code is returned.
- * @details The thread reference counter is not affected by this function,
- *          the caller is responsible for eventually releasing its reference.
+ * @details This function does not modify thread reference ownership. If
+ *          @p CH_CFG_USE_REGISTRY is @p TRUE then the caller remains
+ *          responsible for eventually releasing its reference.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
  * @post    Enabling @p chThdSync() requires 2-4 (depending on the
@@ -868,16 +879,19 @@ msg_t chThdSync(thread_t *tp) {
 /**
  * @brief   Blocks the execution of the invoking thread until the specified
  *          thread terminates then the exit code is returned.
- * @details This function synchronizes with the specified thread then
- *          decrements its reference counter, if the counter reaches zero then
- *          the thread working area is returned to the proper allocator and
- *          the thread is removed from the registry.
+ * @details This function synchronizes with the specified thread. If
+ *          @p CH_CFG_USE_REGISTRY is @p TRUE then it also decrements the
+ *          thread reference counter. If the counter reaches zero then the
+ *          thread working area is returned to the proper allocator and the
+ *          thread is removed from the registry.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
  * @post    Enabling @p chThdWait() requires 2-4 (depending on the
  *          architecture) extra bytes in the @p thread_t structure.
- * @note    If @p CH_CFG_USE_DYNAMIC is not specified this function just waits
- *          for the thread termination, no memory allocators are involved.
+ * @note    If @p CH_CFG_USE_REGISTRY is @p FALSE then this function only
+ *          waits for thread termination, there is no reference to release.
+ * @note    If @p CH_CFG_USE_DYNAMIC is @p FALSE then no memory allocators are
+ *          involved.
  *
  * @param[in] tp        pointer to the thread
  * @return              The exit code from the terminated thread.


### PR DESCRIPTION
## Summary

- correct the SIMIA32 and SIMX86_64 thread-start trampoline function types
- remove the obsolete `__thd_object_init()` declaration from the RT and generated USELIB headers
- qualify thread creation, synchronization, and wait documentation for registry-disabled configurations

## Root cause and impact

The simulator trampolines retained a message-returning function-pointer type after RT thread entry functions adopted a `void` return type, so thread functions were called through an incompatible type. An obsolete internal declaration also survived the transition to `chThdObjectInit()`, advertising a function with no implementation. Finally, lifecycle documentation described registry reference ownership even in configurations where the registry is disabled.

The corrections align the simulator call boundary with the thread function contract, stop exposing the nonexistent function, and document reference ownership accurately across configurations.

## Validation

- default `test/rt/testbuild` SIMX86_64 build and RT/OSLIB run
- SIMIA32 build
- `test/nil/testbuild` ARM build
- RT-ARMCM4-MAKELIB header generation and RT-ARMCM4-USELIB build
- project style checker on all changed non-generated C and header files
- `git diff --check`
- tree-wide checks for the removed symbol and old simulator signature
