### PR TITLE
STM32U5: add I2C5 and I2C6 support

### DIFF
--- a/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/mcuconf.h
+++ b/demos/STM32/RT-STM32-MULTI/cfg/stm32u5a5zj_nucleo144/mcuconf.h
@@ -260,6 +260,8 @@
 #define STM32_IRQ_I2C2_PRIORITY             5
 #define STM32_IRQ_I2C3_PRIORITY             5
 #define STM32_IRQ_I2C4_PRIORITY             5
+#define STM32_IRQ_I2C5_PRIORITY             5
+#define STM32_IRQ_I2C6_PRIORITY             5
 
 #define STM32_IRQ_SPI1_PRIORITY             10
 #define STM32_IRQ_SPI2_PRIORITY             10
@@ -348,16 +350,22 @@
 #define STM32_I2C_USE_I2C2                  FALSE
 #define STM32_I2C_USE_I2C3                  FALSE
 #define STM32_I2C_USE_I2C4                  FALSE
+#define STM32_I2C_USE_I2C5                  FALSE
+#define STM32_I2C_USE_I2C6                  FALSE
 #define STM32_I2C_BUSY_TIMEOUT              50
 #define STM32_I2C_USE_DMA                   TRUE
 #define STM32_I2C_I2C1_DMA_PRIORITY         1
 #define STM32_I2C_I2C2_DMA_PRIORITY         1
 #define STM32_I2C_I2C3_DMA_PRIORITY         1
 #define STM32_I2C_I2C4_DMA_PRIORITY         1
+#define STM32_I2C_I2C5_DMA_PRIORITY         1
+#define STM32_I2C_I2C6_DMA_PRIORITY         1
 #define STM32_I2C_I2C1_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
 #define STM32_I2C_I2C2_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
 #define STM32_I2C_I2C3_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
 #define STM32_I2C_I2C4_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_I2C_I2C5_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
+#define STM32_I2C_I2C6_DMA3_CHANNEL         STM32_DMA3_MASK_FIFO2
 #define STM32_I2C_DMA_ERROR_HOOK(i2cp)      osalSysHalt("DMA failure")
 
 /*

--- a/os/hal/ports/STM32/LLD/I2C/stm32_i2c5.inc
+++ b/os/hal/ports/STM32/LLD/I2C/stm32_i2c5.inc
@@ -1,0 +1,158 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    I2Cv4/stm32_i2c5.inc
+ * @brief   Shared I2C5 handler.
+ *
+ * @addtogroup STM32_I2C5_HANDLER
+ * @{
+ */
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness.*/
+#if !defined(STM32_HAS_I2C5)
+#error "STM32_HAS_I2C5 not defined in registry"
+#endif
+
+#if STM32_HAS_I2C5
+
+/* Checks on vector names and numbers definitions.*/
+#if STM32_I2C_SINGLE_IRQ == TRUE
+#if !defined(STM32_I2C5_GLOBAL_NUMBER)
+#error "STM32_I2C5_GLOBAL_NUMBER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C5_GLOBAL_HANDLER)
+#error "STM32_I2C5_GLOBAL_HANDLER not defined in stm32_isr.h"
+#endif
+
+#else
+#if !defined(STM32_I2C5_EV_HANDLER)
+#error "STM32_I2C5_EV_HANDLER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C5_ER_HANDLER)
+#error "STM32_I2C5_ER_HANDLER not defined in stm32_isr.h"
+#endif
+#endif
+
+/* Checks for mcuconf.h correctness.*/
+#if !defined(STM32_IRQ_I2C5_PRIORITY)
+#error "STM32_IRQ_I2C5_PRIORITY not defined in mcuconf.h"
+#endif
+
+#if !defined(STM32_I2C_USE_I2C5)
+#error "STM32_I2C_USE_I2C5 not defined in mcuconf.h"
+#endif
+
+/* Priority settings checks.*/
+#if !OSAL_IRQ_IS_VALID_PRIORITY(STM32_IRQ_I2C5_PRIORITY)
+#error "Invalid IRQ priority assigned to STM32_IRQ_I2C5_PRIORITY"
+#endif
+
+#endif /* STM32_HAS_I2C5 */
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static inline void i2c5_irq_init(void) {
+#if defined(STM32_I2C5_IS_USED)
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+  nvicEnableVector(STM32_I2C5_GLOBAL_NUMBER, STM32_IRQ_I2C5_PRIORITY);
+#else
+  nvicEnableVector(STM32_I2C5_EV_NUMBER, STM32_IRQ_I2C5_PRIORITY);
+  nvicEnableVector(STM32_I2C5_ER_NUMBER, STM32_IRQ_I2C5_PRIORITY);
+#endif
+#endif
+}
+
+static inline void i2c5_irq_deinit(void) {
+#if defined(STM32_I2C5_IS_USED)
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+  nvicDisableVector(STM32_I2C5_GLOBAL_NUMBER);
+#else
+  nvicDisableVector(STM32_I2C5_EV_NUMBER);
+  nvicDisableVector(STM32_I2C5_ER_NUMBER);
+#endif
+#endif
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if defined(STM32_I2C5_IS_USED) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C5 interrupt handler.
+ *
+ * @isr
+ */
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C5 event interrupt handler.
+ *
+ * @notapi
+ */
+OSAL_IRQ_HANDLER(STM32_I2C5_GLOBAL_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  i2c_lld_serve_global_interrupt(&I2CD5);
+
+  OSAL_IRQ_EPILOGUE();
+}
+
+#else
+OSAL_IRQ_HANDLER(STM32_I2C5_EV_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  i2c_lld_serve_ev_interrupt(&I2CD5);
+
+  OSAL_IRQ_EPILOGUE();
+}
+
+OSAL_IRQ_HANDLER(STM32_I2C5_ER_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  i2c_lld_serve_er_interrupt(&I2CD5);
+
+  OSAL_IRQ_EPILOGUE();
+}
+#endif
+#endif /* defined(STM32_I2C5_IS_USED) */
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/** @} */

--- a/os/hal/ports/STM32/LLD/I2C/stm32_i2c6.inc
+++ b/os/hal/ports/STM32/LLD/I2C/stm32_i2c6.inc
@@ -1,0 +1,158 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    I2Cv4/stm32_i2c6.inc
+ * @brief   Shared I2C6 handler.
+ *
+ * @addtogroup STM32_I2C6_HANDLER
+ * @{
+ */
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness.*/
+#if !defined(STM32_HAS_I2C6)
+#error "STM32_HAS_I2C6 not defined in registry"
+#endif
+
+#if STM32_HAS_I2C6
+
+/* Checks on vector names and numbers definitions.*/
+#if STM32_I2C_SINGLE_IRQ == TRUE
+#if !defined(STM32_I2C6_GLOBAL_NUMBER)
+#error "STM32_I2C6_GLOBAL_NUMBER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C6_GLOBAL_HANDLER)
+#error "STM32_I2C6_GLOBAL_HANDLER not defined in stm32_isr.h"
+#endif
+
+#else
+#if !defined(STM32_I2C6_EV_HANDLER)
+#error "STM32_I2C6_EV_HANDLER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C6_ER_HANDLER)
+#error "STM32_I2C6_ER_HANDLER not defined in stm32_isr.h"
+#endif
+#endif
+
+/* Checks for mcuconf.h correctness.*/
+#if !defined(STM32_IRQ_I2C6_PRIORITY)
+#error "STM32_IRQ_I2C6_PRIORITY not defined in mcuconf.h"
+#endif
+
+#if !defined(STM32_I2C_USE_I2C6)
+#error "STM32_I2C_USE_I2C6 not defined in mcuconf.h"
+#endif
+
+/* Priority settings checks.*/
+#if !OSAL_IRQ_IS_VALID_PRIORITY(STM32_IRQ_I2C6_PRIORITY)
+#error "Invalid IRQ priority assigned to STM32_IRQ_I2C6_PRIORITY"
+#endif
+
+#endif /* STM32_HAS_I2C6 */
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static inline void i2c6_irq_init(void) {
+#if defined(STM32_I2C6_IS_USED)
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+  nvicEnableVector(STM32_I2C6_GLOBAL_NUMBER, STM32_IRQ_I2C6_PRIORITY);
+#else
+  nvicEnableVector(STM32_I2C6_EV_NUMBER, STM32_IRQ_I2C6_PRIORITY);
+  nvicEnableVector(STM32_I2C6_ER_NUMBER, STM32_IRQ_I2C6_PRIORITY);
+#endif
+#endif
+}
+
+static inline void i2c6_irq_deinit(void) {
+#if defined(STM32_I2C6_IS_USED)
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+  nvicDisableVector(STM32_I2C6_GLOBAL_NUMBER);
+#else
+  nvicDisableVector(STM32_I2C6_EV_NUMBER);
+  nvicDisableVector(STM32_I2C6_ER_NUMBER);
+#endif
+#endif
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if defined(STM32_I2C6_IS_USED) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C6 interrupt handler.
+ *
+ * @isr
+ */
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C6 event interrupt handler.
+ *
+ * @notapi
+ */
+OSAL_IRQ_HANDLER(STM32_I2C6_GLOBAL_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  i2c_lld_serve_global_interrupt(&I2CD6);
+
+  OSAL_IRQ_EPILOGUE();
+}
+
+#else
+OSAL_IRQ_HANDLER(STM32_I2C6_EV_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  i2c_lld_serve_ev_interrupt(&I2CD6);
+
+  OSAL_IRQ_EPILOGUE();
+}
+
+OSAL_IRQ_HANDLER(STM32_I2C6_ER_HANDLER) {
+
+  OSAL_IRQ_PROLOGUE();
+
+  i2c_lld_serve_er_interrupt(&I2CD6);
+
+  OSAL_IRQ_EPILOGUE();
+}
+#endif
+#endif /* defined(STM32_I2C6_IS_USED) */
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/** @} */

--- a/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
+++ b/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
@@ -36,6 +36,8 @@
 #define STM32_I2C_I2C2_DMA_CHANNEL          STM32_I2C_I2C2_DMA3_CHANNEL
 #define STM32_I2C_I2C3_DMA_CHANNEL          STM32_I2C_I2C3_DMA3_CHANNEL
 #define STM32_I2C_I2C4_DMA_CHANNEL          STM32_I2C_I2C4_DMA3_CHANNEL
+#define STM32_I2C_I2C5_DMA_CHANNEL          STM32_I2C_I2C5_DMA3_CHANNEL
+#define STM32_I2C_I2C6_DMA_CHANNEL          STM32_I2C_I2C6_DMA3_CHANNEL
 #endif
 
 /* Common GPDMA CR settings.*/
@@ -106,6 +108,16 @@ I2CDriver I2CD3;
 /** @brief I2C4 driver identifier.*/
 #if STM32_I2C_USE_I2C4 || defined(__DOXYGEN__)
 I2CDriver I2CD4;
+#endif
+
+/** @brief I2C5 driver identifier.*/
+#if STM32_I2C_USE_I2C5 || defined(__DOXYGEN__)
+I2CDriver I2CD5;
+#endif
+
+/** @brief I2C6 driver identifier.*/
+#if STM32_I2C_USE_I2C6 || defined(__DOXYGEN__)
+I2CDriver I2CD6;
 #endif
 
 /*===========================================================================*/
@@ -652,6 +664,40 @@ void i2c_lld_init(void) {
 #endif
 #endif /* STM32_I2C_USE_DMA == TRUE */
 #endif /* STM32_I2C_USE_I2C4 */
+
+#if STM32_I2C_USE_I2C5
+  i2cObjectInit(&I2CD5);
+  I2CD5.thread = NULL;
+  I2CD5.i2c    = I2C5;
+#if STM32_I2C_USE_DMA == TRUE
+  I2CD5.dma    = NULL;
+  I2CD5.dprio  = STM32_I2C_I2C5_DMA_PRIORITY;
+#if defined(STM32_DMA3_PRESENT)
+  I2CD5.dreqtx = STM32_DMA3_REQ_I2C5_TX;
+  I2CD5.dreqrx = STM32_DMA3_REQ_I2C5_RX;
+#else /* Assuming old DMAs.*/
+  I2CD5.dreqtx = STM32_DMAMUX1_I2C5_TX;
+  I2CD5.dreqrx = STM32_DMAMUX1_I2C5_RX;
+#endif
+#endif /* STM32_I2C_USE_DMA == TRUE */
+#endif /* STM32_I2C_USE_I2C5 */
+
+#if STM32_I2C_USE_I2C6
+  i2cObjectInit(&I2CD6);
+  I2CD6.thread = NULL;
+  I2CD6.i2c    = I2C6;
+#if STM32_I2C_USE_DMA == TRUE
+  I2CD6.dma    = NULL;
+  I2CD6.dprio  = STM32_I2C_I2C6_DMA_PRIORITY;
+#if defined(STM32_DMA3_PRESENT)
+  I2CD6.dreqtx = STM32_DMA3_REQ_I2C6_TX;
+  I2CD6.dreqrx = STM32_DMA3_REQ_I2C6_RX;
+#else /* Assuming old DMAs.*/
+  I2CD6.dreqtx = STM32_DMAMUX1_I2C6_TX;
+  I2CD6.dreqrx = STM32_DMAMUX1_I2C6_RX;
+#endif
+#endif /* STM32_I2C_USE_DMA == TRUE */
+#endif /* STM32_I2C_USE_I2C6 */
 }
 
 /**
@@ -731,6 +777,36 @@ msg_t i2c_lld_start(I2CDriver *i2cp) {
 #endif
     }
 #endif /* STM32_I2C_USE_I2C4 */
+
+#if STM32_I2C_USE_I2C5
+    if (&I2CD5 == i2cp) {
+
+      rccResetI2C5();
+      rccEnableI2C5(true);
+
+#if STM32_I2C_USE_DMA == TRUE
+      i2c_dma_alloc(i2cp, STM32_I2C_I2C5_DMA_CHANNEL, STM32_IRQ_I2C5_PRIORITY);
+      if (i2cp->dma == NULL) {
+        return HAL_RET_NO_RESOURCE;
+      }
+#endif
+    }
+#endif /* STM32_I2C_USE_I2C5 */
+
+#if STM32_I2C_USE_I2C6
+    if (&I2CD6 == i2cp) {
+
+      rccResetI2C6();
+      rccEnableI2C6(true);
+
+#if STM32_I2C_USE_DMA == TRUE
+      i2c_dma_alloc(i2cp, STM32_I2C_I2C6_DMA_CHANNEL, STM32_IRQ_I2C6_PRIORITY);
+      if (i2cp->dma == NULL) {
+        return HAL_RET_NO_RESOURCE;
+      }
+#endif
+    }
+#endif /* STM32_I2C_USE_I2C6 */
   }
 
   /* Reset i2c peripheral, the TCIE bit will be handled separately.*/
@@ -792,6 +868,20 @@ void i2c_lld_stop(I2CDriver *i2cp) {
     if (&I2CD4 == i2cp) {
 
       rccDisableI2C4();
+    }
+#endif
+
+#if STM32_I2C_USE_I2C5
+    if (&I2CD5 == i2cp) {
+
+      rccDisableI2C5();
+    }
+#endif
+
+#if STM32_I2C_USE_I2C6
+    if (&I2CD6 == i2cp) {
+
+      rccDisableI2C6();
     }
 #endif
   }

--- a/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.h
+++ b/os/hal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.h
@@ -106,6 +106,24 @@
 #endif
 
 /**
+ * @brief   I2C5 driver enable switch.
+ * @details If set to @p TRUE the support for I2C5 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(STM32_I2C_USE_I2C5) || defined(__DOXYGEN__)
+#define STM32_I2C_USE_I2C5                  FALSE
+#endif
+
+/**
+ * @brief   I2C6 driver enable switch.
+ * @details If set to @p TRUE the support for I2C6 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(STM32_I2C_USE_I2C6) || defined(__DOXYGEN__)
+#define STM32_I2C_USE_I2C6                  FALSE
+#endif
+
+/**
  * @brief   I2C timeout on busy condition in milliseconds.
  */
 #if !defined(STM32_I2C_BUSY_TIMEOUT) || defined(__DOXYGEN__)
@@ -148,6 +166,20 @@
 #endif
 
 /**
+ * @brief   I2C5 DMA priority (0..3|lowest..highest).
+ */
+#if !defined(STM32_I2C_I2C5_DMA_PRIORITY) || defined(__DOXYGEN__)
+#define STM32_I2C_I2C5_DMA_PRIORITY         1
+#endif
+
+/**
+ * @brief   I2C6 DMA priority (0..3|lowest..highest).
+ */
+#if !defined(STM32_I2C_I2C6_DMA_PRIORITY) || defined(__DOXYGEN__)
+#define STM32_I2C_I2C6_DMA_PRIORITY         1
+#endif
+
+/**
  * @brief   I2C DMA error hook.
  * @note    The default action for DMA errors is a system halt because DMA
  *          error can only happen because programming errors.
@@ -161,7 +193,15 @@
 /* Derived constants and error checks.                                       */
 /*===========================================================================*/
 
-/* Registry checks.*/
+/* Registry checks. Older registries predate the optional I2C5/I2C6
+   instances, missing definitions mean that the instances are not present.*/
+#if !defined(STM32_HAS_I2C5)
+#define STM32_HAS_I2C5                      FALSE
+#endif
+#if !defined(STM32_HAS_I2C6)
+#define STM32_HAS_I2C6                      FALSE
+#endif
+
 #if !defined(STM32_HAS_I2C1) || !defined(STM32_HAS_I2C2) ||                 \
     !defined(STM32_HAS_I2C3) || !defined(STM32_HAS_I2C4)
 #error "STM32_HAS_I2Cx not defined in registry"
@@ -184,8 +224,16 @@
 #error "I2C4 not present in the selected device"
 #endif
 
+#if STM32_I2C_USE_I2C5 && !STM32_HAS_I2C5
+#error "I2C5 not present in the selected device"
+#endif
+
+#if STM32_I2C_USE_I2C6 && !STM32_HAS_I2C6
+#error "I2C6 not present in the selected device"
+#endif
+
 #if !STM32_I2C_USE_I2C1 && !STM32_I2C_USE_I2C2 && !STM32_I2C_USE_I2C3 &&    \
-    !STM32_I2C_USE_I2C4
+    !STM32_I2C_USE_I2C4 && !STM32_I2C_USE_I2C5 && !STM32_I2C_USE_I2C6
 #error "I2C driver activated but no I2C peripheral assigned"
 #endif
 
@@ -221,6 +269,22 @@
 #endif
 #endif
 
+#if STM32_I2C_USE_I2C5
+#if defined(STM32_I2C5_IS_USED)
+#error "I2CD5 requires I2C5 but it is already used"
+#else
+#define STM32_I2C5_IS_USED
+#endif
+#endif
+
+#if STM32_I2C_USE_I2C6
+#if defined(STM32_I2C6_IS_USED)
+#error "I2CD6 requires I2C6 but it is already used"
+#else
+#define STM32_I2C6_IS_USED
+#endif
+#endif
+
 /* IRQ-related checks.*/
 #if !defined(STM32_I2C_SINGLE_IRQ)
 #error "STM32_I2C_SINGLE_IRQ not defined in registry"
@@ -251,6 +315,14 @@
 #error "I2C4 GPDMA channels not defined"
 #endif
 
+#if STM32_I2C_USE_I2C5 && (!defined(STM32_I2C_I2C5_DMA3_CHANNEL))
+#error "I2C5 GPDMA channels not defined"
+#endif
+
+#if STM32_I2C_USE_I2C6 && (!defined(STM32_I2C_I2C6_DMA3_CHANNEL))
+#error "I2C6 GPDMA channels not defined"
+#endif
+
 /* Check on DMA channels assignment.*/
 #if STM32_I2C_USE_I2C1 &&                                                   \
     !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C1_DMA3_CHANNEL)
@@ -270,6 +342,16 @@
 #if STM32_I2C_USE_I2C4 &&                                                   \
     !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C4_DMA3_CHANNEL)
 #error "Invalid GPDMA channel assigned to I2C4"
+#endif
+
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C5_DMA3_CHANNEL)
+#error "Invalid GPDMA channel assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C6_DMA3_CHANNEL)
+#error "Invalid GPDMA channel assigned to I2C6"
 #endif
 
 #if STM32_I2C_USE_I2C1 &&                                                   \
@@ -292,8 +374,18 @@
 #error "Invalid GPDMA priority assigned to I2C4"
 #endif
 
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA3_IS_VALID_PRIORITY(STM32_I2C_I2C5_DMA_PRIORITY)
+#error "Invalid GPDMA priority assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA3_IS_VALID_PRIORITY(STM32_I2C_I2C6_DMA_PRIORITY)
+#error "Invalid GPDMA priority assigned to I2C6"
+#endif
+
 #if STM32_I2C_USE_I2C1 || STM32_I2C_USE_I2C2 || STM32_I2C_USE_I2C3 ||       \
-    STM32_I2C_USE_I2C4
+    STM32_I2C_USE_I2C4 || STM32_I2C_USE_I2C5 || STM32_I2C_USE_I2C6
 #if !defined(STM32_DMA3_REQUIRED)
 #define STM32_DMA3_REQUIRED
 #endif
@@ -316,6 +408,14 @@
 
 #if STM32_I2C_USE_I2C4 && !defined(STM32_I2C_I2C4_DMA_CHANNEL)
 #error "I2C4 DMA channel not defined"
+#endif
+
+#if STM32_I2C_USE_I2C5 && !defined(STM32_I2C_I2C5_DMA_CHANNEL)
+#error "I2C5 DMA channel not defined"
+#endif
+
+#if STM32_I2C_USE_I2C6 && !defined(STM32_I2C_I2C6_DMA_CHANNEL)
+#error "I2C6 DMA channel not defined"
 #endif
 
 /* Check on DMA channel assignment.*/
@@ -342,6 +442,16 @@
 #error "Invalid DMA channel assigned to I2C4"
 #endif
 
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA_IS_VALID_STREAM(STM32_I2C_I2C5_DMA_CHANNEL)
+#error "Invalid DMA channel assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA_IS_VALID_STREAM(STM32_I2C_I2C6_DMA_CHANNEL)
+#error "Invalid DMA channel assigned to I2C6"
+#endif
+
 #if STM32_I2C_USE_I2C1 &&                                                   \
     !STM32_DMA_IS_VALID_PRIORITY(STM32_I2C_I2C1_DMA_PRIORITY)
 #error "Invalid DMA priority assigned to I2C1"
@@ -362,8 +472,18 @@
 #error "Invalid DMA priority assigned to I2C4"
 #endif
 
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA_IS_VALID_PRIORITY(STM32_I2C_I2C5_DMA_PRIORITY)
+#error "Invalid DMA priority assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA_IS_VALID_PRIORITY(STM32_I2C_I2C6_DMA_PRIORITY)
+#error "Invalid DMA priority assigned to I2C6"
+#endif
+
 #if STM32_I2C_USE_I2C1 || STM32_I2C_USE_I2C2 || STM32_I2C_USE_I2C3 ||       \
-    STM32_I2C_USE_I2C4
+    STM32_I2C_USE_I2C4 || STM32_I2C_USE_I2C5 || STM32_I2C_USE_I2C6
 #if !defined(STM32_DMA_REQUIRED)
 #define STM32_DMA_REQUIRED
 #endif
@@ -558,6 +678,14 @@ extern I2CDriver I2CD3;
 
 #if STM32_I2C_USE_I2C4
 extern I2CDriver I2CD4;
+#endif
+
+#if STM32_I2C_USE_I2C5
+extern I2CDriver I2CD5;
+#endif
+
+#if STM32_I2C_USE_I2C6
+extern I2CDriver I2CD6;
 #endif
 
 #endif /* !defined(__DOXYGEN__) */

--- a/os/hal/ports/STM32/STM32U5xx/stm32_isr.c
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_isr.c
@@ -76,6 +76,8 @@
 #include "stm32_i2c2.inc"
 #include "stm32_i2c3.inc"
 #include "stm32_i2c4.inc"
+#include "stm32_i2c5.inc"
+#include "stm32_i2c6.inc"
 
 #include "stm32_spi1.inc"
 #include "stm32_spi2.inc"
@@ -144,6 +146,8 @@ void irqInit(void) {
   i2c2_irq_init();
   i2c3_irq_init();
   i2c4_irq_init();
+  i2c5_irq_init();
+  i2c6_irq_init();
 
   spi1_irq_init();
   spi2_irq_init();
@@ -209,6 +213,8 @@ void irqDeinit(void) {
   i2c2_irq_deinit();
   i2c3_irq_deinit();
   i2c4_irq_deinit();
+  i2c5_irq_deinit();
+  i2c6_irq_deinit();
 
   spi1_irq_deinit();
   spi2_irq_deinit();

--- a/os/hal/ports/STM32/STM32U5xx/stm32_rcc.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_rcc.h
@@ -467,6 +467,14 @@
 #define rccEnableI2C4(lp) rccEnableAPB1R2(RCC_APB1ENR2_I2C4EN, lp)
 #define rccDisableI2C4() rccDisableAPB1R2(RCC_APB1ENR2_I2C4EN)
 #define rccResetI2C4() rccResetAPB1R2(RCC_APB1RSTR2_I2C4RST)
+
+#define rccEnableI2C5(lp) rccEnableAPB1R2(RCC_APB1ENR2_I2C5EN, lp)
+#define rccDisableI2C5() rccDisableAPB1R2(RCC_APB1ENR2_I2C5EN)
+#define rccResetI2C5() rccResetAPB1R2(RCC_APB1RSTR2_I2C5RST)
+
+#define rccEnableI2C6(lp) rccEnableAPB1R2(RCC_APB1ENR2_I2C6EN, lp)
+#define rccDisableI2C6() rccDisableAPB1R2(RCC_APB1ENR2_I2C6EN)
+#define rccResetI2C6() rccResetAPB1R2(RCC_APB1RSTR2_I2C6RST)
 /** @} */
 
 /**

--- a/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_registry.h
@@ -181,12 +181,22 @@
 #define STM32_DMA3_REQ_LPTIM3_IC2           112U
 #define STM32_DMA3_REQ_LPTIM3_UE            113U
 #define STM32_DMA3_REQ_RESERVED114          114U
+#if defined(STM32U595xx) || defined(STM32U599xx) || defined(STM32U5A5xx) || \
+    defined(STM32U5A9xx) || defined(__DOXYGEN__)
+#define STM32_DMA3_REQ_I2C5_RX              115U
+#define STM32_DMA3_REQ_I2C5_TX              116U
+#define STM32_DMA3_REQ_I2C5_EVC             117U
+#define STM32_DMA3_REQ_I2C6_RX              118U
+#define STM32_DMA3_REQ_I2C6_TX              119U
+#define STM32_DMA3_REQ_I2C6_EVC             120U
+#else
 #define STM32_DMA3_REQ_RESERVED115          115U
 #define STM32_DMA3_REQ_RESERVED116          116U
 #define STM32_DMA3_REQ_RESERVED117          117U
 #define STM32_DMA3_REQ_RESERVED118          118U
 #define STM32_DMA3_REQ_RESERVED119          119U
 #define STM32_DMA3_REQ_RESERVED120          120U
+#endif
 #define STM32_DMA3_REQ_RESERVED121          121U
 #define STM32_DMA3_REQ_RESERVED122          122U
 #if defined(STM32U595xx) || defined(STM32U599xx) || defined(STM32U5A5xx) || \

--- a/os/xhal/ports/STM32/LLD/I2C/stm32_i2c6.inc
+++ b/os/xhal/ports/STM32/LLD/I2C/stm32_i2c6.inc
@@ -1,0 +1,164 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    I2C/stm32_i2c6.inc
+ * @brief   Shared I2C6 handler.
+ *
+ * @addtogroup STM32_I2C6_HANDLER
+ * @{
+ */
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness.*/
+#if !defined(STM32_HAS_I2C6)
+#error "STM32_HAS_I2C6 not defined in registry"
+#endif
+
+#if STM32_HAS_I2C6
+
+/* Checks on vector names and numbers definitions.*/
+#if STM32_I2C_SINGLE_IRQ == TRUE
+#if !defined(STM32_I2C6_GLOBAL_NUMBER)
+#error "STM32_I2C6_GLOBAL_NUMBER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C6_GLOBAL_HANDLER)
+#error "STM32_I2C6_GLOBAL_HANDLER not defined in stm32_isr.h"
+#endif
+
+#else
+#if !defined(STM32_I2C6_EV_HANDLER)
+#error "STM32_I2C6_EV_HANDLER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C6_EV_NUMBER)
+#error "STM32_I2C6_EV_NUMBER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C6_ER_HANDLER)
+#error "STM32_I2C6_ER_HANDLER not defined in stm32_isr.h"
+#endif
+#if !defined(STM32_I2C6_ER_NUMBER)
+#error "STM32_I2C6_ER_NUMBER not defined in stm32_isr.h"
+#endif
+#endif
+
+/* Checks for mcuconf.h correctness.*/
+#if !defined(STM32_IRQ_I2C6_PRIORITY)
+#error "STM32_IRQ_I2C6_PRIORITY not defined in mcuconf.h"
+#endif
+
+#if !defined(STM32_I2C_USE_I2C6)
+#error "STM32_I2C_USE_I2C6 not defined in mcuconf.h"
+#endif
+
+/* Priority settings checks.*/
+#if !CH_IRQ_IS_VALID_PRIORITY(STM32_IRQ_I2C6_PRIORITY)
+#error "Invalid IRQ priority assigned to STM32_IRQ_I2C6_PRIORITY"
+#endif
+
+#endif /* STM32_HAS_I2C6 */
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static inline void i2c6_irq_init(void) {
+#if defined(STM32_I2C6_IS_USED)
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+  nvicEnableVector(STM32_I2C6_GLOBAL_NUMBER, STM32_IRQ_I2C6_PRIORITY);
+#else
+  nvicEnableVector(STM32_I2C6_EV_NUMBER, STM32_IRQ_I2C6_PRIORITY);
+  nvicEnableVector(STM32_I2C6_ER_NUMBER, STM32_IRQ_I2C6_PRIORITY);
+#endif
+#endif
+}
+
+static inline void i2c6_irq_deinit(void) {
+#if defined(STM32_I2C6_IS_USED)
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+  nvicDisableVector(STM32_I2C6_GLOBAL_NUMBER);
+#else
+  nvicDisableVector(STM32_I2C6_EV_NUMBER);
+  nvicDisableVector(STM32_I2C6_ER_NUMBER);
+#endif
+#endif
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if defined(STM32_I2C6_IS_USED) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C6 interrupt handler.
+ *
+ * @isr
+ */
+#if (STM32_I2C_SINGLE_IRQ == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C6 event interrupt handler.
+ *
+ * @notapi
+ */
+CH_IRQ_HANDLER(STM32_I2C6_GLOBAL_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  i2c_lld_serve_global_interrupt(&I2CD6);
+
+  CH_IRQ_EPILOGUE();
+}
+
+#else
+CH_IRQ_HANDLER(STM32_I2C6_EV_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  i2c_lld_serve_ev_interrupt(&I2CD6);
+
+  CH_IRQ_EPILOGUE();
+}
+
+CH_IRQ_HANDLER(STM32_I2C6_ER_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  i2c_lld_serve_er_interrupt(&I2CD6);
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+#endif /* defined(STM32_I2C6_IS_USED) */
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/** @} */

--- a/os/xhal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
+++ b/os/xhal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.c
@@ -36,6 +36,8 @@
 #define STM32_I2C_I2C2_DMA_CHANNEL          STM32_I2C_I2C2_DMA3_CHANNEL
 #define STM32_I2C_I2C3_DMA_CHANNEL          STM32_I2C_I2C3_DMA3_CHANNEL
 #define STM32_I2C_I2C4_DMA_CHANNEL          STM32_I2C_I2C4_DMA3_CHANNEL
+#define STM32_I2C_I2C5_DMA_CHANNEL          STM32_I2C_I2C5_DMA3_CHANNEL
+#define STM32_I2C_I2C6_DMA_CHANNEL          STM32_I2C_I2C6_DMA3_CHANNEL
 #endif
 
 /* Common GPDMA CR settings.*/
@@ -106,6 +108,16 @@ hal_i2c_driver_c I2CD3;
 /** @brief I2C4 driver identifier.*/
 #if STM32_I2C_USE_I2C4 || defined(__DOXYGEN__)
 hal_i2c_driver_c I2CD4;
+#endif
+
+/** @brief I2C5 driver identifier.*/
+#if STM32_I2C_USE_I2C5 || defined(__DOXYGEN__)
+hal_i2c_driver_c I2CD5;
+#endif
+
+/** @brief I2C6 driver identifier.*/
+#if STM32_I2C_USE_I2C6 || defined(__DOXYGEN__)
+hal_i2c_driver_c I2CD6;
 #endif
 
 /*===========================================================================*/
@@ -558,6 +570,38 @@ void i2c_lld_init(void) {
 #endif
 #endif /* STM32_I2C_USE_DMA == TRUE */
 #endif /* STM32_I2C_USE_I2C4 */
+
+#if STM32_I2C_USE_I2C5
+  i2cObjectInit(&I2CD5);
+  I2CD5.i2c    = I2C5;
+#if STM32_I2C_USE_DMA == TRUE
+  I2CD5.dma    = NULL;
+  I2CD5.dprio  = STM32_I2C_I2C5_DMA_PRIORITY;
+#if defined(STM32_DMA3_PRESENT)
+  I2CD5.dreqtx = STM32_DMA3_REQ_I2C5_TX;
+  I2CD5.dreqrx = STM32_DMA3_REQ_I2C5_RX;
+#else /* Assuming old DMAs.*/
+  I2CD5.dreqtx = STM32_DMAMUX1_I2C5_TX;
+  I2CD5.dreqrx = STM32_DMAMUX1_I2C5_RX;
+#endif
+#endif /* STM32_I2C_USE_DMA == TRUE */
+#endif /* STM32_I2C_USE_I2C5 */
+
+#if STM32_I2C_USE_I2C6
+  i2cObjectInit(&I2CD6);
+  I2CD6.i2c    = I2C6;
+#if STM32_I2C_USE_DMA == TRUE
+  I2CD6.dma    = NULL;
+  I2CD6.dprio  = STM32_I2C_I2C6_DMA_PRIORITY;
+#if defined(STM32_DMA3_PRESENT)
+  I2CD6.dreqtx = STM32_DMA3_REQ_I2C6_TX;
+  I2CD6.dreqrx = STM32_DMA3_REQ_I2C6_RX;
+#else /* Assuming old DMAs.*/
+  I2CD6.dreqtx = STM32_DMAMUX1_I2C6_TX;
+  I2CD6.dreqrx = STM32_DMAMUX1_I2C6_RX;
+#endif
+#endif /* STM32_I2C_USE_DMA == TRUE */
+#endif /* STM32_I2C_USE_I2C6 */
 }
 
 /**
@@ -646,6 +690,36 @@ msg_t i2c_lld_start(hal_i2c_driver_c *i2cp) {
 #endif
     }
 #endif /* STM32_I2C_USE_I2C4 */
+
+#if STM32_I2C_USE_I2C5
+    if (&I2CD5 == i2cp) {
+
+      rccResetI2C5();
+      rccEnableI2C5(true);
+
+#if STM32_I2C_USE_DMA == TRUE
+      i2c_dma_alloc(i2cp, STM32_I2C_I2C5_DMA_CHANNEL, STM32_IRQ_I2C5_PRIORITY);
+      if (i2cp->dma == NULL) {
+        return HAL_RET_NO_RESOURCE;
+      }
+#endif
+    }
+#endif /* STM32_I2C_USE_I2C5 */
+
+#if STM32_I2C_USE_I2C6
+    if (&I2CD6 == i2cp) {
+
+      rccResetI2C6();
+      rccEnableI2C6(true);
+
+#if STM32_I2C_USE_DMA == TRUE
+      i2c_dma_alloc(i2cp, STM32_I2C_I2C6_DMA_CHANNEL, STM32_IRQ_I2C6_PRIORITY);
+      if (i2cp->dma == NULL) {
+        return HAL_RET_NO_RESOURCE;
+      }
+#endif
+    }
+#endif /* STM32_I2C_USE_I2C6 */
   }
 
   /* Reset i2c peripheral, the TCIE bit will be handled separately.*/
@@ -707,6 +781,20 @@ void i2c_lld_stop(hal_i2c_driver_c *i2cp) {
     if (&I2CD4 == i2cp) {
 
       rccDisableI2C4();
+    }
+#endif
+
+#if STM32_I2C_USE_I2C5
+    if (&I2CD5 == i2cp) {
+
+      rccDisableI2C5();
+    }
+#endif
+
+#if STM32_I2C_USE_I2C6
+    if (&I2CD6 == i2cp) {
+
+      rccDisableI2C6();
     }
 #endif
   }

--- a/os/xhal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.h
+++ b/os/xhal/ports/STM32/LLD/I2Cv4/hal_i2c_lld.h
@@ -101,6 +101,24 @@
 #endif
 
 /**
+ * @brief   I2C5 driver enable switch.
+ * @details If set to @p TRUE the support for I2C5 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(STM32_I2C_USE_I2C5) || defined(__DOXYGEN__)
+#define STM32_I2C_USE_I2C5                  FALSE
+#endif
+
+/**
+ * @brief   I2C6 driver enable switch.
+ * @details If set to @p TRUE the support for I2C6 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(STM32_I2C_USE_I2C6) || defined(__DOXYGEN__)
+#define STM32_I2C_USE_I2C6                  FALSE
+#endif
+
+/**
  * @brief   DMA use switch.
  */
 #if !defined(STM32_I2C_USE_DMA) || defined(__DOXYGEN__)
@@ -136,6 +154,20 @@
 #endif
 
 /**
+ * @brief   I2C5 DMA priority (0..3|lowest..highest).
+ */
+#if !defined(STM32_I2C_I2C5_DMA_PRIORITY) || defined(__DOXYGEN__)
+#define STM32_I2C_I2C5_DMA_PRIORITY         1
+#endif
+
+/**
+ * @brief   I2C6 DMA priority (0..3|lowest..highest).
+ */
+#if !defined(STM32_I2C_I2C6_DMA_PRIORITY) || defined(__DOXYGEN__)
+#define STM32_I2C_I2C6_DMA_PRIORITY         1
+#endif
+
+/**
  * @brief   I2C DMA error hook.
  * @note    The default action for DMA errors is a system halt because DMA
  *          error can only happen because programming errors.
@@ -150,7 +182,15 @@
 /* Derived constants and error checks.                                       */
 /*===========================================================================*/
 
-/* Registry checks.*/
+/* Registry checks. Older registries predate the optional I2C5/I2C6
+   instances, missing definitions mean that the instances are not present.*/
+#if !defined(STM32_HAS_I2C5)
+#define STM32_HAS_I2C5                      FALSE
+#endif
+#if !defined(STM32_HAS_I2C6)
+#define STM32_HAS_I2C6                      FALSE
+#endif
+
 #if !defined(STM32_HAS_I2C1) || !defined(STM32_HAS_I2C2) ||                 \
     !defined(STM32_HAS_I2C3) || !defined(STM32_HAS_I2C4)
 #error "STM32_HAS_I2Cx not defined in registry"
@@ -173,8 +213,16 @@
 #error "I2C4 not present in the selected device"
 #endif
 
+#if STM32_I2C_USE_I2C5 && !STM32_HAS_I2C5
+#error "I2C5 not present in the selected device"
+#endif
+
+#if STM32_I2C_USE_I2C6 && !STM32_HAS_I2C6
+#error "I2C6 not present in the selected device"
+#endif
+
 #if !STM32_I2C_USE_I2C1 && !STM32_I2C_USE_I2C2 && !STM32_I2C_USE_I2C3 &&    \
-    !STM32_I2C_USE_I2C4
+    !STM32_I2C_USE_I2C4 && !STM32_I2C_USE_I2C5 && !STM32_I2C_USE_I2C6
 #error "I2C driver activated but no I2C peripheral assigned"
 #endif
 
@@ -207,6 +255,22 @@
 #error "I2CD4 requires I2C4 but it is already used"
 #else
 #define STM32_I2C4_IS_USED
+#endif
+#endif
+
+#if STM32_I2C_USE_I2C5
+#if defined(STM32_I2C5_IS_USED)
+#error "I2CD5 requires I2C5 but it is already used"
+#else
+#define STM32_I2C5_IS_USED
+#endif
+#endif
+
+#if STM32_I2C_USE_I2C6
+#if defined(STM32_I2C6_IS_USED)
+#error "I2CD6 requires I2C6 but it is already used"
+#else
+#define STM32_I2C6_IS_USED
 #endif
 #endif
 
@@ -244,6 +308,14 @@
 #error "I2C4 GPDMA channels not defined"
 #endif
 
+#if STM32_I2C_USE_I2C5 && (!defined(STM32_I2C_I2C5_DMA3_CHANNEL))
+#error "I2C5 GPDMA channels not defined"
+#endif
+
+#if STM32_I2C_USE_I2C6 && (!defined(STM32_I2C_I2C6_DMA3_CHANNEL))
+#error "I2C6 GPDMA channels not defined"
+#endif
+
 /* Check on DMA channels assignment.*/
 #if STM32_I2C_USE_I2C1 &&                                                   \
     !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C1_DMA3_CHANNEL)
@@ -263,6 +335,16 @@
 #if STM32_I2C_USE_I2C4 &&                                                   \
     !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C4_DMA3_CHANNEL)
 #error "Invalid GPDMA channel assigned to I2C4"
+#endif
+
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C5_DMA3_CHANNEL)
+#error "Invalid GPDMA channel assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA3_ARE_VALID_CHANNELS(STM32_I2C_I2C6_DMA3_CHANNEL)
+#error "Invalid GPDMA channel assigned to I2C6"
 #endif
 
 #if STM32_I2C_USE_I2C1 &&                                                   \
@@ -285,8 +367,18 @@
 #error "Invalid GPDMA priority assigned to I2C4"
 #endif
 
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA3_IS_VALID_PRIORITY(STM32_I2C_I2C5_DMA_PRIORITY)
+#error "Invalid GPDMA priority assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA3_IS_VALID_PRIORITY(STM32_I2C_I2C6_DMA_PRIORITY)
+#error "Invalid GPDMA priority assigned to I2C6"
+#endif
+
 #if STM32_I2C_USE_I2C1 || STM32_I2C_USE_I2C2 || STM32_I2C_USE_I2C3 ||       \
-    STM32_I2C_USE_I2C4
+    STM32_I2C_USE_I2C4 || STM32_I2C_USE_I2C5 || STM32_I2C_USE_I2C6
 #if !defined(STM32_DMA3_REQUIRED)
 #define STM32_DMA3_REQUIRED
 #endif
@@ -309,6 +401,14 @@
 
 #if STM32_I2C_USE_I2C4 && !defined(STM32_I2C_I2C4_DMA_CHANNEL)
 #error "I2C4 DMA channel not defined"
+#endif
+
+#if STM32_I2C_USE_I2C5 && !defined(STM32_I2C_I2C5_DMA_CHANNEL)
+#error "I2C5 DMA channel not defined"
+#endif
+
+#if STM32_I2C_USE_I2C6 && !defined(STM32_I2C_I2C6_DMA_CHANNEL)
+#error "I2C6 DMA channel not defined"
 #endif
 
 /* Check on DMA channel assignment.*/
@@ -335,6 +435,16 @@
 #error "Invalid DMA channel assigned to I2C4"
 #endif
 
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA_IS_VALID_STREAM(STM32_I2C_I2C5_DMA_CHANNEL)
+#error "Invalid DMA channel assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA_IS_VALID_STREAM(STM32_I2C_I2C6_DMA_CHANNEL)
+#error "Invalid DMA channel assigned to I2C6"
+#endif
+
 #if STM32_I2C_USE_I2C1 &&                                                   \
     !STM32_DMA_IS_VALID_PRIORITY(STM32_I2C_I2C1_DMA_PRIORITY)
 #error "Invalid DMA priority assigned to I2C1"
@@ -355,8 +465,18 @@
 #error "Invalid DMA priority assigned to I2C4"
 #endif
 
+#if STM32_I2C_USE_I2C5 &&                                                   \
+    !STM32_DMA_IS_VALID_PRIORITY(STM32_I2C_I2C5_DMA_PRIORITY)
+#error "Invalid DMA priority assigned to I2C5"
+#endif
+
+#if STM32_I2C_USE_I2C6 &&                                                   \
+    !STM32_DMA_IS_VALID_PRIORITY(STM32_I2C_I2C6_DMA_PRIORITY)
+#error "Invalid DMA priority assigned to I2C6"
+#endif
+
 #if STM32_I2C_USE_I2C1 || STM32_I2C_USE_I2C2 || STM32_I2C_USE_I2C3 ||       \
-    STM32_I2C_USE_I2C4
+    STM32_I2C_USE_I2C4 || STM32_I2C_USE_I2C5 || STM32_I2C_USE_I2C6
 #if !defined(STM32_DMA_REQUIRED)
 #define STM32_DMA_REQUIRED
 #endif
@@ -476,6 +596,14 @@ extern hal_i2c_driver_c I2CD3;
 
 #if STM32_I2C_USE_I2C4
 extern hal_i2c_driver_c I2CD4;
+#endif
+
+#if STM32_I2C_USE_I2C5
+extern hal_i2c_driver_c I2CD5;
+#endif
+
+#if STM32_I2C_USE_I2C6
+extern hal_i2c_driver_c I2CD6;
 #endif
 
 #endif /* !defined(__DOXYGEN__) */

--- a/os/xhal/ports/STM32/STM32U5xx/stm32_isr.c
+++ b/os/xhal/ports/STM32/STM32U5xx/stm32_isr.c
@@ -78,6 +78,8 @@
 #include "stm32_i2c2.inc"
 #include "stm32_i2c3.inc"
 #include "stm32_i2c4.inc"
+#include "stm32_i2c5.inc"
+#include "stm32_i2c6.inc"
 
 #include "stm32_spi1.inc"
 #include "stm32_spi2.inc"
@@ -144,6 +146,8 @@ void irqInit(void) {
   i2c2_irq_init();
   i2c3_irq_init();
   i2c4_irq_init();
+  i2c5_irq_init();
+  i2c6_irq_init();
 
   spi1_irq_init();
   spi2_irq_init();
@@ -208,6 +212,8 @@ void irqDeinit(void) {
   i2c2_irq_deinit();
   i2c3_irq_deinit();
   i2c4_irq_deinit();
+  i2c5_irq_deinit();
+  i2c6_irq_deinit();
 
   spi1_irq_deinit();
   spi2_irq_deinit();

--- a/os/xhal/ports/STM32/STM32U5xx/stm32_rcc.h
+++ b/os/xhal/ports/STM32/STM32U5xx/stm32_rcc.h
@@ -467,6 +467,14 @@
 #define rccEnableI2C4(lp) rccEnableAPB1R2(RCC_APB1ENR2_I2C4EN, lp)
 #define rccDisableI2C4() rccDisableAPB1R2(RCC_APB1ENR2_I2C4EN)
 #define rccResetI2C4() rccResetAPB1R2(RCC_APB1RSTR2_I2C4RST)
+
+#define rccEnableI2C5(lp) rccEnableAPB1R2(RCC_APB1ENR2_I2C5EN, lp)
+#define rccDisableI2C5() rccDisableAPB1R2(RCC_APB1ENR2_I2C5EN)
+#define rccResetI2C5() rccResetAPB1R2(RCC_APB1RSTR2_I2C5RST)
+
+#define rccEnableI2C6(lp) rccEnableAPB1R2(RCC_APB1ENR2_I2C6EN, lp)
+#define rccDisableI2C6() rccDisableAPB1R2(RCC_APB1ENR2_I2C6EN)
+#define rccResetI2C6() rccResetAPB1R2(RCC_APB1RSTR2_I2C6RST)
 /** @} */
 
 /**

--- a/os/xhal/ports/STM32/STM32U5xx/stm32_registry.h
+++ b/os/xhal/ports/STM32/STM32U5xx/stm32_registry.h
@@ -181,12 +181,22 @@
 #define STM32_DMA3_REQ_LPTIM3_IC2           112U
 #define STM32_DMA3_REQ_LPTIM3_UE            113U
 #define STM32_DMA3_REQ_RESERVED114          114U
+#if defined(STM32U595xx) || defined(STM32U599xx) || defined(STM32U5A5xx) || \
+    defined(STM32U5A9xx) || defined(__DOXYGEN__)
+#define STM32_DMA3_REQ_I2C5_RX              115U
+#define STM32_DMA3_REQ_I2C5_TX              116U
+#define STM32_DMA3_REQ_I2C5_EVC             117U
+#define STM32_DMA3_REQ_I2C6_RX              118U
+#define STM32_DMA3_REQ_I2C6_TX              119U
+#define STM32_DMA3_REQ_I2C6_EVC             120U
+#else
 #define STM32_DMA3_REQ_RESERVED115          115U
 #define STM32_DMA3_REQ_RESERVED116          116U
 #define STM32_DMA3_REQ_RESERVED117          117U
 #define STM32_DMA3_REQ_RESERVED118          118U
 #define STM32_DMA3_REQ_RESERVED119          119U
 #define STM32_DMA3_REQ_RESERVED120          120U
+#endif
 #define STM32_DMA3_REQ_RESERVED121          121U
 #define STM32_DMA3_REQ_RESERVED122          122U
 #if defined(STM32U595xx) || defined(STM32U599xx) || defined(STM32U5A5xx) || \

--- a/tools/ftl/processors/conf/xmcuconf_stm32u595xx/xmcuconf.h.ftl
+++ b/tools/ftl/processors/conf/xmcuconf_stm32u595xx/xmcuconf.h.ftl
@@ -19,20 +19,20 @@
 [@pp.dropOutputFile /]
 [#import "/@lib/libutils.ftl" as utils /]
 [#import "/@lib/liblicense.ftl" as license /]
-[@pp.changeOutputFile name="mcuconf.h" /]
+[@pp.changeOutputFile name="xmcuconf.h" /]
 /*
 [@license.EmitLicenseAsText /]
 */
 
-#ifndef MCUCONF_H
-#define MCUCONF_H
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
 
 /*
  * STM32U5xx drivers configuration.
  * The following settings override the default settings present in
  * the various device driver implementation headers.
  * Note that the settings for each driver only have effect if the whole
- * driver is enabled in halconf.h.
+ * driver is enabled in xhalconf.h.
  *
  * IRQ priorities:
  * 15...0       Lowest...Highest.
@@ -41,11 +41,11 @@
  * 0...3        Lowest...Highest.
  */
 
-#define STM32U5xx_MCUCONF
-#define STM32U595_MCUCONF
-#define STM32U599_MCUCONF
-#define STM32U5A5_MCUCONF
-#define STM32U5A9_MCUCONF
+#define STM32U5xx_XMCUCONF
+#define STM32U595_XMCUCONF
+#define STM32U599_XMCUCONF
+#define STM32U5A5_XMCUCONF
+#define STM32U5A9_XMCUCONF
 
 /*
  * HAL driver general settings.
@@ -273,6 +273,8 @@
 #define STM32_IRQ_I2C5_PRIORITY             ${doc.STM32_IRQ_I2C5_PRIORITY!"5"}
 #define STM32_IRQ_I2C6_PRIORITY             ${doc.STM32_IRQ_I2C6_PRIORITY!"5"}
 
+#define STM32_IRQ_ADC1_2_PRIORITY           ${doc.STM32_IRQ_ADC1_2_PRIORITY!"5"}
+
 #define STM32_IRQ_SPI1_PRIORITY             ${doc.STM32_IRQ_SPI1_PRIORITY!"10"}
 #define STM32_IRQ_SPI2_PRIORITY             ${doc.STM32_IRQ_SPI2_PRIORITY!"10"}
 #define STM32_IRQ_SPI3_PRIORITY             ${doc.STM32_IRQ_SPI3_PRIORITY!"10"}
@@ -316,9 +318,6 @@
 #define STM32_ADC_ADC2_DMA3_CHANNEL         ${doc.STM32_ADC_ADC2_DMA3_CHANNEL!"STM32_DMA3_MASK_FIFO2"}
 #define STM32_ADC_ADC1_DMA_PRIORITY         ${doc.STM32_ADC_ADC1_DMA_PRIORITY!"2"}
 #define STM32_ADC_ADC2_DMA_PRIORITY         ${doc.STM32_ADC_ADC2_DMA_PRIORITY!"2"}
-#define STM32_ADC_ADC12_IRQ_PRIORITY        ${doc.STM32_ADC_ADC12_IRQ_PRIORITY!"5"}
-#define STM32_ADC_ADC1_DMA_IRQ_PRIORITY     ${doc.STM32_ADC_ADC1_DMA_IRQ_PRIORITY!"5"}
-#define STM32_ADC_ADC2_DMA_IRQ_PRIORITY     ${doc.STM32_ADC_ADC2_DMA_IRQ_PRIORITY!"5"}
 #define STM32_ADC_ADC12_PRESC               ${doc.STM32_ADC_ADC12_PRESC!"ADC_CCR_PRESC_DIV4"}
 
 /*
@@ -376,7 +375,7 @@
 #define STM32_I2C_I2C4_DMA3_CHANNEL         ${doc.STM32_I2C_I2C4_DMA3_CHANNEL!"STM32_DMA3_MASK_FIFO2"}
 #define STM32_I2C_I2C5_DMA3_CHANNEL         ${doc.STM32_I2C_I2C5_DMA3_CHANNEL!"STM32_DMA3_MASK_FIFO2"}
 #define STM32_I2C_I2C6_DMA3_CHANNEL         ${doc.STM32_I2C_I2C6_DMA3_CHANNEL!"STM32_DMA3_MASK_FIFO2"}
-#define STM32_I2C_DMA_ERROR_HOOK(i2cp)      ${doc.STM32_I2C_DMA_ERROR_HOOK!"osalSysHalt(\"DMA failure\")"}
+#define STM32_I2C_DMA_ERROR_HOOK(i2cp)      ${doc.STM32_I2C_DMA_ERROR_HOOK!"chSysHalt(\"DMA failure\")"}
 
 /*
  * ICU driver system settings.
@@ -485,7 +484,7 @@
 #define STM32_SPI_SPI1_DMA_PRIORITY         ${doc.STM32_SPI_SPI1_DMA_PRIORITY!"1"}
 #define STM32_SPI_SPI2_DMA_PRIORITY         ${doc.STM32_SPI_SPI2_DMA_PRIORITY!"1"}
 #define STM32_SPI_SPI3_DMA_PRIORITY         ${doc.STM32_SPI_SPI3_DMA_PRIORITY!"1"}
-#define STM32_SPI_DMA_ERROR_HOOK(spip)      ${doc.STM32_SPI_DMA_ERROR_HOOK!"osalSysHalt(\"DMA failure\")"}
+#define STM32_SPI_DMA_ERROR_HOOK(spip)      ${doc.STM32_SPI_DMA_ERROR_HOOK!"chSysHalt(\"DMA failure\")"}
 
 /*
  * ST driver system settings.
@@ -522,7 +521,7 @@
 #define STM32_UART_UART4_DMA_PRIORITY       ${doc.STM32_UART_UART4_DMA_PRIORITY!"0"}
 #define STM32_UART_UART5_DMA_PRIORITY       ${doc.STM32_UART_UART5_DMA_PRIORITY!"0"}
 #define STM32_UART_USART6_DMA_PRIORITY      ${doc.STM32_UART_USART6_DMA_PRIORITY!"0"}
-#define STM32_UART_DMA_ERROR_HOOK(uartp)    ${doc.STM32_UART_DMA_ERROR_HOOK!"osalSysHalt(\"DMA failure\")"}
+#define STM32_UART_DMA_ERROR_HOOK(uartp)    ${doc.STM32_UART_DMA_ERROR_HOOK!"chSysHalt(\"DMA failure\")"}
 
 /*
  * USB driver system settings.
@@ -543,4 +542,4 @@
 #define STM32_WSPI_USE_OCTOSPI1             ${doc.STM32_WSPI_USE_OCTOSPI1!"FALSE"}
 #define STM32_WSPI_USE_OCTOSPI2             ${doc.STM32_WSPI_USE_OCTOSPI2!"FALSE"}
 
-#endif /* MCUCONF_H */
+#endif /* XMCUCONF_H */

--- a/tools/updater/update_xmcuconf_stm32u595xx.sh
+++ b/tools/updater/update_xmcuconf_stm32u595xx.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+if [ $# -eq 2 ]
+  then
+  if [ $1 = "rootpath" ]
+  then
+    find $2 -name "xmcuconf.h" -exec bash update_xmcuconf_stm32u595xx.sh "{}" \;
+  else
+    echo "Usage: update_xmcuconf_stm32u595xx.sh [rootpath <root path>]"
+  fi
+elif [ $# -eq 1 ]
+then
+  declare conffile=$(<$1)
+  if egrep -q "STM32U595_XMCUCONF" <<< "$conffile" || \
+     egrep -q "STM32U599_XMCUCONF" <<< "$conffile" || \
+     egrep -q "STM32U5A5_XMCUCONF" <<< "$conffile" || \
+     egrep -q "STM32U5A9_XMCUCONF" <<< "$conffile"
+  then
+    echo Processing: $1
+    egrep -e "\#define\s+[a-zA-Z0-9_()]*\s+[^\s]" <<< "$conffile" | sed -r 's/\#define\s+([a-zA-Z0-9_]*)(\([^)]*\))?\s+/\1=/g' > ./values.txt
+    if ! fmpp -q -C conf.fmpp -S ../ftl/processors/conf/xmcuconf_stm32u595xx
+    then
+      echo
+      echo "aborted"
+      exit 1
+    fi
+    cp ./xmcuconf.h $1
+    rm ./xmcuconf.h ./values.txt
+  fi
+else
+ echo "Usage: update_xmcuconf_stm32u595xx.sh [rootpath <root path>]"
+ echo "       update_xmcuconf_stm32u595xx.sh <configuration file>]"
+fi


### PR DESCRIPTION
## Summary

- add STM32U5 I2C5 and I2C6 low-level driver instances
- add the required IRQ, RCC, and registry definitions in HAL and XHAL
- add configuration defaults for STM32U595/U599/U5A5/U5A9
- add the missing STM32U595-class XHAL configuration template and updater
- regenerate the affected STM32U5A5 demo configuration

## Why

The supported STM32U5 devices expose I2C5 and I2C6, but the ChibiOS U5 port did not provide the complete driver, interrupt, clock-control, registry, and generated-configuration plumbing needed to enable them.

## Impact

Applications targeting STM32U595, STM32U599, STM32U5A5, or STM32U5A9 can enable I2C5 and I2C6 through the normal HAL or XHAL configuration paths.

## Validation

- legacy HAL STM32U5A5 build with I2C5 and I2C6 enabled
- XHAL STM32U5A5 build with I2C5 and I2C6 enabled
- legacy and XHAL STM32U595-class configuration updaters run sequentially
- regenerated configurations preserve the new I2C settings
- `git diff --check`
