### PR TITLE
XHAL: check the requested alarm in stBindAlarmN()

### DIFF
--- a/os/xhal/src/hal_st.c
+++ b/os/xhal/src/hal_st.c
@@ -211,7 +211,7 @@ void stSetCallback(unsigned alarm, st_callback_t cb) {
 void stBindAlarmN(unsigned alarm) {
 
   chDbgCheck(alarm < (unsigned)ST_LLD_NUM_ALARMS);
-  chDbgAssert(stIsAlarmActive() == false, "already active");
+  chDbgAssert(stIsAlarmActiveN(alarm) == false, "already active");
 
   st_lld_bind_alarm_n(alarm);
 }


### PR DESCRIPTION
## Summary

- `stBindAlarmN(alarm)` asserted `stIsAlarmActive()`, which always inspects alarm 0, instead of `stIsAlarmActiveN(alarm)`.
- Classic HAL (`os/hal/src/hal_st.c`) checks the indexed alarm; this aligns XHAL with it. The sibling multi-alarm functions in the same file (`stStartAlarmN`/`stStopAlarmN`/`stSetAlarmN`) already use the indexed form.

## Impact

No in-tree XHAL port defines `ST_LLD_MULTICORE_SUPPORT` yet, so today this is latent. It becomes live with the upcoming RP2040/RP2350 XHAL port (first multicore ST consumer): during SMP startup, core 1 binds alarm `core_id` via `port_timer_enable()` → `stBindAlarmN(1)` while core 0 may already have armed alarm 0 — with `CH_DBG_ENABLE_ASSERTS` this trips a spurious "already active" assertion depending on startup timing.

## Regression procedure (deterministic)

The race can be pinned for verification on RP silicon: hold core 1 in a pre-kernel spin, arm alarm 0 on core 0 (start the kernel / a virtual timer), then release core 1 to run `chInstanceObjectInit()`. Before this fix the assertion fires every time; after it, core 1 binds alarm 1 cleanly. This will be exercised by the RP XHAL port's SMP demo with full debug checks enabled.

## Verification

- `demos/STM32/RT-XHAL-STM32G474RE-NUCLEO64` builds clean (shared-code regression reference; STM32 does not compile the multicore path).
- coderabbit CLI review: 0 findings.

## Changelog

- XHAL: fixed stBindAlarmN() asserting on alarm 0 instead of the requested alarm.