### PR TITLE
RT: validate thread creation resource reuse

### DIFF
--- a/os/rt/include/chregistry.h
+++ b/os/rt/include/chregistry.h
@@ -131,6 +131,11 @@ extern "C" {
   thread_t *chRegNextThread(thread_t *tp);
   thread_t *chRegFindThreadByName(const char *name);
   thread_t *chRegFindThreadByPointer(thread_t *tp);
+#if (CH_DBG_ENABLE_ASSERTS == TRUE) || defined(__DOXYGEN__)
+  bool __reg_is_thread_area_in_use_i(const thread_t *tp,
+                                     const stkline_t *wbase,
+                                     const stkline_t *wend);
+#endif
   bool chRegIsWorkingAreaInUseI(stkline_t *wa);
   thread_t *chRegFindThreadByWorkingArea(stkline_t *wa);
 #ifdef __cplusplus

--- a/os/rt/src/chregistry.c
+++ b/os/rt/src/chregistry.c
@@ -111,6 +111,14 @@ typedef char chdebug_layout_fits_uint8_t[
 /* Module local functions.                                                   */
 /*===========================================================================*/
 
+#if CH_DBG_ENABLE_ASSERTS == TRUE
+static bool reg_ranges_overlap(uintptr_t astart, uintptr_t aend,
+                               uintptr_t bstart, uintptr_t bend) {
+
+  return (astart < bend) && (bstart < aend);
+}
+#endif
+
 /*===========================================================================*/
 /* Module exported functions.                                                */
 /*===========================================================================*/
@@ -345,6 +353,57 @@ thread_t *chRegFindThreadByWorkingArea(stkline_t *wa) {
 
   return NULL;
 }
+
+#if CH_DBG_ENABLE_ASSERTS == TRUE
+/**
+ * @brief   Checks if a thread object or working area is already in use.
+ * @details The specified thread object is checked against registered thread
+ *          objects and the working area is checked against registered working
+ *          areas. Cross-type overlaps are permitted.
+ * @pre     The specified working area must be a valid non-empty interval.
+ *
+ * @param[in] tp        pointer to the candidate thread object
+ * @param[in] wbase     base of the candidate working area
+ * @param[in] wend      end of the candidate working area
+ * @retval true         if a conflicting thread has been found.
+ * @retval false        if a conflicting thread has not been found.
+ *
+ * @iclass
+ * @notapi
+ */
+bool __reg_is_thread_area_in_use_i(const thread_t *tp,
+                                   const stkline_t *wbase,
+                                   const stkline_t *wend) {
+  ch_queue_t *tqp;
+  uintptr_t tpstart, tpend, wastart, waend;
+
+  chDbgCheckClassI();
+
+  tpstart = (uintptr_t)(const void *)tp;
+  tpend   = (uintptr_t)(const void *)(tp + 1);
+  wastart = (uintptr_t)(const void *)wbase;
+  waend   = (uintptr_t)(const void *)wend;
+
+  /* Scanning registry.*/
+  tqp = REG_HEADER(currcore)->next;
+  while (tqp != REG_HEADER(currcore)) {
+    thread_t *ctp = __CH_OWNEROF((uint8_t *)tqp, thread_t, rqueue);
+    uintptr_t ctpstart = (uintptr_t)(void *)ctp;
+    uintptr_t ctpend   = (uintptr_t)(void *)(ctp + 1);
+    uintptr_t cwastart = (uintptr_t)(void *)ctp->wabase;
+    uintptr_t cwaend   = (uintptr_t)(void *)ctp->waend;
+
+    if (reg_ranges_overlap(tpstart, tpend, ctpstart, ctpend) ||
+        reg_ranges_overlap(wastart, waend, cwastart, cwaend)) {
+      return true;
+    }
+
+    tqp = tqp->next;
+  }
+
+  return false;
+}
+#endif /* CH_DBG_ENABLE_ASSERTS == TRUE */
 
 /**
  * @brief   Confirms that a working area is being used by some active thread.

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -270,9 +270,9 @@ void chThdObjectDispose(thread_t *tp) {
 thread_t *__thd_spawn_suspended(thread_t *tp,
                                 const thread_descriptor_t *tdp) {
 
-#if CH_CFG_USE_REGISTRY == TRUE
-  chDbgAssert(!chRegIsWorkingAreaInUseI(tdp->wbase),
-              "working area in use");
+#if (CH_CFG_USE_REGISTRY == TRUE) && (CH_DBG_ENABLE_ASSERTS == TRUE)
+  chDbgAssert(!__reg_is_thread_area_in_use_i(tp, tdp->wbase, tdp->wend),
+              "thread or working area in use");
 #endif
 
   /* Thread object initialization.*/
@@ -302,6 +302,9 @@ thread_t *__thd_spawn_suspended(thread_t *tp,
  * @note    Threads created using this function do not honor the
  *          @p CH_DBG_FILL_THREADS debug option because it would stay
  *          in a critical section for too long while filling.
+ * @pre     The thread object and its working area must not overlap each other.
+ *          Neither resource may overlap a resource of the same type belonging
+ *          to an active thread.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
@@ -323,6 +326,11 @@ thread_t *chThdSpawnSuspendedI(thread_t *tp,
              (tdp->wend > tdp->wbase) &&
              (((size_t)tdp->wend - (size_t)tdp->wbase) >= THD_STACK_SIZE(0)));
 
+  /* The external thread object cannot be part of its working area.*/
+  chDbgCheck(((uintptr_t)(void *)(tp + 1) <=
+              (uintptr_t)(void *)tdp->wbase) ||
+             ((uintptr_t)(void *)tp >= (uintptr_t)(void *)tdp->wend));
+
   /* Other checks.*/
   chDbgCheck((tdp->prio >= LOWPRIO) &&
              (tdp->prio <= HIGHPRIO) &&
@@ -341,6 +349,9 @@ thread_t *chThdSpawnSuspendedI(thread_t *tp,
  *          to eventually release that reference using @p chThdRelease() or,
  *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
  *          persists in the registry until its reference counter reaches zero.
+ * @pre     The thread object and its working area must not overlap each other.
+ *          Neither resource may overlap a resource of the same type belonging
+ *          to an active thread.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
@@ -371,6 +382,9 @@ thread_t *chThdSpawnSuspended(thread_t *tp,
  * @note    Threads created using this function do not honor the
  *          @p CH_DBG_FILL_THREADS debug option because it would keep
  *          the kernel locked for too much time.
+ * @pre     The thread object and its working area must not overlap each other.
+ *          Neither resource may overlap a resource of the same type belonging
+ *          to an active thread.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
@@ -396,6 +410,9 @@ thread_t *chThdSpawnRunningI(thread_t *tp, const thread_descriptor_t *tdp) {
  *          to eventually release that reference using @p chThdRelease() or,
  *          if @p CH_CFG_USE_WAITEXIT is @p TRUE, @p chThdWait(). The thread
  *          persists in the registry until its reference counter reaches zero.
+ * @pre     The thread object and its working area must not overlap each other.
+ *          Neither resource may overlap a resource of the same type belonging
+ *          to an active thread.
  *
  * @param[out] tp       pointer to a @p thread_t object
  * @param[in] tdp       pointer to a @p thread_descriptor_t object
@@ -462,13 +479,15 @@ thread_t *chThdCreateSuspendedI(const thread_descriptor_t *tdp) {
   chDbgCheck(MEM_IS_ALIGNED(stkbase, PORT_WORKING_AREA_ALIGN) &&
              MEM_IS_ALIGNED(stktop, PORT_STACK_ALIGN));
 
-#if CH_CFG_USE_REGISTRY == TRUE
-  chDbgAssert(!chRegIsWorkingAreaInUseI(tdp->wbase),
-              "working area in use");
+  tp = threadref(stktop);
+
+#if (CH_CFG_USE_REGISTRY == TRUE) && (CH_DBG_ENABLE_ASSERTS == TRUE)
+  chDbgAssert(!__reg_is_thread_area_in_use_i(tp, tdp->wbase, tdp->wend),
+              "thread or working area in use");
 #endif
 
   /* The thread object is initialized but not started.*/
-  tp = chThdObjectInit(threadref(stktop), tdp);
+  tp = chThdObjectInit(tp, tdp);
 
   /* Setting up the port-dependent part of the working area.*/
   port_setup_context(&tp->ctx, stkbase, tp, tdp->funcp, tdp->arg);
@@ -633,12 +652,15 @@ thread_t *chThdCreateStatic(stkline_t *wbase, size_t wsize,
 
   chSysLock();
 
-#if CH_CFG_USE_REGISTRY == TRUE
+#if (CH_CFG_USE_REGISTRY == TRUE) && (CH_DBG_ENABLE_ASSERTS == TRUE)
   /* Special situation where the working area is already in use by an
      active thread.*/
-  chDbgAssert(!chRegIsWorkingAreaInUseI(wbase),
-              "working area in use");
+  chDbgAssert(!__reg_is_thread_area_in_use_i(tp, wbase,
+                                             (stkline_t *)(void *)wend),
+              "thread or working area in use");
+#endif
 
+#if CH_CFG_USE_REGISTRY == TRUE
   REG_INSERT(tp->owner, tp);
 #endif
 

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1205,6 +1205,14 @@ do {
   test_emit_token(*(char *)p);
 }
 
+#if ((CH_CFG_USE_REGISTRY == TRUE) &&                                   \
+     (CH_DBG_ENABLE_ASSERTS == TRUE)) || defined(__DOXYGEN__)
+static THD_FUNCTION(registry_thread, p) {
+
+  (void)p;
+}
+#endif
+
 #if (CH_CFG_USE_MUTEXES == TRUE) || defined(__DOXYGEN__)
 static MUTEX_DECL(priority_mtx);
 
@@ -1843,7 +1851,10 @@ test_assert_sequence("H", "invalid sequence");]]></value>
               <value><![CDATA[test_wait_threads();]]></value>
             </teardown_code>
             <local_variables>
-              <value><![CDATA[thread_t *tp, *ntp;
+              <value><![CDATA[#if CH_DBG_ENABLE_ASSERTS == TRUE
+thread_descriptor_t td;
+#endif
+thread_t *tp, *ntp;
 const char *oldname, *newname;
 bool found;]]></value>
             </local_variables>
@@ -1914,6 +1925,64 @@ chThdRelease(tp);
 
 tp = chRegFindThreadByName("registry-missing");
 test_assert(tp == NULL, "unexpected thread found");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>When debug assertions are enabled, creation conflict
+                  checks are exercised for a live thread object, a partially
+                  overlapping working area, disjoint resources and permitted
+                  cross-type overlaps.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[#if CH_DBG_ENABLE_ASSERTS == TRUE
+test_assert_lock(
+  __reg_is_thread_area_in_use_i(threads[0],
+                                TEST_THREAD_STACK_BASE(1),
+                                TEST_THREAD_STACK_END(1)),
+  "live thread object not detected");
+test_assert_lock(
+  __reg_is_thread_area_in_use_i(
+    TEST_THREAD_OBJECT(1),
+    (stkline_t *)(void *)((uint8_t *)TEST_THREAD_WA_BASE(0) +
+                          PORT_WORKING_AREA_ALIGN),
+    TEST_THREAD_WA_END(0)),
+  "working area overlap not detected");
+test_assert_lock(
+  !__reg_is_thread_area_in_use_i(TEST_THREAD_OBJECT(1),
+                                 TEST_THREAD_STACK_BASE(1),
+                                 TEST_THREAD_STACK_END(1)),
+  "disjoint resources reported in use");
+
+setup_thread_descriptor(&td, "registry-external",
+                        TEST_THREAD_STACK_BASE(2),
+                        TEST_THREAD_STACK_END(2),
+                        chThdGetPriorityX() + 1, NULL);
+td.funcp = registry_thread;
+chSysLock();
+threads[1] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(2), &td);
+chSysUnlock();
+
+test_assert_lock(
+  !__reg_is_thread_area_in_use_i(
+    (thread_t *)(void *)TEST_THREAD_STACK_BASE(2),
+    TEST_THREAD_STACK_BASE(1), TEST_THREAD_STACK_END(1)),
+  "thread object in another working area rejected");
+test_assert_lock(
+  !__reg_is_thread_area_in_use_i(
+    TEST_THREAD_OBJECT(1),
+    (stkline_t *)(void *)TEST_THREAD_OBJECT(2),
+    TEST_THREAD_WA_END(3)),
+  "working area containing another thread object rejected");
+
+chThdStart(threads[1]);
+(void) chThdWait(threads[1]);
+threads[1] = NULL;
+chThdObjectDispose(TEST_THREAD_OBJECT(2));
+#endif /* CH_DBG_ENABLE_ASSERTS == TRUE */]]></value>
               </code>
             </step>
             <step>

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -51,6 +51,14 @@ static THD_FUNCTION(thread, p) {
   test_emit_token(*(char *)p);
 }
 
+#if ((CH_CFG_USE_REGISTRY == TRUE) &&                                   \
+     (CH_DBG_ENABLE_ASSERTS == TRUE)) || defined(__DOXYGEN__)
+static THD_FUNCTION(registry_thread, p) {
+
+  (void)p;
+}
+#endif
+
 #if (CH_CFG_USE_MUTEXES == TRUE) || defined(__DOXYGEN__)
 static MUTEX_DECL(priority_mtx);
 
@@ -640,7 +648,10 @@ static const testcase_t rt_test_005_006 = {
  * - [5.7.2] A static thread is created then retrieved by name, pointer
  *   and working area while an unnamed thread is in the registry. Its initial
  *   reference is released and reacquired through the registry.
- * - [5.7.3] The registry is scanned forward until the end and the
+ * - [5.7.3] When debug assertions are enabled, creation conflict checks are
+ *   exercised for a live thread object, a partially overlapping working area,
+ *   disjoint resources and permitted cross-type overlaps.
+ * - [5.7.4] The registry is scanned forward until the end and the
  *   created thread is found in the scan.
  * .
  */
@@ -650,6 +661,9 @@ static void rt_test_005_007_teardown(void) {
 }
 
 static void rt_test_005_007_execute(void) {
+#if CH_DBG_ENABLE_ASSERTS == TRUE
+  thread_descriptor_t td;
+#endif
   thread_t *tp, *ntp;
   const char *oldname, *newname;
   bool found;
@@ -711,9 +725,62 @@ static void rt_test_005_007_execute(void) {
   }
   test_end_step(2);
 
-  /* [5.7.3] The registry is scanned forward until the end and the
-     created thread is found in the scan.*/
+  /* [5.7.3] When debug assertions are enabled, creation conflict checks are
+     exercised for a live thread object, a partially overlapping working area,
+     disjoint resources and permitted cross-type overlaps.*/
   test_set_step(3);
+  {
+#if CH_DBG_ENABLE_ASSERTS == TRUE
+    test_assert_lock(
+      __reg_is_thread_area_in_use_i(threads[0],
+                                    TEST_THREAD_STACK_BASE(1),
+                                    TEST_THREAD_STACK_END(1)),
+      "live thread object not detected");
+    test_assert_lock(
+      __reg_is_thread_area_in_use_i(
+        TEST_THREAD_OBJECT(1),
+        (stkline_t *)(void *)((uint8_t *)TEST_THREAD_WA_BASE(0) +
+                              PORT_WORKING_AREA_ALIGN),
+        TEST_THREAD_WA_END(0)),
+      "working area overlap not detected");
+    test_assert_lock(
+      !__reg_is_thread_area_in_use_i(TEST_THREAD_OBJECT(1),
+                                     TEST_THREAD_STACK_BASE(1),
+                                     TEST_THREAD_STACK_END(1)),
+      "disjoint resources reported in use");
+
+    setup_thread_descriptor(&td, "registry-external",
+                            TEST_THREAD_STACK_BASE(2),
+                            TEST_THREAD_STACK_END(2),
+                            chThdGetPriorityX() + 1, NULL);
+    td.funcp = registry_thread;
+    chSysLock();
+    threads[1] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(2), &td);
+    chSysUnlock();
+
+    test_assert_lock(
+      !__reg_is_thread_area_in_use_i(
+        (thread_t *)(void *)TEST_THREAD_STACK_BASE(2),
+        TEST_THREAD_STACK_BASE(1), TEST_THREAD_STACK_END(1)),
+      "thread object in another working area rejected");
+    test_assert_lock(
+      !__reg_is_thread_area_in_use_i(
+        TEST_THREAD_OBJECT(1),
+        (stkline_t *)(void *)TEST_THREAD_OBJECT(2),
+        TEST_THREAD_WA_END(3)),
+      "working area containing another thread object rejected");
+
+    chThdStart(threads[1]);
+    (void) chThdWait(threads[1]);
+    threads[1] = NULL;
+    chThdObjectDispose(TEST_THREAD_OBJECT(2));
+#endif /* CH_DBG_ENABLE_ASSERTS == TRUE */
+  }
+  test_end_step(3);
+
+  /* [5.7.4] The registry is scanned forward until the end and the
+     created thread is found in the scan.*/
+  test_set_step(4);
   {
     found = false;
     tp = chRegFirstThread();
@@ -729,7 +796,7 @@ static void rt_test_005_007_execute(void) {
     test_wait_threads();
     test_assert_sequence("R", "invalid sequence");
   }
-  test_end_step(3);
+  test_end_step(4);
 }
 
 static const testcase_t rt_test_005_007 = {


### PR DESCRIPTION
## Summary

- diagnose overlapping live thread objects and partially overlapping working areas during thread creation
- keep cross-type overlaps valid, allowing a `thread_t` to reside in another thread's working area
- reject an external thread object overlapping its own stack
- compile the new registry scanner and its tests only when debug assertions are enabled

## Root cause

The existing creation diagnostic compared only the exact working-area base. A reused external thread object or a differently based overlapping working area could therefore bypass the assertion. Treating every TCB-to-working-area overlap as a conflict would also reject valid layouts, so the check must compare only resources of the same type.

## Impact

Assertion-enabled builds now diagnose TCB-to-TCB and working-area-to-working-area reuse before the checked creation paths initialize the object. Assertion-disabled configurations contain no scanner declaration, implementation, call, or symbol and do not depend on linker garbage collection.

## Validation

- default SIMX86_64 RT/OSLIB build and run
- optimized SIMX86_64 RT/OSLIB build and run with system-state checking, parameter checks, and assertions enabled
- registry-disabled optimized simulator build with assertions enabled
- ARMCM4 library build; symbol inspection confirms the scanner is absent when assertions are disabled
- RP2040 ARMv6-M SMP build
- RT style checks, XML validation, generated-header comparison, and `git diff --check`