### PR TITLE
RT: preserve semaphore reset queue order

### DIFF
--- a/os/rt/src/chsem.c
+++ b/os/rt/src/chsem.c
@@ -180,7 +180,7 @@ void chSemResetWithMessageI(semaphore_t *sp, cnt_t n, msg_t msg) {
 
   sp->cnt = n;
   while (ch_queue_notempty(&sp->queue)) {
-    chSchReadyI(threadref(ch_queue_lifo_remove(&sp->queue)))->u.rdymsg = msg;
+    chSchReadyI(threadref(ch_queue_fifo_remove(&sp->queue)))->u.rdymsg = msg;
   }
 }
 

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -2587,12 +2587,10 @@ test_assert_lock(chSemGetCounterI(&sem1) == 2, "wrong counter value");]]></value
             <value>Semaphore enqueuing test.</value>
           </brief>
           <description>
-            <value>Five threads with randomized priorities are enqueued
-              to a semaphore then awakened one at time. The test expects
-              that the threads reach their goal in FIFO order or
-              priority order depending on the @p
-              CH_CFG_USE_SEMAPHORES_PRIORITY configuration setting.
-            </value>
+            <value>Mixed-priority threads are enqueued then awakened one
+              at time to verify signal selection. Equal-priority threads
+              are then released together to verify that reset preserves
+              peer order.</value>
           </description>
           <condition>
             <value />
@@ -2646,6 +2644,26 @@ test_assert_sequence("ADCEB", "invalid sequence");
 #else
 test_assert_sequence("ABCDE", "invalid sequence");
 #endif]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Five equal-priority threads are enqueued then
+                  released using a semaphore reset. The thread
+                  activation sequence is tested.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()+1, thread1, "A");
+threads[1] = chThdCreateStatic(wa[1], WA_SIZE, chThdGetPriorityX()+1, thread1, "B");
+threads[2] = chThdCreateStatic(wa[2], WA_SIZE, chThdGetPriorityX()+1, thread1, "C");
+threads[3] = chThdCreateStatic(wa[3], WA_SIZE, chThdGetPriorityX()+1, thread1, "D");
+threads[4] = chThdCreateStatic(wa[4], WA_SIZE, chThdGetPriorityX()+1, thread1, "E");
+chSemReset(&sem1, 0);
+test_wait_threads();
+test_assert_sequence("ABCDE", "invalid sequence");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_sequence_007.c
+++ b/test/rt/source/test/rt_test_sequence_007.c
@@ -157,10 +157,9 @@ static const testcase_t rt_test_007_001 = {
  * @page rt_test_007_002 [7.2] Semaphore enqueuing test
  *
  * <h2>Description</h2>
- * Five threads with randomized priorities are enqueued to a semaphore
- * then awakened one at time. The test expects that the threads reach
- * their goal in FIFO order or priority order depending on the @p
- * CH_CFG_USE_SEMAPHORES_PRIORITY configuration setting.
+ * Mixed-priority threads are enqueued then awakened one at time to verify
+ * signal selection. Equal-priority threads are then released together to
+ * verify that reset preserves peer order.
  *
  * <h2>Test Steps</h2>
  * - [7.2.1] Five threads are created with mixed priority levels (not
@@ -168,6 +167,8 @@ static const testcase_t rt_test_007_001 = {
  *   initialized to zero.
  * - [7.2.2] The semaphore is signaled 5 times. The thread activation
  *   sequence is tested.
+ * - [7.2.3] Five equal-priority threads are enqueued then released using
+ *   a semaphore reset. The thread activation sequence is tested.
  * .
  */
 
@@ -211,6 +212,21 @@ static void rt_test_007_002_execute(void) {
 #endif
   }
   test_end_step(2);
+
+  /* [7.2.3] Five equal-priority threads are enqueued then released using
+     a semaphore reset. The thread activation sequence is tested.*/
+  test_set_step(3);
+  {
+    threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()+1, thread1, "A");
+    threads[1] = chThdCreateStatic(wa[1], WA_SIZE, chThdGetPriorityX()+1, thread1, "B");
+    threads[2] = chThdCreateStatic(wa[2], WA_SIZE, chThdGetPriorityX()+1, thread1, "C");
+    threads[3] = chThdCreateStatic(wa[3], WA_SIZE, chThdGetPriorityX()+1, thread1, "D");
+    threads[4] = chThdCreateStatic(wa[4], WA_SIZE, chThdGetPriorityX()+1, thread1, "E");
+    chSemReset(&sem1, 0);
+    test_wait_threads();
+    test_assert_sequence("ABCDE", "invalid sequence");
+  }
+  test_end_step(3);
 }
 
 static const testcase_t rt_test_007_002 = {


### PR DESCRIPTION
## Summary

- drain semaphore reset waiters from the FIFO head instead of the LIFO tail
- preserve arrival order among equal-priority waiters in both FIFO and priority-ordered semaphore modes
- extend RT test 7.2 and its XML source with equal-priority reset coverage

## Root cause

`chSemResetWithMessageI()` removed waiters from the tail and then made each thread ready behind its equal-priority peers. A queue containing `A, B, C` was therefore published to the ready list as `C, B, A`. Mixed priorities hid the reversal because the ready list restored priority ordering.

## Impact

Semaphore reset now follows the module's FIFO queuing policy and matches the ordering used by the other RT wake-all paths. Priority-ordered semaphores continue to select higher-priority bands first while retaining arrival order among peers.

## Validation

- default SIMX86_64 RT and OSLIB suites: pass
- `CH_CFG_USE_SEMAPHORES_PRIORITY=TRUE` SIMX86_64 RT and OSLIB suites: pass
- `xmllint --noout test/rt/configuration.xml`: pass
- `git diff --check`: pass