### PR TITLE
RT: initialize lifecycle ready messages

### DIFF
--- a/demos/various/RT-ARMCM4-USELIB/rt/ch.h
+++ b/demos/various/RT-ARMCM4-USELIB/rt/ch.h
@@ -1305,6 +1305,7 @@ static inline bool chThdShouldTerminateX(void) {
 static inline thread_t *chThdStartI(thread_t *tp) {
   chDbgCheckClassI();
   chDbgAssert(tp->state == CH_STATE_WTSTART, "wrong state");
+  tp->u.rdymsg = MSG_OK;
   return chSchReadyI(tp);
 }
 static inline void chThdSleepS(sysinterval_t ticks) {

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -630,6 +630,8 @@ static inline thread_t *chThdStartI(thread_t *tp) {
 
   chDbgAssert(tp->state == CH_STATE_WTSTART, "wrong state");
 
+  tp->u.rdymsg = MSG_OK;
+
   return chSchReadyI(tp);
 }
 

--- a/os/rt/src/chinstances.c
+++ b/os/rt/src/chinstances.c
@@ -173,6 +173,8 @@ void chInstanceObjectInit(os_instance_t *oip,
 
 #if CH_CFG_NO_IDLE_THREAD == FALSE
   {
+    thread_t *tp;
+
     const THD_DECL(idle_thd_desc,
                    "idle", oicp->idlestack_base, oicp->idlestack_end,
                    IDLEPRIO, __idle_thread, NULL, oip
@@ -186,8 +188,9 @@ void chInstanceObjectInit(os_instance_t *oip,
     /* This thread has the lowest priority in the system, its role is just to
        serve interrupts in its context while keeping the lowest energy saving
        mode compatible with the system status.*/
-    (void) chSchReadyI(__thd_spawn_suspended(&oip->idlethread,
-                                             &idle_thd_desc));
+    tp = __thd_spawn_suspended(&oip->idlethread, &idle_thd_desc);
+    tp->u.rdymsg = MSG_OK;
+    (void) chSchReadyI(tp);
   }
 #endif /* CH_CFG_NO_IDLE_THREAD == FALSE */
 }

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -154,6 +154,7 @@ thread_t *chThdObjectInit(thread_t *tp,
   tp->hdr.pqueue.prio   = tdp->prio;
   tp->state             = CH_STATE_WTSTART;
   tp->flags             = (tmode_t)0;
+  tp->u.rdymsg          = MSG_OK;
   if (tdp->owner != NULL) {
     tp->owner           = tdp->owner;
   }
@@ -381,7 +382,10 @@ thread_t *chThdSpawnRunningI(thread_t *tp, const thread_descriptor_t *tdp) {
 
   chDbgCheckClassI();
 
-  return chSchReadyI(chThdSpawnSuspendedI(tp, tdp));
+  tp = chThdSpawnSuspendedI(tp, tdp);
+  tp->u.rdymsg = MSG_OK;
+
+  return chSchReadyI(tp);
 }
 
 /**
@@ -528,10 +532,14 @@ thread_t *chThdCreateSuspended(const thread_descriptor_t *tdp) {
  * @iclass
  */
 thread_t *chThdCreateI(const thread_descriptor_t *tdp) {
+  thread_t *tp;
 
   chDbgCheckClassI();
 
-  return chSchReadyI(chThdCreateSuspendedI(tdp));
+  tp = chThdCreateSuspendedI(tdp);
+  tp->u.rdymsg = MSG_OK;
+
+  return chSchReadyI(tp);
 }
 
 /**
@@ -798,7 +806,10 @@ void chThdExitS(msg_t msg) {
 #if CH_CFG_USE_WAITEXIT == TRUE
   /* Waking up any waiting thread.*/
   while (unlikely(ch_list_notempty(&currtp->waiting))) {
-    (void) chSchReadyI(threadref(ch_list_unlink(&currtp->waiting)));
+    thread_t *tp = threadref(ch_list_unlink(&currtp->waiting));
+
+    tp->u.rdymsg = MSG_OK;
+    (void) chSchReadyI(tp);
   }
 #endif
 

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1230,7 +1230,32 @@ static void setup_thread_descriptor(thread_descriptor_t *tdp,
   tdp->funcp = thread;
   tdp->arg   = arg;
   tdp->owner = NULL;
-}]]></value>
+}
+
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
+     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
+static bool find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp) {
+  trace_buffer_t *tbp = &currcore->trace_buffer;
+  trace_event_t *tep = tbp->ptr;
+  unsigned i;
+
+  for (i = 0U; i < (unsigned)CH_DBG_TRACE_BUFFER_SIZE; i++) {
+    if (tep == &tbp->buffer[0]) {
+      tep = &tbp->buffer[CH_DBG_TRACE_BUFFER_SIZE];
+    }
+    tep--;
+    if ((tep->type == CH_TRACE_TYPE_READY) &&
+        (tep->state == (uint8_t)state) &&
+        (tep->u.rdy.tp == tp)) {
+      *msgp = tep->u.rdy.msg;
+      return true;
+    }
+  }
+
+  return false;
+}
+#endif]]></value>
       </shared_code>
       <cases>
         <case>
@@ -1969,6 +1994,134 @@ test_assert(oldprio == prio - 2, "wrong old priority");
 test_assert(switched, "thread B not scheduled internally");
 test_wait_threads();
 test_assert_sequence("BA", "ready list not reordered");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Lifecycle ready trace messages.</value>
+          </brief>
+          <description>
+            <value>Lifecycle transitions into the ready state are verified to
+              trace a defined MSG_OK ready message.</value>
+          </description>
+          <condition>
+            <value><![CDATA[(CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&
+((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&
+(CH_CFG_USE_WAITEXIT == TRUE)]]></value>
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[test_wait_threads();]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[thread_descriptor_t td;
+thread_t *self;
+msg_t initmsg, tracemsg = MSG_RESET;
+bool found;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>A suspended external thread object is initialized and
+                  started through I-class APIs. Its initialized and traced
+                  messages are checked.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "trace-start-i",
+                        TEST_THREAD_STACK_BASE(0), TEST_THREAD_STACK_END(0),
+                        chThdGetPriorityX() - 1, "A");
+TEST_THREAD_OBJECT(0)->u.rdymsg = MSG_RESET;
+chSysLock();
+threads[0] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(0), &td);
+initmsg = threads[0]->u.rdymsg;
+chThdStartI(threads[0]);
+found = find_ready_trace(threads[0], CH_STATE_WTSTART, &tracemsg);
+chSysUnlock();
+test_assert(initmsg == MSG_OK, "ready message not initialized");
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+test_wait_threads();
+test_assert_sequence("A", "invalid sequence");
+chThdObjectDispose(TEST_THREAD_OBJECT(0));]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A running external thread is spawned through an I-class
+                  API and its ready trace is checked.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "trace-spawn-i",
+                        TEST_THREAD_STACK_BASE(1), TEST_THREAD_STACK_END(1),
+                        chThdGetPriorityX() - 1, "B");
+TEST_THREAD_OBJECT(1)->u.rdymsg = MSG_RESET;
+chSysLock();
+threads[1] = chThdSpawnRunningI(TEST_THREAD_OBJECT(1), &td);
+found = find_ready_trace(threads[1], CH_STATE_WTSTART, &tracemsg);
+chSysUnlock();
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+test_wait_threads();
+test_assert_sequence("B", "invalid sequence");
+chThdObjectDispose(TEST_THREAD_OBJECT(1));]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A running embedded thread is created through an I-class
+                  API and its ready trace is checked.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[setup_thread_descriptor(&td, "trace-create-i",
+                        TEST_THREAD_WA_BASE(2), TEST_THREAD_WA_END(2),
+                        chThdGetPriorityX() - 1, "C");
+TEST_THREAD_OBJECT(2)->u.rdymsg = MSG_RESET;
+chSysLock();
+threads[2] = chThdCreateI(&td);
+found = find_ready_trace(threads[2], CH_STATE_WTSTART, &tracemsg);
+chSysUnlock();
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+test_wait_threads();
+test_assert_sequence("C", "invalid sequence");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A thread exit wakes its waiter and the waiter's ready
+                  trace is checked.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[self = chThdGetSelfX();
+threads[3] = chThdCreateStatic(wa[3], WA_SIZE,
+                               chThdGetPriorityX() - 1, thread, "D");
+self->u.rdymsg = MSG_RESET;
+(void) chThdWait(threads[3]);
+threads[3] = NULL;
+chSysLock();
+found = find_ready_trace(self, CH_STATE_WTEXIT, &tracemsg);
+chSysUnlock();
+test_assert(found, "waiter ready trace not found");
+test_assert(tracemsg == MSG_OK, "invalid waiter trace message");
+test_assert_sequence("D", "invalid sequence");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -38,6 +38,7 @@
  * - @subpage rt_test_005_006
  * - @subpage rt_test_005_007
  * - @subpage rt_test_005_008
+ * - @subpage rt_test_005_009
  * .
  */
 
@@ -76,6 +77,31 @@ static void setup_thread_descriptor(thread_descriptor_t *tdp,
   tdp->arg   = arg;
   tdp->owner = NULL;
 }
+
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
+     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
+static bool find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp) {
+  trace_buffer_t *tbp = &currcore->trace_buffer;
+  trace_event_t *tep = tbp->ptr;
+  unsigned i;
+
+  for (i = 0U; i < (unsigned)CH_DBG_TRACE_BUFFER_SIZE; i++) {
+    if (tep == &tbp->buffer[0]) {
+      tep = &tbp->buffer[CH_DBG_TRACE_BUFFER_SIZE];
+    }
+    tep--;
+    if ((tep->type == CH_TRACE_TYPE_READY) &&
+        (tep->state == (uint8_t)state) &&
+        (tep->u.rdy.tp == tp)) {
+      *msgp = tep->u.rdy.msg;
+      return true;
+    }
+  }
+
+  return false;
+}
+#endif
 
 /*===========================================================================*/
 /* Test cases.                                                               */
@@ -765,6 +791,132 @@ static const testcase_t rt_test_005_008 = {
   rt_test_005_008_execute
 };
 
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
+     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
+/**
+ * @page rt_test_005_009 [5.9] Lifecycle ready trace messages
+ *
+ * <h2>Description</h2>
+ * Lifecycle transitions into the ready state are verified to trace a defined
+ * @p MSG_OK ready message.
+ *
+ * <h2>Conditions</h2>
+ * This test is only executed if ready tracing and thread-wait support are
+ * enabled.
+ *
+ * <h2>Test Steps</h2>
+ * - [5.9.1] A suspended external thread object is initialized and started
+ *   through I-class APIs. Its initialized and traced messages are checked.
+ * - [5.9.2] A running external thread is spawned through an I-class API and
+ *   its ready trace is checked.
+ * - [5.9.3] A running embedded thread is created through an I-class API and
+ *   its ready trace is checked.
+ * - [5.9.4] A thread exit wakes its waiter and the waiter's ready trace is
+ *   checked.
+ * .
+ */
+
+static void rt_test_005_009_teardown(void) {
+  test_wait_threads();
+}
+
+static void rt_test_005_009_execute(void) {
+  thread_descriptor_t td;
+  thread_t *self;
+  msg_t initmsg, tracemsg = MSG_RESET;
+  bool found;
+
+  /* [5.9.1] A suspended external thread object is initialized and started
+     through I-class APIs. Its initialized and traced messages are checked.*/
+  test_set_step(1);
+  {
+    setup_thread_descriptor(&td, "trace-start-i",
+                            TEST_THREAD_STACK_BASE(0), TEST_THREAD_STACK_END(0),
+                            chThdGetPriorityX() - 1, "A");
+    TEST_THREAD_OBJECT(0)->u.rdymsg = MSG_RESET;
+    chSysLock();
+    threads[0] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(0), &td);
+    initmsg = threads[0]->u.rdymsg;
+    chThdStartI(threads[0]);
+    found = find_ready_trace(threads[0], CH_STATE_WTSTART, &tracemsg);
+    chSysUnlock();
+    test_assert(initmsg == MSG_OK, "ready message not initialized");
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+    test_wait_threads();
+    test_assert_sequence("A", "invalid sequence");
+    chThdObjectDispose(TEST_THREAD_OBJECT(0));
+  }
+  test_end_step(1);
+
+  /* [5.9.2] A running external thread is spawned through an I-class API and
+     its ready trace is checked.*/
+  test_set_step(2);
+  {
+    setup_thread_descriptor(&td, "trace-spawn-i",
+                            TEST_THREAD_STACK_BASE(1), TEST_THREAD_STACK_END(1),
+                            chThdGetPriorityX() - 1, "B");
+    TEST_THREAD_OBJECT(1)->u.rdymsg = MSG_RESET;
+    chSysLock();
+    threads[1] = chThdSpawnRunningI(TEST_THREAD_OBJECT(1), &td);
+    found = find_ready_trace(threads[1], CH_STATE_WTSTART, &tracemsg);
+    chSysUnlock();
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+    test_wait_threads();
+    test_assert_sequence("B", "invalid sequence");
+    chThdObjectDispose(TEST_THREAD_OBJECT(1));
+  }
+  test_end_step(2);
+
+  /* [5.9.3] A running embedded thread is created through an I-class API and
+     its ready trace is checked.*/
+  test_set_step(3);
+  {
+    setup_thread_descriptor(&td, "trace-create-i",
+                            TEST_THREAD_WA_BASE(2), TEST_THREAD_WA_END(2),
+                            chThdGetPriorityX() - 1, "C");
+    TEST_THREAD_OBJECT(2)->u.rdymsg = MSG_RESET;
+    chSysLock();
+    threads[2] = chThdCreateI(&td);
+    found = find_ready_trace(threads[2], CH_STATE_WTSTART, &tracemsg);
+    chSysUnlock();
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+    test_wait_threads();
+    test_assert_sequence("C", "invalid sequence");
+  }
+  test_end_step(3);
+
+  /* [5.9.4] A thread exit wakes its waiter and the waiter's ready trace is
+     checked.*/
+  test_set_step(4);
+  {
+    self = chThdGetSelfX();
+    threads[3] = chThdCreateStatic(wa[3], WA_SIZE,
+                                   chThdGetPriorityX() - 1, thread, "D");
+    self->u.rdymsg = MSG_RESET;
+    (void) chThdWait(threads[3]);
+    threads[3] = NULL;
+    chSysLock();
+    found = find_ready_trace(self, CH_STATE_WTEXIT, &tracemsg);
+    chSysUnlock();
+    test_assert(found, "waiter ready trace not found");
+    test_assert(tracemsg == MSG_OK, "invalid waiter trace message");
+    test_assert_sequence("D", "invalid sequence");
+  }
+  test_end_step(4);
+}
+
+static const testcase_t rt_test_005_009 = {
+  "Lifecycle ready trace messages",
+  NULL,
+  rt_test_005_009_teardown,
+  rt_test_005_009_execute
+};
+#endif
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -785,6 +937,11 @@ const testcase_t * const rt_test_sequence_005_array[] = {
   &rt_test_005_007,
 #endif
   &rt_test_005_008,
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
+     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
+  &rt_test_005_009,
+#endif
   NULL
 };
 


### PR DESCRIPTION
## Summary

- initialize each thread's ready message to `MSG_OK` during object construction
- assign `MSG_OK` immediately before lifecycle ready transitions for thread start, running spawn/create, idle-thread setup, and exit-waiter wakeup
- add trace-enabled lifecycle regression coverage and regenerate the ARMCM4 combined header

## Root cause

Ready tracing records `tp->u.rdymsg` before changing the thread state to ready. Initial lifecycle transitions could therefore read an uninitialized union member, while exit-waiter wakeups could record a stale state-specific union value.

## Impact

Lifecycle ready trace records now contain a defined `MSG_OK` message without changing synchronization results or scheduler behavior.

## Validation

- default SIMX86_64 RT/OSLIB build and full test run
- optimized SIMX86_64 build with all trace classes enabled and full test run, including new test 5.9
- ARMCM4 MAKELIB header/library generation
- ARMCM4 USELIB build and link
- source style checks, XML validation, and `git diff --check`