### PR TITLE
STM32: harden RTC clock validation

### DIFF
--- a/os/hal/ports/STM32/LLD/RCCv1/stm32_bd.inc
+++ b/os/hal/ports/STM32/LLD/RCCv1/stm32_bd.inc
@@ -74,7 +74,8 @@ __STATIC_INLINE void bd_init(void) {
 __STATIC_INLINE void bd_reset(void) {
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & RCC_BDCR_RTCSEL_Msk) != STM32_RTCSEL) {
+  if ((RCC->BDCR & RCC_BDCR_RTCSEL_Msk) !=
+      (STM32_RTCSEL & RCC_BDCR_RTCSEL_Msk)) {
     /* Backup domain reset.*/
 #if defined(RCC_BDCR_BDRST)
     RCC->BDCR = RCC_BDCR_BDRST;

--- a/os/hal/ports/STM32/LLD/RTCv2/hal_rtc_lld.h
+++ b/os/hal/ports/STM32/LLD/RTCv2/hal_rtc_lld.h
@@ -144,7 +144,11 @@
 #error "RTC clock not exported by HAL layer"
 #endif
 
-#if STM32_PCLK1 < (STM32_RTCCLK * 7)
+#if defined(STM32_PCLK1_FREQ) && defined(STM32_RTC_FREQ)
+#if STM32_PCLK1_FREQ < (STM32_RTC_FREQ * 7U)
+#error "STM32_PCLK1 frequency is too low"
+#endif
+#elif STM32_PCLK1 < (STM32_RTCCLK * 7)
 #error "STM32_PCLK1 frequency is too low"
 #endif
 

--- a/os/hal/ports/STM32/LLD/RTCv3/hal_rtc_lld.h
+++ b/os/hal/ports/STM32/LLD/RTCv3/hal_rtc_lld.h
@@ -174,11 +174,19 @@
 #error "RTC clock not exported by HAL layer"
 #endif
 
-#if STM32_RTCCLK == 0
+#if defined(STM32_RTC_FREQ)
+#if STM32_RTC_FREQ == 0U
+#error "RTC has no clock source selected"
+#endif
+#elif STM32_RTCCLK == 0
 #error "RTC has no clock source selected"
 #endif
 
-#if STM32_PCLK1 < (STM32_RTCCLK * 7)
+#if defined(STM32_PCLK1_FREQ) && defined(STM32_RTC_FREQ)
+#if STM32_PCLK1_FREQ < (STM32_RTC_FREQ * 7U)
+#error "STM32_PCLK1 frequency is too low for RTC"
+#endif
+#elif STM32_PCLK1 < (STM32_RTCCLK * 7)
 #error "STM32_PCLK1 frequency is too low for RTC"
 #endif
 

--- a/os/hal/ports/STM32/LLD/RTCv4/hal_rtc_lld.h
+++ b/os/hal/ports/STM32/LLD/RTCv4/hal_rtc_lld.h
@@ -110,11 +110,19 @@
 #error "RTC clock not exported by HAL layer"
 #endif
 
-#if STM32_RTCCLK == 0
+#if defined(STM32_RTC_FREQ)
+#if STM32_RTC_FREQ == 0U
+#error "RTC has no clock source selected"
+#endif
+#elif STM32_RTCCLK == 0
 #error "RTC has no clock source selected"
 #endif
 
-#if STM32_PCLK1 < (STM32_RTCCLK * 7)
+#if defined(STM32_PCLK1_FREQ) && defined(STM32_RTC_FREQ)
+#if STM32_PCLK1_FREQ < (STM32_RTC_FREQ * 7U)
+#error "STM32_PCLK1 frequency is too low for RTC"
+#endif
+#elif STM32_PCLK1 < (STM32_RTCCLK * 7)
 #error "STM32_PCLK1 frequency is too low for RTC"
 #endif
 

--- a/os/hal/ports/STM32/STM32C0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32C0xx/hal_lld.c
@@ -365,6 +365,12 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
     pclktim = pclk * 2U;
   }
 
+#if HAL_USE_RTC == TRUE
+  if (pclk < (STM32_RTC_FREQ * 7U)) {
+    return true;
+  }
+#endif
+
   /* MCO clock.*/
   switch (ccp->rcc_cfgr & RCC_CFGR_MCOSEL_Msk) {
   case RCC_CFGR_MCOSEL_SYSCLK:

--- a/os/hal/ports/STM32/STM32C0xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32C0xx/hal_lld.h
@@ -990,6 +990,7 @@
  */
 #define STM32_PCLK1                         STM32_PCLK
 #define STM32_PCLK2                         STM32_PCLK
+#define STM32_PCLK1_FREQ                    STM32_PCLK1
 
 /**
  * @brief   MCO divider clock frequency.
@@ -1108,15 +1109,19 @@
  */
 #if (STM32_RTCSEL == RCC_CSR1_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTCCLK                      0
+  #define STM32_RTC_FREQ                    0U
 
 #elif STM32_RTCSEL == RCC_CSR1_RTCSEL_LSE
   #define STM32_RTCCLK                      STM32_LSECLK
+  #define STM32_RTC_FREQ                    STM32_LSECLK
 
 #elif STM32_RTCSEL == RCC_CSR1_RTCSEL_LSI
   #define STM32_RTCCLK                      STM32_LSICLK
+  #define STM32_RTC_FREQ                    STM32_LSICLK
 
 #elif STM32_RTCSEL == RCC_CSR1_RTCSEL_HSEDIV
   #define STM32_RTCCLK                      (hal_lld_get_clock_point(CLK_HSE) / 32)
+  #define STM32_RTC_FREQ                    (STM32_HSECLK / 32U)
 
 #else
   #error "invalid STM32_RTCSEL value specified"

--- a/os/hal/ports/STM32/STM32G4xx_TEST/hal_lld.c
+++ b/os/hal/ports/STM32/STM32G4xx_TEST/hal_lld.c
@@ -607,6 +607,12 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
     pclk1tim = pclk1 * 2U;
   }
 
+#if HAL_USE_RTC == TRUE
+  if (pclk1 < (STM32_RTC_FREQ * 7U)) {
+    return true;
+  }
+#endif
+
   /* PPRE2 frequency.*/
   pclk2 = hclk / pprediv[(ccp->rcc_cfgr & RCC_CFGR_PPRE2_Msk) >> RCC_CFGR_PPRE2_Pos];
   if ((ccp->rcc_cfgr & RCC_CFGR_PPRE2_Msk) < RCC_CFGR_PPRE2_DIV2) {

--- a/os/hal/ports/STM32/STM32U0xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U0xx/hal_lld.c
@@ -589,6 +589,12 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
     pclktim = pclk * 2U;
   }
 
+#if HAL_USE_RTC == TRUE
+  if (pclk < (STM32_RTC_FREQ * 7U)) {
+    return true;
+  }
+#endif
+
   /* MCO clock.*/
   switch (ccp->rcc_cfgr & RCC_CFGR_MCO1SEL_Msk) {
   case RCC_CFGR_MCO1SEL_SYSCLK:

--- a/os/hal/ports/STM32/STM32U0xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32U0xx/hal_lld.h
@@ -1103,6 +1103,7 @@
  */
 #define STM32_PCLK1                         STM32_PCLK
 #define STM32_PCLK2                         STM32_PCLK
+#define STM32_PCLK1_FREQ                    STM32_PCLK1
 
 /**
  * @brief   MCO divider clock source.
@@ -1285,15 +1286,19 @@
  */
 #if (STM32_RTCSEL == RCC_BDCR_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTCCLK                      0
+  #define STM32_RTC_FREQ                    0U
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSE
   #define STM32_RTCCLK                      STM32_LSECLK
+  #define STM32_RTC_FREQ                    STM32_LSECLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSI
   #define STM32_RTCCLK                      STM32_LSICLK
+  #define STM32_RTC_FREQ                    STM32_LSICLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_HSEDIV
   #define STM32_RTCCLK                      (hal_lld_get_clock_point(CLK_HSE) / 32)
+  #define STM32_RTC_FREQ                    (STM32_HSECLK / 32U)
 
 #else
   #error "invalid STM32_RTCSEL value specified"

--- a/os/hal/ports/STM32/STM32U3xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U3xx/hal_lld.c
@@ -593,6 +593,12 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
     pclk1tim = pclk1 * 2U;
   }
 
+#if HAL_USE_RTC == TRUE
+  if (pclk1 < (STM32_RTC_FREQ * 7U)) {
+    return true;
+  }
+#endif
+
   /* PPRE2 frequency.*/
   n = pprediv[(ccp->rcc_cfgr2 & STM32_PPRE2_MASK) >> STM32_PPRE2_POS];
   pclk2 = hclk / n;

--- a/os/hal/ports/STM32/STM32U3xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32U3xx/hal_lld.h
@@ -1711,6 +1711,9 @@
 #include "stm32_apb2.inc"
 #include "stm32_apb3.inc"
 
+/* Static frequency exported for compile-time checks.*/
+#define STM32_PCLK1_FREQ                    STM32_PCLK1
+
 /* STOPWUCK setting check.*/
 #if (STM32_STOPWUCK == RCC_CFGR1_STOPWUCK_MSIS) || defined(__DOXYGEN__)
 
@@ -1869,15 +1872,19 @@
  */
 #if (STM32_RTCSEL == RCC_BDCR_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTCCLK                      0U
+  #define STM32_RTC_FREQ                    0U
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSE
   #define STM32_RTCCLK                      STM32_LSECLK
+  #define STM32_RTC_FREQ                    STM32_LSECLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSI
   #define STM32_RTCCLK                      STM32_LSICLK
+  #define STM32_RTC_FREQ                    STM32_LSICLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_HSEDIV
   #define STM32_RTCCLK                      (hal_lld_get_clock_point(CLK_HSE) / 32U)
+  #define STM32_RTC_FREQ                    (STM32_HSECLK / 32U)
 
 #else
   #error "invalid STM32_RTCSEL value specified"

--- a/os/hal/ports/STM32/STM32U3xx_TEST/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U3xx_TEST/hal_lld.c
@@ -555,6 +555,12 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
     pclk1tim = pclk1 * 2U;
   }
 
+#if HAL_USE_RTC == TRUE
+  if (pclk1 < (STM32_RTC_FREQ * 7U)) {
+    return true;
+  }
+#endif
+
   /* PPRE2 frequency.*/
   n = pprediv[(ccp->rcc_cfgr2 & RCC_CFGR2_PPRE2_Msk) >> RCC_CFGR2_PPRE2_Pos];
   pclk2 = hclk / n;

--- a/os/hal/ports/STM32/STM32U5xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U5xx/hal_lld.c
@@ -919,6 +919,9 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
   halfreq_t pll3inclk, pll3refclk, pll3vcoclk;
   halfreq_t pll3pclk, pll3qclk, pll3rclk;
   halfreq_t sysclk, hclk, pclk1, pclk2, pclk3, pclk1tim, pclk2tim, mcoclk;
+#if HAL_USE_RTC == TRUE
+  halfreq_t rtcclk;
+#endif
 
   switch (ccp->pwr_vosr & PWR_VOSR_VOS_Msk) {
   case PWR_VOSR_VOS_RANGE1:
@@ -1066,6 +1069,30 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
   if (pclk1 > slp->pclk1_max) {
     return true;
   }
+
+#if HAL_USE_RTC == TRUE
+  if ((ccp->rcc_bdcr & RCC_BDCR_RTCEN) == 0U) {
+    return true;
+  }
+
+  switch (ccp->rcc_bdcr & RCC_BDCR_RTCSEL_Msk) {
+  case RCC_BDCR_RTCSEL_LSE:
+    rtcclk = lseclk;
+    break;
+  case RCC_BDCR_RTCSEL_LSI:
+    rtcclk = lsiclk;
+    break;
+  case RCC_BDCR_RTCSEL_HSEDIV:
+    rtcclk = hseclk / 32U;
+    break;
+  default:
+    rtcclk = 0U;
+  }
+
+  if ((rtcclk == 0U) || (pclk1 < (rtcclk * 7U))) {
+    return true;
+  }
+#endif
 
   n = pprediv[(ccp->rcc_cfgr2 & RCC_CFGR2_PPRE2_Msk) >> RCC_CFGR2_PPRE2_Pos];
   pclk2 = hclk / n;

--- a/os/xhal/ports/STM32/LLD/RCCv1/stm32_bd.inc
+++ b/os/xhal/ports/STM32/LLD/RCCv1/stm32_bd.inc
@@ -74,7 +74,8 @@ __STATIC_INLINE void bd_init(void) {
 __STATIC_INLINE void bd_reset(void) {
 
   /* Reset BKP domain if different clock source selected.*/
-  if ((RCC->BDCR & RCC_BDCR_RTCSEL_Msk) != STM32_RTCSEL) {
+  if ((RCC->BDCR & RCC_BDCR_RTCSEL_Msk) !=
+      (STM32_RTCSEL & RCC_BDCR_RTCSEL_Msk)) {
     /* Backup domain reset.*/
 #if defined(RCC_BDCR_BDRST)
     RCC->BDCR = RCC_BDCR_BDRST;

--- a/os/xhal/ports/STM32/LLD/RTCv3/hal_rtc_lld.h
+++ b/os/xhal/ports/STM32/LLD/RTCv3/hal_rtc_lld.h
@@ -114,11 +114,19 @@
 #error "RTC clock not exported by HAL layer"
 #endif
 
-#if STM32_RTCCLK == 0
+#if defined(STM32_RTC_FREQ)
+#if STM32_RTC_FREQ == 0U
+#error "RTC has no clock source selected"
+#endif
+#elif STM32_RTCCLK == 0
 #error "RTC has no clock source selected"
 #endif
 
-#if STM32_PCLK1 < (STM32_RTCCLK * 7)
+#if defined(STM32_PCLK1_FREQ) && defined(STM32_RTC_FREQ)
+#if STM32_PCLK1_FREQ < (STM32_RTC_FREQ * 7U)
+#error "STM32_PCLK1 frequency is too low for RTC"
+#endif
+#elif STM32_PCLK1 < (STM32_RTCCLK * 7)
 #error "STM32_PCLK1 frequency is too low for RTC"
 #endif
 

--- a/os/xhal/ports/STM32/LLD/RTCv4/hal_rtc_lld.h
+++ b/os/xhal/ports/STM32/LLD/RTCv4/hal_rtc_lld.h
@@ -98,11 +98,19 @@
 #error "RTC clock not exported by HAL layer"
 #endif
 
-#if STM32_RTCCLK == 0
+#if defined(STM32_RTC_FREQ)
+#if STM32_RTC_FREQ == 0U
+#error "RTC has no clock source selected"
+#endif
+#elif STM32_RTCCLK == 0
 #error "RTC has no clock source selected"
 #endif
 
-#if STM32_PCLK1 < (STM32_RTCCLK * 7)
+#if defined(STM32_PCLK1_FREQ) && defined(STM32_RTC_FREQ)
+#if STM32_PCLK1_FREQ < (STM32_RTC_FREQ * 7U)
+#error "STM32_PCLK1 frequency is too low for RTC"
+#endif
+#elif STM32_PCLK1 < (STM32_RTCCLK * 7)
 #error "STM32_PCLK1 frequency is too low for RTC"
 #endif
 

--- a/os/xhal/ports/STM32/STM32C0xx/hal_lld.c
+++ b/os/xhal/ports/STM32/STM32C0xx/hal_lld.c
@@ -365,6 +365,12 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
     pclktim = pclk * 2U;
   }
 
+#if HAL_USE_RTC == TRUE
+  if (pclk < (STM32_RTC_FREQ * 7U)) {
+    return true;
+  }
+#endif
+
   /* MCO clock.*/
   switch (ccp->rcc_cfgr & RCC_CFGR_MCOSEL_Msk) {
   case RCC_CFGR_MCOSEL_SYSCLK:

--- a/os/xhal/ports/STM32/STM32C0xx/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32C0xx/hal_lld.h
@@ -990,6 +990,7 @@
  */
 #define STM32_PCLK1                         STM32_PCLK
 #define STM32_PCLK2                         STM32_PCLK
+#define STM32_PCLK1_FREQ                    STM32_PCLK1
 
 /**
  * @brief   MCO divider clock frequency.
@@ -1108,15 +1109,19 @@
  */
 #if (STM32_RTCSEL == RCC_CSR1_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTCCLK                      0
+  #define STM32_RTC_FREQ                    0U
 
 #elif STM32_RTCSEL == RCC_CSR1_RTCSEL_LSE
   #define STM32_RTCCLK                      STM32_LSECLK
+  #define STM32_RTC_FREQ                    STM32_LSECLK
 
 #elif STM32_RTCSEL == RCC_CSR1_RTCSEL_LSI
   #define STM32_RTCCLK                      STM32_LSICLK
+  #define STM32_RTC_FREQ                    STM32_LSICLK
 
 #elif STM32_RTCSEL == RCC_CSR1_RTCSEL_HSEDIV
   #define STM32_RTCCLK                      (hal_lld_get_clock_point(CLK_HSE) / 32)
+  #define STM32_RTC_FREQ                    (STM32_HSECLK / 32U)
 
 #else
   #error "invalid STM32_RTCSEL value specified"

--- a/os/xhal/ports/STM32/STM32U0xx/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32U0xx/hal_lld.h
@@ -1103,6 +1103,7 @@
  */
 #define STM32_PCLK1                         STM32_PCLK
 #define STM32_PCLK2                         STM32_PCLK
+#define STM32_PCLK1_FREQ                    STM32_PCLK1
 
 /**
  * @brief   MCO divider clock source.
@@ -1285,15 +1286,19 @@
  */
 #if (STM32_RTCSEL == RCC_BDCR_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTCCLK                      0
+  #define STM32_RTC_FREQ                    0U
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSE
   #define STM32_RTCCLK                      STM32_LSECLK
+  #define STM32_RTC_FREQ                    STM32_LSECLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSI
   #define STM32_RTCCLK                      STM32_LSICLK
+  #define STM32_RTC_FREQ                    STM32_LSICLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_HSEDIV
   #define STM32_RTCCLK                      (hal_lld_get_clock_point(CLK_HSE) / 32)
+  #define STM32_RTC_FREQ                    (STM32_HSECLK / 32U)
 
 #else
   #error "invalid STM32_RTCSEL value specified"

--- a/os/xhal/ports/STM32/STM32U3xx/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32U3xx/hal_lld.h
@@ -1711,6 +1711,9 @@
 #include "stm32_apb2.inc"
 #include "stm32_apb3.inc"
 
+/* Static frequency exported for compile-time checks.*/
+#define STM32_PCLK1_FREQ                    STM32_PCLK1
+
 /* STOPWUCK setting check.*/
 #if (STM32_STOPWUCK == RCC_CFGR1_STOPWUCK_MSIS) || defined(__DOXYGEN__)
 
@@ -1869,15 +1872,19 @@
  */
 #if (STM32_RTCSEL == RCC_BDCR_RTCSEL_NOCLOCK) || defined(__DOXYGEN__)
   #define STM32_RTCCLK                      0U
+  #define STM32_RTC_FREQ                    0U
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSE
   #define STM32_RTCCLK                      STM32_LSECLK
+  #define STM32_RTC_FREQ                    STM32_LSECLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_LSI
   #define STM32_RTCCLK                      STM32_LSICLK
+  #define STM32_RTC_FREQ                    STM32_LSICLK
 
 #elif STM32_RTCSEL == RCC_BDCR_RTCSEL_HSEDIV
   #define STM32_RTCCLK                      (hal_lld_get_clock_point(CLK_HSE) / 32U)
+  #define STM32_RTC_FREQ                    (STM32_HSECLK / 32U)
 
 #else
   #error "invalid STM32_RTCSEL value specified"

--- a/os/xhal/ports/STM32/STM32U5xx/hal_lld.c
+++ b/os/xhal/ports/STM32/STM32U5xx/hal_lld.c
@@ -919,6 +919,9 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
   halfreq_t pll3inclk, pll3refclk, pll3vcoclk;
   halfreq_t pll3pclk, pll3qclk, pll3rclk;
   halfreq_t sysclk, hclk, pclk1, pclk2, pclk3, pclk1tim, pclk2tim, mcoclk;
+#if HAL_USE_RTC == TRUE
+  halfreq_t rtcclk;
+#endif
 
   switch (ccp->pwr_vosr & PWR_VOSR_VOS_Msk) {
   case PWR_VOSR_VOS_RANGE1:
@@ -1066,6 +1069,30 @@ static bool hal_lld_clock_check_tree(const halclkcfg_t *ccp) {
   if (pclk1 > slp->pclk1_max) {
     return true;
   }
+
+#if HAL_USE_RTC == TRUE
+  if ((ccp->rcc_bdcr & RCC_BDCR_RTCEN) == 0U) {
+    return true;
+  }
+
+  switch (ccp->rcc_bdcr & RCC_BDCR_RTCSEL_Msk) {
+  case RCC_BDCR_RTCSEL_LSE:
+    rtcclk = lseclk;
+    break;
+  case RCC_BDCR_RTCSEL_LSI:
+    rtcclk = lsiclk;
+    break;
+  case RCC_BDCR_RTCSEL_HSEDIV:
+    rtcclk = hseclk / 32U;
+    break;
+  default:
+    rtcclk = 0U;
+  }
+
+  if ((rtcclk == 0U) || (pclk1 < (rtcclk * 7U))) {
+    return true;
+  }
+#endif
 
   n = pprediv[(ccp->rcc_cfgr2 & RCC_CFGR2_PPRE2_Msk) >> RCC_CFGR2_PPRE2_Pos];
   pclk2 = hclk / n;


### PR DESCRIPTION
## Summary

- make RTC compile-time checks use static frequency exports when dynamic clock points are runtime expressions
- add static RTC and PCLK1 frequency exports for the STM32C0, STM32U0, and STM32U3 HAL/XHAL ports
- enforce the required PCLK1 >= 7 x RTC relationship during dynamic clock switches
- validate the selected and enabled RTC clock source during STM32U5 clock switches
- mask the expected backup-domain RTC selector before comparing it, so RTCEN cannot force an unnecessary backup-domain reset

## Root cause

On dynamic-clock ports, STM32_RTCCLK can expand to a runtime clock-point lookup. Using that expression in a preprocessor condition breaks HSE/32 RTC configurations. Compile-time checks also cover only the default clock tree, so alternate runtime modes could bypass the APB/RTC ratio requirement. Generated clock-tree compatibility values can additionally carry RTCEN alongside RTCSEL, making the backup-domain selector comparison permanently unequal.

## Impact

Dynamic RTC configurations now compile on affected STM32C0, STM32U0, and STM32U3 targets, and invalid runtime APB/RTC combinations are rejected by the clock-tree validator. HAL and XHAL mirrors are kept aligned.

STM32C5 is intentionally excluded because that port is not complete enough to validate this change.

## Validation

- HAL STM32C0, STM32U0, and STM32U3 dynamic HSE/32 RTC builds
- XHAL STM32C0 dynamic HSE/32 RTC build
- XHAL STM32U0 and STM32U3 baseline builds
- STM32G4_TEST and STM32U3_TEST RTC-enabled clock-tree builds
- STM32G4_TEST and STM32U3_TEST builds with tautological-comparison warnings promoted to errors
- STM32U5 HAL and XHAL validation builds
- XHAL STM32G4 baseline build
- affected mcuconf/xmcuconf updaters run sequentially
- `git diff --check`
