### PR TITLE
RT: publish wake messages before ready tracing

### DIFF
--- a/os/rt/src/chcond.c
+++ b/os/rt/src/chcond.c
@@ -177,6 +177,7 @@ void chCondBroadcast(condition_variable_t *cp) {
  * @iclass
  */
 void chCondBroadcastI(condition_variable_t *cp) {
+  thread_t *tp;
 
   chDbgCheckClassI();
   chDbgCheck(cp != NULL);
@@ -185,7 +186,9 @@ void chCondBroadcastI(condition_variable_t *cp) {
      ready list in FIFO order. The wakeup message is set to @p MSG_RESET in
      order to make a chCondBroadcast() detectable from a chCondSignal().*/
   while (ch_queue_notempty(&cp->queue)) {
-    chSchReadyI(threadref(ch_queue_fifo_remove(&cp->queue)))->u.rdymsg = MSG_RESET;
+    tp = threadref(ch_queue_fifo_remove(&cp->queue));
+    tp->u.rdymsg = MSG_RESET;
+    (void) chSchReadyI(tp);
   }
 }
 

--- a/os/rt/src/chsem.c
+++ b/os/rt/src/chsem.c
@@ -171,6 +171,7 @@ void chSemResetWithMessage(semaphore_t *sp, cnt_t n, msg_t msg) {
  * @iclass
  */
 void chSemResetWithMessageI(semaphore_t *sp, cnt_t n, msg_t msg) {
+  thread_t *tp;
 
   chDbgCheckClassI();
   chDbgCheck((sp != NULL) && (n >= (cnt_t)0));
@@ -180,7 +181,9 @@ void chSemResetWithMessageI(semaphore_t *sp, cnt_t n, msg_t msg) {
 
   sp->cnt = n;
   while (ch_queue_notempty(&sp->queue)) {
-    chSchReadyI(threadref(ch_queue_fifo_remove(&sp->queue)))->u.rdymsg = msg;
+    tp = threadref(ch_queue_fifo_remove(&sp->queue));
+    tp->u.rdymsg = msg;
+    (void) chSchReadyI(tp);
   }
 }
 
@@ -371,6 +374,7 @@ void chSemSignalI(semaphore_t *sp) {
  * @iclass
  */
 void chSemAddCounterI(semaphore_t *sp, cnt_t n) {
+  thread_t *tp;
 
   chDbgCheckClassI();
   chDbgCheck((sp != NULL) && (n > (cnt_t)0));
@@ -380,7 +384,9 @@ void chSemAddCounterI(semaphore_t *sp, cnt_t n) {
 
   while (n > (cnt_t)0) {
     if (++sp->cnt <= (cnt_t)0) {
-      chSchReadyI(threadref(ch_queue_fifo_remove(&sp->queue)))->u.rdymsg = MSG_OK;
+      tp = threadref(ch_queue_fifo_remove(&sp->queue));
+      tp->u.rdymsg = MSG_OK;
+      (void) chSchReadyI(tp);
     }
     n--;
   }
@@ -400,6 +406,7 @@ void chSemAddCounterI(semaphore_t *sp, cnt_t n) {
  * @api
  */
 msg_t chSemSignalWait(semaphore_t *sps, semaphore_t *spw) {
+  thread_t *tp;
   msg_t msg;
 
   chDbgCheck((sps != NULL) && (spw != NULL));
@@ -412,7 +419,9 @@ msg_t chSemSignalWait(semaphore_t *sps, semaphore_t *spw) {
               ((spw->cnt < (cnt_t)0) && ch_queue_notempty(&spw->queue)),
               "inconsistent semaphore");
   if (++sps->cnt <= (cnt_t)0) {
-    chSchReadyI(threadref(ch_queue_fifo_remove(&sps->queue)))->u.rdymsg = MSG_OK;
+    tp = threadref(ch_queue_fifo_remove(&sps->queue));
+    tp->u.rdymsg = MSG_OK;
+    (void) chSchReadyI(tp);
   }
   if (--spw->cnt < (cnt_t)0) {
     thread_t *currtp = chThdGetSelfX();

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -97,7 +97,11 @@ extern void * ROMCONST wa[MAX_THREADS];
 void test_print_port_info(void);
 void test_terminate_threads(void);
 void test_wait_threads(void);
-systime_t test_wait_tick(void);]]></value>
+systime_t test_wait_tick(void);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+bool test_find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp);
+#endif]]></value>
     </global_definitions>
     <global_code>
       <value><![CDATA[/*
@@ -152,7 +156,34 @@ systime_t test_wait_tick(void) {
 
   chThdSleep(1);
   return chVTGetSystemTime();
-}]]></value>
+}
+
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+/*
+ * Searches backward in the trace buffer for a thread ready event.
+ */
+bool test_find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp) {
+  trace_buffer_t *tbp = &currcore->trace_buffer;
+  trace_event_t *tep = tbp->ptr;
+  unsigned i;
+
+  for (i = 0U; i < (unsigned)CH_DBG_TRACE_BUFFER_SIZE; i++) {
+    if (tep == &tbp->buffer[0]) {
+      tep = &tbp->buffer[CH_DBG_TRACE_BUFFER_SIZE];
+    }
+    tep--;
+    if ((tep->type == CH_TRACE_TYPE_READY) &&
+        (tep->state == (uint8_t)state) &&
+        (tep->u.rdy.tp == tp)) {
+      *msgp = tep->u.rdy.msg;
+      return true;
+    }
+  }
+
+  return false;
+}
+#endif]]></value>
     </global_code>
   </global_data_and_code>
   <sequences>
@@ -1239,31 +1270,7 @@ static void setup_thread_descriptor(thread_descriptor_t *tdp,
   tdp->arg   = arg;
   tdp->owner = NULL;
 }
-
-#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
-     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
-static bool find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp) {
-  trace_buffer_t *tbp = &currcore->trace_buffer;
-  trace_event_t *tep = tbp->ptr;
-  unsigned i;
-
-  for (i = 0U; i < (unsigned)CH_DBG_TRACE_BUFFER_SIZE; i++) {
-    if (tep == &tbp->buffer[0]) {
-      tep = &tbp->buffer[CH_DBG_TRACE_BUFFER_SIZE];
-    }
-    tep--;
-    if ((tep->type == CH_TRACE_TYPE_READY) &&
-        (tep->state == (uint8_t)state) &&
-        (tep->u.rdy.tp == tp)) {
-      *msgp = tep->u.rdy.msg;
-      return true;
-    }
-  }
-
-  return false;
-}
-#endif]]></value>
+]]></value>
       </shared_code>
       <cases>
         <case>
@@ -2120,7 +2127,7 @@ chSysLock();
 threads[0] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(0), &td);
 initmsg = threads[0]->u.rdymsg;
 chThdStartI(threads[0]);
-found = find_ready_trace(threads[0], CH_STATE_WTSTART, &tracemsg);
+found = test_find_ready_trace(threads[0], CH_STATE_WTSTART, &tracemsg);
 chSysUnlock();
 test_assert(initmsg == MSG_OK, "ready message not initialized");
 test_assert(found, "ready trace not found");
@@ -2145,7 +2152,7 @@ chThdObjectDispose(TEST_THREAD_OBJECT(0));]]></value>
 TEST_THREAD_OBJECT(1)->u.rdymsg = MSG_RESET;
 chSysLock();
 threads[1] = chThdSpawnRunningI(TEST_THREAD_OBJECT(1), &td);
-found = find_ready_trace(threads[1], CH_STATE_WTSTART, &tracemsg);
+found = test_find_ready_trace(threads[1], CH_STATE_WTSTART, &tracemsg);
 chSysUnlock();
 test_assert(found, "ready trace not found");
 test_assert(tracemsg == MSG_OK, "invalid ready trace message");
@@ -2169,7 +2176,7 @@ chThdObjectDispose(TEST_THREAD_OBJECT(1));]]></value>
 TEST_THREAD_OBJECT(2)->u.rdymsg = MSG_RESET;
 chSysLock();
 threads[2] = chThdCreateI(&td);
-found = find_ready_trace(threads[2], CH_STATE_WTSTART, &tracemsg);
+found = test_find_ready_trace(threads[2], CH_STATE_WTSTART, &tracemsg);
 chSysUnlock();
 test_assert(found, "ready trace not found");
 test_assert(tracemsg == MSG_OK, "invalid ready trace message");
@@ -2193,7 +2200,7 @@ self->u.rdymsg = MSG_RESET;
 (void) chThdWait(threads[3]);
 threads[3] = NULL;
 chSysLock();
-found = find_ready_trace(self, CH_STATE_WTEXIT, &tracemsg);
+found = test_find_ready_trace(self, CH_STATE_WTEXIT, &tracemsg);
 chSysUnlock();
 test_assert(found, "waiter ready trace not found");
 test_assert(tracemsg == MSG_OK, "invalid waiter trace message");
@@ -2372,7 +2379,12 @@ chThdQueueObjectDispose(&tq1);]]></value>
             </teardown_code>
             <local_variables>
               <value><![CDATA[msg_t msg;
-bool empty;]]></value>
+bool empty;
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+msg_t tracemsg;
+bool found;
+#endif]]></value>
             </local_variables>
           </various_code>
           <steps>
@@ -2414,7 +2426,8 @@ test_assert(empty, "queue not empty");]]></value>
             <step>
               <description>
                 <value>One queued thread is resumed using
-                  chThdDequeueNextI().</value>
+                  chThdDequeueNextI() and, when enabled, its ready trace
+                  message is tested.</value>
               </description>
               <tags>
                 <value />
@@ -2427,8 +2440,17 @@ chThdYield();
 chSysLock();
 empty = chThdQueueIsEmptyI(&tq1);
 chThdDequeueNextI(&tq1, MSG_RESET);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+found = test_find_ready_trace(threads[0], CH_STATE_QUEUED, &tracemsg);
+#endif
 chSysUnlock();
 test_assert(!empty, "queue empty");
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_RESET, "invalid ready trace message");
+#endif
 test_wait_threads();
 test_assert(qmsg1 == MSG_RESET, "wrong returned message");
 test_assert_sequence("C", "invalid sequence");]]></value>
@@ -2603,7 +2625,11 @@ test_assert_lock(chSemGetCounterI(&sem1) == 2, "wrong counter value");]]></value
               <value><![CDATA[chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
-              <value />
+              <value><![CDATA[#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+msg_t tracemsg;
+bool found;
+#endif]]></value>
             </local_variables>
           </various_code>
           <steps>
@@ -2626,14 +2652,27 @@ threads[4] = chThdCreateStatic(wa[4], WA_SIZE, chThdGetPriorityX()+2, thread1, "
             </step>
             <step>
               <description>
-                <value>The semaphore is signaled 5 times. The thread
-                  activation sequence is tested.</value>
+                <value>The semaphore is signaled 5 times, first through
+                  the I-class API. The thread activation sequence and,
+                  when enabled, a ready trace message are tested.</value>
               </description>
               <tags>
                 <value />
               </tags>
               <code>
-                <value><![CDATA[chSemSignal(&sem1);
+                <value><![CDATA[chSysLock();
+chSemSignalI(&sem1);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+#endif
+chSchRescheduleS();
+chSysUnlock();
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+#endif
 chSemSignal(&sem1);
 chSemSignal(&sem1);
 chSemSignal(&sem1);
@@ -2649,8 +2688,9 @@ test_assert_sequence("ABCDE", "invalid sequence");
             <step>
               <description>
                 <value>Five equal-priority threads are enqueued then
-                  released using a semaphore reset. The thread
-                  activation sequence is tested.</value>
+                  released using a semaphore reset with a non-default
+                  message. The thread activation sequence and, when
+                  enabled, the ready trace message are tested.</value>
               </description>
               <tags>
                 <value />
@@ -2661,7 +2701,15 @@ threads[1] = chThdCreateStatic(wa[1], WA_SIZE, chThdGetPriorityX()+1, thread1, "
 threads[2] = chThdCreateStatic(wa[2], WA_SIZE, chThdGetPriorityX()+1, thread1, "C");
 threads[3] = chThdCreateStatic(wa[3], WA_SIZE, chThdGetPriorityX()+1, thread1, "D");
 threads[4] = chThdCreateStatic(wa[4], WA_SIZE, chThdGetPriorityX()+1, thread1, "E");
-chSemReset(&sem1, 0);
+chSemResetWithMessage(&sem1, 0, MSG_TIMEOUT);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+chSysLock();
+found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+chSysUnlock();
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_TIMEOUT, "invalid ready trace message");
+#endif
 test_wait_threads();
 test_assert_sequence("ABCDE", "invalid sequence");]]></value>
               </code>
@@ -2771,7 +2819,11 @@ test_assert_time_window(target_time,
               <value><![CDATA[chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
-              <value />
+              <value><![CDATA[#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+msg_t tracemsg;
+bool found;
+#endif]]></value>
             </local_variables>
           </various_code>
           <steps>
@@ -2790,7 +2842,8 @@ test_assert_time_window(target_time,
             <step>
               <description>
                 <value>The semaphore counter is increased by two, it is
-                  then tested to be one, the thread must have completed.
+                  then tested to be one, the thread must have completed
+                  and, when enabled, its ready trace message is tested.
                 </value>
               </description>
               <tags>
@@ -2799,8 +2852,17 @@ test_assert_time_window(target_time,
               <code>
                 <value><![CDATA[chSysLock();
 chSemAddCounterI(&sem1, 2);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+#endif
 chSchRescheduleS();
 chSysUnlock();
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+#endif
 test_wait_threads();
 test_assert_lock(chSemGetCounterI(&sem1) == 1, "invalid counter");
 test_assert_sequence("A", "invalid sequence");]]></value>
@@ -2834,7 +2896,11 @@ test_assert_sequence("A", "invalid sequence");]]></value>
 chSemObjectDispose(&sem1);]]></value>
             </teardown_code>
             <local_variables>
-              <value />
+              <value><![CDATA[#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+msg_t tracemsg;
+bool found;
+#endif]]></value>
             </local_variables>
           </various_code>
           <steps>
@@ -2855,13 +2921,23 @@ chSemObjectDispose(&sem1);]]></value>
               <description>
                 <value>The function chSemSignalWait() is invoked by
                   specifying the same semaphore for the wait and signal
-                  phases. The counter value must be one on exit.</value>
+                  phases. The counter value and, when enabled, the
+                  signaled thread's ready trace message are tested on
+                  exit.</value>
               </description>
               <tags>
                 <value />
               </tags>
               <code>
                 <value><![CDATA[chSemSignalWait(&sem1, &sem1);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+chSysLock();
+found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+chSysUnlock();
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+#endif
 test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
 test_assert(sem1.cnt == 0, "counter not zero");]]></value>
               </code>
@@ -4139,7 +4215,11 @@ chMtxObjectInit(&m1);]]></value>
 chMtxObjectDispose(&m1);]]></value>
             </teardown_code>
             <local_variables>
-              <value />
+              <value><![CDATA[#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+msg_t tracemsg;
+bool found;
+#endif]]></value>
             </local_variables>
           </various_code>
           <steps>
@@ -4165,13 +4245,22 @@ threads[4] = chThdCreateStatic(wa[4], WA_SIZE, prio+5, thread6, "A");]]></value>
               <description>
                 <value>Broarcasting on the condition variable then
                   waiting for the threads to terminate in priority
-                  order, the order is tested.</value>
+                  order, the order and, when enabled, a ready trace
+                  message are tested.</value>
               </description>
               <tags>
                 <value />
               </tags>
               <code>
                 <value><![CDATA[chCondBroadcast(&c1);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+chSysLock();
+found = test_find_ready_trace(threads[0], CH_STATE_WTCOND, &tracemsg);
+chSysUnlock();
+test_assert(found, "ready trace not found");
+test_assert(tracemsg == MSG_RESET, "invalid ready trace message");
+#endif
 test_wait_threads();
 test_assert_sequence("ABCDE", "invalid sequence");]]></value>
               </code>

--- a/test/rt/source/test/rt_test_root.c
+++ b/test/rt/source/test/rt_test_root.c
@@ -149,4 +149,31 @@ systime_t test_wait_tick(void) {
   return chVTGetSystemTime();
 }
 
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+/*
+ * Searches backward in the trace buffer for a thread ready event.
+ */
+bool test_find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp) {
+  trace_buffer_t *tbp = &currcore->trace_buffer;
+  trace_event_t *tep = tbp->ptr;
+  unsigned i;
+
+  for (i = 0U; i < (unsigned)CH_DBG_TRACE_BUFFER_SIZE; i++) {
+    if (tep == &tbp->buffer[0]) {
+      tep = &tbp->buffer[CH_DBG_TRACE_BUFFER_SIZE];
+    }
+    tep--;
+    if ((tep->type == CH_TRACE_TYPE_READY) &&
+        (tep->state == (uint8_t)state) &&
+        (tep->u.rdy.tp == tp)) {
+      *msgp = tep->u.rdy.msg;
+      return true;
+    }
+  }
+
+  return false;
+}
+#endif
+
 #endif /* !defined(__DOXYGEN__) */

--- a/test/rt/source/test/rt_test_root.h
+++ b/test/rt/source/test/rt_test_root.h
@@ -122,6 +122,10 @@ void test_print_port_info(void);
 void test_terminate_threads(void);
 void test_wait_threads(void);
 systime_t test_wait_tick(void);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+bool test_find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp);
+#endif
 
 #endif /* !defined(__DOXYGEN__) */
 

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -86,31 +86,6 @@ static void setup_thread_descriptor(thread_descriptor_t *tdp,
   tdp->owner = NULL;
 }
 
-#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
-     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
-static bool find_ready_trace(thread_t *tp, tstate_t state, msg_t *msgp) {
-  trace_buffer_t *tbp = &currcore->trace_buffer;
-  trace_event_t *tep = tbp->ptr;
-  unsigned i;
-
-  for (i = 0U; i < (unsigned)CH_DBG_TRACE_BUFFER_SIZE; i++) {
-    if (tep == &tbp->buffer[0]) {
-      tep = &tbp->buffer[CH_DBG_TRACE_BUFFER_SIZE];
-    }
-    tep--;
-    if ((tep->type == CH_TRACE_TYPE_READY) &&
-        (tep->state == (uint8_t)state) &&
-        (tep->u.rdy.tp == tp)) {
-      *msgp = tep->u.rdy.msg;
-      return true;
-    }
-  }
-
-  return false;
-}
-#endif
-
 /*===========================================================================*/
 /* Test cases.                                                               */
 /*===========================================================================*/
@@ -913,7 +888,7 @@ static void rt_test_005_009_execute(void) {
     threads[0] = chThdSpawnSuspendedI(TEST_THREAD_OBJECT(0), &td);
     initmsg = threads[0]->u.rdymsg;
     chThdStartI(threads[0]);
-    found = find_ready_trace(threads[0], CH_STATE_WTSTART, &tracemsg);
+    found = test_find_ready_trace(threads[0], CH_STATE_WTSTART, &tracemsg);
     chSysUnlock();
     test_assert(initmsg == MSG_OK, "ready message not initialized");
     test_assert(found, "ready trace not found");
@@ -934,7 +909,7 @@ static void rt_test_005_009_execute(void) {
     TEST_THREAD_OBJECT(1)->u.rdymsg = MSG_RESET;
     chSysLock();
     threads[1] = chThdSpawnRunningI(TEST_THREAD_OBJECT(1), &td);
-    found = find_ready_trace(threads[1], CH_STATE_WTSTART, &tracemsg);
+    found = test_find_ready_trace(threads[1], CH_STATE_WTSTART, &tracemsg);
     chSysUnlock();
     test_assert(found, "ready trace not found");
     test_assert(tracemsg == MSG_OK, "invalid ready trace message");
@@ -954,7 +929,7 @@ static void rt_test_005_009_execute(void) {
     TEST_THREAD_OBJECT(2)->u.rdymsg = MSG_RESET;
     chSysLock();
     threads[2] = chThdCreateI(&td);
-    found = find_ready_trace(threads[2], CH_STATE_WTSTART, &tracemsg);
+    found = test_find_ready_trace(threads[2], CH_STATE_WTSTART, &tracemsg);
     chSysUnlock();
     test_assert(found, "ready trace not found");
     test_assert(tracemsg == MSG_OK, "invalid ready trace message");
@@ -974,7 +949,7 @@ static void rt_test_005_009_execute(void) {
     (void) chThdWait(threads[3]);
     threads[3] = NULL;
     chSysLock();
-    found = find_ready_trace(self, CH_STATE_WTEXIT, &tracemsg);
+    found = test_find_ready_trace(self, CH_STATE_WTEXIT, &tracemsg);
     chSysUnlock();
     test_assert(found, "waiter ready trace not found");
     test_assert(tracemsg == MSG_OK, "invalid waiter trace message");

--- a/test/rt/source/test/rt_test_sequence_006.c
+++ b/test/rt/source/test/rt_test_sequence_006.c
@@ -181,7 +181,8 @@ static const testcase_t rt_test_006_001 = {
  * - [6.2.1] A threads queue is initialized, tested as empty, then
  *   touched with empty dequeue operations.
  * - [6.2.2] Immediate timeout enqueue is tested on an empty queue.
- * - [6.2.3] One queued thread is resumed using chThdDequeueNextI().
+ * - [6.2.3] One queued thread is resumed using chThdDequeueNextI() and,
+ *   when enabled, its ready trace message is tested.
  * - [6.2.4] Two queued threads are resumed using chThdDequeueAllI().
  * .
  */
@@ -200,6 +201,11 @@ static void rt_test_006_002_teardown(void) {
 static void rt_test_006_002_execute(void) {
   msg_t msg;
   bool empty;
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+  msg_t tracemsg;
+  bool found;
+#endif
 
   /* [6.2.1] A threads queue is initialized, tested as empty, then
      touched with empty dequeue operations.*/
@@ -226,7 +232,8 @@ static void rt_test_006_002_execute(void) {
   }
   test_end_step(2);
 
-  /* [6.2.3] One queued thread is resumed using chThdDequeueNextI().*/
+  /* [6.2.3] One queued thread is resumed using chThdDequeueNextI() and,
+     when enabled, its ready trace message is tested.*/
   test_set_step(3);
   {
     qmsg1 = MSG_OK;
@@ -236,8 +243,17 @@ static void rt_test_006_002_execute(void) {
     chSysLock();
     empty = chThdQueueIsEmptyI(&tq1);
     chThdDequeueNextI(&tq1, MSG_RESET);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    found = test_find_ready_trace(threads[0], CH_STATE_QUEUED, &tracemsg);
+#endif
     chSysUnlock();
     test_assert(!empty, "queue empty");
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_RESET, "invalid ready trace message");
+#endif
     test_wait_threads();
     test_assert(qmsg1 == MSG_RESET, "wrong returned message");
     test_assert_sequence("C", "invalid sequence");

--- a/test/rt/source/test/rt_test_sequence_007.c
+++ b/test/rt/source/test/rt_test_sequence_007.c
@@ -165,10 +165,12 @@ static const testcase_t rt_test_007_001 = {
  * - [7.2.1] Five threads are created with mixed priority levels (not
  *   increasing nor decreasing). Threads enqueue on a semaphore
  *   initialized to zero.
- * - [7.2.2] The semaphore is signaled 5 times. The thread activation
- *   sequence is tested.
+ * - [7.2.2] The semaphore is signaled 5 times, first through the I-class
+ *   API. The thread activation sequence and, when enabled, a ready trace
+ *   message are tested.
  * - [7.2.3] Five equal-priority threads are enqueued then released using
- *   a semaphore reset. The thread activation sequence is tested.
+ *   a semaphore reset with a non-default message. The thread activation
+ *   sequence and, when enabled, the ready trace message are tested.
  * .
  */
 
@@ -181,6 +183,11 @@ static void rt_test_007_002_teardown(void) {
 }
 
 static void rt_test_007_002_execute(void) {
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+  msg_t tracemsg;
+  bool found;
+#endif
 
   /* [7.2.1] Five threads are created with mixed priority levels (not
      increasing nor decreasing). Threads enqueue on a semaphore
@@ -195,11 +202,24 @@ static void rt_test_007_002_execute(void) {
   }
   test_end_step(1);
 
-  /* [7.2.2] The semaphore is signaled 5 times. The thread activation
-     sequence is tested.*/
+  /* [7.2.2] The semaphore is signaled 5 times, first through the I-class
+     API. The thread activation sequence and, when enabled, a ready trace
+     message are tested.*/
   test_set_step(2);
   {
-    chSemSignal(&sem1);
+    chSysLock();
+    chSemSignalI(&sem1);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+#endif
+    chSchRescheduleS();
+    chSysUnlock();
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+#endif
     chSemSignal(&sem1);
     chSemSignal(&sem1);
     chSemSignal(&sem1);
@@ -214,7 +234,8 @@ static void rt_test_007_002_execute(void) {
   test_end_step(2);
 
   /* [7.2.3] Five equal-priority threads are enqueued then released using
-     a semaphore reset. The thread activation sequence is tested.*/
+     a semaphore reset with a non-default message. The thread activation
+     sequence and, when enabled, the ready trace message are tested.*/
   test_set_step(3);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()+1, thread1, "A");
@@ -222,7 +243,15 @@ static void rt_test_007_002_execute(void) {
     threads[2] = chThdCreateStatic(wa[2], WA_SIZE, chThdGetPriorityX()+1, thread1, "C");
     threads[3] = chThdCreateStatic(wa[3], WA_SIZE, chThdGetPriorityX()+1, thread1, "D");
     threads[4] = chThdCreateStatic(wa[4], WA_SIZE, chThdGetPriorityX()+1, thread1, "E");
-    chSemReset(&sem1, 0);
+    chSemResetWithMessage(&sem1, 0, MSG_TIMEOUT);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    chSysLock();
+    found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+    chSysUnlock();
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_TIMEOUT, "invalid ready trace message");
+#endif
     test_wait_threads();
     test_assert_sequence("ABCDE", "invalid sequence");
   }
@@ -325,7 +354,8 @@ static const testcase_t rt_test_007_003 = {
  * <h2>Test Steps</h2>
  * - [7.4.1] A thread is created, it goes to wait on the semaphore.
  * - [7.4.2] The semaphore counter is increased by two, it is then
- *   tested to be one, the thread must have completed.
+ *   tested to be one, the thread must have completed and, when enabled,
+ *   its ready trace message is tested.
  * .
  */
 
@@ -338,6 +368,11 @@ static void rt_test_007_004_teardown(void) {
 }
 
 static void rt_test_007_004_execute(void) {
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+  msg_t tracemsg;
+  bool found;
+#endif
 
   /* [7.4.1] A thread is created, it goes to wait on the semaphore.*/
   test_set_step(1);
@@ -347,13 +382,23 @@ static void rt_test_007_004_execute(void) {
   test_end_step(1);
 
   /* [7.4.2] The semaphore counter is increased by two, it is then
-     tested to be one, the thread must have completed.*/
+     tested to be one, the thread must have completed and, when enabled,
+     its ready trace message is tested.*/
   test_set_step(2);
   {
     chSysLock();
     chSemAddCounterI(&sem1, 2);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+#endif
     chSchRescheduleS();
     chSysUnlock();
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+#endif
     test_wait_threads();
     test_assert_lock(chSemGetCounterI(&sem1) == 1, "invalid counter");
     test_assert_sequence("A", "invalid sequence");
@@ -384,7 +429,8 @@ static const testcase_t rt_test_007_004 = {
  *   non-atomical wait and signal operations on a semaphore.
  * - [7.5.2] The function chSemSignalWait() is invoked by specifying
  *   the same semaphore for the wait and signal phases. The counter
- *   value must be one on exit.
+ *   value and, when enabled, the signaled thread's ready trace message
+ *   are tested on exit.
  * - [7.5.3] The function chSemSignalWait() is invoked again by
  *   specifying the same semaphore for the wait and signal phases. The
  *   counter value must be one on exit.
@@ -401,6 +447,11 @@ static void rt_test_007_005_teardown(void) {
 }
 
 static void rt_test_007_005_execute(void) {
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+  msg_t tracemsg;
+  bool found;
+#endif
 
   /* [7.5.1] An higher priority thread is created that performs
      non-atomical wait and signal operations on a semaphore.*/
@@ -412,10 +463,19 @@ static void rt_test_007_005_execute(void) {
 
   /* [7.5.2] The function chSemSignalWait() is invoked by specifying
      the same semaphore for the wait and signal phases. The counter
-     value must be one on exit.*/
+     value and, when enabled, the signaled thread's ready trace message
+     are tested on exit.*/
   test_set_step(2);
   {
     chSemSignalWait(&sem1, &sem1);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    chSysLock();
+    found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
+    chSysUnlock();
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_OK, "invalid ready trace message");
+#endif
     test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
     test_assert(sem1.cnt == 0, "counter not zero");
   }

--- a/test/rt/source/test/rt_test_sequence_008.c
+++ b/test/rt/source/test/rt_test_sequence_008.c
@@ -1138,7 +1138,8 @@ static const testcase_t rt_test_008_008 = {
  * - [8.9.1] Starting the five threads with increasing priority, the
  *   threads will queue on the condition variable.
  * - [8.9.2] Broarcasting on the condition variable then waiting for
- *   the threads to terminate in priority order, the order is tested.
+ *   the threads to terminate in priority order, the order and, when
+ *   enabled, a ready trace message are tested.
  * .
  */
 
@@ -1153,6 +1154,11 @@ static void rt_test_008_009_teardown(void) {
 }
 
 static void rt_test_008_009_execute(void) {
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+  msg_t tracemsg;
+  bool found;
+#endif
 
   /* [8.9.1] Starting the five threads with increasing priority, the
      threads will queue on the condition variable.*/
@@ -1168,10 +1174,19 @@ static void rt_test_008_009_execute(void) {
   test_end_step(1);
 
   /* [8.9.2] Broarcasting on the condition variable then waiting for
-     the threads to terminate in priority order, the order is tested.*/
+     the threads to terminate in priority order, the order and, when
+     enabled, a ready trace message are tested.*/
   test_set_step(2);
   {
     chCondBroadcast(&c1);
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+    chSysLock();
+    found = test_find_ready_trace(threads[0], CH_STATE_WTCOND, &tracemsg);
+    chSysUnlock();
+    test_assert(found, "ready trace not found");
+    test_assert(tracemsg == MSG_RESET, "invalid ready trace message");
+#endif
     test_wait_threads();
     test_assert_sequence("ABCDE", "invalid sequence");
   }


### PR DESCRIPTION
## Summary

- publish semaphore and condition-variable wake messages before making waiters ready
- share the ready-trace lookup helper across RT test sequences
- verify ready-event messages for semaphore signal-I, add-counter, reset-with-message, signal/wait, generic thread queues, and condition-variable broadcast

## Root cause

Several wake paths assigned `thread_t.u.rdymsg` through the pointer returned by `chSchReadyI()`. Ready tracing happens inside `chSchReadyI()`, before that assignment, while the thread union still contains its semaphore or condition-variable wait-object pointer. The trace therefore recorded stale pointer-derived data instead of the wake result, although the eventual wait return value remained correct.

The affected paths now extract the waiter, store its wake message, and only then call `chSchReadyI()`.

## Validation

- RT and OSLIB simulator suites with the default configuration
- RT and OSLIB simulator suites with full tracing and priority-ordered semaphore queues
- `xmllint --noout test/rt/configuration.xml`
- `git diff --check`
