### PR TITLE
RT: enforce thread API class contracts

### DIFF
--- a/demos/various/RT-ARMCM4-USELIB/rt/ch.h
+++ b/demos/various/RT-ARMCM4-USELIB/rt/ch.h
@@ -1303,10 +1303,12 @@ static inline bool chThdShouldTerminateX(void) {
   return (bool)((*flagsp & CH_FLAGS_TERMINATE) != (tmode_t)0);
 }
 static inline thread_t *chThdStartI(thread_t *tp) {
+  chDbgCheckClassI();
   chDbgAssert(tp->state == CH_STATE_WTSTART, "wrong state");
   return chSchReadyI(tp);
 }
 static inline void chThdSleepS(sysinterval_t ticks) {
+  chDbgCheckClassS();
   chDbgCheck(ticks != TIME_IMMEDIATE);
   (void) chSchGoSleepTimeoutS(CH_STATE_SLEEPING, ticks);
 }
@@ -1316,6 +1318,7 @@ static inline bool chThdQueueIsEmptyI(threads_queue_t *tqp) {
 }
 static inline void chThdDoDequeueNextI(threads_queue_t *tqp, msg_t msg) {
   thread_t *tp;
+  chDbgCheckClassI();
   chDbgAssert(ch_queue_notempty(&tqp->queue), "empty queue");
   tp = threadref(ch_queue_fifo_remove(&tqp->queue));
   chDbgAssert(tp->state == CH_STATE_QUEUED, "invalid state");

--- a/demos/various/RT-ARMCM4-USELIB/rt/ch.h
+++ b/demos/various/RT-ARMCM4-USELIB/rt/ch.h
@@ -1295,10 +1295,12 @@ static inline stkline_t *chThdGetWorkingAreaX(thread_t *tp) {
   return tp->wabase;
 }
 static inline bool chThdTerminatedX(thread_t *tp) {
-  return (bool)(tp->state == CH_STATE_FINAL);
+  const volatile tstate_t *statep = &tp->state;
+  return (bool)(*statep == CH_STATE_FINAL);
 }
 static inline bool chThdShouldTerminateX(void) {
-  return (bool)((chThdGetSelfX()->flags & CH_FLAGS_TERMINATE) != (tmode_t)0);
+  const volatile tmode_t *flagsp = &chThdGetSelfX()->flags;
+  return (bool)((*flagsp & CH_FLAGS_TERMINATE) != (tmode_t)0);
 }
 static inline thread_t *chThdStartI(thread_t *tp) {
   chDbgAssert(tp->state == CH_STATE_WTSTART, "wrong state");

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -614,7 +614,9 @@ static inline bool chThdShouldTerminateX(void) {
 }
 
 /**
- * @brief   Resumes a thread created with @p chThdCreateI().
+ * @brief   Starts a thread created in the suspended state.
+ * @details The thread must have been created using one of the suspended
+ *          create or spawn functions.
  *
  * @param[in] tp        pointer to the thread
  * @return              The pointer to the @p thread_t structure allocated for
@@ -623,6 +625,8 @@ static inline bool chThdShouldTerminateX(void) {
  * @iclass
  */
 static inline thread_t *chThdStartI(thread_t *tp) {
+
+  chDbgCheckClassI();
 
   chDbgAssert(tp->state == CH_STATE_WTSTART, "wrong state");
 
@@ -641,6 +645,8 @@ static inline thread_t *chThdStartI(thread_t *tp) {
  * @sclass
  */
 static inline void chThdSleepS(sysinterval_t ticks) {
+
+  chDbgCheckClassS();
 
   chDbgCheck(ticks != TIME_IMMEDIATE);
 
@@ -677,6 +683,8 @@ static inline bool chThdQueueIsEmptyI(threads_queue_t *tqp) {
  */
 static inline void chThdDoDequeueNextI(threads_queue_t *tqp, msg_t msg) {
   thread_t *tp;
+
+  chDbgCheckClassI();
 
   chDbgAssert(ch_queue_notempty(&tqp->queue), "empty queue");
 

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -586,12 +586,15 @@ static inline stkline_t *chThdGetWorkingAreaX(thread_t *tp) {
  * @param[in] tp        pointer to the thread
  * @retval true         thread terminated.
  * @retval false        thread not terminated.
+ * @note    The state is read through a volatile-qualified access because it
+ *          can be modified by another core.
  *
  * @xclass
  */
 static inline bool chThdTerminatedX(thread_t *tp) {
+  const volatile tstate_t *statep = &tp->state;
 
-  return (bool)(tp->state == CH_STATE_FINAL);
+  return (bool)(*statep == CH_STATE_FINAL);
 }
 
 /**
@@ -599,12 +602,15 @@ static inline bool chThdTerminatedX(thread_t *tp) {
  *
  * @retval true         termination request pending.
  * @retval false        termination request not pending.
+ * @note    The flags are read through a volatile-qualified access because
+ *          they can be modified by another core.
  *
  * @xclass
  */
 static inline bool chThdShouldTerminateX(void) {
+  const volatile tmode_t *flagsp = &chThdGetSelfX()->flags;
 
-  return (bool)((chThdGetSelfX()->flags & CH_FLAGS_TERMINATE) != (tmode_t)0);
+  return (bool)((*flagsp & CH_FLAGS_TERMINATE) != (tmode_t)0);
 }
 
 /**

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -306,11 +306,12 @@ thread_t *__thd_spawn_suspended(thread_t *tp,
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
  * @return              Pointer to the @p thread_t object.
  *
- * @api
+ * @iclass
  */
 thread_t *chThdSpawnSuspendedI(thread_t *tp,
                                const thread_descriptor_t *tdp) {
 
+  chDbgCheckClassI();
   chDbgCheck(tp != NULL);
   chDbgCheck(tdp != NULL);
 
@@ -378,6 +379,8 @@ thread_t *chThdSpawnSuspended(thread_t *tp,
  */
 thread_t *chThdSpawnRunningI(thread_t *tp, const thread_descriptor_t *tdp) {
 
+  chDbgCheckClassI();
+
   return chSchReadyI(chThdSpawnSuspendedI(tp, tdp));
 }
 
@@ -394,7 +397,7 @@ thread_t *chThdSpawnRunningI(thread_t *tp, const thread_descriptor_t *tdp) {
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
  * @return              Pointer to the @p thread_t object.
  *
- * @iclass
+ * @api
  */
 thread_t *chThdSpawnRunning(thread_t *tp, const thread_descriptor_t *tdp) {
 
@@ -526,6 +529,8 @@ thread_t *chThdCreateSuspended(const thread_descriptor_t *tdp) {
  */
 thread_t *chThdCreateI(const thread_descriptor_t *tdp) {
 
+  chDbgCheckClassI();
+
   return chSchReadyI(chThdCreateSuspendedI(tdp));
 }
 
@@ -541,7 +546,7 @@ thread_t *chThdCreateI(const thread_descriptor_t *tdp) {
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
  * @return              Pointer to the @p thread_t object.
  *
- * @iclass
+ * @api
  */
 thread_t *chThdCreate(const thread_descriptor_t *tdp) {
   thread_t *tp;
@@ -771,7 +776,11 @@ void chThdExit(msg_t msg) {
  * @sclass
  */
 void chThdExitS(msg_t msg) {
-  thread_t *currtp = chThdGetSelfX();
+  thread_t *currtp;
+
+  chDbgCheckClassS();
+
+  currtp = chThdGetSelfX();
 
 #if CH_CFG_USE_MUTEXES == TRUE
   chDbgAssert(currtp->mtxlist == NULL, "owning mutexes");
@@ -832,10 +841,12 @@ void chThdExitS(msg_t msg) {
  * @sclass
  */
 msg_t chThdSyncS(thread_t *tp) {
-  thread_t *currtp = chThdGetSelfX();
+  thread_t *currtp;
 
   chDbgCheckClassS();
   chDbgCheck(tp != NULL);
+
+  currtp = chThdGetSelfX();
 
   chDbgAssert(tp != currtp, "waiting self");
 #if CH_CFG_USE_REGISTRY == TRUE
@@ -1157,7 +1168,11 @@ void chThdYield(void) {
  * @sclass
  */
 msg_t chThdSuspendS(thread_reference_t *trp) {
-  thread_t *tp = chThdGetSelfX();
+  thread_t *tp;
+
+  chDbgCheckClassS();
+
+  tp = chThdGetSelfX();
 
   chDbgAssert(*trp == NULL, "not NULL");
 
@@ -1187,7 +1202,11 @@ msg_t chThdSuspendS(thread_reference_t *trp) {
  * @sclass
  */
 msg_t chThdSuspendTimeoutS(thread_reference_t *trp, sysinterval_t timeout) {
-  thread_t *tp = chThdGetSelfX();
+  thread_t *tp;
+
+  chDbgCheckClassS();
+
+  tp = chThdGetSelfX();
 
   chDbgAssert(*trp == NULL, "not NULL");
 
@@ -1213,6 +1232,8 @@ msg_t chThdSuspendTimeoutS(thread_reference_t *trp, sysinterval_t timeout) {
  */
 void chThdResumeI(thread_reference_t *trp, msg_t msg) {
 
+  chDbgCheckClassI();
+
   if (*trp != NULL) {
     thread_t *tp = *trp;
 
@@ -1232,9 +1253,11 @@ void chThdResumeI(thread_reference_t *trp, msg_t msg) {
  * @param[in] trp       a pointer to a thread reference object
  * @param[in] msg       the message code
  *
- * @iclass
+ * @sclass
  */
 void chThdResumeS(thread_reference_t *trp, msg_t msg) {
+
+  chDbgCheckClassS();
 
   if (*trp != NULL) {
     thread_t *tp = *trp;
@@ -1329,12 +1352,15 @@ void chThdQueueObjectDispose(threads_queue_t *tqp) {
  * @sclass
  */
 msg_t chThdEnqueueTimeoutS(threads_queue_t *tqp, sysinterval_t timeout) {
-  thread_t *currtp = chThdGetSelfX();
+  thread_t *currtp;
+
+  chDbgCheckClassS();
 
   if (unlikely(TIME_IMMEDIATE == timeout)) {
     return MSG_TIMEOUT;
   }
 
+  currtp = chThdGetSelfX();
   ch_queue_insert(&tqp->queue, (ch_queue_t *)currtp);
 
   return chSchGoSleepTimeoutS(CH_STATE_QUEUED, timeout);
@@ -1351,6 +1377,8 @@ msg_t chThdEnqueueTimeoutS(threads_queue_t *tqp, sysinterval_t timeout) {
  */
 void chThdDequeueNextI(threads_queue_t *tqp, msg_t msg) {
 
+  chDbgCheckClassI();
+
   if (ch_queue_notempty(&tqp->queue)) {
     chThdDoDequeueNextI(tqp, msg);
   }
@@ -1365,6 +1393,8 @@ void chThdDequeueNextI(threads_queue_t *tqp, msg_t msg) {
  * @iclass
  */
 void chThdDequeueAllI(threads_queue_t *tqp, msg_t msg) {
+
+  chDbgCheckClassI();
 
   while (ch_queue_notempty(&tqp->queue)) {
     chThdDoDequeueNextI(tqp, msg);


### PR DESCRIPTION
## Dependency

This branch is stacked on #187 so its generated header cannot undo the TL-4 correction. Merge #187 first; once it lands on `master`, this pull request's effective diff will narrow to the TL-6 commit.

## Summary

- validate the execution class at the start of every RT thread-module S/I entry point
- cover immediate, empty, and null-reference fast paths that previously skipped validation
- perform validation before current-thread lookup, pointer dereference, queue mutation, registry mutation, or state mutation
- correct the Doxygen classifications of the affected spawn, create, and resume APIs
- correct `chThdStartI()` documentation to reference suspended creation and spawn operations
- regenerate the RT-ARMCM4 USELIB header

## Root cause and impact

Several thread lifecycle and thread-queue functions relied on deeper scheduler or registry helpers to diagnose an invalid calling context. Some paths mutated objects before reaching those helpers, while fast paths returned without validating the S/I contract at all. This could leave partial state changes when system-state checking diagnosed an invalid call.

Each public S/I entry point now validates its own contract before inspecting or changing kernel state. Deeper checks remain in place as local scheduler and registry invariants. The checks compile out with system-state checking disabled, so normal release paths are unchanged.

## Validation

- full optimized SIMX86_64 RT and OSLIB suites with `CH_DBG_SYSTEM_STATE_CHECK=TRUE`
- same suites with registry and dynamic threads disabled
- combined TL-4/TL-6 state-checking build and run
- RT-ARMCM4 USELIB build using the regenerated header
- changed-line style check
- `git diff --check`

The current test harness does not recover from an expected kernel halt, so explicit invalid-context assertion tests remain a test-harness gap.
