### PR TITLE
STM32G0xx EFL: Add support 256K/512K devices

### DIFF
--- a/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.c
+++ b/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.c
@@ -89,6 +89,38 @@ static const flash_descriptor_t efl_lld_size2[STM32_FLASH_NUMBER_OF_BANKS] = {
       }
 };
 
+/* The descriptor for 256K devices. */
+static const flash_descriptor_t efl_lld_size3[STM32_FLASH_NUMBER_OF_BANKS] = {
+      { /* Bank 1. */
+       .attributes        = FLASH_ATTR_ERASED_IS_ONE |
+                            FLASH_ATTR_MEMORY_MAPPED |
+                            FLASH_ATTR_ECC_CAPABLE   |
+                            FLASH_ATTR_ECC_ZERO_LINE_CAPABLE,
+       .page_size         = STM32_FLASH_LINE_SIZE,
+       .sectors_count     = STM32_FLASH_SECTORS_TOTAL_256K,
+       .sectors           = NULL,
+       .sectors_size      = STM32_FLASH_SECTOR_SIZE_256K,
+       .address           = (uint8_t *)FLASH_BASE,
+       .size              = STM32_FLASH_SIZE_256K * STM32_FLASH_SIZE_SCALE
+      }
+};
+
+/* The descriptor for 512K devices. */
+static const flash_descriptor_t efl_lld_size4[STM32_FLASH_NUMBER_OF_BANKS] = {
+      { /* Bank 1. */
+       .attributes        = FLASH_ATTR_ERASED_IS_ONE |
+                            FLASH_ATTR_MEMORY_MAPPED |
+                            FLASH_ATTR_ECC_CAPABLE   |
+                            FLASH_ATTR_ECC_ZERO_LINE_CAPABLE,
+       .page_size         = STM32_FLASH_LINE_SIZE,
+       .sectors_count     = STM32_FLASH_SECTORS_TOTAL_512K,
+       .sectors           = NULL,
+       .sectors_size      = STM32_FLASH_SECTOR_SIZE_512K,
+       .address           = (uint8_t *)FLASH_BASE,
+       .size              = STM32_FLASH_SIZE_512K * STM32_FLASH_SIZE_SCALE
+      }
+};
+
 /* Table describing possible flash sizes and descriptors for this device. */
 static const efl_lld_size_t efl_lld_flash_sizes[] = {
       {
@@ -96,6 +128,12 @@ static const efl_lld_size_t efl_lld_flash_sizes[] = {
       },
       {
        .desc = efl_lld_size2
+      },
+      {
+       .desc = efl_lld_size3
+      },
+      {
+       .desc = efl_lld_size4
       }
 };
 

--- a/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.h
+++ b/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.h
@@ -60,13 +60,17 @@
 #define STM32_FLASH_SIZE_SCALE              1024U
 
 /*
- * Flash size is organised as 32 or 64 x 2K pages.
+ * Flash size is organised as 32, 64, 128 or 256 x 2K pages.
  *
  */
 #define STM32_FLASH_SIZE_64K                64U
 #define STM32_FLASH_SIZE_128K               128U
+#define STM32_FLASH_SIZE_256K               256U
+#define STM32_FLASH_SIZE_512K               512U
 #define STM32_FLASH_SECTORS_TOTAL_64K       32
 #define STM32_FLASH_SECTORS_TOTAL_128K      64
+#define STM32_FLASH_SECTORS_TOTAL_256K      128
+#define STM32_FLASH_SECTORS_TOTAL_512K      256
 
 /* 64K flash.*/
 #define STM32_FLASH_SECTOR_SIZE_64K         ((STM32_FLASH_SIZE_64K         \
@@ -76,6 +80,14 @@
 #define STM32_FLASH_SECTOR_SIZE_128K         ((STM32_FLASH_SIZE_128K        \
                                              * STM32_FLASH_SIZE_SCALE)      \
                                              / STM32_FLASH_SECTORS_TOTAL_128K)
+/* 256K flash.*/
+#define STM32_FLASH_SECTOR_SIZE_256K         ((STM32_FLASH_SIZE_256K        \
+                                             * STM32_FLASH_SIZE_SCALE)      \
+                                             / STM32_FLASH_SECTORS_TOTAL_256K)
+/* 512K flash.*/
+#define STM32_FLASH_SECTOR_SIZE_512K         ((STM32_FLASH_SIZE_512K        \
+                                             * STM32_FLASH_SIZE_SCALE)      \
+                                             / STM32_FLASH_SECTORS_TOTAL_512K)
 
 #else
 #error "This EFL driver does not support the selected device"

--- a/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.h
+++ b/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.h
@@ -89,6 +89,16 @@
                                              * STM32_FLASH_SIZE_SCALE)      \
                                              / STM32_FLASH_SECTORS_TOTAL_512K)
 
+/*
+ * NOTE: the 256K and 512K descriptors assume single-bank operation
+ *       (FLASH_OPTR.DUAL_BANK = 0). STM32G0B1/G0C1 (and dual-bank 256K
+ *       parts) ship with DUAL_BANK = 1, where the flash is split into two
+ *       banks with non-contiguous page numbering (RM0444 Table 11); this
+ *       driver does not support that mode. On such devices the option byte
+ *       must be set to single-bank before the upper flash can be erased or
+ *       programmed through this driver.
+ */
+
 #else
 #error "This EFL driver does not support the selected device"
 #endif


### PR DESCRIPTION
## Summary

<!-- describe what changed, why is this change needed -->
`NUCLEO-G0B1RE` (and `xC` based boards) currently fail to configure a valid flash configuration due to the missing config

https://github.com/chibios-upstream/chibios/blob/fa13c03d8d8ac870553de0b92d651bbab4367361/os/hal/ports/STM32/STM32G0xx/hal_efl_lld.c#L205

## Related

- Issue(s):
- Notes for reviewers:
 
## Target Branch Check

<!-- put a x instead of the space in the [ ] to check the box [x] -->

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files
- [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [ ] Test run successfully locally
- Any other tests run on a device?

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
