### PR TITLE
RT: fix SMP lifecycle polling

### DIFF
--- a/demos/various/RT-ARMCM4-USELIB/rt/ch.h
+++ b/demos/various/RT-ARMCM4-USELIB/rt/ch.h
@@ -1295,10 +1295,12 @@ static inline stkline_t *chThdGetWorkingAreaX(thread_t *tp) {
   return tp->wabase;
 }
 static inline bool chThdTerminatedX(thread_t *tp) {
-  return (bool)(tp->state == CH_STATE_FINAL);
+  const volatile tstate_t *statep = &tp->state;
+  return (bool)(*statep == CH_STATE_FINAL);
 }
 static inline bool chThdShouldTerminateX(void) {
-  return (bool)((chThdGetSelfX()->flags & CH_FLAGS_TERMINATE) != (tmode_t)0);
+  const volatile tmode_t *flagsp = &chThdGetSelfX()->flags;
+  return (bool)((*flagsp & CH_FLAGS_TERMINATE) != (tmode_t)0);
 }
 static inline thread_t *chThdStartI(thread_t *tp) {
   chDbgAssert(tp->state == CH_STATE_WTSTART, "wrong state");

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -586,12 +586,15 @@ static inline stkline_t *chThdGetWorkingAreaX(thread_t *tp) {
  * @param[in] tp        pointer to the thread
  * @retval true         thread terminated.
  * @retval false        thread not terminated.
+ * @note    The state is read through a volatile-qualified access because it
+ *          can be modified by another core.
  *
  * @xclass
  */
 static inline bool chThdTerminatedX(thread_t *tp) {
+  const volatile tstate_t *statep = &tp->state;
 
-  return (bool)(tp->state == CH_STATE_FINAL);
+  return (bool)(*statep == CH_STATE_FINAL);
 }
 
 /**
@@ -599,12 +602,15 @@ static inline bool chThdTerminatedX(thread_t *tp) {
  *
  * @retval true         termination request pending.
  * @retval false        termination request not pending.
+ * @note    The flags are read through a volatile-qualified access because
+ *          they can be modified by another core.
  *
  * @xclass
  */
 static inline bool chThdShouldTerminateX(void) {
+  const volatile tmode_t *flagsp = &chThdGetSelfX()->flags;
 
-  return (bool)((chThdGetSelfX()->flags & CH_FLAGS_TERMINATE) != (tmode_t)0);
+  return (bool)((*flagsp & CH_FLAGS_TERMINATE) != (tmode_t)0);
 }
 
 /**


### PR DESCRIPTION
## Summary

- read thread state through a local `const volatile` pointer in `chThdTerminatedX()`
- read termination flags through a local `const volatile` pointer in `chThdShouldTerminateX()`
- document why the unlocked X-class queries require volatile-qualified accesses
- regenerate the RT-ARMCM4 USELIB header

## Root cause and impact

The lifecycle X-class queries read ordinary byte fields without taking the global kernel lock. In SMP use, another core modifies those fields under the lock, but an optimized polling loop was not required to reload an ordinary field and could retain or hoist a previous value.

The local qualification makes only these two observations compiler-visible. It leaves normal scheduler accesses unchanged and does not alter `thread_t` layout or ABI.

## Validation

- full SIMX86_64 RT and OSLIB test suites
- optimized POSIX simulator build and generated-code inspection
- optimized ARMv6-M RP2040 SMP build with LTO
- RT-ARMCM4 USELIB build using the regenerated header
- changed-line style check
- `git diff --check`

Target-hardware SMP stress testing remains pending.
