### PR TITLE
RT: enforce thread reference ownership

### DIFF
--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -287,6 +287,9 @@ thread_t *chRegFindThreadByName(const char *name) {
 
 /**
  * @brief   Confirms that a pointer is a valid thread pointer.
+ * @details Unlike @p chThdAddRef(), this function does not require the caller
+ *          to already own a reference. Registry membership is checked and a
+ *          reference is acquired while protected by the kernel lock.
  * @note    The reference counter of the found thread is increased by one so
  *          it cannot be disposed incidentally after the pointer has been
  *          returned.

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -669,21 +669,25 @@ thread_t *chThdStart(thread_t *tp) {
 
 #if (CH_CFG_USE_REGISTRY == TRUE) || defined(__DOXYGEN__)
 /**
- * @brief   Adds a reference to a thread object.
+ * @brief   Duplicates an owned reference to a thread object.
+ * @details A non-owning thread identity must be reacquired using
+ *          @p chRegFindThreadByPointer() instead.
  * @pre     The configuration option @p CH_CFG_USE_REGISTRY must be enabled in
  *          order to use this function.
+ * @pre     The caller must own a valid reference to the thread.
  * @pre     The thread must have fewer than @p THREAD_MAX_REFERENCES
  *          references.
  *
  * @param[in] tp        pointer to the thread
- * @return              The same thread pointer passed as parameter
- *                      representing the new reference.
+ * @return              The same thread pointer passed as parameter,
+ *                      representing the duplicated reference.
  *
  * @api
  */
 thread_t *chThdAddRef(thread_t *tp) {
 
   chSysLock();
+  chDbgAssert(tp->refs > (trefs_t)0, "not referenced");
   chDbgAssert(tp->refs < THREAD_MAX_REFERENCES, "too many references");
   tp->refs++;
   chSysUnlock();
@@ -703,6 +707,7 @@ thread_t *chThdAddRef(thread_t *tp) {
  *          removed by performing a registry scan operation.
  * @pre     The configuration option @p CH_CFG_USE_REGISTRY must be enabled in
  *          order to use this function.
+ * @pre     The caller must own the reference being released.
  * @note    Static threads are not affected, only removed from the registry.
  *
  * @param[in] tp        pointer to the thread
@@ -843,6 +848,8 @@ void chThdExitS(msg_t msg) {
  *          responsible for eventually releasing its reference.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
+ * @pre     If @p CH_CFG_USE_REGISTRY is @p TRUE then the caller must own a
+ *          valid reference to the thread.
  * @post    Enabling @p chThdSyncS() requires 2-4 (depending on the
  *          architecture) extra bytes in the @p thread_t structure.
  *
@@ -880,6 +887,8 @@ msg_t chThdSyncS(thread_t *tp) {
  *          responsible for eventually releasing its reference.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
+ * @pre     If @p CH_CFG_USE_REGISTRY is @p TRUE then the caller must own a
+ *          valid reference to the thread.
  * @post    Enabling @p chThdSync() requires 2-4 (depending on the
  *          architecture) extra bytes in the @p thread_t structure.
  *
@@ -908,6 +917,8 @@ msg_t chThdSync(thread_t *tp) {
  *          thread is removed from the registry.
  * @pre     The configuration option @p CH_CFG_USE_WAITEXIT must be enabled in
  *          order to use this function.
+ * @pre     If @p CH_CFG_USE_REGISTRY is @p TRUE then the caller must own the
+ *          reference consumed by this function.
  * @post    Enabling @p chThdWait() requires 2-4 (depending on the
  *          architecture) extra bytes in the @p thread_t structure.
  * @note    If @p CH_CFG_USE_REGISTRY is @p FALSE then this function only

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1871,7 +1871,8 @@ test_assert(chRegGetThreadNameX(tp) == oldname, "name not restored");]]></value>
               <description>
                 <value>A static thread is created then retrieved by name,
                   pointer and working area while an unnamed thread is in the
-                  registry.</value>
+                  registry. Its initial reference is released and reacquired
+                  through the registry.</value>
               </description>
               <tags>
                 <value />
@@ -1888,6 +1889,12 @@ chThdRelease(tp);
 tp = chRegFindThreadByName("registry-missing");
 test_assert(tp == NULL, "unexpected thread found");
 chRegSetThreadName(oldname);
+
+chThdRelease(threads[0]);
+tp = chRegFindThreadByPointer(threads[0]);
+test_assert(tp == threads[0], "detached thread not reacquired");
+test_assert(tp->refs == (trefs_t)1, "wrong reference counter");
+threads[0] = tp;
 
 tp = chThdAddRef(threads[0]);
 test_assert(tp == threads[0], "wrong referenced thread");

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -638,7 +638,8 @@ static const testcase_t rt_test_005_006 = {
  * - [5.7.1] The current thread registry name is changed and then
  *   restored.
  * - [5.7.2] A static thread is created then retrieved by name, pointer
- *   and working area while an unnamed thread is in the registry.
+ *   and working area while an unnamed thread is in the registry. Its initial
+ *   reference is released and reacquired through the registry.
  * - [5.7.3] The registry is scanned forward until the end and the
  *   created thread is found in the scan.
  * .
@@ -682,6 +683,12 @@ static void rt_test_005_007_execute(void) {
     tp = chRegFindThreadByName("registry-missing");
     test_assert(tp == NULL, "unexpected thread found");
     chRegSetThreadName(oldname);
+
+    chThdRelease(threads[0]);
+    tp = chRegFindThreadByPointer(threads[0]);
+    test_assert(tp == threads[0], "detached thread not reacquired");
+    test_assert(tp->refs == (trefs_t)1, "wrong reference counter");
+    threads[0] = tp;
 
     tp = chThdAddRef(threads[0]);
     test_assert(tp == threads[0], "wrong referenced thread");


### PR DESCRIPTION
## Summary

- require `chThdAddRef()` to duplicate an already-owned positive reference
- document ownership preconditions for reference release, synchronization, and wait operations
- distinguish ordinary reference duplication from registry-based reacquisition
- extend registry tests to release a live thread's initial reference and reacquire it through `chRegFindThreadByPointer()`

## Root cause

`chThdAddRef()` previously accepted a zero reference count. A detached static thread can be removed from the registry when it terminates while its storage remains addressable. Calling `chThdAddRef()` through that stale non-owning pointer created a disconnected reference, and releasing it could operate on stale registry links.

Registry lookup is intentionally different: it validates membership and increments the reference count directly under the kernel lock, allowing safe acquisition from a non-owning identity.

## Impact

Thread reference ownership is now explicit and enforceable in assertion-enabled builds. Existing registry reacquisition remains supported, and thread-exit registry removal behavior is unchanged.

## Validation

- default SIMX86_64 RT/OSLIB build and full test run
- optimized SIMX86_64 build and full test run with system-state checking, parameter checks, and debug assertions enabled
- ARMCM4 MAKELIB header/library generation
- ARMCM4 USELIB build and link
- source style checks, XML validation, and `git diff --check`