### PR TITLE
XHAL: initial RP2040/RP2350 port with ST and PAL support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -65,6 +65,7 @@ port/RP:
   - changed-files:
     - any-glob-to-any-file:
       - 'os/hal/ports/RP/**'
+      - 'os/xhal/ports/RP/**'
       - 'demos/RP/**'
       - 'testhal/RP/**'
 

--- a/demos/RP/RT-XHAL-RP-MULTI/Makefile
+++ b/demos/RP/RT-XHAL-RP-MULTI/Makefile
@@ -1,0 +1,23 @@
+##############################################################################
+# Multi-project makefile rules
+#
+
+SUB_MAKES := $(sort $(wildcard make/*.make))
+
+all:
+	@for m in $(SUB_MAKES); do \
+		echo; \
+		echo "=== Building $$m ==="; \
+		$(MAKE) --no-print-directory -f $$m all || exit $$?; \
+		echo; \
+	done
+	@echo
+
+clean:
+	@for m in $(SUB_MAKES); do \
+		echo "=== Cleaning $$m ==="; \
+		$(MAKE) --no-print-directory -f $$m clean || exit $$?; \
+		echo; \
+	done
+#
+##############################################################################

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/chconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/chconf.h
@@ -1,0 +1,857 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Disabled because the non-SMP ARMv6-M port has no realtime
+ *          counter support.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.c
@@ -1,0 +1,63 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.c
+ * @brief   Application portability module code.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#include "hal.h"
+
+#include "portab.h"
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+void portab_setup(void) {
+
+  /*
+   * LED line as output.
+   */
+  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_OUTPUT_PUSHPULL |
+                                  PAL_RP_PAD_DRIVE12);
+  palWriteLine(PORTAB_LINE_LED, PORTAB_LED_OFF);
+}
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
@@ -1,0 +1,70 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.h
+ * @brief   Application portability macros and structures.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+#define PORTAB_LINE_LED             25U
+#define PORTAB_LED_OFF              PAL_LOW
+#define PORTAB_LED_ON               PAL_HIGH
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+#endif /* PORTAB_H */
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         FALSE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         FALSE
+#define HAL_USE_SPI                         FALSE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         FALSE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   TRUE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               FALSE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
@@ -1,0 +1,55 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2040 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2040_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+#endif /* XMCUCONF_H */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/chconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.c
@@ -1,0 +1,63 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.c
+ * @brief   Application portability module code.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#include "hal.h"
+
+#include "portab.h"
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+void portab_setup(void) {
+
+  /*
+   * LED line as output.
+   */
+  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_OUTPUT_PUSHPULL |
+                                  PAL_RP_PAD_DRIVE12);
+  palWriteLine(PORTAB_LINE_LED, PORTAB_LED_OFF);
+}
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
@@ -1,0 +1,70 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.h
+ * @brief   Application portability macros and structures.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+#define PORTAB_LINE_LED             25U
+#define PORTAB_LED_OFF              PAL_LOW
+#define PORTAB_LED_ON               PAL_HIGH
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+#endif /* PORTAB_H */
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         FALSE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         FALSE
+#define HAL_USE_SPI                         FALSE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         FALSE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   TRUE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               FALSE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
@@ -1,0 +1,56 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest (4 bits on Cortex-M33).
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2350_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CLOCK_DYNAMIC                    FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+#endif /* XMCUCONF_H */

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -1,0 +1,50 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "ch.h"
+#include "hal.h"
+
+#include "portab.h"
+
+/*
+ * Application entry point.
+ */
+int main(void) {
+
+  /*
+   * System initializations.
+   * - HAL initialization, this also initializes the configured device drivers
+   *   and performs the board-specific initializations.
+   * - Kernel initialization, the main() function becomes a thread and the
+   *   RTOS is active.
+   */
+  halInit();
+  chSysInit();
+
+  /*
+   * Initialization of portability code, could be empty.
+   */
+  portab_setup();
+
+  /*
+   * Normal main() thread activity, in this demo it toggles the board LED
+   * in a loop.
+   */
+  while (true) {
+    palToggleLine(PORTAB_LINE_LED);
+    chThdSleepMilliseconds(500);
+  }
+}

--- a/demos/RP/RT-XHAL-RP-MULTI/make/rp2040_pico.make
+++ b/demos/RP/RT-XHAL-RP-MULTI/make/rp2040_pico.make
@@ -1,0 +1,185 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m0plus
+
+# Imported source files and paths.
+CHIBIOS  := ../../..
+CONFDIR  := ./cfg/rp2040_pico
+BUILDDIR := ./build/rp2040_pico
+DEPDIR   := ./.dep/rp2040_pico
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv6-M/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2040_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/demos/RP/RT-XHAL-RP-MULTI/make/rp2350_pico2.make
+++ b/demos/RP/RT-XHAL-RP-MULTI/make/rp2350_pico2.make
@@ -1,0 +1,190 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = softfp
+endif
+
+# FPU-related options.
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-sp-d16
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../..
+CONFDIR  := ./cfg/rp2350_pico2
+BUILDDIR := ./build/rp2350_pico2
+DEPDIR   := ./.dep/rp2350_pico2
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/os/xhal/OSAL_REMOVAL_BUILDS.txt
+++ b/os/xhal/OSAL_REMOVAL_BUILDS.txt
@@ -1,4 +1,6 @@
 # XHAL OSAL-removal build manifest, one make recipe per line.
+demos/RP/RT-XHAL-RP-MULTI/make/rp2040_pico.make
+demos/RP/RT-XHAL-RP-MULTI/make/rp2350_pico2.make
 demos/STM32/RT-STM32-LWIP/make/stm32h563zi_nucleo144_xhal.make
 demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_NOSWITCH/Makefile
 demos/STM32/RT-STM32G474RE-NUCLEO64-SB_HOST_SWITCHED/Makefile

--- a/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_PAL TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1

--- a/os/xhal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
+++ b/os/xhal/ports/RP/LLD/GPIOv1/hal_pal_lld.c
@@ -1,0 +1,319 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    GPIOv1/hal_pal_lld.c
+ * @brief   RP PAL low level driver code.
+ *
+ * @addtogroup PAL
+ * @{
+ */
+
+#include "hal.h"
+
+#if HAL_USE_PAL || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define RP_PAL_LINE_REG(line)           ((uint32_t)(line) >> 3U)
+#define RP_PAL_LINE_SHIFT(line)         (4U * ((uint32_t)(line) & 0x07U))
+#define RP_PAL_LINE_MASK(line)          (0x0FU << RP_PAL_LINE_SHIFT(line))
+#define RP_PAL_REG_ALIAS_SET            0x2000U
+#define RP_PAL_REG_ALIAS_CLR            0x3000U
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+#if (PAL_USE_WAIT == TRUE) || (PAL_USE_CALLBACKS == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Event records for GPIO lines.
+ */
+palevent_t _pal_events[RP_GPIO_NUM_LINES];
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static inline void rp_pal_reg_set(volatile uint32_t *reg, uint32_t mask) {
+
+  *(volatile uint32_t *)((uintptr_t)reg + RP_PAL_REG_ALIAS_SET) = mask;
+}
+
+static inline void rp_pal_reg_clr(volatile uint32_t *reg, uint32_t mask) {
+
+  *(volatile uint32_t *)((uintptr_t)reg + RP_PAL_REG_ALIAS_CLR) = mask;
+}
+
+static void rp_pal_pad_set_mode(ioportid_t port,
+                                iopadid_t pad,
+                                iomode_t mode) {
+  uint32_t ctrlbits, padbits, oebits, bit, abspad;
+
+  ctrlbits = mode & 0x007FFFFFU;
+  oebits   = (mode >> 23U) & 1U;
+  padbits  = mode >> 24U;
+  bit      = 1U << pad;
+  abspad   = ((uint32_t)port << 5U) | (uint32_t)pad;
+
+  if ((pad >= PAL_IOPORTS_WIDTH) ||
+      (((RP_PAL_VALID_MASK(port) >> pad) & 1U) == 0U) ||
+      (abspad >= RP_GPIO_NUM_LINES)) {
+    return;
+  }
+
+  /* Release the output driver while reprogramming mux and pad control. */
+  RP_PAL_SIO_REG(GPIO_OE_CLR, port) = bit;
+
+  IO_BANK0->GPIO[abspad].CTRL = ctrlbits;
+  PADS_BANK0->GPIO[abspad] = padbits;
+
+  if (oebits != 0U) {
+    RP_PAL_SIO_REG(GPIO_OE_SET, port) = bit;
+  }
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if (PAL_USE_WAIT || PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+/**
+ * @brief   IO_BANK0 GPIO interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_IO_IRQ_BANK0_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  for (int i = 0; i < RP_GPIO_INTR_REGS; ++i) {
+    int line;
+    uint32_t ints = IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTS[i];
+
+    IO_BANK0->INTR[i] = ints;
+    line = i * 8;
+    while (ints != 0U) {
+      if (ints & 0x0FU) {
+        _pal_isr_code(line);
+      }
+      ints >>= 4;
+      ++line;
+    }
+  }
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   PAL driver initialization.
+ *
+ * @notapi
+ */
+void _pal_lld_init(void) {
+
+  /* Ensures a clean peripheral state */
+  rp_peripheral_reset(RESETS_ALLREG_IO_BANK0);
+  rp_peripheral_reset(RESETS_ALLREG_PADS_BANK0);
+  rp_peripheral_unreset(RESETS_ALLREG_IO_BANK0);
+  rp_peripheral_unreset(RESETS_ALLREG_PADS_BANK0);
+
+#if defined(RP2040)
+  /* The PADS_BANK0 reset re-enables the digital input buffer and the
+     pull-down on the ADC-capable pads, undoing the boot-ROM mitigation
+     for erratum RP2040-E6 (increased leakage on GPIO26..GPIO29).
+     Analogue-safe state is restored immediately; configuring one of
+     these lines through the PAL deliberately makes it digital again.*/
+  {
+    unsigned pad;
+
+    for (pad = 26U; pad <= 29U; pad++) {
+      uint32_t padbits = PADS_BANK0->GPIO[pad];
+
+      /* The PAL_RP_PAD_* mode encodings carry the raw pad field at
+         bit position 24 upwards.*/
+      padbits &= ~((PAL_RP_PAD_PUE | PAL_RP_PAD_PDE | PAL_RP_PAD_IE) >> 24);
+      padbits |= (PAL_RP_PAD_OD >> 24);
+      PADS_BANK0->GPIO[pad] = padbits;
+    }
+  }
+#endif
+
+  #if PAL_USE_CALLBACKS || PAL_USE_WAIT || defined(__DOXYGEN__)
+  unsigned i;
+
+  for (i = 0U; i < RP_GPIO_NUM_LINES; i++) {
+    _pal_init_event(i);
+  }
+
+  /* The ISR reads the interrupt statuses of the per-core PROC block
+     selected by RP_PAL_EVENT_CORE_AFFINITY and the NVIC is a per-core
+     resource, so the vector can only be enabled here when halInit() is
+     running on the affinity core. Otherwise the application must call
+     palRPEnableEventsIrqX() from the affinity core.*/
+  if (SIO->CPUID == (uint32_t)RP_PAL_EVENT_CORE_AFFINITY) {
+    nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+  }
+  #endif
+}
+
+/**
+ * @brief   Pads group mode setup.
+ * @details Programs each selected pad in the specified port using the
+ *          RP pad/mux configuration helper.
+ *
+ * @param[in] port      port identifier
+ * @param[in] mask      group mask, already shifted to port bit positions
+ * @param[in] mode      group mode
+ *
+ * @notapi
+ */
+void _pal_lld_setgroupmode(ioportid_t port,
+                           ioportmask_t mask,
+                           iomode_t mode) {
+  iopadid_t pad = 0U;
+
+  while (mask != 0U) {
+    if ((mask & 1U) != 0U) {
+      rp_pal_pad_set_mode(port, pad, mode);
+    }
+    mask >>= 1U;
+    pad++;
+  }
+}
+
+#if (PAL_USE_WAIT || PAL_USE_CALLBACKS) || defined(__DOXYGEN__)
+
+bool _pal_lld_ispadeventenabled(ioportid_t port, iopadid_t pad) {
+  ioline_t line = PAL_LINE(port, pad);
+
+  return (bool)((IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY]
+                 .INTE[RP_PAL_LINE_REG(line)] &
+                 RP_PAL_LINE_MASK(line)) != 0U);
+}
+
+/**
+ * @brief   Line event enable.
+ * @note    Programming an unknown or unsupported mode is silently ignored.
+ *
+ * @param[in] line      line identifier
+ * @param[in] mode      line event mode
+ *
+ * @notapi
+ */
+void _pal_lld_enablelineevent(ioline_t line, ioeventmode_t mode) {
+  uint32_t inte = 0U;
+  uint32_t reg = RP_PAL_LINE_REG(line);
+  uint32_t shift = RP_PAL_LINE_SHIFT(line);
+  uint32_t mask = RP_PAL_LINE_MASK(line);
+  volatile uint32_t *inte_reg =
+    &IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTE[reg];
+
+  chDbgAssert((IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTE[reg] &
+               mask) == 0U, "channel in use");
+
+  if (mode & PAL_EVENT_MODE_RISING_EDGE) {
+    inte |= 8U;
+  }
+  if (mode & PAL_EVENT_MODE_FALLING_EDGE) {
+    inte |= 4U;
+  }
+  if (mode & RP_PAL_EVENT_MODE_LEVEL_LOW) {
+    inte |= 1U;
+  }
+  if (mode & RP_PAL_EVENT_MODE_LEVEL_HIGH) {
+    inte |= 2U;
+  }
+
+  IO_BANK0->INTR[reg] = mask;
+  rp_pal_reg_clr(inte_reg, mask);
+  rp_pal_reg_set(inte_reg, inte << shift);
+}
+
+/**
+ * @brief   Line event disable.
+ * @details This function disables previously programmed event callbacks.
+ *
+ * @param[in] line      line identifier
+ *
+ * @notapi
+ */
+void _pal_lld_disablelineevent(ioline_t line) {
+  uint32_t reg = RP_PAL_LINE_REG(line);
+  uint32_t mask = RP_PAL_LINE_MASK(line);
+  volatile uint32_t *inte_reg =
+    &IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTE[reg];
+
+  rp_pal_reg_clr(inte_reg, mask);
+
+  /* Clear pending interrupt status. INTR is W1C.*/
+  IO_BANK0->INTR[reg] = mask;
+
+#if PAL_USE_CALLBACKS || PAL_USE_WAIT
+  /* Callback cleared and/or thread reset.*/
+  _pal_clear_event(line);
+#endif
+}
+
+/**
+ * @brief Force a trigger event on the line.
+ *
+ * @param[in]         line identifier
+ */
+void _pal_lld_forcelineevent(ioline_t line) {
+  uint32_t reg = RP_PAL_LINE_REG(line);
+  volatile uint32_t *intf =
+    &IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTF[reg];
+  uint32_t force_mask = IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTE[reg] &
+                        RP_PAL_LINE_MASK(line);
+
+  /* Clear then set only the target bits, without an RMW race on sibling bits. */
+  rp_pal_reg_clr(intf, force_mask);
+  rp_pal_reg_set(intf, force_mask);
+}
+
+/**
+ * @brief Clear all forced trigger event on the line.
+ *
+ * @param[in]         line identifier
+ */
+void _pal_lld_unforcelineevent(ioline_t line) {
+  uint32_t reg = RP_PAL_LINE_REG(line);
+  volatile uint32_t *intf =
+    &IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTF[reg];
+  uint32_t force_mask = IO_BANK0->PROC[RP_PAL_EVENT_CORE_AFFINITY].INTE[reg] &
+                        RP_PAL_LINE_MASK(line);
+
+  rp_pal_reg_clr(intf, force_mask);
+}
+
+#endif
+
+#endif /* HAL_USE_PAL */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
+++ b/os/xhal/ports/RP/LLD/GPIOv1/hal_pal_lld.h
@@ -1,0 +1,551 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    GPIOv1/hal_pal_lld.h
+ * @brief   RP PAL low level driver header.
+ *
+ * @addtogroup PAL
+ * @{
+ */
+
+#ifndef HAL_PAL_LLD_H
+#define HAL_PAL_LLD_H
+
+#if HAL_USE_PAL || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Unsupported modes and specific modes                                      */
+/*===========================================================================*/
+
+/* Specifies palInit() without parameter, required until all platforms will
+   be updated to the new style.*/
+#define PAL_NEW_INIT
+
+#undef PAL_MODE_RESET
+#undef PAL_MODE_UNCONNECTED
+#undef PAL_MODE_INPUT
+#undef PAL_MODE_INPUT_PULLUP
+#undef PAL_MODE_INPUT_PULLDOWN
+#undef PAL_MODE_INPUT_ANALOG
+#undef PAL_MODE_OUTPUT_PUSHPULL
+#undef PAL_MODE_OUTPUT_OPENDRAIN
+
+/**
+ * @name    RP-specific I/O mode flags
+ * @{
+ */
+#define PAL_RP_IOCTRL_INOVER_NOTINV         (0U << 16)
+#define PAL_RP_IOCTRL_INOVER_INV            (1U << 16)
+#define PAL_RP_IOCTRL_INOVER_DRVLOW         (2U << 16)
+#define PAL_RP_IOCTRL_INOVER_DRVHIGH        (3U << 16)
+
+#define PAL_RP_IOCTRL_OEOVER_DRVPERI        (0U << RP_GPIO_IOCTRL_OEOVER_Pos)
+#define PAL_RP_IOCTRL_OEOVER_DRVINVPERI     (1U << RP_GPIO_IOCTRL_OEOVER_Pos)
+#define PAL_RP_IOCTRL_OEOVER_DISABLE        (2U << RP_GPIO_IOCTRL_OEOVER_Pos)
+#define PAL_RP_IOCTRL_OEOVER_ENABLE         (3U << RP_GPIO_IOCTRL_OEOVER_Pos)
+
+#define PAL_RP_IOCTRL_OUTOVER_DRVPERI       (0U << RP_GPIO_IOCTRL_OUTOVER_Pos)
+#define PAL_RP_IOCTRL_OUTOVER_DRVINVPERI    (1U << RP_GPIO_IOCTRL_OUTOVER_Pos)
+#define PAL_RP_IOCTRL_OUTOVER_DRVLOW        (2U << RP_GPIO_IOCTRL_OUTOVER_Pos)
+#define PAL_RP_IOCTRL_OUTOVER_DRVHIGH       (3U << RP_GPIO_IOCTRL_OUTOVER_Pos)
+
+#define PAL_RP_IOCTRL_FUNCSEL(n)            ((n) << 0)
+#define PAL_RP_IOCTRL_FUNCSEL_SPI           PAL_RP_IOCTRL_FUNCSEL(1U)
+#define PAL_RP_IOCTRL_FUNCSEL_UART          PAL_RP_IOCTRL_FUNCSEL(2U)
+#define PAL_RP_IOCTRL_FUNCSEL_I2C           PAL_RP_IOCTRL_FUNCSEL(3U)
+#define PAL_RP_IOCTRL_FUNCSEL_PWM           PAL_RP_IOCTRL_FUNCSEL(4U)
+#define PAL_RP_IOCTRL_FUNCSEL_SIO           PAL_RP_IOCTRL_FUNCSEL(5U)
+#define PAL_RP_IOCTRL_FUNCSEL_PIO0          PAL_RP_IOCTRL_FUNCSEL(6U)
+#define PAL_RP_IOCTRL_FUNCSEL_PIO1          PAL_RP_IOCTRL_FUNCSEL(7U)
+#define PAL_RP_IOCTRL_FUNCSEL_NULL          PAL_RP_IOCTRL_FUNCSEL(31U)
+
+#define PAL_RP_GPIO_OE                      (1U << (23 + 0))
+
+#define PAL_RP_PAD_OD                       (1U << (24 + 7))
+
+#define PAL_RP_PAD_IE                       (1U << (24 + 6))
+
+#define PAL_RP_PAD_DRIVE2                   (0U << (24 + 4))
+#define PAL_RP_PAD_DRIVE4                   (1U << (24 + 4))
+#define PAL_RP_PAD_DRIVE8                   (2U << (24 + 4))
+#define PAL_RP_PAD_DRIVE12                  (3U << (24 + 4))
+
+#define PAL_RP_PAD_PUE                      (1U << (24 + 3))
+
+#define PAL_RP_PAD_PDE                      (1U << (24 + 2))
+
+#define PAL_RP_PAD_SCHMITT                  (1U << (24 + 1))
+
+#define PAL_RP_PAD_SLEWFAST                 (1U << (24 + 0))
+/** @} */
+
+#include "rp_pal_lld.h"
+
+/**
+ * @name    RP-specific I/O event flags
+ * @{
+ */
+#define RP_PAL_EVENT_MODE_LEVEL_LOW         4U
+#define RP_PAL_EVENT_MODE_LEVEL_HIGH        8U
+/** @} */
+
+#if !defined(RP_PAL_EVENT_CORE_AFFINITY)
+  /**
+   * @brief   Core that handles all the PAL event interrupts.
+   * @note    The NVIC is a per-core resource, halInit() enables the events
+   *          interrupt vector only when it is executed on this core. When
+   *          the affinity core is not the core running halInit(), the
+   *          application must call @p palRPEnableEventsIrqX() from the
+   *          affinity core (e.g. from @p c1_main() after
+   *          @p chInstanceObjectInit()) before PAL events can be served.
+   */
+  #define RP_PAL_EVENT_CORE_AFFINITY        0
+#endif
+
+/**
+ * @name    Alternate functions
+ * @{
+ * @param[in] n         alternate function selector
+ */
+#define PAL_MODE_ALTERNATE(n)               (PAL_RP_IOCTRL_FUNCSEL(n)   |   \
+                                             PAL_RP_PAD_IE              |   \
+                                             PAL_RP_PAD_SCHMITT)
+#define PAL_MODE_ALTERNATE_SPI              (PAL_MODE_ALTERNATE(1U))
+#define PAL_MODE_ALTERNATE_UART             (PAL_MODE_ALTERNATE(2U))
+#define PAL_MODE_ALTERNATE_I2C              (PAL_MODE_ALTERNATE(3U))
+#define PAL_MODE_ALTERNATE_PWM              (PAL_MODE_ALTERNATE(4U))
+#define PAL_MODE_ALTERNATE_SIO              (PAL_MODE_ALTERNATE(5U))
+#define PAL_MODE_ALTERNATE_PIO0             (PAL_MODE_ALTERNATE(6U))
+#define PAL_MODE_ALTERNATE_PIO1             (PAL_MODE_ALTERNATE(7U))
+/** @} */
+
+/**
+ * @name    Standard I/O mode flags
+ * @{
+ */
+/**
+ * @brief   Implemented as post-reset state.
+ */
+#define PAL_MODE_RESET                  (PAL_RP_IOCTRL_FUNCSEL_NULL     |   \
+                                         PAL_RP_PAD_DRIVE4              |   \
+                                         PAL_RP_PAD_IE                  |   \
+                                         PAL_RP_PAD_SCHMITT)
+
+/**
+ * @brief   Implemented as input with pull-up.
+ */
+#define PAL_MODE_UNCONNECTED            (PAL_RP_IOCTRL_FUNCSEL_SIO      |   \
+                                         PAL_RP_PAD_IE                  |   \
+                                         PAL_RP_PAD_SCHMITT             |   \
+                                         PAL_RP_PAD_PUE)
+
+/**
+ * @brief   Regular input high-Z pad.
+ */
+#define PAL_MODE_INPUT                  (PAL_RP_IOCTRL_FUNCSEL_SIO      |   \
+                                         PAL_RP_PAD_IE                  |   \
+                                         PAL_RP_PAD_SCHMITT)
+
+/**
+ * @brief   Input pad with weak pull up resistor.
+ */
+#define PAL_MODE_INPUT_PULLUP           (PAL_RP_IOCTRL_FUNCSEL_SIO      |   \
+                                         PAL_RP_PAD_IE                  |   \
+                                         PAL_RP_PAD_SCHMITT             |   \
+                                         PAL_RP_PAD_PUE)
+
+/**
+ * @brief   Input pad with weak pull down resistor.
+ * @note    On RP2350 revisions affected by erratum RP2350-E9, the internal
+ *          pull-down may not behave as expected with the input buffer
+ *          enabled. This driver does not apply a workaround automatically.
+ */
+#define PAL_MODE_INPUT_PULLDOWN         (PAL_RP_IOCTRL_FUNCSEL_SIO      |   \
+                                         PAL_RP_PAD_IE                  |   \
+                                         PAL_RP_PAD_SCHMITT             |   \
+                                         PAL_RP_PAD_PDE)
+
+/**
+ * @brief   Analog input mode.
+ */
+#define PAL_MODE_INPUT_ANALOG           (PAL_RP_IOCTRL_FUNCSEL_NULL)
+
+/**
+ * @brief   Push-pull output pad.
+ */
+#define PAL_MODE_OUTPUT_PUSHPULL        (PAL_RP_IOCTRL_FUNCSEL_SIO      |   \
+                                         PAL_RP_GPIO_OE                 |   \
+                                         PAL_RP_PAD_IE)
+/** @} */
+
+/*===========================================================================*/
+/* I/O Ports Types and constants.                                            */
+/*===========================================================================*/
+
+/**
+ * @name    Port related definitions
+ * @{
+ */
+/**
+ * @brief   Width, in bits, of an I/O port.
+ */
+#define PAL_IOPORTS_WIDTH 32
+
+/**
+ * @brief   Whole port mask.
+ * @details This macro specifies all the valid bits into a port.
+ */
+#define PAL_WHOLE_PORT ((ioportmask_t)0xFFFFFFFF)
+/** @} */
+
+/**
+ * @brief   Type of digital I/O port sized unsigned integer.
+ */
+typedef uint32_t ioportmask_t;
+
+/**
+ * @brief   Type of digital I/O modes.
+ */
+typedef uint32_t iomode_t;
+
+/**
+ * @brief   Type of an I/O line.
+ */
+typedef uint32_t ioline_t;
+
+/**
+ * @brief   Type of an event mode.
+ */
+typedef uint32_t ioeventmode_t;
+
+/**
+ * @brief   Type of a port Identifier.
+ * @details This type can be a scalar or some kind of pointer, do not make
+ *          any assumption about it, use the provided macros when populating
+ *          variables of this type.
+ */
+typedef uint32_t ioportid_t;
+
+/**
+ * @brief   Type of an pad identifier.
+ */
+typedef uint32_t iopadid_t;
+
+#define RP_PAL_IOPORTS_COUNT            ((RP_GPIO_NUM_LINES + 31U) / 32U)
+
+#if RP_GPIO_NUM_LINES >= 32U
+  #define RP_PAL_PORT0_VALID_MASK       0xFFFFFFFFU
+#else
+  #define RP_PAL_PORT0_VALID_MASK       ((1U << RP_GPIO_NUM_LINES) - 1U)
+#endif
+
+#if RP_GPIO_NUM_LINES > 32U
+  #define RP_PAL_PORT1_VALID_MASK       ((1U << (RP_GPIO_NUM_LINES - 32U)) - 1U)
+  #define RP_PAL_VALID_MASK(port)                                               \
+    ((uint32_t)(port) == 0U ? RP_PAL_PORT0_VALID_MASK : RP_PAL_PORT1_VALID_MASK)
+#else
+  #define RP_PAL_VALID_MASK(port)       RP_PAL_PORT0_VALID_MASK
+#endif
+
+/**
+ * @name    Line handling macros
+ * @{
+ */
+/**
+ * @brief   Forms a line identifier.
+ * @details A port/pad pair are encoded into an @p ioline_t type. The encoding
+ *          of this type is platform-dependent.
+ * @note    In this driver a line is the absolute GPIO number obtained by
+ *          adding the port base to the port-relative pad number.
+ */
+#define PAL_LINE(port, pad)                                                 \
+  ((ioline_t)(((uint32_t)(port) << 5U) | (uint32_t)(pad)))
+
+/**
+ * @brief   Decodes a port identifier from a line identifier.
+ */
+#define PAL_PORT(line)                                                      \
+  ((ioportid_t)((uint32_t)(line) >> 5U))
+
+/**
+ * @brief   Decodes a pad identifier from a line identifier.
+ */
+#define PAL_PAD(line)                                                       \
+  ((iopadid_t)((uint32_t)(line) & 31U))
+
+/**
+ * @brief   Value identifying an invalid line.
+ */
+#define PAL_NOLINE                      0xFFFFFFFFU
+/** @} */
+
+/*===========================================================================*/
+/* I/O Ports Identifiers.                                                    */
+/* The low level driver exposes RP GPIO banks as PAL ports.                  */
+/*===========================================================================*/
+
+/**
+ * @brief   RP GPIO low port identifier.
+ */
+#define IOPORT1                         0U
+
+#if RP_GPIO_NUM_LINES > 32U || defined(__DOXYGEN__)
+/**
+ * @brief   RP GPIO high port identifier.
+ */
+#define IOPORT2                         1U
+#endif
+
+/*===========================================================================*/
+/* Implementation, some of the following macros could be implemented as
+   functions, if so please put them in pal_lld.c.                            */
+/*===========================================================================*/
+
+/**
+ * @brief   GPIO ports subsystem initialization.
+ *
+ * @notapi
+ */
+#define pal_lld_init()                  _pal_lld_init()
+
+/**
+ * @brief   Reads the physical I/O port states.
+ *
+ * @param[in] port      port identifier
+ * @return              The port bits.
+ *
+ * @notapi
+ */
+#define pal_lld_readport(port)                                              \
+  ((ioportmask_t)RP_PAL_SIO_REG(GPIO_IN, (port)))
+
+/**
+ * @brief   Reads the output latch.
+ * @details The purpose of this function is to read back the latched output
+ *          value.
+ *
+ * @param[in] port      port identifier
+ * @return              The latched logical states.
+ *
+ * @notapi
+ */
+#define pal_lld_readlatch(port)                                             \
+  ((ioportmask_t)RP_PAL_SIO_REG(GPIO_OUT, (port)))
+
+/**
+ * @brief   Writes a bits mask on a I/O port.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be written on the specified port
+ *
+ * @notapi
+ */
+/* @note    On RP2350, IOPORT2 maps to SIO GPIO_HI_OUT which is shared with
+ *          QSPI/USB outputs in bits 31:16. Only the bits belonging to PAL
+ *          lines are updated, using a single write to the GPIO_OUT_XOR
+ *          alias, so the shared non-PAL latch bits are preserved.
+ * @note    The latch read and XOR write are not one atomic step: a
+ *          full-port write must be serialized by the application against
+ *          ALL concurrent output updates to the SAME port - including
+ *          line/group set, clear and toggle - because an update landing
+ *          between the read and the XOR write is folded into a value
+ *          neither writer requested. The set, clear and toggle APIs are
+ *          only atomic among themselves. Different ports are independent.
+ */
+#define pal_lld_writeport(port, bits)                                       \
+  do {                                                                      \
+    RP_PAL_SIO_REG(GPIO_OUT_XOR, (port)) =                                  \
+      (RP_PAL_SIO_REG(GPIO_OUT, (port)) ^ (uint32_t)(bits)) &               \
+      (uint32_t)RP_PAL_VALID_MASK(port);                                    \
+  } while (false)
+
+/**
+ * @brief   Sets a bits mask on a I/O port.
+ * @note    The @ref PAL provides a default software implementation of this
+ *          functionality, implement this function if can optimize it by using
+ *          special hardware functionalities or special coding.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be ORed on the specified port
+ *
+ * @notapi
+ */
+#define pal_lld_setport(port, bits)                                         \
+  do {                                                                      \
+    chDbgAssert(((uint32_t)(bits) & ~(uint32_t)RP_PAL_VALID_MASK(port))     \
+                == 0U, "invalid port bits");                                \
+    RP_PAL_SIO_REG(GPIO_OUT_SET, (port)) = (uint32_t)(bits);               \
+  } while (false)
+
+/**
+ * @brief   Clears a bits mask on a I/O port.
+ * @note    The @ref PAL provides a default software implementation of this
+ *          functionality, implement this function if can optimize it by using
+ *          special hardware functionalities or special coding.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be cleared on the specified port
+ *
+ * @notapi
+ */
+#define pal_lld_clearport(port, bits)                                       \
+  do {                                                                      \
+    chDbgAssert(((uint32_t)(bits) & ~(uint32_t)RP_PAL_VALID_MASK(port))     \
+                == 0U, "invalid port bits");                                \
+    RP_PAL_SIO_REG(GPIO_OUT_CLR, (port)) = (uint32_t)(bits);               \
+  } while (false)
+
+/**
+ * @brief   Toggles a bits mask on a I/O port.
+ * @note    The @ref PAL provides a default software implementation of this
+ *          functionality, implement this function if can optimize it by using
+ *          special hardware functionalities or special coding.
+ *
+ * @param[in] port      port identifier
+ * @param[in] bits      bits to be XORed on the specified port
+ *
+ * @notapi
+ */
+#define pal_lld_toggleport(port, bits)                                      \
+  do {                                                                      \
+    chDbgAssert(((uint32_t)(bits) & ~(uint32_t)RP_PAL_VALID_MASK(port))     \
+                == 0U, "invalid port bits");                                \
+    RP_PAL_SIO_REG(GPIO_OUT_XOR, (port)) = (uint32_t)(bits);               \
+  } while (false)
+
+/**
+ * @brief   Pads group mode setup.
+ *
+ * @param[in] port      port identifier
+ * @param[in] mask      group mask
+ * @param[in] offset    group bit offset within the port
+ * @param[in] mode      group mode
+ *
+ * @notapi
+ */
+#define pal_lld_setgroupmode(port, mask, offset, mode)                     \
+  _pal_lld_setgroupmode(port, (mask) << (offset), mode)
+
+#if (PAL_USE_WAIT == TRUE) || (PAL_USE_CALLBACKS == TRUE)
+
+#define pal_lld_enablepadevent(port, pad, mode)                             \
+  _pal_lld_enablelineevent(PAL_LINE(port, pad), mode)
+
+#define pal_lld_disablepadevent(port, pad)                                  \
+  _pal_lld_disablelineevent(PAL_LINE(port, pad))
+
+#define pal_lld_ispadeventenabled(port, pad)                                \
+  _pal_lld_ispadeventenabled(port, pad)
+
+#if !defined(RP_IO_IRQ_BANK0_PRIORITY)
+  /** @brief IRQ priority of the external pad events. */
+  #define RP_IO_IRQ_BANK0_PRIORITY          2
+#endif
+
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IO_IRQ_BANK0_PRIORITY)
+#error "invalid IRQ priority assigned to IO_BANK0"
+#endif
+
+/**
+ * @brief   Enables the PAL events interrupt vector on the calling core.
+ * @details The NVIC is a per-core resource and the PAL events interrupts are
+ *          routed to the core selected by @p RP_PAL_EVENT_CORE_AFFINITY.
+ *          halInit() enables the vector only when running on the affinity
+ *          core, otherwise this function must be called from the affinity
+ *          core after it has been started.
+ * @note    Must be called from the @p RP_PAL_EVENT_CORE_AFFINITY core.
+ *
+ * @special
+ */
+__STATIC_INLINE void palRPEnableEventsIrqX(void) {
+
+  chDbgAssert(SIO->CPUID == (uint32_t)RP_PAL_EVENT_CORE_AFFINITY,
+              "wrong core");
+
+  nvicEnableVector(RP_IO_IRQ_BANK0_NUMBER, RP_IO_IRQ_BANK0_PRIORITY);
+}
+
+#if !defined(__DOXYGEN__)
+extern palevent_t _pal_events[RP_GPIO_NUM_LINES];
+#endif
+
+/**
+ * @brief   Returns a PAL event structure associated to a line.
+ *
+ * @param[in] line      line identifier
+ *
+ * @notapi
+ */
+#define pal_lld_get_line_event(line)                                        \
+  &_pal_events[line]
+
+/**
+ * @brief   Returns a PAL event structure associated to a pad.
+ *
+ * @param[in] port      port identifier
+ * @param[in] pad       pad number within the port
+ *
+ * @notapi
+ */
+#define pal_lld_get_pad_event(port, pad)                                    \
+  &_pal_events[PAL_LINE(port, pad)]
+
+/**
+ * @brief Force a trigger event on the line.
+ *
+ * @param[in]         line identifier
+ *
+ * @notapi
+ */
+#define pal_lld_forcelineevent(line)                                        \
+  _pal_lld_forcelineevent(line)
+
+/**
+ * @brief Clear any previously forced trigger on the line.
+ *
+ * @param[in]         line identifier
+ *
+ * @notapi
+ */
+#define pal_lld_unforcelineevent(line)                                      \
+  _pal_lld_unforcelineevent(line)
+
+#endif /* (PAL_USE_WAIT == TRUE) || (PAL_USE_CALLBACKS == TRUE) */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void _pal_lld_setgroupmode(ioportid_t port,
+                             ioportmask_t mask,
+                             iomode_t mode);
+  void _pal_lld_init(void);
+#if (PAL_USE_WAIT == TRUE) || (PAL_USE_CALLBACKS == TRUE)
+  bool _pal_lld_ispadeventenabled(ioportid_t port, iopadid_t pad);
+  void _pal_lld_enablelineevent(ioline_t line, ioeventmode_t mode);
+  void _pal_lld_disablelineevent(ioline_t line);
+  void _pal_lld_forcelineevent(ioline_t line);
+  void _pal_lld_unforcelineevent(ioline_t line);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_PAL */
+
+#endif /* HAL_PAL_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
@@ -1,0 +1,3 @@
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/hal_st_lld.c
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1

--- a/os/xhal/ports/RP/LLD/TIMERv1/hal_st_lld.c
+++ b/os/xhal/ports/RP/LLD/TIMERv1/hal_st_lld.c
@@ -1,0 +1,281 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    TIMERv1/hal_st_lld.c
+ * @brief   ST Driver subsystem low level driver code.
+ *
+ * @addtogroup ST
+ * @{
+ */
+
+#include "hal.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#if CH_CFG_ST_TIMEDELTA > 0
+#define ST_HANDLER                          SysTick_Handler
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+
+#if CH_CFG_ST_TIMEDELTA == 0
+#define ST_HANDLER                          SysTick_Handler
+#endif /* CH_CFG_ST_TIMEDELTA == 0 */
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local types.                                                       */
+/*===========================================================================*/
+
+typedef struct {
+  uint32_t n;
+  uint32_t prio;
+} alarm_irq_t;
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+#if (ST_LLD_NUM_ALARMS > 1) || defined(__DOXYGEN__)
+static const alarm_irq_t alarm_irqs[ST_LLD_NUM_ALARMS] = {
+  {RP_TIMER0_IRQ0_NUMBER, RP_IRQ_TIMER0_ALARM0_PRIORITY},
+  {RP_TIMER0_IRQ1_NUMBER, RP_IRQ_TIMER0_ALARM1_PRIORITY},
+  {RP_TIMER0_IRQ2_NUMBER, RP_IRQ_TIMER0_ALARM2_PRIORITY},
+  {RP_TIMER0_IRQ3_NUMBER, RP_IRQ_TIMER0_ALARM3_PRIORITY}
+};
+#endif
+#endif
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if (CH_CFG_ST_TIMEDELTA == 0) || defined(__DOXYGEN__)
+#if !defined(ST_SYSTICK_SUPPRESS_ISR)
+/**
+ * @brief   SysTick interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(SysTick_Handler) {
+
+  CH_IRQ_PROLOGUE();
+
+  chSysLockFromISR();
+  chSysTimerHandlerI();
+  chSysUnlockFromISR();
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+#endif /* CH_CFG_ST_TIMEDELTA == 0 */
+
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+#if !defined(ST_TIMER_ALARM0_SUPPRESS_ISR)
+/**
+ * @brief   TIMER alarm 0 interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_TIMER0_IRQ0_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM0) != 0U, "not pending");
+
+  TIMER0->INTR = TIMER_INTR_ALARM0;
+
+#if defined(ST_LLD_ALARM0_STATIC_CB)
+  ST_LLD_ALARM0_STATIC_CB();
+#else
+  if (st_callbacks[0] != NULL) {
+    st_callbacks[0](0U);
+  }
+#endif
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+
+#if !defined(ST_TIMER_ALARM1_SUPPRESS_ISR)
+/**
+ * @brief   TIMER alarm 1 interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_TIMER0_IRQ1_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM1) != 0U, "not pending");
+
+  TIMER0->INTR = TIMER_INTR_ALARM1;
+
+#if defined(ST_LLD_ALARM1_STATIC_CB)
+  ST_LLD_ALARM1_STATIC_CB();
+#else
+  if (st_callbacks[1] != NULL) {
+    st_callbacks[1](1U);
+  }
+#endif
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+
+#if !defined(ST_TIMER_ALARM2_SUPPRESS_ISR)
+/**
+ * @brief   TIMER alarm 2 interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_TIMER0_IRQ2_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM2) != 0U, "not pending");
+
+  TIMER0->INTR = TIMER_INTR_ALARM2;
+
+#if defined(ST_LLD_ALARM2_STATIC_CB)
+  ST_LLD_ALARM2_STATIC_CB();
+#else
+  if (st_callbacks[2] != NULL) {
+    st_callbacks[2](2U);
+  }
+#endif
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+
+#if !defined(ST_TIMER_ALARM3_SUPPRESS_ISR)
+/**
+ * @brief   TIMER alarm 3 interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_TIMER0_IRQ3_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM3) != 0U, "not pending");
+
+  TIMER0->INTR = TIMER_INTR_ALARM3;
+
+#if defined(ST_LLD_ALARM3_STATIC_CB)
+  ST_LLD_ALARM3_STATIC_CB();
+#else
+  if (st_callbacks[3] != NULL) {
+    st_callbacks[3](3U);
+  }
+#endif
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level ST driver initialization.
+ *
+ * @notapi
+ */
+void st_lld_init(void) {
+
+#if CH_CFG_ST_TIMEDELTA > 0
+  /* The timer needs to stop during debug or the virtual timers list would
+     go out of sync.*/
+  TIMER0->DBGPAUSE  = TIMER_DBGPAUSE_DBG0 | TIMER_DBGPAUSE_DBG1;
+
+  /* Comparators and counter initially at zero.*/
+  TIMER0->TIMELW    = 0U;
+  TIMER0->TIMEHW    = 0U;
+  TIMER0->ALARM[0]  = 0U;
+  TIMER0->ALARM[1]  = 0U;
+  TIMER0->ALARM[2]  = 0U;
+  TIMER0->ALARM[3]  = 0U;
+  TIMER0->INTE      = 0U;
+  TIMER0->INTR      = TIMER_INTR_ALARM3 | TIMER_INTR_ALARM2 |
+                      TIMER_INTR_ALARM1 | TIMER_INTR_ALARM0;
+
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+}
+
+/**
+ * @brief   Enables an alarm interrupt on the invoking core.
+ * @note    Must be called before any other alarm-related function.
+ *
+ * @notapi
+ */
+void st_lld_bind(void) {
+
+#if CH_CFG_ST_TIMEDELTA > 0
+  nvicEnableVector(RP_TIMER0_IRQ0_NUMBER, RP_IRQ_TIMER0_ALARM0_PRIORITY);
+#endif
+#if CH_CFG_ST_TIMEDELTA == 0
+  uint32_t  timer_clk = RP_CORE_CLK;
+
+  chDbgAssert(timer_clk % CH_CFG_ST_FREQUENCY == 0U,
+              "division remainder");
+  chDbgAssert((timer_clk / CH_CFG_ST_FREQUENCY) - 1U <= 0x00FFFFFFU,
+              "prescaler range");
+
+  /* Periodic systick mode, the Cortex-Mx internal systick timer is used
+     in this mode.*/
+  SysTick->LOAD = (timer_clk / CH_CFG_ST_FREQUENCY) - 1;
+  SysTick->VAL = 0;
+  SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |
+                  SysTick_CTRL_ENABLE_Msk |
+                  SysTick_CTRL_TICKINT_Msk;
+
+  /* IRQ enabled.*/
+  nvicSetSystemHandlerPriority(HANDLER_SYSTICK, RP_IRQ_SYSTICK_PRIORITY);
+#endif /* CH_CFG_ST_TIMEDELTA == 0 */
+}
+
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+#if (ST_LLD_NUM_ALARMS > 1) || defined(__DOXYGEN__)
+/**
+ * @brief   Enables an alarm interrupt on the invoking core.
+ * @note    Must be called before any other alarm-related function.
+ *
+ * @param[in] alarm     alarm channel number (0..ST_LLD_NUM_ALARMS-1)
+ *
+ * @notapi
+ */
+void st_lld_bind_alarm_n(unsigned alarm) {
+
+  nvicEnableVector(alarm_irqs[alarm].n, alarm_irqs[alarm].prio);
+}
+#endif /* ST_LLD_NUM_ALARMS > 1 */
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/TIMERv1/hal_st_lld.c
+++ b/os/xhal/ports/RP/LLD/TIMERv1/hal_st_lld.c
@@ -100,20 +100,25 @@ CH_IRQ_HANDLER(SysTick_Handler) {
  * @isr
  */
 CH_IRQ_HANDLER(RP_TIMER0_IRQ0_HANDLER) {
+  uint32_t ints;
 
   CH_IRQ_PROLOGUE();
 
-  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM0) != 0U, "not pending");
-
+  ints = TIMER0->INTS;
   TIMER0->INTR = TIMER_INTR_ALARM0;
 
+  /* Dismissing spurious wakeups, the alarm can be stopped from within a
+     critical section while its interrupt is already latched and pended
+     in the NVIC, in that case the callback must not be invoked.*/
+  if ((ints & TIMER_INTS_ALARM0) != 0U) {
 #if defined(ST_LLD_ALARM0_STATIC_CB)
-  ST_LLD_ALARM0_STATIC_CB();
+    ST_LLD_ALARM0_STATIC_CB();
 #else
-  if (st_callbacks[0] != NULL) {
-    st_callbacks[0](0U);
-  }
+    if (st_callbacks[0] != NULL) {
+      st_callbacks[0](0U);
+    }
 #endif
+  }
 
   CH_IRQ_EPILOGUE();
 }
@@ -126,20 +131,25 @@ CH_IRQ_HANDLER(RP_TIMER0_IRQ0_HANDLER) {
  * @isr
  */
 CH_IRQ_HANDLER(RP_TIMER0_IRQ1_HANDLER) {
+  uint32_t ints;
 
   CH_IRQ_PROLOGUE();
 
-  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM1) != 0U, "not pending");
-
+  ints = TIMER0->INTS;
   TIMER0->INTR = TIMER_INTR_ALARM1;
 
+  /* Dismissing spurious wakeups, the alarm can be stopped from within a
+     critical section while its interrupt is already latched and pended
+     in the NVIC, in that case the callback must not be invoked.*/
+  if ((ints & TIMER_INTS_ALARM1) != 0U) {
 #if defined(ST_LLD_ALARM1_STATIC_CB)
-  ST_LLD_ALARM1_STATIC_CB();
+    ST_LLD_ALARM1_STATIC_CB();
 #else
-  if (st_callbacks[1] != NULL) {
-    st_callbacks[1](1U);
-  }
+    if (st_callbacks[1] != NULL) {
+      st_callbacks[1](1U);
+    }
 #endif
+  }
 
   CH_IRQ_EPILOGUE();
 }
@@ -152,20 +162,25 @@ CH_IRQ_HANDLER(RP_TIMER0_IRQ1_HANDLER) {
  * @isr
  */
 CH_IRQ_HANDLER(RP_TIMER0_IRQ2_HANDLER) {
+  uint32_t ints;
 
   CH_IRQ_PROLOGUE();
 
-  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM2) != 0U, "not pending");
-
+  ints = TIMER0->INTS;
   TIMER0->INTR = TIMER_INTR_ALARM2;
 
+  /* Dismissing spurious wakeups, the alarm can be stopped from within a
+     critical section while its interrupt is already latched and pended
+     in the NVIC, in that case the callback must not be invoked.*/
+  if ((ints & TIMER_INTS_ALARM2) != 0U) {
 #if defined(ST_LLD_ALARM2_STATIC_CB)
-  ST_LLD_ALARM2_STATIC_CB();
+    ST_LLD_ALARM2_STATIC_CB();
 #else
-  if (st_callbacks[2] != NULL) {
-    st_callbacks[2](2U);
-  }
+    if (st_callbacks[2] != NULL) {
+      st_callbacks[2](2U);
+    }
 #endif
+  }
 
   CH_IRQ_EPILOGUE();
 }
@@ -178,20 +193,25 @@ CH_IRQ_HANDLER(RP_TIMER0_IRQ2_HANDLER) {
  * @isr
  */
 CH_IRQ_HANDLER(RP_TIMER0_IRQ3_HANDLER) {
+  uint32_t ints;
 
   CH_IRQ_PROLOGUE();
 
-  chDbgAssert((TIMER0->INTS & TIMER_INTS_ALARM3) != 0U, "not pending");
-
+  ints = TIMER0->INTS;
   TIMER0->INTR = TIMER_INTR_ALARM3;
 
+  /* Dismissing spurious wakeups, the alarm can be stopped from within a
+     critical section while its interrupt is already latched and pended
+     in the NVIC, in that case the callback must not be invoked.*/
+  if ((ints & TIMER_INTS_ALARM3) != 0U) {
 #if defined(ST_LLD_ALARM3_STATIC_CB)
-  ST_LLD_ALARM3_STATIC_CB();
+    ST_LLD_ALARM3_STATIC_CB();
 #else
-  if (st_callbacks[3] != NULL) {
-    st_callbacks[3](3U);
-  }
+    if (st_callbacks[3] != NULL) {
+      st_callbacks[3](3U);
+    }
 #endif
+  }
 
   CH_IRQ_EPILOGUE();
 }

--- a/os/xhal/ports/RP/LLD/TIMERv1/hal_st_lld.h
+++ b/os/xhal/ports/RP/LLD/TIMERv1/hal_st_lld.h
@@ -1,0 +1,392 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    TIMERv1/hal_st_lld.h
+ * @brief   ST Driver subsystem low level driver header.
+ * @details This header is designed to be include-able without having to
+ *          include other files from the HAL.
+ *
+ * @addtogroup ST
+ * @{
+ */
+
+#ifndef HAL_ST_LLD_H
+#define HAL_ST_LLD_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of supported alarms.
+ */
+#define ST_LLD_NUM_ALARMS                   RP_ST_NUM_ALARMS
+
+/**
+ * @brief   Static callback for alarm 0.
+ */
+#define ST_LLD_ALARM0_STATIC_CB()                                           \
+  do {                                                                      \
+    chSysLockFromISR();                                                     \
+    chSysTimerHandlerI();                                                   \
+    chSysUnlockFromISR();                                                   \
+  } while (false)
+
+/**
+ * @brief   Static callback for alarm 1.
+ */
+#define ST_LLD_ALARM1_STATIC_CB()                                           \
+  do {                                                                      \
+    chSysLockFromISR();                                                     \
+    chSysTimerHandlerI();                                                   \
+    chSysUnlockFromISR();                                                   \
+  } while (false)
+
+/**
+ * @brief   Defined for inclusion of the IRQ-binding API.
+ */
+#define ST_LLD_MULTICORE_SUPPORT
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   SysTick timer IRQ priority.
+ */
+#if !defined(RP_IRQ_SYSTICK_PRIORITY) || defined(__DOXYGEN__)
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#endif
+
+/**
+ * @brief   TIMER0 alarm 0 IRQ priority.
+ */
+#if !defined(RP_IRQ_TIMER0_ALARM0_PRIORITY) || defined(__DOXYGEN__)
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY        2
+#endif
+
+/**
+ * @brief   TIMER0 alarm 1 IRQ priority.
+ */
+#if !defined(RP_IRQ_TIMER0_ALARM1_PRIORITY) || defined(__DOXYGEN__)
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY        2
+#endif
+
+/**
+ * @brief   TIMER0 alarm 2 IRQ priority.
+ */
+#if !defined(RP_IRQ_TIMER0_ALARM2_PRIORITY) || defined(__DOXYGEN__)
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY        2
+#endif
+
+/**
+ * @brief   TIMER0 alarm 3 IRQ priority.
+ */
+#if !defined(RP_IRQ_TIMER0_ALARM3_PRIORITY) || defined(__DOXYGEN__)
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY        2
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if (CH_CFG_ST_TIMEDELTA > 0) && (CH_CFG_ST_RESOLUTION != 32)
+#error "CH_CFG_ST_RESOLUTION must be 32 in free running mode"
+#endif
+
+#if CH_CFG_ST_TIMEDELTA > 0
+
+#define RP_ST_USE_SYSTICK                   FALSE
+#define RP_ST_USE_TIMER                     TRUE
+
+#elif CH_CFG_ST_TIMEDELTA == 0
+
+#define RP_ST_USE_SYSTICK                   TRUE
+#define RP_ST_USE_TIMER                     FALSE
+
+#else
+
+#define RP_ST_USE_SYSTICK                   FALSE
+#define RP_ST_USE_TIMER                     FALSE
+
+#endif
+
+#if RP_ST_USE_SYSTICK == TRUE
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_SYSTICK_PRIORITY)
+#error "invalid IRQ priority assigned to SysTick"
+#endif
+#endif
+
+#if RP_ST_USE_TIMER == TRUE
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_TIMER0_ALARM0_PRIORITY)
+#error "invalid IRQ priority assigned to TIMER0 alarm 0"
+#endif
+
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_TIMER0_ALARM1_PRIORITY)
+#error "invalid IRQ priority assigned to TIMER0 alarm 1"
+#endif
+
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_TIMER0_ALARM2_PRIORITY)
+#error "invalid IRQ priority assigned to TIMER0 alarm 2"
+#endif
+
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_TIMER0_ALARM3_PRIORITY)
+#error "invalid IRQ priority assigned to TIMER0 alarm 3"
+#endif
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void st_lld_init(void);
+  void st_lld_bind(void);
+#if CH_CFG_ST_TIMEDELTA > 0
+  void st_lld_bind_alarm_n(unsigned alarm);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Driver inline functions.                                                  */
+/*===========================================================================*/
+
+#if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
+/**
+ * @brief   Returns the time counter value.
+ *
+ * @return              The counter value.
+ *
+ * @notapi
+ */
+__STATIC_INLINE systime_t st_lld_get_counter(void) {
+
+  return (systime_t)TIMER0->TIMERAWL;
+}
+
+/**
+ * @brief   Starts the alarm.
+ * @note    Makes sure that no spurious alarms are triggered after
+ *          this call.
+ * @note    Uses atomic SET/CLR registers for dual-core safe INTE access.
+ *
+ * @param[in] abstime   the time to be set for the first alarm
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_start_alarm(systime_t abstime) {
+
+  TIMER0->ALARM[0]       = (uint32_t)abstime;
+  TIMER0->INTR           = (1U << 0);
+  TIMER0->SET.INTE       = (1U << 0);
+  /* Re-arm if abstime already past to avoid ~71 min wait for counter wrap. */
+  if ((int32_t)(abstime - TIMER0->TIMERAWL) <= 0) {
+    TIMER0->ALARM[0]     = TIMER0->TIMERAWL + 2U;
+  }
+}
+
+/**
+ * @brief   Stops the alarm interrupt.
+ * @note    Uses atomic CLR register for dual-core safe INTE access.
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_stop_alarm(void) {
+
+  TIMER0->CLR.INTE       = (1U << 0);
+}
+
+/**
+ * @brief   Sets the alarm time.
+ *
+ * @param[in] abstime   the time to be set for the next alarm
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_set_alarm(systime_t abstime) {
+  uint32_t target = (uint32_t)abstime;
+
+  TIMER0->ALARM[0] = target;
+  /* Verify-and-retry: the counter can pass the programmed value between
+     the check and the store (an interrupt or bus stall in the window
+     recreates the ~71 min wrap wait), so the deadline is re-armed until
+     either it is provably in the future or the compare has genuinely
+     fired (ARMED bit cleared by hardware). ARMED is sampled immediately
+     before deciding to re-arm so a firing that lands mid-check is seen
+     in the narrowest possible window; the residual race, firing between
+     that read and the store, can at worst produce one spurious alarm
+     interrupt which the ST layer tolerates - the opposite failure, not
+     re-arming a missed deadline, is the one that must not happen. */
+  while (true) {
+    uint32_t now = TIMER0->TIMERAWL;
+
+    if ((int32_t)(target - now) > 0) {
+      break;
+    }
+    if ((TIMER0->ARMED & 1U) == 0U) {
+      break;
+    }
+    target = now + 2U;
+    TIMER0->ALARM[0] = target;
+  }
+}
+
+/**
+ * @brief   Returns the current alarm time.
+ *
+ * @return              The currently set alarm time.
+ *
+ * @notapi
+ */
+__STATIC_INLINE systime_t st_lld_get_alarm(void) {
+
+  return (systime_t)TIMER0->ALARM[0];
+}
+
+/**
+ * @brief   Determines if the alarm is active.
+ *
+ * @return              The alarm status.
+ * @retval false        if the alarm is not active.
+ * @retval true         is the alarm is active
+ *
+ * @notapi
+ */
+__STATIC_INLINE bool st_lld_is_alarm_active(void) {
+
+  return (bool)((TIMER0->INTE & (1U << 0)) != 0U);
+}
+
+#if (ST_LLD_NUM_ALARMS > 1) || defined(__DOXYGEN__)
+/**
+ * @brief   Starts an alarm.
+ * @note    Makes sure that no spurious alarms are triggered after
+ *          this call.
+ * @note    This functionality is only available in free running mode, the
+ *          behavior in periodic mode is undefined.
+ *
+ * @param[in] abstime   the time to be set for the first alarm
+ * @param[in] alarm     alarm channel number
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_start_alarm_n(unsigned alarm, systime_t abstime) {
+
+  TIMER0->ALARM[alarm]   = (uint32_t)abstime;
+  TIMER0->INTR           = (1U << alarm);
+  TIMER0->SET.INTE       = (1U << alarm);
+  /* Re-arm if abstime already past to avoid ~71 min wait for counter wrap. */
+  if ((int32_t)(abstime - TIMER0->TIMERAWL) <= 0) {
+    TIMER0->ALARM[alarm] = TIMER0->TIMERAWL + 2U;
+  }
+}
+
+/**
+ * @brief   Stops an alarm interrupt.
+ * @note    This functionality is only available in free running mode, the
+ *          behavior in periodic mode is undefined.
+ *
+ * @param[in] alarm     alarm channel number
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_stop_alarm_n(unsigned alarm) {
+
+  TIMER0->CLR.INTE       = (1U << alarm);
+}
+
+/**
+ * @brief   Sets an alarm time.
+ * @note    This functionality is only available in free running mode, the
+ *          behavior in periodic mode is undefined.
+ *
+ * @param[in] alarm     alarm channel number
+ * @param[in] abstime   the time to be set for the next alarm
+ *
+ * @notapi
+ */
+__STATIC_INLINE void st_lld_set_alarm_n(unsigned alarm, systime_t abstime) {
+  uint32_t target = (uint32_t)abstime;
+
+  TIMER0->ALARM[alarm] = target;
+  /* Verify-and-retry, see st_lld_set_alarm(). */
+  while (true) {
+    uint32_t now = TIMER0->TIMERAWL;
+
+    if ((int32_t)(target - now) > 0) {
+      break;
+    }
+    if ((TIMER0->ARMED & (1U << alarm)) == 0U) {
+      break;
+    }
+    target = now + 2U;
+    TIMER0->ALARM[alarm] = target;
+  }
+}
+
+/**
+ * @brief   Returns an alarm current time.
+ * @note    This functionality is only available in free running mode, the
+ *          behavior in periodic mode is undefined.
+ *
+ * @param[in] alarm     alarm channel number
+ * @return              The currently set alarm time.
+ *
+ * @notapi
+ */
+__STATIC_INLINE systime_t st_lld_get_alarm_n(unsigned alarm) {
+
+  return (systime_t)TIMER0->ALARM[alarm];
+}
+
+/**
+ * @brief   Determines if an alarm is active.
+ *
+ * @param[in] alarm     alarm channel number
+ * @return              The alarm status.
+ * @retval false        if the alarm is not active.
+ * @retval true         is the alarm is active
+ *
+ * @notapi
+ */
+static inline bool st_lld_is_alarm_active_n(unsigned alarm) {
+
+  return (bool)((TIMER0->INTE & (1U << alarm)) != 0U);
+}
+#endif /* ST_LLD_NUM_ALARMS > 1 */
+#endif /* CH_CFG_ST_TIMEDELTA > 0 */
+
+#endif /* HAL_ST_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/README.md
+++ b/os/xhal/ports/RP/README.md
@@ -1,0 +1,36 @@
+# RP2040 / RP2350 XHAL port
+
+XHAL port for the Raspberry Pi RP2040 (Cortex-M0+) and RP2350 (Cortex-M33,
+Hazard3 RISC-V planned as a separate milestone). The port is a twin of the
+classic HAL port at `os/hal/ports/RP`, adapted to the XHAL driver contract
+(no OSAL, `drvStart()`/`drvStop()` lifecycle, `setcfg`/`selcfg` configuration
+model, callback-driver semantics).
+
+## Fork provenance and drift policy
+
+Files below were forked from `os/hal/ports/RP` and converted; the classic
+tree remains the reference for hardware behavior. When a fix lands in a
+classic-RP file listed here, mirror it (re-converted) or record the
+intentional divergence in this table.
+
+| File group | Forked from (commit) | Notes |
+|---|---|---|
+| `rp_bootrom.c/.h` | `0db31951d5` | debug macros converted |
+| `LLD/GPIOv1` (PAL) | `0db31951d5` | event macros align with XHAL `hal_pal.h` |
+| `LLD/TIMERv1` (ST) | `0db31951d5` | `CH_CFG_ST_TIMEDELTA` replaces the OSAL ST mode selection |
+| `RP2040/`, `RP2350/` family files | `0db31951d5` | UART shared-vector includes deferred to the SIO stage |
+
+Intentional divergences from the classic tree:
+
+- `hal_lld_init()` calls `stBind()` unconditionally (classic gates it to
+  free running mode, leaving the periodic SysTick path configured by
+  `st_lld_bind()` but never started).
+- The ST and PAL headers validate their IRQ priority knobs with
+  `CH_IRQ_IS_VALID_KERNEL_PRIORITY` (classic performs no checks; these
+  handlers take kernel locks, so architectural-only validity would be
+  insufficient).
+
+Shared with the classic tree (referenced in place, not forked): startup
+files and kernel ports (`os/common/startup/…`, `os/common/ports/…`), board
+files (`os/hal/boards/RP_PICO_RP2040`, `RP_PICO2_RP2350`), and
+`os/hal/ports/RP/rp_uf2_image.mk`.

--- a/os/xhal/ports/RP/RP2040/hal_lld.c
+++ b/os/xhal/ports/RP/RP2040/hal_lld.c
@@ -1,0 +1,142 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/hal_lld.c
+ * @brief   RP2040 HAL subsystem low level driver source.
+ * @note    The Core 1 launch sequence follows the multicore launch protocol
+ *          documented in RP2040 Datasheet 2.8.2 "Launching Code On
+ *          Processor Core 1".
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#include "hal.h"
+#include "rp_clocks.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   CMSIS system core clock variable.
+ * @note    It is declared in system_rp2040.h.
+ */
+uint32_t SystemCoreClock = RP_CLK_SYS_FREQ;
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+#if RP_CORE1_START == TRUE
+static void start_core1(void) {
+  extern uint32_t RP_CORE1_STACK_END;
+  extern uint32_t RP_CORE1_VECTORS_TABLE;
+  extern void RP_CORE1_ENTRY_POINT(void);
+  static const uint32_t cmd_sequence[] = {0, 0, 1,
+                             (uint32_t)&RP_CORE1_VECTORS_TABLE,
+                             (uint32_t)&RP_CORE1_STACK_END,
+                             (uint32_t)RP_CORE1_ENTRY_POINT};
+  unsigned seq;
+
+  /* Force-reset core1 via PSM before starting the FIFO launch handshake.
+   *
+   * If core1 survived a preceding soft reset (e.g. a bootloader that uses
+   * BX to jump to the application rather than SYSRESETREQ), it may still
+   * be executing application code from a previous run.  In that case the
+   * ROM FIFO handshake protocol will deadlock: core0 sends the sync
+   * sequence but core1 is not in the ROM wait-for-launch loop so it never
+   * echoes back.
+   *
+   * PSM FRCE_OFF holds core1 in reset (powered-off state).  Clearing it
+   * releases core1 into the ROM boot-path which immediately enters the
+   * wait-for-launch loop.  The PSM DONE bit falls while the core is held
+   * off, and rises again once it has been released and is running.*/
+  PSM->SET.FRCE_OFF = PSM_ANY_PROC1;         /* Assert reset to core1.     */
+  while (PSM->DONE & PSM_ANY_PROC1) {}       /* Wait until it powers off.  */
+  PSM->CLR.FRCE_OFF = PSM_ANY_PROC1;         /* Release, core1 enters ROM. */
+
+  /* Starting core 1.*/
+  seq = 0;
+  do {
+    uint32_t response;
+    uint32_t cmd = cmd_sequence[seq];
+
+    /* Flushing the FIFO state before sending a zero.*/
+    if (!cmd) {
+      fifoFlushRead();
+    }
+    fifoBlockingWrite(cmd);
+    response = fifoBlockingRead();
+    /* Checking response, going forward or back to first step.*/
+    seq = cmd == response ? seq + 1U : 0U;
+  } while (seq < 6U);
+}
+#endif
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level HAL driver initialization.
+ *
+ * @notapi
+ */
+void hal_lld_init(void) {
+
+#if RP_NO_INIT == FALSE
+  rp_peripheral_unreset(RESETS_ALLREG_BUSCTRL);
+  rp_peripheral_unreset(RESETS_ALLREG_SYSINFO);
+  rp_peripheral_unreset(RESETS_ALLREG_SYSCFG);
+#endif /* RP_NO_INIT */
+
+  /* NVIC initialization.*/
+  nvicInit();
+
+  /* IRQ subsystem initialization.*/
+  irqInit();
+#if defined(RP_DMA_REQUIRED)
+  dmaInit();
+#endif
+#if defined(RP_PIO_REQUIRED)
+  pioInit();
+#endif
+
+  /* Bind the system timer to this core, in free running mode this enables
+     the alarm 0 vector, in periodic mode this configures the core-local
+     SysTick timer.*/
+  stBind();
+
+#if RP_CORE1_START == TRUE
+  start_core1();
+#endif
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/hal_lld.h
+++ b/os/xhal/ports/RP/RP2040/hal_lld.h
@@ -1,0 +1,314 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/hal_lld.h
+ * @brief   RP2040 HAL subsystem low level driver header.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef HAL_LLD_H
+#define HAL_LLD_H
+
+/*
+ * Registry definitions.
+ */
+#include "rp_registry.h"
+#include "rp_clocks.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Platform identification macros
+ * @{
+ */
+#if defined(RP2040) || defined(__DOXYGEN__)
+#define PLATFORM_NAME           "RP2040"
+
+#else
+#error "RP2040 device not specified"
+#endif
+/** @} */
+
+/**
+ * @name    Internal clock sources
+ * @{
+ */
+#define RP_ROSCCLK              6500000     /**< 6.5MHz internal clock.     */
+/** @} */
+
+/**
+ * @name    GPIO IOCTRL register field positions
+ * @{
+ */
+#define RP_GPIO_IOCTRL_OEOVER_Pos           12
+#define RP_GPIO_IOCTRL_OUTOVER_Pos          8
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   Disables the clocks initialization in the HAL.
+ */
+#if !defined(RP_NO_INIT) || defined(__DOXYGEN__)
+#define RP_NO_INIT                          FALSE
+#endif
+
+/**
+ * @brief   Starts core 1 after initialization.
+ */
+#if !defined(RP_CORE1_START) || defined(__DOXYGEN__)
+#define RP_CORE1_START                      FALSE
+#endif
+
+/**
+ * @brief   Symbol for core 1 vectors table.
+ */
+#if !defined(RP_CORE1_VECTORS_TABLE) || defined(__DOXYGEN__)
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#endif
+
+/**
+ * @brief   Symbol for core 1 entry point.
+ */
+#if !defined(RP_CORE1_ENTRY_POINT) || defined(__DOXYGEN__)
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#endif
+
+/**
+ * @brief   Symbol for core 1 initial MSP position.
+ */
+#if !defined(RP_CORE1_STACK_END) || defined(__DOXYGEN__)
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*
+ * Configuration-related checks.
+ */
+#if !defined(__RP2040_XMCUCONF__)
+#error "Using a wrong xmcuconf.h file, __RP2040_XMCUCONF__ not defined"
+#endif
+
+/*
+ * Board files sanity checks.
+ */
+#if !defined(RP_XOSCCLK)
+#error "RP_XOSCCLK not defined in board.h"
+#endif
+
+#if (RP_XOSCCLK < 1000000) || (RP_XOSCCLK > 15000000)
+#error "RP_XOSCCLK out of valid range (1-15 MHz)"
+#endif
+
+/*
+ * The watchdog tick generator divides the crystal down to the 1 MHz
+ * time base advertised to the OS and the timer; a non-integer-MHz
+ * crystal would silently produce a wrong tick frequency.
+ */
+#if (RP_XOSCCLK % 1000000) != 0
+#error "RP_XOSCCLK must be an integer number of MHz for the 1 MHz tick generator"
+#endif
+
+/*
+ * PLL_SYS configuration checks. The checks form a single chain so that
+ * a derived check dividing by a parameter is never evaluated while that
+ * parameter is out of range: a stray "division by zero in #if"
+ * diagnostic would bury the intended message.
+ */
+#if (RP_PLL_SYS_REFDIV < 1) || (RP_PLL_SYS_REFDIV > 63)
+#error "RP_PLL_SYS_REFDIV out of valid range (1-63)"
+#elif (RP_PLL_SYS_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_SYS_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#error "RP_PLL_SYS_VCO_FREQ out of valid range (750-1600 MHz)"
+#elif (RP_PLL_SYS_POSTDIV1 < 1) || (RP_PLL_SYS_POSTDIV1 > 7)
+#error "RP_PLL_SYS_POSTDIV1 out of valid range (1-7)"
+#elif (RP_PLL_SYS_POSTDIV2 < 1) || (RP_PLL_SYS_POSTDIV2 > 7)
+#error "RP_PLL_SYS_POSTDIV2 out of valid range (1-7)"
+#elif RP_PLL_SYS_POSTDIV1 < RP_PLL_SYS_POSTDIV2
+#error "RP_PLL_SYS_POSTDIV1 must be >= RP_PLL_SYS_POSTDIV2"
+#elif (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_SYS_REFDIV"
+#elif (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
+#error "PLL_SYS reference frequency below 5 MHz minimum"
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not an integer multiple of the PLL_SYS reference frequency"
+#elif ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||    \
+      ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
+#error "PLL_SYS FBDIV out of valid range (16-320)"
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not divisible by RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2"
+#endif
+
+/*
+ * PLL_USB configuration checks, chained for the same reason as the
+ * PLL_SYS checks above.
+ */
+#if (RP_PLL_USB_REFDIV < 1) || (RP_PLL_USB_REFDIV > 63)
+#error "RP_PLL_USB_REFDIV out of valid range (1-63)"
+#elif (RP_PLL_USB_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_USB_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#error "RP_PLL_USB_VCO_FREQ out of valid range (750-1600 MHz)"
+#elif (RP_PLL_USB_POSTDIV1 < 1) || (RP_PLL_USB_POSTDIV1 > 7)
+#error "RP_PLL_USB_POSTDIV1 out of valid range (1-7)"
+#elif (RP_PLL_USB_POSTDIV2 < 1) || (RP_PLL_USB_POSTDIV2 > 7)
+#error "RP_PLL_USB_POSTDIV2 out of valid range (1-7)"
+#elif RP_PLL_USB_POSTDIV1 < RP_PLL_USB_POSTDIV2
+#error "RP_PLL_USB_POSTDIV1 must be >= RP_PLL_USB_POSTDIV2"
+#elif (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_USB_REFDIV"
+#elif (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
+#error "PLL_USB reference frequency below 5 MHz minimum"
+#elif (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not an integer multiple of the PLL_USB reference frequency"
+#elif ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||    \
+      ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
+#error "PLL_USB FBDIV out of valid range (16-320)"
+#elif (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not divisible by RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2"
+#endif
+
+#if RP_PLL_USB_CLK != 48000000
+#error "RP_PLL_USB_CLK must be 48 MHz for USB to work"
+#endif
+
+/*
+ * RP2040-E16 erratum check: reliable USB operation requires
+ * clk_sys >= 1.1 * clk_usb.
+ */
+#if ((RP_CLK_SYS_FREQ) * 10U) < ((RP_CLK_USB_FREQ) * 11U)
+#error "RP2040-E16: clk_sys must be at least 1.1 * clk_usb for reliable USB operation"
+#endif
+
+/**
+ * @name    Various clock points.
+ * @{
+ */
+#define RP_GPOUT0_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT0)
+#define RP_GPOUT1_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT1)
+#define RP_GPOUT2_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT2)
+#define RP_GPOUT3_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT3)
+#define RP_REF_CLK              hal_lld_get_clock_point(RP_CLK_REF)
+#define RP_CORE_CLK             hal_lld_get_clock_point(RP_CLK_SYS)
+#define RP_PERI_CLK             hal_lld_get_clock_point(RP_CLK_PERI)
+#define RP_USB_CLK              hal_lld_get_clock_point(RP_CLK_USB)
+#define RP_ADC_CLK              hal_lld_get_clock_point(RP_CLK_ADC)
+#define RP_RTC_CLK              hal_lld_get_clock_point(RP_CLK_RTC)
+/** @} */
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @name    Safety module counter support
+ * @note    Uses TIMER0 peripheral which counts at 1 us resolution.
+ *          During early clock init, accuracy depends on ROSC variance.
+ *          After clock init completes, timing is precise.
+ * @{
+ */
+
+/**
+ * @brief   Counter type for safety timeouts.
+ */
+typedef uint32_t halcnt_t;
+
+/**
+ * @brief   Returns the counter frequency in Hz.
+ * @note    Always returns 1 MHz (1 us ticks).
+ */
+#define HAL_LLD_GET_CNT_FREQUENCY()     1000000U
+
+/**
+ * @brief   Returns the current counter value.
+ */
+#define HAL_LLD_GET_CNT_VALUE()         ((halcnt_t)TIMER0->TIMERAWL)
+
+/** @} */
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+/* Various helpers.*/
+#include "nvic.h"
+#include "cache.h"
+#include "rp_isr.h"
+#include "rp_fifo.h"
+#include "rp_bootrom.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void hal_lld_init(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Driver inline functions.                                                  */
+/*===========================================================================*/
+
+__STATIC_INLINE void rp_peripheral_reset(uint32_t mask) {
+
+  RESETS->SET.RESET = mask;
+}
+
+__STATIC_INLINE void rp_peripheral_unreset(uint32_t mask) {
+
+  RESETS->CLR.RESET = mask;
+  while ((RESETS->RESET_DONE & mask) != mask) {
+    /* Waiting for peripheral to come out of reset */
+  }
+}
+
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+__STATIC_INLINE halfreq_t hal_lld_get_clock_point(halclkpt_t clkpt) {
+
+  chDbgAssert(clkpt < RP_CLK_COUNT, "invalid clock point");
+
+  return rp_clock_get_hz(clkpt);
+}
+
+#endif /* HAL_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/platform.mk
+++ b/os/xhal/ports/RP/RP2040/platform.mk
@@ -1,0 +1,38 @@
+# Required platform files.
+PLATFORMSRC := $(CHIBIOS)/os/xhal/ports/common/ARMCMx/nvic.c \
+               $(CHIBIOS)/os/xhal/ports/RP/rp_bootrom.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040/rp_clocks.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040/rp_isr.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040/rp_pll.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040/rp_xosc.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040/hal_lld.c
+
+# Required include directories.
+PLATFORMINC := $(CHIBIOS)/os/xhal/ports/common/ARMCMx \
+               $(CHIBIOS)/os/xhal/ports/RP \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040
+
+# Optional platform files.
+ifeq ($(USE_SMART_BUILD),yes)
+
+# Configuration files directory
+ifeq ($(HALCONFDIR),)
+  ifeq ($(CONFDIR),)
+    HALCONFDIR = .
+  else
+    HALCONFDIR := $(CONFDIR)
+  endif
+endif
+
+HALCONF := $(strip $(shell cat $(HALCONFDIR)/xhalconf.h | grep -E "\#define"))
+
+else
+endif
+
+# Drivers compatible with the platform.
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
+
+# Shared variables
+ALLCSRC += $(PLATFORMSRC)
+ALLINC  += $(PLATFORMINC)

--- a/os/xhal/ports/RP/RP2040/rp_clocks.c
+++ b/os/xhal/ports/RP/RP2040/rp_clocks.c
@@ -1,0 +1,214 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_clocks.c
+ * @brief   RP2040 clocks driver source.
+ * @note    See RP2040 Datasheet 2.15 Clocks
+ *
+ * @addtogroup RP_CLOCKS
+ * @{
+ */
+
+#include "hal.h"
+#include "rp_clocks.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Estimated ROSC frequency for early timing.
+ * @note    RP2040 ROSC varies 1.8-12 MHz, we assume ~6 MHz.
+ *          This gives roughly +/-50% accuracy which is acceptable for
+ *          safety timeouts during early clock initialization.
+ */
+#define RP_ROSC_ASSUMED_HZ      6000000U
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+#if RP_SYS_VREG_VOLTAGE > 0U
+static void delay_us(uint32_t delay) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((TIMER0->TIMERAWL - start) < delay) {
+  }
+}
+#endif
+
+static void set_vreg(void) {
+#if RP_SYS_VREG_VOLTAGE > 0U
+  uint32_t current_vsel;
+
+  current_vsel = (VREG_AND_CHIP_RESET->VREG & VREG_VSEL_Msk) >> VREG_VSEL_Pos;
+  if (current_vsel < RP_SYS_VREG_VOLTAGE) {
+    VREG_AND_CHIP_RESET->VREG =
+        (VREG_AND_CHIP_RESET->VREG & ~VREG_VSEL_Msk) |
+        (RP_SYS_VREG_VOLTAGE << VREG_VSEL_Pos);
+    delay_us(RP_SYS_VREG_SETTLE_DELAY_US);
+  }
+#endif
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes all clocks.
+ * @note    Most of this is derived from the RP2040 datasheet which directly
+ *          references suggested code from the Pico SDK which is Copyright
+ *          2020 Raspberry Pi (Trading) Ltd and licensed under the
+ *          BSD-3-Clause license. We always start with ROSC and then switch
+ *          to XOSC. With the RP2040 WATCHDOG->TICK services the watchdog,
+ *          the system timer and SYSTICK.
+ * @note    See RP2040 Datasheet 2.15.3.1 Clock Instances (Table 205)
+ */
+void rp_clock_init(void) {
+
+  /* Start early tick generator for safety module timeouts. */
+  rp_peripheral_unreset(RESETS_ALLREG_TIMER0);
+
+  /* Configure tick generator for ~1 us ticks. */
+  WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_ROSC_ASSUMED_HZ / 1000000U);
+
+  /* Clear clock resus that may be in an unknown state */
+  CLOCKS->RESUS.CTRL = 0U;
+
+  rp_xosc_init();
+
+  /* Switch clk_sys and clk_ref to safe sources */
+  CLOCKS->CLR.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 1U) == 0U) {
+    /* Wait for clk_sys to switch to clk_ref */
+  }
+  CLOCKS->CLR.CLK[RP_CLK_REF].CTRL = CLOCKS_CLK_REF_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_REF].SELECTED & 1U) == 0U) {
+    /* Wait for clk_ref to switch to ROSC */
+  }
+
+  /* Initialize PLL_SYS: 12 MHz * 125 / 6 / 2 = 125 MHz. */
+  rp_pll_init(PLL_SYS, RP_PLL_SYS_REFDIV, RP_PLL_SYS_VCO_FREQ,
+              RP_PLL_SYS_POSTDIV1, RP_PLL_SYS_POSTDIV2);
+
+  /* Initialize PLL_USB: 12 MHz * 100 / 5 / 5 = 48 MHz. */
+  rp_pll_init(PLL_USB, RP_PLL_USB_REFDIV, RP_PLL_USB_VCO_FREQ,
+              RP_PLL_USB_POSTDIV1, RP_PLL_USB_POSTDIV2);
+
+  /* CLK_REF = XOSC = 12 MHz */
+  {
+    uint32_t src = CLOCKS_CLK_REF_CTRL_SRC_XOSC >> CLOCKS_CLK_REF_CTRL_SRC_Pos;
+    CLOCKS->CLK[RP_CLK_REF].DIV = 1U << 8;
+    CLOCKS->XOR.CLK[RP_CLK_REF].CTRL =
+        (CLOCKS->CLK[RP_CLK_REF].CTRL ^ (src << CLOCKS_CLK_REF_CTRL_SRC_Pos)) &
+        CLOCKS_CLK_REF_CTRL_SRC_Msk;
+    while ((CLOCKS->CLK[RP_CLK_REF].SELECTED & (1U << src)) == 0U) {
+      /* Wait for switch to XOSC */
+    }
+  }
+
+  /* Reconfigure tick generator for accurate 1 us ticks now that clk_ref
+   * is on XOSC, then raise core voltage if needed before the fast
+   * clk_sys switch.  */
+  WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_XOSCCLK / 1000000U);
+  set_vreg();
+
+  /* CLK_SYS = PLL_SYS */
+  CLOCKS->CLR.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 1U) == 0U) {
+    /* Wait for switch to clk_ref */
+  }
+  CLOCKS->XOR.CLK[RP_CLK_SYS].CTRL =
+      (CLOCKS->CLK[RP_CLK_SYS].CTRL ^ CLOCKS_CLK_SYS_CTRL_AUXSRC_PLL_SYS) &
+      CLOCKS_CLK_SYS_CTRL_AUXSRC_Msk;
+  CLOCKS->SET.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_AUX;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 2U) == 0U) {
+    /* Wait for switch to aux */
+  }
+
+  /* CLK_USB = PLL_USB = 48 MHz */
+  CLOCKS->XOR.CLK[RP_CLK_USB].CTRL =
+      (CLOCKS->CLK[RP_CLK_USB].CTRL ^ CLOCKS_CLK_USB_CTRL_AUXSRC_PLL_USB) &
+      CLOCKS_CLK_USB_CTRL_AUXSRC_Msk;
+  CLOCKS->CLK[RP_CLK_USB].DIV = 1U << 8;
+  CLOCKS->SET.CLK[RP_CLK_USB].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
+
+  /* CLK_ADC = PLL_USB = 48 MHz */
+  CLOCKS->XOR.CLK[RP_CLK_ADC].CTRL =
+      (CLOCKS->CLK[RP_CLK_ADC].CTRL ^ CLOCKS_CLK_ADC_CTRL_AUXSRC_PLL_USB) &
+      CLOCKS_CLK_ADC_CTRL_AUXSRC_Msk;
+  CLOCKS->CLK[RP_CLK_ADC].DIV = 1U << 8;
+  CLOCKS->SET.CLK[RP_CLK_ADC].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
+
+  /* CLK_RTC = PLL_USB / 1024 = 46875Hz */
+  CLOCKS->XOR.CLK[RP_CLK_RTC].CTRL =
+      (CLOCKS->CLK[RP_CLK_RTC].CTRL ^ CLOCKS_CLK_RTC_CTRL_AUXSRC_PLL_USB) &
+      CLOCKS_CLK_RTC_CTRL_AUXSRC_Msk;
+  CLOCKS->CLK[RP_CLK_RTC].DIV = RP_RTC_CLK_DIV << 8;
+  CLOCKS->SET.CLK[RP_CLK_RTC].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
+
+  /* CLK_PERI = PLL_SYS = 125 MHz */
+  CLOCKS->XOR.CLK[RP_CLK_PERI].CTRL =
+      (CLOCKS->CLK[RP_CLK_PERI].CTRL ^ CLOCKS_CLK_PERI_CTRL_AUXSRC_SYS) &
+      CLOCKS_CLK_PERI_CTRL_AUXSRC_Msk;
+  CLOCKS->CLK[RP_CLK_PERI].DIV = 1U << 8;
+  CLOCKS->SET.CLK[RP_CLK_PERI].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
+
+  /* Calculate cycles for 1us tick based on clk_ref frequency. */
+  WATCHDOG->TICK = WATCHDOG_TICK_ENABLE | (RP_XOSCCLK / 1000000U);
+}
+
+/**
+ * @brief   Returns the frequency of a clock in Hz.
+ * @note    Uses compile-time constants so this function is safe to call
+ *          before BSS/DATA initialization.
+ *
+ * @param[in] clk_index     clock index (RP_CLK_xxx)
+ * @return                  clock frequency in Hz
+ */
+uint32_t rp_clock_get_hz(uint32_t clk_index) {
+
+  chDbgAssert(clk_index < RP_CLK_COUNT, "invalid clock index");
+
+  switch (clk_index) {
+  case RP_CLK_REF:
+    return RP_CLK_REF_FREQ;
+  case RP_CLK_SYS:
+    return RP_CLK_SYS_FREQ;
+  case RP_CLK_PERI:
+    return RP_CLK_PERI_FREQ;
+  case RP_CLK_USB:
+    return RP_CLK_USB_FREQ;
+  case RP_CLK_ADC:
+    return RP_CLK_ADC_FREQ;
+  case RP_CLK_RTC:
+    return RP_CLK_RTC_FREQ;
+  default:
+    return 0U;
+  }
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_clocks.h
+++ b/os/xhal/ports/RP/RP2040/rp_clocks.h
@@ -1,0 +1,192 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_clocks.h
+ * @brief   RP2040 clocks header.
+ *
+ * @addtogroup RP_CLOCKS
+ * @{
+ */
+
+#ifndef RP_CLOCKS_H
+#define RP_CLOCKS_H
+
+#include "rp_xosc.h"
+#include "rp_pll.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   RTC clock divisor
+ */
+#define RP_RTC_CLK_DIV                      1024U
+
+/**
+ * @name    PLL_SYS configuration
+ * @note    Default configuration produces 125 MHz system clock
+ * @{
+ */
+#if !defined(RP_PLL_SYS_REFDIV) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_REFDIV               1U
+#endif
+#if !defined(RP_PLL_SYS_VCO_FREQ) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_VCO_FREQ             1500000000U     /* 1500 MHz VCO */
+#endif
+#if !defined(RP_PLL_SYS_POSTDIV1) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_POSTDIV1             6U              /* 125 MHz output */
+#endif
+#if !defined(RP_PLL_SYS_POSTDIV2) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_POSTDIV2             2U
+#endif
+/** @} */
+
+/**
+ * @name    PLL_USB configuration
+ * @{
+ */
+#if !defined(RP_PLL_USB_REFDIV) || defined(__DOXYGEN__)
+#define RP_PLL_USB_REFDIV               1U
+#endif
+#if !defined(RP_PLL_USB_VCO_FREQ) || defined(__DOXYGEN__)
+#define RP_PLL_USB_VCO_FREQ             1200000000U     /* 1200 MHz VCO */
+#endif
+#if !defined(RP_PLL_USB_POSTDIV1) || defined(__DOXYGEN__)
+#define RP_PLL_USB_POSTDIV1             5U
+#endif
+#if !defined(RP_PLL_USB_POSTDIV2) || defined(__DOXYGEN__)
+#define RP_PLL_USB_POSTDIV2             5U
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/**
+ * @name    PLL output frequencies
+ * @{
+ */
+/**
+ * @brief   PLL_SYS output frequency in Hz.
+ */
+#define RP_PLL_SYS_CLK                      (RP_PLL_SYS_VCO_FREQ /           \
+                                             (RP_PLL_SYS_POSTDIV1 *          \
+                                              RP_PLL_SYS_POSTDIV2))
+
+/**
+ * @brief   PLL_USB output frequency in Hz (must be 48 MHz for USB).
+ */
+#define RP_PLL_USB_CLK                      (RP_PLL_USB_VCO_FREQ /           \
+                                             (RP_PLL_USB_POSTDIV1 *          \
+                                              RP_PLL_USB_POSTDIV2))
+/** @} */
+
+/**
+ * @name    VREG voltage configuration for high-speed operation
+ * @note    200 MHz is supported by the pico-sdk and requires 1.15V.
+ *          Frequencies above 200 MHz are not officially supported.
+ *          Automatically selected based on RP_PLL_SYS_CLK.
+ *          Set to 0 to disable VREG adjustment.
+ * @{
+ */
+#if !defined(RP_SYS_VREG_VOLTAGE) || defined(__DOXYGEN__)
+#if RP_PLL_SYS_CLK >= 250000000U
+#define RP_SYS_VREG_VOLTAGE             13U     /* 1.20V */
+#elif RP_PLL_SYS_CLK >= 200000000U
+#define RP_SYS_VREG_VOLTAGE             12U     /* 1.15V */
+#else
+#define RP_SYS_VREG_VOLTAGE             0U      /* No adjustment */
+#endif
+#endif
+
+#if !defined(RP_SYS_VREG_SETTLE_DELAY_US) || defined(__DOXYGEN__)
+#define RP_SYS_VREG_SETTLE_DELAY_US     1000U   /* 1 ms */
+#endif
+/** @} */
+
+/**
+ * @name    Compile-time clock frequencies
+ * @note    These are compile-time constants derived from PLL configuration.
+ *          For runtime clock queries, use the hal_lld_get_clock_point() API.
+ * @{
+ */
+/**
+ * @brief   System core clock frequency in Hz.
+ */
+#define RP_CLK_SYS_FREQ                     RP_PLL_SYS_CLK
+
+/**
+ * @brief   Reference clock frequency in Hz.
+ */
+#define RP_CLK_REF_FREQ                     RP_XOSCCLK
+
+/**
+ * @brief   Peripheral clock frequency in Hz.
+ * @note    CLK_PERI runs at CLK_SYS frequency by default.
+ */
+#define RP_CLK_PERI_FREQ                    RP_PLL_SYS_CLK
+
+/**
+ * @brief   USB clock frequency in Hz (must be 48 MHz).
+ */
+#define RP_CLK_USB_FREQ                     RP_PLL_USB_CLK
+
+/**
+ * @brief   ADC clock frequency in Hz (must be 48 MHz).
+ */
+#define RP_CLK_ADC_FREQ                     RP_PLL_USB_CLK
+
+/**
+ * @brief   RTC clock frequency in Hz.
+ * @note    Derived from PLL_USB (48 MHz) because it provides a stable
+ *          reference independent of system clock changes. 48 MHz / 1024
+ *          = 46875 Hz, which divides evenly into seconds for accurate
+ *          timekeeping.
+ */
+#define RP_CLK_RTC_FREQ                     (RP_PLL_USB_CLK / RP_RTC_CLK_DIV)
+/** @} */
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rp_clock_init(void);
+  uint32_t rp_clock_get_hz(uint32_t clk_index);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_CLOCKS_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_fifo.h
+++ b/os/xhal/ports/RP/RP2040/rp_fifo.h
@@ -1,0 +1,114 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_fifo.h
+ * @brief   RP2040 FIFO handler header.
+ *
+ * @addtogroup RP2040_FIFO
+ * @{
+ */
+
+#ifndef RP_FIFO_H
+#define RP_FIFO_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* EInline functions.                                                        */
+/*===========================================================================*/
+
+__STATIC_INLINE bool fifoIsReadNotEmpty(void) {
+
+  return (bool)((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U);
+}
+
+__STATIC_INLINE bool fifoIsWriteNotFull(void) {
+
+  return (bool)((SIO->FIFO_ST & SIO_FIFO_ST_RDY) != 0U);
+}
+
+__STATIC_INLINE void fifoFlushRead(void) {
+
+  while (fifoIsReadNotEmpty()) {
+    (void)SIO->FIFO_RD;
+  }
+
+  /* In case the other core is in WFE.*/
+  __SEV();
+}
+
+__STATIC_INLINE void fifoBlockingWrite(uint32_t data) {
+
+  /* Waiting for space into the FIFO.*/
+  while (!fifoIsWriteNotFull()) {
+    __WFE();
+  }
+
+  SIO->FIFO_WR = data;
+
+  /* In case the other core is in WFE, signaling data available.*/
+  __SEV();
+}
+
+__STATIC_INLINE uint32_t fifoBlockingRead(void) {
+  uint32_t data;
+
+  /* Waiting for data to appear.*/
+  while (!fifoIsReadNotEmpty()) {
+    __WFE();
+  }
+
+  data = SIO->FIFO_RD;
+
+  /* In case the other core is in WFE, signaling space available.*/
+  __SEV();
+
+  return data;
+}
+
+#endif /* RP_FIFO_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_isr.c
+++ b/os/xhal/ports/RP/RP2040/rp_isr.c
@@ -1,0 +1,71 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_isr.c
+ * @brief   RP2040 ISR handler code.
+ *
+ * @addtogroup RP2040_ISR
+ * @{
+ */
+
+#include "hal.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   IRQ subsystem initialization.
+ * @details Puts the IRQ controller in a known clean state before any
+ *          HAL drivers enable their individual interrupts.
+ *
+ * @notapi
+ */
+void irqInit(void) {
+
+}
+
+/**
+ * @brief   Disables IRQ sources.
+ *
+ * @notapi
+ */
+void irqDeinit(void) {
+
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_isr.h
+++ b/os/xhal/ports/RP/RP2040/rp_isr.h
@@ -1,0 +1,147 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_isr.h
+ * @brief   RP2040 ISR handler header.
+ *
+ * @addtogroup RP2040_ISR
+ * @{
+ */
+
+#ifndef RP_ISR_H
+#define RP_ISR_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    ISR names and numbers
+ * @{
+ */
+
+/* TIMER0 interrupts (4 alarms) */
+#define RP_TIMER0_IRQ0_HANDLER              Vector40
+#define RP_TIMER0_IRQ1_HANDLER              Vector44
+#define RP_TIMER0_IRQ2_HANDLER              Vector48
+#define RP_TIMER0_IRQ3_HANDLER              Vector4C
+
+/* PWM interrupts */
+#define RP_PWM_IRQ_WRAP_0_HANDLER           Vector50
+
+/* DMA interrupts */
+#define RP_DMA_IRQ_0_HANDLER                Vector6C
+#define RP_DMA_IRQ_1_HANDLER                Vector70
+
+/* USB interrupt */
+#define RP_USBCTRL_IRQ_HANDLER              Vector54
+#define RP_XIP_IRQ_HANDLER                  Vector58
+
+/* PIO interrupts */
+#define RP_PIO0_IRQ_0_HANDLER               Vector5C
+#define RP_PIO0_IRQ_1_HANDLER               Vector60
+#define RP_PIO1_IRQ_0_HANDLER               Vector64
+#define RP_PIO1_IRQ_1_HANDLER               Vector68
+
+/* IO Bank interrupts */
+#define RP_IO_IRQ_BANK0_HANDLER             Vector74
+#define RP_IO_IRQ_QSPI_HANDLER              Vector78
+
+/* SIO interrupts */
+#define RP_SIO_IRQ_PROC0_HANDLER            Vector7C
+#define RP_SIO_IRQ_PROC1_HANDLER            Vector80
+
+/* Clocks interrupt */
+#define RP_CLOCKS_IRQ_HANDLER               Vector84
+
+/* SPI interrupts */
+#define RP_SPI0_IRQ_HANDLER                 Vector88
+#define RP_SPI1_IRQ_HANDLER                 Vector8C
+
+/* UART interrupts */
+#define RP_UART0_IRQ_HANDLER                Vector90
+#define RP_UART1_IRQ_HANDLER                Vector94
+
+/* ADC interrupt */
+#define RP_ADC_IRQ_FIFO_HANDLER             Vector98
+
+/* I2C interrupts */
+#define RP_I2C0_IRQ_HANDLER                 Vector9C
+#define RP_I2C1_IRQ_HANDLER                 VectorA0
+#define RP_RTC_IRQ_HANDLER                  VectorA4
+
+/* IRQ numbers */
+#define RP_TIMER0_IRQ0_NUMBER               0
+#define RP_TIMER0_IRQ1_NUMBER               1
+#define RP_TIMER0_IRQ2_NUMBER               2
+#define RP_TIMER0_IRQ3_NUMBER               3
+#define RP_PWM_IRQ_WRAP_0_NUMBER            4
+#define RP_USBCTRL_IRQ_NUMBER               5
+#define RP_XIP_IRQ_NUMBER                   6
+#define RP_PIO0_IRQ_0_NUMBER                7
+#define RP_PIO0_IRQ_1_NUMBER                8
+#define RP_PIO1_IRQ_0_NUMBER                9
+#define RP_PIO1_IRQ_1_NUMBER                10
+#define RP_DMA_IRQ_0_NUMBER                 11
+#define RP_DMA_IRQ_1_NUMBER                 12
+#define RP_IO_IRQ_BANK0_NUMBER              13
+#define RP_IO_IRQ_QSPI_NUMBER               14
+#define RP_SIO_IRQ_PROC0_NUMBER             15
+#define RP_SIO_IRQ_PROC1_NUMBER             16
+#define RP_CLOCKS_IRQ_NUMBER                17
+#define RP_SPI0_IRQ_NUMBER                  18
+#define RP_SPI1_IRQ_NUMBER                  19
+#define RP_UART0_IRQ_NUMBER                 20
+#define RP_UART1_IRQ_NUMBER                 21
+#define RP_ADC_IRQ_FIFO_NUMBER              22
+#define RP_I2C0_IRQ_NUMBER                  23
+#define RP_I2C1_IRQ_NUMBER                  24
+#define RP_RTC_IRQ_NUMBER                   25
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void irqInit(void);
+  void irqDeinit(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_ISR_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_pal_lld.h
+++ b/os/xhal/ports/RP/RP2040/rp_pal_lld.h
@@ -1,0 +1,54 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_pal_lld.h
+ * @brief   RP2040-specific PAL low level driver definitions.
+ */
+
+#ifndef RP2040_RP_PAL_LLD_H
+#define RP2040_RP_PAL_LLD_H
+
+/**
+ * @name    RP2040-specific alternate function selectors
+ * @{
+ */
+#define PAL_RP_IOCTRL_FUNCSEL_CLK           PAL_RP_IOCTRL_FUNCSEL(8U)
+#define PAL_RP_IOCTRL_FUNCSEL_USB           PAL_RP_IOCTRL_FUNCSEL(9U)
+
+#define PAL_MODE_ALTERNATE_CLK              (PAL_RP_IOCTRL_FUNCSEL_CLK     | \
+                                             PAL_RP_PAD_IE                 | \
+                                             PAL_RP_PAD_SCHMITT)
+#define PAL_MODE_ALTERNATE_USB              (PAL_RP_IOCTRL_FUNCSEL_USB     | \
+                                             PAL_RP_PAD_IE                 | \
+                                             PAL_RP_PAD_SCHMITT)
+/** @} */
+
+/**
+ * @brief   Access a SIO GPIO register by port.
+ * @details Given a register name (field of SIO) and port (0, 1), produce a
+ *          reference to the correct GPIO register for the port. On the RP2040
+ *          every "hi" output and output-enable register is eight uint32_t's
+ *          after the corresponding "low" register. The input registers
+ *          GPIO_IN / GPIO_HI_IN are only one apart, but port 1 does not exist
+ *          on RP2040 (only 30 GPIO lines) so the offset is never applied.
+ *
+ * @notapi
+ */
+#define RP_PAL_SIO_REG(reg, port)                                               \
+  ((&SIO->reg)[(port) ? 8U : 0U])
+
+#endif /* RP2040_RP_PAL_LLD_H */

--- a/os/xhal/ports/RP/RP2040/rp_pll.c
+++ b/os/xhal/ports/RP/RP2040/rp_pll.c
@@ -1,0 +1,147 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_pll.c
+ * @brief   RP2040 PLL source.
+ *
+ * @addtogroup RP_PLL
+ * @{
+ */
+
+#include "hal.h"
+#include "hal_safety.h"
+#include "rp_pll.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout for PLL lock in microseconds.
+ * @note    PLL lock typically takes <1 ms. We allow up to 10 ms
+ *          to account for ROSC timing variance during early init.
+ */
+#define RP_PLL_LOCK_TIMEOUT_US          10000U
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes a PLL.
+ *
+ * @param[in] pll       pointer to PLL registers (PLL_SYS or PLL_USB)
+ * @param[in] refdiv    reference divider (1-63)
+ * @param[in] vco_freq  target VCO frequency in Hz (750-1600 MHz)
+ * @param[in] postdiv1  post divider 1 (1-7)
+ * @param[in] postdiv2  post divider 2 (1-7)
+ *
+ * @note    Output frequency = vco_freq / (postdiv1 * postdiv2)
+ * @note    VCO frequency = (XOSC / refdiv) * fbdiv
+ * @note    See RP2040 Datasheet 2.18 PLL
+ */
+void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
+                 uint32_t postdiv1, uint32_t postdiv2) {
+
+  uint32_t ref_freq, fbdiv, pdiv;
+
+  /* Raw parameters are asserted before anything is derived from them,
+     a zero REFDIV would otherwise fault on the division below before
+     any assert had fired. */
+  chDbgAssert(refdiv >= 1U && refdiv <= 63U, "REFDIV out of range");
+  chDbgAssert((RP_XOSCCLK % refdiv) == 0U, "XOSC not divisible by REFDIV");
+  chDbgAssert(vco_freq >= RP_PLL_VCO_MIN_FREQ &&
+              vco_freq <= RP_PLL_VCO_MAX_FREQ,
+              "VCO frequency out of range");
+  chDbgAssert(postdiv1 >= 1U && postdiv1 <= 7U, "POSTDIV1 out of range");
+  chDbgAssert(postdiv2 >= 1U && postdiv2 <= 7U, "POSTDIV2 out of range");
+  chDbgAssert(postdiv1 >= postdiv2, "POSTDIV1 must be >= POSTDIV2");
+
+  pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
+
+  ref_freq = RP_XOSCCLK / refdiv;
+  chDbgAssert(ref_freq >= 5000000U, "reference frequency below 5 MHz");
+  chDbgAssert(ref_freq <= (vco_freq / 16U), "Reference frequency too high");
+  chDbgAssert((vco_freq % ref_freq) == 0U,
+              "VCO not an integer multiple of reference");
+
+  fbdiv = vco_freq / ref_freq;
+  chDbgAssert(fbdiv >= 16U && fbdiv <= 320U, "FBDIV out of range");
+  chDbgAssert((vco_freq % (postdiv1 * postdiv2)) == 0U,
+              "VCO frequency not divisible by POSTDIV1*POSTDIV2");
+
+  /* Check if PLL is already configured */
+  if ((pll->CS & PLL_CS_LOCK) &&
+      (refdiv == (pll->CS & PLL_CS_REFDIV_Msk)) &&
+      (fbdiv == (pll->FBDIV_INT & PLL_FBDIV_INT_Msk)) &&
+      (pdiv == (pll->PRIM & (PLL_PRIM_POSTDIV1_Msk | PLL_PRIM_POSTDIV2_Msk)))) {
+    return;
+  }
+
+  /* Reset the PLL */
+  if (pll == PLL_SYS) {
+    rp_peripheral_reset(RESETS_ALLREG_PLL_SYS);
+    rp_peripheral_unreset(RESETS_ALLREG_PLL_SYS);
+  } else {
+    rp_peripheral_reset(RESETS_ALLREG_PLL_USB);
+    rp_peripheral_unreset(RESETS_ALLREG_PLL_USB);
+  }
+
+  /* Set VCO divider */
+  pll->CS = refdiv;
+  pll->FBDIV_INT = fbdiv;
+
+  /* Turn on PLL */
+  pll->CLR.PWR = PLL_PWR_PD | PLL_PWR_VCOPD;
+
+  /* Wait for PLL lock */
+  if (halRegWaitAnySet32X(&pll->CS, PLL_CS_LOCK,
+                          RP_PLL_LOCK_TIMEOUT_US, NULL)) {
+    halSftFail("PLL lock timeout");
+  }
+
+  /* Set post divider */
+  pll->PRIM = pdiv;
+
+  /* Turn on post divider */
+  pll->CLR.PWR = PLL_PWR_POSTDIVPD;
+}
+
+/**
+ * @brief   Deinitialize a PLL.
+ *
+ * @param[in] pll       pointer to PLL register
+ */
+void rp_pll_deinit(PLL_TypeDef *pll) {
+
+  /* Power down the PLL */
+  pll->PWR = PLL_PWR_PD | PLL_PWR_VCOPD | PLL_PWR_POSTDIVPD | PLL_PWR_DSMPD;
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_pll.h
+++ b/os/xhal/ports/RP/RP2040/rp_pll.h
@@ -1,0 +1,74 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_pll.h
+ * @brief   RP2040 PLL header.
+ *
+ * @addtogroup RP_PLL
+ * @{
+ */
+
+#ifndef RP_PLL_H
+#define RP_PLL_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Minimum VCO frequency in Hz.
+ */
+#define RP_PLL_VCO_MIN_FREQ             750000000U
+
+/**
+ * @brief   Maximum VCO frequency in Hz.
+ */
+#define RP_PLL_VCO_MAX_FREQ             1600000000U
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
+                   uint32_t postdiv1, uint32_t postdiv2);
+  void rp_pll_deinit(PLL_TypeDef *pll);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_PLL_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_registry.h
+++ b/os/xhal/ports/RP/RP2040/rp_registry.h
@@ -1,0 +1,123 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_registry.h
+ * @brief   RP2040 capabilities registry.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef RP_REGISTRY_H
+#define RP_REGISTRY_H
+
+/*===========================================================================*/
+/* Platform capabilities.                                                    */
+/*===========================================================================*/
+
+/**
+ * @name    RP2040 capabilities
+ * @{
+ */
+
+/*===========================================================================*/
+/* Common.                                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* RP2040.                                                                   */
+/*===========================================================================*/
+
+/* GPIO attributes.*/
+#define RP_GPIO_NUM_LINES                   30
+#define RP_GPIO_INTR_REGS                   4
+
+/* UART attributes.*/
+#define RP_HAS_UART0                        TRUE
+#define RP_HAS_UART1                        TRUE
+
+/* PIO attributes.*/
+#define RP_HAS_PIO0                         TRUE
+#define RP_HAS_PIO1                         TRUE
+#define RP_HAS_PIO2                         FALSE
+#define RP_PIO_NUM_BLOCKS                   2
+#define RP_PIO_HAS_GPIOBASE                 FALSE
+
+/* TIMER attributes.*/
+#define RP_HAS_TIMER0                       TRUE
+#define RP_ST_NUM_ALARMS                    4
+
+/* RTC attributes.*/
+#define RP_HAS_RTC                          TRUE
+
+/* SPI attributes.*/
+#define RP_HAS_SPI0                         TRUE
+#define RP_HAS_SPI1                         TRUE
+
+/* I2C attributes.*/
+#define RP_HAS_I2C0                         TRUE
+#define RP_HAS_I2C1                         TRUE
+
+/* DMA attributes.*/
+#define RP_HAS_DMA                          TRUE
+#define RP_DMA_NUM_CHANNELS                 12
+
+/* WDG attributes.*/
+#define RP_HAS_WDG                          TRUE
+#define RP_WDG_STORAGE_SIZE                 32U
+#define RP_PSM_WDSEL_ALL_BITS               0x1FFFFU
+#define RP_WDG_HAS_E1_ERRATA                TRUE
+
+/* USB attributes.*/
+#define RP_HAS_USB                          TRUE
+#define USB_ENDPOINTS_NUMBER                15
+
+/* Flash attributes.*/
+#define RP_HAS_FLASH                        TRUE
+
+/* PWM attributes.*/
+#define RP_HAS_PWM                          TRUE
+#define RP_PWM_NUM_SLICES                   8
+#define RP_HAS_PWM0                         TRUE
+#define RP_HAS_PWM1                         TRUE
+#define RP_HAS_PWM2                         TRUE
+#define RP_HAS_PWM3                         TRUE
+#define RP_HAS_PWM4                         TRUE
+#define RP_HAS_PWM5                         TRUE
+#define RP_HAS_PWM6                         TRUE
+#define RP_HAS_PWM7                         TRUE
+#define RP_HAS_PWM8                         FALSE
+#define RP_HAS_PWM9                         FALSE
+#define RP_HAS_PWM10                        FALSE
+#define RP_HAS_PWM11                        FALSE
+
+/* ADC attributes.*/
+#define RP_HAS_ADC                          TRUE
+#define RP_ADC_NUM_CHANNELS                 5U
+#define RP_ADC_HAS_TEMPERATURE_SENSOR       TRUE
+#define RP_ADC_TEMPERATURE_CHANNEL          4U
+#define RP_ADC_FIFO_DEPTH                   4U
+#define RP_ADC_BASE_PIN                     26U
+#define RP_ADC_DREQ                         36U
+#define RP_ADC_AINSEL_BITS                  3U
+#define RP_ADC_RROBIN_MASK                  0x001F0000U
+
+/** @} */
+
+#endif /* RP_REGISTRY_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_xosc.c
+++ b/os/xhal/ports/RP/RP2040/rp_xosc.c
@@ -1,0 +1,89 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_xosc.c
+ * @brief   RP2040 XOSC source.
+ *
+ * @addtogroup RP_XOSC
+ * @{
+ */
+
+#include "hal.h"
+#include "hal_safety.h"
+#include "rp_xosc.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout for XOSC stabilization in microseconds.
+ * @note    Crystal startup typically takes 1-2 ms. We allow up to 100 ms
+ *          to account for slow crystals and ROSC timing variance.
+ */
+#define RP_XOSC_STABLE_TIMEOUT_US       100000U
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes the XOSC
+ * @note    Assumes 1-15 MHz crystal is attached.
+ * @note    See RP2040 Datasheet 2.16 XOSC
+ */
+void rp_xosc_init(void) {
+
+  /* Set frequency range */
+  XOSC->CTRL = XOSC_CTRL_FREQ_RANGE_1_15MHZ;
+
+  /* Set startup delay */
+  XOSC->STARTUP = RP_XOSC_STARTUP_DELAY;
+
+  /* Enable the XOSC */
+  XOSC->SET.CTRL = XOSC_CTRL_ENABLE_ENABLE;
+
+  /* Wait for XOSC to be stable with timeout protection. */
+  if (halRegWaitAnySet32X((volatile uint32_t *)&XOSC->STATUS, XOSC_STATUS_STABLE,
+                          RP_XOSC_STABLE_TIMEOUT_US, NULL)) {
+    halSftFail("XOSC stable timeout");
+  }
+}
+
+/**
+ * @brief   Disable the XOSC
+ * @pre     The XOSC must not be the current source for CLK_REF.
+ */
+void rp_xosc_disable(void) {
+
+  /* Disable XOSC */
+  XOSC->XOR.CTRL = (XOSC->CTRL ^ XOSC_CTRL_ENABLE_DISABLE) & XOSC_CTRL_ENABLE_Msk;
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/rp_xosc.h
+++ b/os/xhal/ports/RP/RP2040/rp_xosc.h
@@ -1,0 +1,80 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_xosc.h
+ * @brief   RP2040 XOSC header.
+ *
+ * @addtogroup RP_XOSC
+ * @{
+ */
+
+#ifndef RP_XOSC_H
+#define RP_XOSC_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   XOSC startup delay multiplier.
+ * @note    Default value of 6 matches the pico-sdk default, giving extra
+ *          margin for slow-starting crystals on power-up.
+ */
+#if !defined(RP_XOSC_STARTUP_DELAY_MULTIPLIER)
+#define RP_XOSC_STARTUP_DELAY_MULTIPLIER    6U
+#endif
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/**
+ * @brief   XOSC startup delay value.
+ * @note    Delay is in multiples of 256 crystal periods
+ *          For 12MHz, each count is ~21.3us. Default gives 1ms startup.
+ */
+#define RP_XOSC_STARTUP_DELAY               \
+    ((((RP_XOSCCLK / 1000U) + 128U) / 256U) * RP_XOSC_STARTUP_DELAY_MULTIPLIER)
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rp_xosc_init(void);
+  void rp_xosc_disable(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_XOSC_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/hal_lld.c
+++ b/os/xhal/ports/RP/RP2350/hal_lld.c
@@ -1,0 +1,143 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/hal_lld.c
+ * @brief   RP2350 HAL subsystem low level driver source.
+ * @note    The Core 1 launch sequence follows the multicore launch protocol
+ *          documented in RP2350 Datasheet 3.5 "Multicore Launch".
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#include "hal.h"
+#include "rp_clocks.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   CMSIS system core clock variable.
+ * @note    It is declared in system_rp2350.h.
+ */
+uint32_t SystemCoreClock = RP_CLK_SYS_FREQ;
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+#if RP_CORE1_START == TRUE
+static void start_core1(void) {
+  extern uint32_t RP_CORE1_STACK_END;
+  extern uint32_t RP_CORE1_VECTORS_TABLE;
+  extern void RP_CORE1_ENTRY_POINT(void);
+  static const uint32_t cmd_sequence[] = {0, 0, 1,
+                             (uint32_t)&RP_CORE1_VECTORS_TABLE,
+                             (uint32_t)&RP_CORE1_STACK_END,
+                             (uint32_t)RP_CORE1_ENTRY_POINT};
+  unsigned seq;
+
+  /* Force-reset core1 via PSM before starting the FIFO launch handshake.
+   *
+   * If core1 survived a preceding soft reset (e.g. a bootloader that uses
+   * BX to jump to the application rather than SYSRESETREQ), it may still
+   * be executing application code from a previous run.  In that case the
+   * ROM FIFO handshake protocol will deadlock: core0 sends the sync
+   * sequence but core1 is not in the ROM wait-for-launch loop so it never
+   * echoes back.
+   *
+   * PSM FRCE_OFF holds core1 in reset (powered-off state).  Clearing it
+   * releases core1 into the ROM boot-path which immediately enters the
+   * wait-for-launch loop.  The PSM DONE bit falls while the core is held
+   * off, and rises again once it has been released and is running.*/
+  PSM->SET.FRCE_OFF = PSM_ANY_PROC1;         /* Assert reset to core1.     */
+  while (PSM->DONE & PSM_ANY_PROC1) {}       /* Wait until it powers off.  */
+  PSM->CLR.FRCE_OFF = PSM_ANY_PROC1;         /* Release, core1 enters ROM. */
+
+  /* Starting core 1.*/
+  seq = 0;
+  do {
+    uint32_t response;
+    uint32_t cmd = cmd_sequence[seq];
+
+    /* Flushing the FIFO state before sending a zero.*/
+    if (!cmd) {
+      fifoFlushRead();
+    }
+    fifoBlockingWrite(cmd);
+    response = fifoBlockingRead();
+    /* Checking response, going forward or back to first step.*/
+    seq = cmd == response ? seq + 1U : 0U;
+  } while (seq < 6U);
+}
+#endif
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level HAL driver initialization.
+ *
+ * @notapi
+ */
+void hal_lld_init(void) {
+
+#if RP_NO_INIT == FALSE
+  rp_peripheral_unreset(RESETS_ALLREG_BUSCTRL);
+  rp_peripheral_unreset(RESETS_ALLREG_SYSINFO);
+  rp_peripheral_unreset(RESETS_ALLREG_SYSCFG);
+#endif /* RP_NO_INIT */
+
+  /* NVIC initialization.*/
+  nvicInit();
+
+  /* IRQ subsystem initialization.*/
+  irqInit();
+#if defined(RP_DMA_REQUIRED)
+  dmaInit();
+#endif
+#if defined(RP_PIO_REQUIRED)
+  pioInit();
+#endif
+
+  /* ARM system timer requires binding, in free running mode this enables
+     the TIMER0 alarm 0 vector, in periodic mode this configures the
+     core-local SysTick timer. Hazard3 MTIMECMP is core-local instead.*/
+#if !defined(__riscv)
+  stBind();
+#endif
+
+#if RP_CORE1_START == TRUE
+  start_core1();
+#endif
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/hal_lld.h
+++ b/os/xhal/ports/RP/RP2350/hal_lld.h
@@ -1,0 +1,440 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/hal_lld.h
+ * @brief   RP2350 HAL subsystem low level driver header.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef HAL_LLD_H
+#define HAL_LLD_H
+
+/*
+ * Registry definitions.
+ */
+#include "rp_registry.h"
+#include "rp_clocks.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Platform identification macros
+ * @{
+ */
+#if defined(RP2350) || defined(__DOXYGEN__)
+#define PLATFORM_NAME           "RP2350"
+
+#else
+#error "RP2350 device not specified"
+#endif
+/** @} */
+
+/**
+ * @name    Internal clock sources
+ * @{
+ */
+#define RP_ROSCCLK              6500000     /**< 6.5MHz internal clock.     */
+/** @} */
+
+/**
+ * @name    GPIO IOCTRL register field positions
+ * @{
+ */
+#define RP_GPIO_IOCTRL_OEOVER_Pos           14
+#define RP_GPIO_IOCTRL_OUTOVER_Pos          12
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   Disables the clocks initialization in the HAL.
+ */
+#if !defined(RP_NO_INIT) || defined(__DOXYGEN__)
+#define RP_NO_INIT                          FALSE
+#endif
+
+/**
+ * @brief   Enables runtime changes of the system clock.
+ * @details When @p TRUE the port advertises the generic clock management
+ *          API (@p halClockSwitchMode()) and clock point queries become
+ *          dynamic. When @p FALSE (default) the clock tree is fixed at
+ *          initialization time and this feature costs nothing.
+ */
+#if !defined(RP_CLOCK_DYNAMIC) || defined(__DOXYGEN__)
+#define RP_CLOCK_DYNAMIC                    FALSE
+#endif
+
+/**
+ * @brief   Allows runtime clock configurations above the rated system
+ *          frequency.
+ * @details Effective only together with @p RP_CLOCK_DYNAMIC. When
+ *          @p FALSE (default) the runtime validation rejects any
+ *          configuration above the rated maximum system frequency
+ *          (@p RP_CLK_SYS_MAX); a boot configuration below the rated
+ *          maximum may still switch up to it.
+ *          Overclocked operation is outside the device specification;
+ *          configurations above the rated frequency must carry an
+ *          explicit QMI flash divider and may require a raised core
+ *          voltage (@p vreg_mv).
+ */
+#if !defined(RP_ALLOW_OVERCLOCK) || defined(__DOXYGEN__)
+#define RP_ALLOW_OVERCLOCK                  FALSE
+#endif
+
+/**
+ * @brief   Rated maximum system frequency of the device.
+ * @note    This is the specification limit, independent of the
+ *          compile-time boot configuration which may be lower.
+ */
+#if !defined(RP_CLK_SYS_MAX) || defined(__DOXYGEN__)
+#define RP_CLK_SYS_MAX                      150000000U
+#endif
+
+/**
+ * @brief   Upper frequency bound admitted when overclocking is enabled.
+ */
+#if !defined(RP_CLK_SYS_OVERCLOCK_MAX) || defined(__DOXYGEN__)
+#define RP_CLK_SYS_OVERCLOCK_MAX            300000000U
+#endif
+
+/**
+ * @brief   Starts core 1 after initialization.
+ */
+#if !defined(RP_CORE1_START) || defined(__DOXYGEN__)
+#define RP_CORE1_START                      FALSE
+#endif
+
+/**
+ * @brief   Symbol for core 1 vectors table.
+ */
+#if !defined(RP_CORE1_VECTORS_TABLE) || defined(__DOXYGEN__)
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#endif
+
+/**
+ * @brief   Symbol for core 1 entry point.
+ */
+#if !defined(RP_CORE1_ENTRY_POINT) || defined(__DOXYGEN__)
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#endif
+
+/**
+ * @brief   Symbol for core 1 initial MSP position.
+ */
+#if !defined(RP_CORE1_STACK_END) || defined(__DOXYGEN__)
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*
+ * Configuration-related checks.
+ */
+#if !defined(__RP2350_XMCUCONF__)
+#error "Using a wrong xmcuconf.h file, __RP2350_XMCUCONF__ not defined"
+#endif
+
+/*
+ * Board files sanity checks.
+ */
+#if !defined(RP_XOSCCLK)
+#error "RP_XOSCCLK not defined in board.h"
+#endif
+
+#if (RP_XOSCCLK < 1000000) || (RP_XOSCCLK > 15000000)
+#error "RP_XOSCCLK out of valid range (1-15 MHz)"
+#endif
+
+#if (RP_XOSCCLK % 1000000U) != 0
+#error "RP_XOSCCLK must be an integer number of MHz (1us tick granularity)"
+#endif
+
+/*
+ * PLL_SYS configuration checks. The checks form a single chain so that
+ * a derived check dividing by a parameter is never evaluated while that
+ * parameter is out of range: a stray "division by zero in #if"
+ * diagnostic would bury the intended message.
+ */
+#if (RP_PLL_SYS_REFDIV < 1) || (RP_PLL_SYS_REFDIV > 63)
+#error "RP_PLL_SYS_REFDIV out of valid range (1-63)"
+#elif (RP_PLL_SYS_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_SYS_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#error "RP_PLL_SYS_VCO_FREQ out of valid range (750-1600 MHz)"
+#elif (RP_PLL_SYS_POSTDIV1 < 1) || (RP_PLL_SYS_POSTDIV1 > 7)
+#error "RP_PLL_SYS_POSTDIV1 out of valid range (1-7)"
+#elif (RP_PLL_SYS_POSTDIV2 < 1) || (RP_PLL_SYS_POSTDIV2 > 7)
+#error "RP_PLL_SYS_POSTDIV2 out of valid range (1-7)"
+#elif RP_PLL_SYS_POSTDIV1 < RP_PLL_SYS_POSTDIV2
+#error "RP_PLL_SYS_POSTDIV1 must be >= RP_PLL_SYS_POSTDIV2"
+#elif (RP_XOSCCLK % RP_PLL_SYS_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_SYS_REFDIV"
+#elif (RP_XOSCCLK / RP_PLL_SYS_REFDIV) < 5000000
+#error "PLL_SYS reference frequency below 5 MHz minimum"
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not an integer multiple of the PLL_SYS reference frequency"
+#elif ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) < 16) ||    \
+      ((RP_PLL_SYS_VCO_FREQ / (RP_XOSCCLK / RP_PLL_SYS_REFDIV)) > 320)
+#error "PLL_SYS FBDIV out of valid range (16-320)"
+#elif (RP_PLL_SYS_VCO_FREQ % (RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2)) != 0
+#error "RP_PLL_SYS_VCO_FREQ is not divisible by RP_PLL_SYS_POSTDIV1 * RP_PLL_SYS_POSTDIV2"
+#endif
+
+/*
+ * PLL_USB configuration checks, chained for the same reason as the
+ * PLL_SYS checks above.
+ */
+#if (RP_PLL_USB_REFDIV < 1) || (RP_PLL_USB_REFDIV > 63)
+#error "RP_PLL_USB_REFDIV out of valid range (1-63)"
+#elif (RP_PLL_USB_VCO_FREQ < RP_PLL_VCO_MIN_FREQ) ||                        \
+      (RP_PLL_USB_VCO_FREQ > RP_PLL_VCO_MAX_FREQ)
+#error "RP_PLL_USB_VCO_FREQ out of valid range (750-1600 MHz)"
+#elif (RP_PLL_USB_POSTDIV1 < 1) || (RP_PLL_USB_POSTDIV1 > 7)
+#error "RP_PLL_USB_POSTDIV1 out of valid range (1-7)"
+#elif (RP_PLL_USB_POSTDIV2 < 1) || (RP_PLL_USB_POSTDIV2 > 7)
+#error "RP_PLL_USB_POSTDIV2 out of valid range (1-7)"
+#elif RP_PLL_USB_POSTDIV1 < RP_PLL_USB_POSTDIV2
+#error "RP_PLL_USB_POSTDIV1 must be >= RP_PLL_USB_POSTDIV2"
+#elif (RP_XOSCCLK % RP_PLL_USB_REFDIV) != 0
+#error "RP_XOSCCLK is not divisible by RP_PLL_USB_REFDIV"
+#elif (RP_XOSCCLK / RP_PLL_USB_REFDIV) < 5000000
+#error "PLL_USB reference frequency below 5 MHz minimum"
+#elif (RP_PLL_USB_VCO_FREQ % (RP_XOSCCLK / RP_PLL_USB_REFDIV)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not an integer multiple of the PLL_USB reference frequency"
+#elif ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) < 16) ||    \
+      ((RP_PLL_USB_VCO_FREQ / (RP_XOSCCLK / RP_PLL_USB_REFDIV)) > 320)
+#error "PLL_USB FBDIV out of valid range (16-320)"
+#elif (RP_PLL_USB_VCO_FREQ % (RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2)) != 0
+#error "RP_PLL_USB_VCO_FREQ is not divisible by RP_PLL_USB_POSTDIV1 * RP_PLL_USB_POSTDIV2"
+#endif
+
+#if RP_PLL_USB_CLK != 48000000
+#error "RP_PLL_USB_CLK must be 48 MHz for USB to work"
+#endif
+
+/*
+ * RP2350-E12 erratum check: reliable USB operation requires
+ * clk_sys >= 1.1 * clk_usb.
+ */
+#if ((RP_CLK_SYS_FREQ) * 10U) < ((RP_CLK_USB_FREQ) * 11U)
+#error "RP2350-E12: clk_sys must be at least 1.1 * clk_usb for reliable USB operation"
+#endif
+
+#if (RP_CLOCK_DYNAMIC == TRUE) && defined(CH_CFG_ST_TIMEDELTA) &&           \
+    (CH_CFG_ST_TIMEDELTA == 0)
+#error "RP_CLOCK_DYNAMIC requires tick-less mode, in periodic mode SysTick counts clk_sys and the kernel tick would scale with every switch"
+#endif
+
+#if (RP_ALLOW_OVERCLOCK == TRUE) && (RP_CLOCK_DYNAMIC == FALSE)
+#error "RP_ALLOW_OVERCLOCK requires RP_CLOCK_DYNAMIC"
+#endif
+
+#if (RP_ALLOW_OVERCLOCK == TRUE) &&                                         \
+    ((RP_CLK_SYS_OVERCLOCK_MAX) < (RP_CLK_SYS_MAX))
+#error "RP_CLK_SYS_OVERCLOCK_MAX below the rated system frequency"
+#endif
+
+/**
+ * @name    Various clock points.
+ * @{
+ */
+#define RP_GPOUT0_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT0)
+#define RP_GPOUT1_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT1)
+#define RP_GPOUT2_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT2)
+#define RP_GPOUT3_CLK           hal_lld_get_clock_point(RP_CLK_GPOUT3)
+#define RP_REF_CLK              hal_lld_get_clock_point(RP_CLK_REF)
+#define RP_CORE_CLK             hal_lld_get_clock_point(RP_CLK_SYS)
+#define RP_PERI_CLK             hal_lld_get_clock_point(RP_CLK_PERI)
+/* Note: the HSTX clock is reported as a clock point but it is not
+   configured by this HAL.*/
+#define RP_HSTX_CLK             hal_lld_get_clock_point(RP_CLK_HSTX)
+#define RP_USB_CLK              hal_lld_get_clock_point(RP_CLK_USB)
+#define RP_ADC_CLK              hal_lld_get_clock_point(RP_CLK_ADC)
+/** @} */
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   The port supports the generic clock management API.
+ */
+#define HAL_LLD_USE_CLOCK_MANAGEMENT
+
+/**
+ * @brief   Type of a clock configuration structure.
+ * @details Describes a PLL_SYS setting reachable at runtime through
+ *          @p halClockSwitchMode(). The reference is always the crystal
+ *          (@p RP_XOSCCLK); clk_peri follows clk_sys, clk_ref, clk_usb
+ *          and clk_adc are not affected by a switch.
+ */
+typedef struct {
+  /**
+   * @brief   PLL_SYS reference divider, 1..63.
+   */
+  uint32_t          pll_sys_refdiv;
+  /**
+   * @brief   PLL_SYS VCO frequency in Hz, 750 MHz..1600 MHz.
+   */
+  uint32_t          pll_sys_vco_freq;
+  /**
+   * @brief   PLL_SYS first post divider, 1..7.
+   */
+  uint32_t          pll_sys_postdiv1;
+  /**
+   * @brief   PLL_SYS second post divider, 1..postdiv1.
+   */
+  uint32_t          pll_sys_postdiv2;
+  /**
+   * @brief   Effective QMI flash clock divider for the new frequency,
+   *          0 or 1..255.
+   * @details Zero selects the divider the system booted with (captured
+   *          before the first switch), accepted only for targets at or
+   *          below the boot frequency where it is known-safe. A
+   *          non-zero value must keep the flash SCK within the device
+   *          rating at the new clk_sys. The switch first widens the
+   *          divider to a value safe at both the old and the new
+   *          frequency, and programs this target value only after the
+   *          new frequency is established, so flash timing stays in
+   *          specification at every instant.
+   */
+  uint32_t          qmi_clkdiv;
+  /**
+   * @brief   Core voltage in millivolts, 0 or 1100..1300 in steps of
+   *          50.
+   * @details Zero leaves the regulator untouched. A non-zero value is
+   *          only accepted when @p RP_ALLOW_OVERCLOCK is enabled; the
+   *          regulator is raised before an upward frequency change and
+   *          lowered after a downward one. Values above 1300 mV are
+   *          not supported (they require the POWMAN voltage-limit
+   *          unlock, deliberately out of scope).
+   */
+  uint32_t          vreg_mv;
+} halclkcfg_t;
+#endif /* RP_CLOCK_DYNAMIC == TRUE */
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @name    Safety module counter support
+ * @note    Uses TIMER0 peripheral which counts at 1 us resolution.
+ *          During early clock init, accuracy depends on ROSC variance.
+ *          After clock init completes, timing is precise.
+ * @{
+ */
+
+/**
+ * @brief   Counter type for safety timeouts.
+ */
+typedef uint32_t halcnt_t;
+
+/**
+ * @brief   Returns the counter frequency in Hz.
+ * @note    Always returns 1 MHz (1 us ticks).
+ */
+#define HAL_LLD_GET_CNT_FREQUENCY()     1000000U
+
+/**
+ * @brief   Returns the current counter value.
+ */
+#define HAL_LLD_GET_CNT_VALUE()         ((halcnt_t)TIMER0->TIMERAWL)
+
+/** @} */
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+/* Various helpers.*/
+#include "nvic.h"
+#include "cache.h"
+#include "rp_isr.h"
+#include "rp_fifo.h"
+#include "rp_bootrom.h"
+
+extern uint32_t SystemCoreClock;
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+extern const halclkcfg_t hal_clkcfg_default;
+extern const halclkcfg_t hal_clkcfg_low;
+#if (RP_ALLOW_OVERCLOCK == TRUE) || defined(__DOXYGEN__)
+extern const halclkcfg_t hal_clkcfg_overclock;
+#endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void hal_lld_init(void);
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+  bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Driver inline functions.                                                  */
+/*===========================================================================*/
+
+__STATIC_INLINE void rp_peripheral_reset(uint32_t mask) {
+
+  RESETS->SET.RESET = mask;
+}
+
+__STATIC_INLINE void rp_peripheral_unreset(uint32_t mask) {
+
+  RESETS->CLR.RESET = mask;
+  while ((RESETS->RESET_DONE & mask) != mask) {
+    /* Waiting for peripheral to come out of reset */
+  }
+}
+
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ *
+ * @param[in] clkpt     clock point to be returned
+ * @return              The clock point frequency in Hz or zero if the
+ *                      frequency is unknown.
+ *
+ * @notapi
+ */
+__STATIC_INLINE halfreq_t hal_lld_get_clock_point(halclkpt_t clkpt) {
+
+  chDbgAssert(clkpt < RP_CLK_COUNT, "invalid clock point");
+
+  return rp_clock_get_hz(clkpt);
+}
+
+#endif /* HAL_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/platform.mk
+++ b/os/xhal/ports/RP/RP2350/platform.mk
@@ -1,0 +1,38 @@
+# Required platform files.
+PLATFORMSRC := $(CHIBIOS)/os/xhal/ports/common/ARMCMx/nvic.c \
+               $(CHIBIOS)/os/xhal/ports/RP/rp_bootrom.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350/rp_clocks.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350/rp_isr.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350/rp_pll.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350/rp_xosc.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350/hal_lld.c
+
+# Required include directories.
+PLATFORMINC := $(CHIBIOS)/os/xhal/ports/common/ARMCMx \
+               $(CHIBIOS)/os/xhal/ports/RP \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350
+
+# Optional platform files.
+ifeq ($(USE_SMART_BUILD),yes)
+
+# Configuration files directory
+ifeq ($(HALCONFDIR),)
+  ifeq ($(CONFDIR),)
+    HALCONFDIR = .
+  else
+    HALCONFDIR := $(CONFDIR)
+  endif
+endif
+
+HALCONF := $(strip $(shell cat $(HALCONFDIR)/xhalconf.h | grep -E "\#define"))
+
+else
+endif
+
+# Drivers compatible with the platform.
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
+
+# Shared variables
+ALLCSRC += $(PLATFORMSRC)
+ALLINC  += $(PLATFORMINC)

--- a/os/xhal/ports/RP/RP2350/rp_clocks.c
+++ b/os/xhal/ports/RP/RP2350/rp_clocks.c
@@ -1,0 +1,612 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_clocks.c
+ * @brief   RP2350 clock driver source.
+ * @note    See RP2350 Datasheet 8 Clocks
+ *
+ * @addtogroup RP_CLOCKS
+ * @{
+ */
+
+#include "hal.h"
+#include "rp_clocks.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Estimated ROSC frequency for early timing.
+ * @note    RP2350 ROSC varies 4.6-19.6 MHz, we assume ~6 MHz.
+ *          This gives roughly +/-60% accuracy which is acceptable for
+ *          safety timeouts during early clock initialization.
+ */
+#define RP_ROSC_ASSUMED_HZ      6000000U
+
+#if RP_CLOCK_DYNAMIC == TRUE
+#define RAMFUNC __attribute__((noinline, section(".ramtext")))
+#endif
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   The clock configuration the system boots with.
+ */
+const halclkcfg_t hal_clkcfg_default = {
+  .pll_sys_refdiv   = RP_PLL_SYS_REFDIV,
+  .pll_sys_vco_freq = RP_PLL_SYS_VCO_FREQ,
+  .pll_sys_postdiv1 = RP_PLL_SYS_POSTDIV1,
+  .pll_sys_postdiv2 = RP_PLL_SYS_POSTDIV2,
+  .qmi_clkdiv       = 0U,
+  .vreg_mv          = 0U
+};
+
+/**
+ * @brief   A reduced-frequency configuration, 96 MHz.
+ * @note    Assumes the default 12 MHz crystal; rejected by validation
+ *          on configurations where the VCO settings do not divide.
+ */
+const halclkcfg_t hal_clkcfg_low = {
+  .pll_sys_refdiv   = RP_PLL_SYS_REFDIV,
+  .pll_sys_vco_freq = 768000000U,
+  .pll_sys_postdiv1 = 4U,
+  .pll_sys_postdiv2 = 2U,
+  .qmi_clkdiv       = 0U,
+  .vreg_mv          = 0U
+};
+
+#if (RP_ALLOW_OVERCLOCK == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   An overclocked configuration, 200 MHz at 1.15 V.
+ * @note    Outside the device specification. Assumes the default
+ *          12 MHz crystal. The explicit flash divider yields a 50 MHz
+ *          SCK, conservative for common flash devices.
+ */
+const halclkcfg_t hal_clkcfg_overclock = {
+  .pll_sys_refdiv   = RP_PLL_SYS_REFDIV,
+  .pll_sys_vco_freq = 1200000000U,
+  .pll_sys_postdiv1 = 3U,
+  .pll_sys_postdiv2 = 2U,
+  .qmi_clkdiv       = 4U,
+  .vreg_mv          = 1150U
+};
+#endif
+#endif /* RP_CLOCK_DYNAMIC == TRUE */
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Current clock point frequencies.
+ * @details All-zero until the first successful runtime switch populates
+ *          every entry; @p rp_clock_get_hz() serves the compile-time
+ *          constants while the activation entry (@p RP_CLK_SYS, written
+ *          last) is zero. Volatile: written on one core, read lock-free
+ *          on the other.
+ */
+static volatile uint32_t rp_clock_points[RP_CLK_COUNT];
+
+/**
+ * @brief   Clock point table sequence counter.
+ * @details Incremented to odd before and to even after every table
+ *          update; lock-free readers on the other core retry while an
+ *          update is in progress or has intervened. The first-switch
+ *          activation is still gated on a non-zero @p RP_CLK_SYS entry.
+ */
+static volatile uint32_t rp_clock_seq;
+
+/**
+ * @brief   Effective QMI flash divider the system booted with, 1..256.
+ * @details Captured on the first switch, before anything has changed
+ *          it; zero means not yet captured (BSS state). The boot value
+ *          is safe at the boot frequency, which is the highest the
+ *          validation admits, therefore safe at every admitted
+ *          frequency.
+ */
+static uint32_t rp_clock_boot_qmi_div;
+#endif
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Safely programs and starts a tick generator.
+ * @note    The CYCLES register must not be rewritten while the generator
+ *          is running, the counter is only reloaded when it reaches zero
+ *          so a live rewrite can produce one wrong-length tick period.
+ *          Disable the generator and wait until it reports not running
+ *          before reprogramming it.
+ *
+ * @param[in] index     tick generator index (TICKS_xxx)
+ * @param[in] cycles    clk_ref cycles per tick
+ */
+static void rp_tick_start(uint32_t index, uint32_t cycles) {
+
+  chDbgAssert(index <= TICKS_RISCV, "invalid tick generator index");
+
+  TICKS->TICK[index].CTRL = 0U;
+  while ((TICKS->TICK[index].CTRL & TICKS_CTRL_RUNNING) != 0U) {
+    /* Waiting for the tick generator to stop */
+  }
+  TICKS->TICK[index].CYCLES = cycles;
+  TICKS->TICK[index].CTRL = TICKS_CTRL_ENABLE;
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes all clocks.
+ * @note    Most of this is derived from the RP2350 datasheet which directly
+ *          references suggested code from the Pico SDK which is Copyright
+ *          2020 Raspberry Pi (Trading) Ltd and licensed under the
+ *          BSD-3-Clause license. We always start with ROSC and then switch
+ *          to XOSC.
+ * @note    See RP2350 Datasheet 8.1.3.1 Clock Instances (Table 541)
+ */
+void rp_clock_init(void) {
+  uint32_t cycles;
+
+#if RP_CLOCK_DYNAMIC == TRUE
+  {
+    /* Deactivating the dynamic table explicitly: this code can run
+       before CRT0 clears BSS and retained SRAM after a warm reset
+       could otherwise present a stale table or an odd sequence to
+       early callers. */
+    unsigned i;
+
+    for (i = 0U; i < RP_CLK_COUNT; i++) {
+      rp_clock_points[i] = 0U;
+    }
+    rp_clock_seq = 0U;
+    rp_clock_boot_qmi_div = 0U;
+  }
+#endif
+
+  /* Start early tick generator for safety module timeouts. */
+  rp_peripheral_unreset(RESETS_ALLREG_TIMER0);
+
+  /* Configure tick generator for ~1 us ticks. */
+  rp_tick_start(TICKS_TIMER0, RP_ROSC_ASSUMED_HZ / 1000000U);
+
+  /* Clear clock resus that may be in an unknown state */
+  CLOCKS->RESUS.CTRL = 0U;
+
+  rp_xosc_init();
+
+  /* Switch clk_sys and clk_ref to safe sources */
+  CLOCKS->CLR.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 1U) == 0U) {
+    /* Wait for clk_sys to switch to clk_ref */
+  }
+  CLOCKS->CLR.CLK[RP_CLK_REF].CTRL = CLOCKS_CLK_REF_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_REF].SELECTED & 1U) == 0U) {
+    /* Wait for clk_ref to switch to ROSC */
+  }
+
+  /* Initialize PLL_SYS: 12 MHz * 125 / 5 / 2 = 150 MHz. */
+  rp_pll_init(PLL_SYS, RP_PLL_SYS_REFDIV, RP_PLL_SYS_VCO_FREQ,
+              RP_PLL_SYS_POSTDIV1, RP_PLL_SYS_POSTDIV2);
+
+  /* Initialize PLL_USB: 12 MHz * 100 / 5 / 5 = 48 MHz. */
+  rp_pll_init(PLL_USB, RP_PLL_USB_REFDIV, RP_PLL_USB_VCO_FREQ,
+              RP_PLL_USB_POSTDIV1, RP_PLL_USB_POSTDIV2);
+
+  /* CLK_REF = XOSC = 12 MHz */
+  {
+    uint32_t src = CLOCKS_CLK_REF_CTRL_SRC_XOSC >> CLOCKS_CLK_REF_CTRL_SRC_Pos;
+    CLOCKS->CLK[RP_CLK_REF].DIV = 1U << 16;
+    CLOCKS->XOR.CLK[RP_CLK_REF].CTRL =
+        (CLOCKS->CLK[RP_CLK_REF].CTRL ^ (src << CLOCKS_CLK_REF_CTRL_SRC_Pos)) &
+        CLOCKS_CLK_REF_CTRL_SRC_Msk;
+    while ((CLOCKS->CLK[RP_CLK_REF].SELECTED & (1U << src)) == 0U) {
+      /* Wait for switch to XOSC */
+    }
+  }
+
+  /* CLK_SYS = PLL_SYS = 150 MHz */
+  CLOCKS->CLR.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 1U) == 0U) {
+    /* Wait for switch to clk_ref */
+  }
+  CLOCKS->XOR.CLK[RP_CLK_SYS].CTRL =
+      (CLOCKS->CLK[RP_CLK_SYS].CTRL ^ CLOCKS_CLK_SYS_CTRL_AUXSRC_PLL_SYS) &
+      CLOCKS_CLK_SYS_CTRL_AUXSRC_Msk;
+  CLOCKS->SET.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_AUX;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 2U) == 0U) {
+    /* Wait for switch to aux */
+  }
+
+  /* CLK_USB = PLL_USB = 48 MHz */
+  CLOCKS->XOR.CLK[RP_CLK_USB].CTRL =
+      (CLOCKS->CLK[RP_CLK_USB].CTRL ^ CLOCKS_CLK_USB_CTRL_AUXSRC_PLL_USB) &
+      CLOCKS_CLK_USB_CTRL_AUXSRC_Msk;
+  CLOCKS->CLK[RP_CLK_USB].DIV = 1U << 16;
+  CLOCKS->SET.CLK[RP_CLK_USB].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
+
+  /* CLK_ADC = PLL_USB = 48 MHz */
+  CLOCKS->XOR.CLK[RP_CLK_ADC].CTRL =
+      (CLOCKS->CLK[RP_CLK_ADC].CTRL ^ CLOCKS_CLK_ADC_CTRL_AUXSRC_PLL_USB) &
+      CLOCKS_CLK_ADC_CTRL_AUXSRC_Msk;
+  CLOCKS->CLK[RP_CLK_ADC].DIV = 1U << 16;
+  CLOCKS->SET.CLK[RP_CLK_ADC].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
+
+  /* CLK_PERI = CLK_SYS = 150 MHz */
+  CLOCKS->XOR.CLK[RP_CLK_PERI].CTRL =
+      (CLOCKS->CLK[RP_CLK_PERI].CTRL ^ CLOCKS_CLK_PERI_CTRL_AUXSRC_SYS) &
+      CLOCKS_CLK_PERI_CTRL_AUXSRC_Msk;
+  CLOCKS->CLK[RP_CLK_PERI].DIV = 1U << 16;
+  CLOCKS->SET.CLK[RP_CLK_PERI].CTRL = CLOCKS_CLK_PERI_CTRL_ENABLE;
+
+  /* Calculate cycles for 1us tick based on clk_ref frequency, RP_XOSCCLK
+     is checked at compile time to be an integer number of MHz. */
+  cycles = RP_XOSCCLK / 1000000U;
+
+  /* Start tick generators */
+  for (uint32_t i = 0U; i < 6U; i++) {
+    rp_tick_start(i, cycles);
+  }
+
+}
+
+/**
+ * @brief   Returns the frequency of a clock in Hz.
+ * @note    Uses compile-time constants so this function is safe to call
+ *          before BSS/DATA initialization.
+ *
+ * @param[in] clk_index     clock index (RP_CLK_xxx)
+ * @return                  clock frequency in Hz
+ */
+uint32_t rp_clock_get_hz(uint32_t clk_index) {
+
+  chDbgAssert(clk_index < RP_CLK_COUNT, "invalid clock index");
+
+#if RP_CLOCK_DYNAMIC == TRUE
+  /* The table stays zero (explicitly cleared at rp_clock_init() entry,
+     again by the CRT0 BSS clear) until the first successful runtime
+     switch populates every entry; falling through to the compile-time
+     constants preserves the documented pre-initialization callability
+     and the constants are correct by definition until that first
+     switch. Reads are guarded by a sequence counter, a reader racing
+     an update on the other core retries until it holds a consistent
+     snapshot; the writer's update window is a handful of stores. */
+  {
+    uint32_t seq, value, active;
+
+    do {
+      seq = rp_clock_seq;
+      __DMB();
+      active = rp_clock_points[RP_CLK_SYS];
+      value  = rp_clock_points[clk_index];
+      __DMB();
+    } while (((seq & 1U) != 0U) || (seq != rp_clock_seq));
+    if (active != 0U) {
+      return value;
+    }
+  }
+#endif
+
+  switch (clk_index) {
+  case RP_CLK_REF:
+    return RP_CLK_REF_FREQ;
+  case RP_CLK_SYS:
+    return RP_CLK_SYS_FREQ;
+  case RP_CLK_PERI:
+    return RP_CLK_PERI_FREQ;
+  case RP_CLK_USB:
+    return RP_CLK_USB_FREQ;
+  case RP_CLK_ADC:
+    return RP_CLK_ADC_FREQ;
+  default:
+    return 0U;
+  }
+}
+
+#if (RP_CLOCK_DYNAMIC == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Checks a clock configuration for validity.
+ * @details Applies at runtime the same constraints the port enforces at
+ *          compile time on the static configuration, including the
+ *          RP2350-E12 clk_sys/clk_usb ratio.
+ *
+ * @param[in] ccp       pointer to a @p halclkcfg_t structure
+ * @return              @p true if the configuration is acceptable.
+ */
+static bool rp_clock_config_valid(const halclkcfg_t *ccp) {
+  uint32_t ref_freq, fbdiv, pdiv, sys_freq;
+
+  if ((ccp->pll_sys_refdiv < 1U) || (ccp->pll_sys_refdiv > 63U)) {
+    return false;
+  }
+  if ((RP_XOSCCLK % ccp->pll_sys_refdiv) != 0U) {
+    return false;
+  }
+  ref_freq = RP_XOSCCLK / ccp->pll_sys_refdiv;
+  if (ref_freq < 5000000U) {
+    return false;
+  }
+  if ((ccp->pll_sys_vco_freq < RP_PLL_VCO_MIN_FREQ) ||
+      (ccp->pll_sys_vco_freq > RP_PLL_VCO_MAX_FREQ)) {
+    return false;
+  }
+  if ((ccp->pll_sys_vco_freq % ref_freq) != 0U) {
+    return false;
+  }
+  fbdiv = ccp->pll_sys_vco_freq / ref_freq;
+  if ((fbdiv < 16U) || (fbdiv > 320U)) {
+    return false;
+  }
+  if ((ccp->pll_sys_postdiv1 < 1U) || (ccp->pll_sys_postdiv1 > 7U) ||
+      (ccp->pll_sys_postdiv2 < 1U) ||
+      (ccp->pll_sys_postdiv2 > ccp->pll_sys_postdiv1)) {
+    return false;
+  }
+  pdiv = ccp->pll_sys_postdiv1 * ccp->pll_sys_postdiv2;
+  if ((ccp->pll_sys_vco_freq % pdiv) != 0U) {
+    return false;
+  }
+  sys_freq = ccp->pll_sys_vco_freq / pdiv;
+
+#if RP_ALLOW_OVERCLOCK == TRUE
+  if (sys_freq > RP_CLK_SYS_OVERCLOCK_MAX) {
+    return false;
+  }
+  /* Regulator range: 1100..1300 mV in 50 mV steps, or untouched. */
+  if (ccp->vreg_mv != 0U) {
+    if ((ccp->vreg_mv < 1100U) || (ccp->vreg_mv > 1300U) ||
+        ((ccp->vreg_mv % 50U) != 0U)) {
+      return false;
+    }
+  }
+#else
+  /* Without overclocking support the port admits configurations up to
+     the rated maximum, which may exceed a lower compile-time boot
+     frequency; the regulator is off limits. */
+  if (sys_freq > RP_CLK_SYS_MAX) {
+    return false;
+  }
+  if (ccp->vreg_mv != 0U) {
+    return false;
+  }
+#endif
+
+  /* The boot flash divider is only known-safe up to the boot
+     frequency; any target above it requires an explicit divider,
+     whether overclocked or merely above a low boot configuration. */
+  if ((sys_freq > RP_PLL_SYS_CLK) && (ccp->qmi_clkdiv == 0U)) {
+    return false;
+  }
+
+  /* RP2350-E12: reliable USB operation requires clk_sys >= 1.1 *
+     clk_usb; clk_usb stays at its fixed frequency across switches. The
+     comparison is done in 64 bits, this is runtime arithmetic. */
+  if (((uint64_t)sys_freq * 10ULL) < ((uint64_t)RP_CLK_USB_FREQ * 11ULL)) {
+    return false;
+  }
+
+  if (ccp->qmi_clkdiv > 255U) {
+    return false;
+  }
+
+  return true;
+}
+
+#if RP_ALLOW_OVERCLOCK == TRUE
+/**
+ * @brief   Programs the core voltage regulator.
+ * @details Millivolts are mapped onto the VSEL encoding (1100 mV is
+ *          VSEL 0x0B, 50 mV per step); voltages above 1300 mV would
+ *          require the POWMAN voltage-limit unlock and are rejected by
+ *          validation. Every POWMAN write carries the password.
+ *
+ * @param[in] mv        target voltage, 1100..1300 in steps of 50
+ * @return              @p true on regulator update timeout.
+ */
+static bool rp_clock_set_vreg(uint32_t mv) {
+  uint32_t vsel = 0x0BU + ((mv - 1100U) / 50U);
+  uint32_t vreg, start;
+
+  vreg = (POWMAN->VREG & 0xFFFFU & ~POWMAN_VREG_VSEL_Msk) |
+         POWMAN_VREG_VSEL(vsel);
+  POWMAN->VREG = POWMAN_PASSWORD | vreg;
+  start = TIMER0->TIMERAWL;
+  while ((POWMAN->VREG & POWMAN_VREG_UPDATE_IN_PROGRESS) != 0U) {
+    if ((uint32_t)(TIMER0->TIMERAWL - start) > 1000U) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief   Returns the currently programmed regulator voltage in mV.
+ */
+static uint32_t rp_clock_get_vreg_mv(void) {
+  uint32_t vsel = (POWMAN->VREG & POWMAN_VREG_VSEL_Msk) >>
+                  POWMAN_VREG_VSEL_Pos;
+
+  /* Encodings below 1.10 V exist (down to 0.55 V); reporting them as
+     zero makes any upward request actually raise the regulator instead
+     of underflowing into a nonsensically high reading. */
+  if (vsel < 0x0BU) {
+    return 0U;
+  }
+  return 1100U + ((vsel - 0x0BU) * 50U);
+}
+#endif /* RP_ALLOW_OVERCLOCK == TRUE */
+
+/**
+ * @brief   Reprograms the QMI flash clock divider.
+ * @details Runs from RAM so no XIP fetch from this core is in flight
+ *          while the timing register changes.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] clkdiv    new CLKDIV encoding, 0..255 where zero encodes
+ *                      the effective divider 256
+ */
+RAMFUNC static void rp_clock_set_qmi_clkdiv(uint32_t clkdiv) {
+
+  QMI->M0_TIMING = (QMI->M0_TIMING & ~QMI_TIMING_CLKDIV_Msk) |
+                   QMI_TIMING_CLKDIV(clkdiv);
+  (void)QMI->M0_TIMING;
+  __DSB();
+  __ISB();
+}
+
+/**
+ * @brief   Switches to a different clock configuration.
+ * @details The switch keeps every clock consumer within specification
+ *          at all times: the flash divider is first widened to a value
+ *          safe at both the current and the target frequency, clk_sys
+ *          (and clk_peri with it) is parked on clk_ref through the
+ *          glitchless mux while PLL_SYS relocks, then the final flash
+ *          divider is applied. clk_ref, clk_usb and clk_adc are not
+ *          touched, so kernel time (TIMER0, fed from clk_ref) and the
+ *          48 MHz peripherals are unaffected.
+ * @note    Running peripheral drivers whose bit rates derive from
+ *          clk_sys/clk_peri keep their old divider settings; the
+ *          application must restart them after a switch, they then
+ *          recompute from the updated clock points.
+ * @note    On SMP configurations the other core keeps executing during
+ *          the switch (timing stays in specification throughout); it
+ *          slows to the parked frequency while PLL_SYS relocks. Only
+ *          local interrupts are masked, no kernel lock is taken.
+ * @note    While PLL_SYS relocks the system transits through the
+ *          reference frequency, transiently violating the RP2350-E12
+ *          clk_sys/clk_usb ratio; do not switch while USB traffic is
+ *          active. This mirrors the transition-window caveat of the
+ *          other ports implementing this API.
+ *
+ * @param[in] ccp       pointer to a @p halclkcfg_t structure
+ * @return              The operation status.
+ * @retval false        if the switch operation succeeded.
+ * @retval true         if the switch operation failed.
+ *
+ * @special
+ */
+bool hal_lld_clock_switch_mode(const halclkcfg_t *ccp) {
+  uint32_t sys_freq, div_old, div_new, div_safe, primask;
+
+  chDbgCheck(ccp != NULL);
+
+  if (!rp_clock_config_valid(ccp)) {
+    return true;
+  }
+  sys_freq = ccp->pll_sys_vco_freq /
+             (ccp->pll_sys_postdiv1 * ccp->pll_sys_postdiv2);
+
+  /* Effective divider values: the CLKDIV encoding zero means divide by
+     256, comparisons must never be done on raw encodings. The boot
+     divider is captured on the first switch, before anything has
+     changed it. */
+  div_old = (QMI->M0_TIMING & QMI_TIMING_CLKDIV_Msk) >>
+            QMI_TIMING_CLKDIV_Pos;
+  div_old = (div_old == 0U) ? 256U : div_old;
+  if (rp_clock_boot_qmi_div == 0U) {
+    rp_clock_boot_qmi_div = div_old;
+  }
+  div_new  = (ccp->qmi_clkdiv != 0U) ? ccp->qmi_clkdiv
+                                     : rp_clock_boot_qmi_div;
+  div_safe = (div_new > div_old) ? div_new : div_old;
+
+#if RP_ALLOW_OVERCLOCK == TRUE
+  /* A raised core voltage must be stable before the frequency goes up;
+     a timeout aborts the switch with the clocks untouched. */
+  if ((ccp->vreg_mv != 0U) && (ccp->vreg_mv > rp_clock_get_vreg_mv())) {
+    if (rp_clock_set_vreg(ccp->vreg_mv)) {
+      return true;
+    }
+  }
+#endif
+
+  /* Only local interrupts are masked: the sequence touches no kernel
+     state and taking the kernel lock here would stall the other core
+     on any kernel entry for the whole PLL relock. */
+  primask = __get_PRIMASK();
+  __disable_irq();
+
+  /* Flash divider safe at both the current and the target frequency
+     before anything changes. */
+  rp_clock_set_qmi_clkdiv(div_safe & 0xFFU);
+
+  /* Parking clk_sys on clk_ref through the glitchless mux; execution
+     continues from flash at the reference frequency. */
+  CLOCKS->CLR.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_Msk;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 1U) == 0U) {
+    /* Waiting for clk_sys to run from clk_ref. */
+  }
+
+  /* Reprogramming PLL_SYS while nothing runs from it. */
+  rp_pll_init(PLL_SYS, ccp->pll_sys_refdiv, ccp->pll_sys_vco_freq,
+              ccp->pll_sys_postdiv1, ccp->pll_sys_postdiv2);
+
+  /* Back onto the PLL through the glitchless mux. */
+  CLOCKS->XOR.CLK[RP_CLK_SYS].CTRL =
+      (CLOCKS->CLK[RP_CLK_SYS].CTRL ^ CLOCKS_CLK_SYS_CTRL_AUXSRC_PLL_SYS) &
+      CLOCKS_CLK_SYS_CTRL_AUXSRC_Msk;
+  CLOCKS->SET.CLK[RP_CLK_SYS].CTRL = CLOCKS_CLK_SYS_CTRL_SRC_AUX;
+  while ((CLOCKS->CLK[RP_CLK_SYS].SELECTED & 2U) == 0U) {
+    /* Waiting for clk_sys to run from PLL_SYS. */
+  }
+
+  /* Final flash divider for the new frequency; the encoding for the
+     effective divider 256 is zero. */
+  rp_clock_set_qmi_clkdiv(div_new & 0xFFU);
+
+  /* Publishing the new frequencies under the sequence counter: odd
+     while the table is inconsistent, readers retry across the window.
+     Every entry is written on every switch because the table may have
+     been cleared after a partial early population; RP_CLK_SYS doubles
+     as the first-switch activation entry. */
+  rp_clock_seq = rp_clock_seq + 1U;
+  __DMB();
+  rp_clock_points[RP_CLK_REF]  = RP_CLK_REF_FREQ;
+  rp_clock_points[RP_CLK_USB]  = RP_CLK_USB_FREQ;
+  rp_clock_points[RP_CLK_ADC]  = RP_CLK_ADC_FREQ;
+  rp_clock_points[RP_CLK_PERI] = sys_freq;
+  rp_clock_points[RP_CLK_SYS]  = sys_freq;
+  __DMB();
+  rp_clock_seq = rp_clock_seq + 1U;
+  SystemCoreClock = sys_freq;
+
+  __set_PRIMASK(primask);
+
+#if RP_ALLOW_OVERCLOCK == TRUE
+  /* A lowered voltage is applied only after the frequency has come
+     down. A late regulator timeout is deliberately not reported: the
+     clocks are already at the target and the voltage stays at its
+     previous, higher and therefore safe, level - a missed power
+     optimization must not make callers believe the frequency change
+     failed and skip their driver restarts. */
+  if ((ccp->vreg_mv != 0U) && (ccp->vreg_mv < rp_clock_get_vreg_mv())) {
+    (void)rp_clock_set_vreg(ccp->vreg_mv);
+  }
+#endif
+
+  return false;
+}
+#endif /* RP_CLOCK_DYNAMIC == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_clocks.h
+++ b/os/xhal/ports/RP/RP2350/rp_clocks.h
@@ -1,0 +1,155 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_clocks.h
+ * @brief   RP2350 clocks header.
+ *
+ * @addtogroup RP_CLOCKS
+ * @{
+ */
+
+#ifndef RP_CLOCKS_H
+#define RP_CLOCKS_H
+
+#include "rp_xosc.h"
+#include "rp_pll.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    PLL_SYS configuration
+ * @note    Default configuration produces 150 MHz system clock
+ * @{
+ */
+#if !defined(RP_PLL_SYS_REFDIV) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_REFDIV               1U
+#endif
+#if !defined(RP_PLL_SYS_VCO_FREQ) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_VCO_FREQ             1500000000U     /* 1500 MHz VCO */
+#endif
+#if !defined(RP_PLL_SYS_POSTDIV1) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_POSTDIV1             5U              /* 150 MHz output */
+#endif
+#if !defined(RP_PLL_SYS_POSTDIV2) || defined(__DOXYGEN__)
+#define RP_PLL_SYS_POSTDIV2             2U
+#endif
+/** @} */
+
+/**
+ * @name    PLL_USB configuration
+ * @{
+ */
+#if !defined(RP_PLL_USB_REFDIV) || defined(__DOXYGEN__)
+#define RP_PLL_USB_REFDIV               1U
+#endif
+#if !defined(RP_PLL_USB_VCO_FREQ) || defined(__DOXYGEN__)
+#define RP_PLL_USB_VCO_FREQ             1200000000U     /* 1200 MHz VCO */
+#endif
+#if !defined(RP_PLL_USB_POSTDIV1) || defined(__DOXYGEN__)
+#define RP_PLL_USB_POSTDIV1             5U
+#endif
+#if !defined(RP_PLL_USB_POSTDIV2) || defined(__DOXYGEN__)
+#define RP_PLL_USB_POSTDIV2             5U
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/**
+ * @name    PLL output frequencies
+ * @{
+ */
+/**
+ * @brief   PLL_SYS output frequency in Hz.
+ */
+#define RP_PLL_SYS_CLK                      (RP_PLL_SYS_VCO_FREQ /           \
+                                             (RP_PLL_SYS_POSTDIV1 *          \
+                                              RP_PLL_SYS_POSTDIV2))
+
+/**
+ * @brief   PLL_USB output frequency in Hz (must be 48 MHz for USB).
+ */
+#define RP_PLL_USB_CLK                      (RP_PLL_USB_VCO_FREQ /           \
+                                             (RP_PLL_USB_POSTDIV1 *          \
+                                              RP_PLL_USB_POSTDIV2))
+/** @} */
+
+/**
+ * @name    Compile-time clock frequencies
+ * @note    These are compile-time constants derived from PLL configuration.
+ *          For runtime clock queries, use the hal_lld_get_clock_point() API.
+ * @{
+ */
+/**
+ * @brief   System core clock frequency in Hz.
+ */
+#define RP_CLK_SYS_FREQ                     RP_PLL_SYS_CLK
+
+/**
+ * @brief   Reference clock frequency in Hz.
+ */
+#define RP_CLK_REF_FREQ                     RP_XOSCCLK
+
+/**
+ * @brief   Peripheral clock frequency in Hz.
+ * @note    CLK_PERI runs at CLK_SYS frequency by default.
+ */
+#define RP_CLK_PERI_FREQ                    RP_PLL_SYS_CLK
+
+/**
+ * @brief   USB clock frequency in Hz (must be 48 MHz).
+ */
+#define RP_CLK_USB_FREQ                     RP_PLL_USB_CLK
+
+/**
+ * @brief   ADC clock frequency in Hz (must be 48 MHz).
+ */
+#define RP_CLK_ADC_FREQ                     RP_PLL_USB_CLK
+/** @} */
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rp_clock_init(void);
+  uint32_t rp_clock_get_hz(uint32_t clk_index);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_CLOCKS_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_fifo.h
+++ b/os/xhal/ports/RP/RP2350/rp_fifo.h
@@ -1,0 +1,114 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_fifo.h
+ * @brief   RP2350 FIFO handler header.
+ *
+ * @addtogroup RP2350_FIFO
+ * @{
+ */
+
+#ifndef RP_FIFO_H
+#define RP_FIFO_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* EInline functions.                                                        */
+/*===========================================================================*/
+
+__STATIC_INLINE bool fifoIsReadNotEmpty(void) {
+
+  return (bool)((SIO->FIFO_ST & SIO_FIFO_ST_VLD) != 0U);
+}
+
+__STATIC_INLINE bool fifoIsWriteNotFull(void) {
+
+  return (bool)((SIO->FIFO_ST & SIO_FIFO_ST_RDY) != 0U);
+}
+
+__STATIC_INLINE void fifoFlushRead(void) {
+
+  while (fifoIsReadNotEmpty()) {
+    (void)SIO->FIFO_RD;
+  }
+
+  /* In case the other core is in WFE.*/
+  __SEV();
+}
+
+__STATIC_INLINE void fifoBlockingWrite(uint32_t data) {
+
+  /* Waiting for space into the FIFO.*/
+  while (!fifoIsWriteNotFull()) {
+    __WFE();
+  }
+
+  SIO->FIFO_WR = data;
+
+  /* In case the other core is in WFE, signaling data available.*/
+  __SEV();
+}
+
+__STATIC_INLINE uint32_t fifoBlockingRead(void) {
+  uint32_t data;
+
+  /* Waiting for data to appear.*/
+  while (!fifoIsReadNotEmpty()) {
+    __WFE();
+  }
+
+  data = SIO->FIFO_RD;
+
+  /* In case the other core is in WFE, signaling space available.*/
+  __SEV();
+
+  return data;
+}
+
+#endif /* RP_FIFO_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_isr.c
+++ b/os/xhal/ports/RP/RP2350/rp_isr.c
@@ -1,0 +1,71 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_isr.c
+ * @brief   RP2350 ISR handler code.
+ *
+ * @addtogroup RP2350_ISR
+ * @{
+ */
+
+#include "hal.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   IRQ subsystem initialization.
+ * @details Puts the IRQ controller in a known clean state before any
+ *          HAL drivers enable their individual interrupts.
+ *
+ * @notapi
+ */
+void irqInit(void) {
+
+}
+
+/**
+ * @brief   Disables IRQ sources.
+ *
+ * @notapi
+ */
+void irqDeinit(void) {
+
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_isr.h
+++ b/os/xhal/ports/RP/RP2350/rp_isr.h
@@ -1,0 +1,213 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_isr.h
+ * @brief   RP2350 ISR handler header.
+ *
+ * @addtogroup RP2350_ISR
+ * @{
+ */
+
+#ifndef RP_ISR_H
+#define RP_ISR_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    ISR names and numbers
+ * @{
+ */
+
+/* TIMER0 interrupts (4 alarms) */
+#define RP_TIMER0_IRQ0_HANDLER              Vector40
+#define RP_TIMER0_IRQ1_HANDLER              Vector44
+#define RP_TIMER0_IRQ2_HANDLER              Vector48
+#define RP_TIMER0_IRQ3_HANDLER              Vector4C
+
+/* TIMER1 interrupts (4 alarms) */
+#define RP_TIMER1_IRQ0_HANDLER              Vector50
+#define RP_TIMER1_IRQ1_HANDLER              Vector54
+#define RP_TIMER1_IRQ2_HANDLER              Vector58
+#define RP_TIMER1_IRQ3_HANDLER              Vector5C
+
+/* PWM interrupts */
+#define RP_PWM_IRQ_WRAP_0_HANDLER           Vector60
+#define RP_PWM_IRQ_WRAP_1_HANDLER           Vector64
+
+/* DMA interrupts */
+#define RP_DMA_IRQ_0_HANDLER                Vector68
+#define RP_DMA_IRQ_1_HANDLER                Vector6C
+#define RP_DMA_IRQ_2_HANDLER                Vector70
+#define RP_DMA_IRQ_3_HANDLER                Vector74
+
+/* USB interrupt */
+#define RP_USBCTRL_IRQ_HANDLER              Vector78
+
+/* PIO interrupts */
+#define RP_PIO0_IRQ_0_HANDLER               Vector7C
+#define RP_PIO0_IRQ_1_HANDLER               Vector80
+#define RP_PIO1_IRQ_0_HANDLER               Vector84
+#define RP_PIO1_IRQ_1_HANDLER               Vector88
+#define RP_PIO2_IRQ_0_HANDLER               Vector8C
+#define RP_PIO2_IRQ_1_HANDLER               Vector90
+
+/* IO Bank interrupts */
+#define RP_IO_IRQ_BANK0_HANDLER             Vector94
+#define RP_IO_IRQ_BANK0_NS_HANDLER          Vector98
+#define RP_IO_IRQ_QSPI_HANDLER              Vector9C
+#define RP_IO_IRQ_QSPI_NS_HANDLER           VectorA0
+
+/* SIO interrupts */
+#define RP_SIO_IRQ_FIFO_HANDLER             VectorA4
+#define RP_SIO_IRQ_BELL_HANDLER             VectorA8
+#define RP_SIO_IRQ_FIFO_NS_HANDLER          VectorAC
+#define RP_SIO_IRQ_BELL_NS_HANDLER          VectorB0
+#define RP_SIO_IRQ_MTIMECMP_HANDLER         VectorB4
+
+/* Clocks interrupt */
+#define RP_CLOCKS_IRQ_HANDLER               VectorB8
+
+/* SPI interrupts */
+#define RP_SPI0_IRQ_HANDLER                 VectorBC
+#define RP_SPI1_IRQ_HANDLER                 VectorC0
+
+/* UART interrupts */
+#define RP_UART0_IRQ_HANDLER                VectorC4
+#define RP_UART1_IRQ_HANDLER                VectorC8
+
+/* ADC interrupt */
+#define RP_ADC_IRQ_FIFO_HANDLER             VectorCC
+
+/* I2C interrupts */
+#define RP_I2C0_IRQ_HANDLER                 VectorD0
+#define RP_I2C1_IRQ_HANDLER                 VectorD4
+
+/* OTP interrupt */
+#define RP_OTP_IRQ_HANDLER                  VectorD8
+
+/* TRNG interrupt */
+#define RP_TRNG_IRQ_HANDLER                 VectorDC
+
+/* CTI interrupts */
+#define RP_PROC0_IRQ_CTI_HANDLER            VectorE0
+#define RP_PROC1_IRQ_CTI_HANDLER            VectorE4
+
+/* PLL interrupts */
+#define RP_PLL_SYS_IRQ_HANDLER              VectorE8
+#define RP_PLL_USB_IRQ_HANDLER              VectorEC
+
+/* Power manager interrupts */
+#define RP_POWMAN_IRQ_POW_HANDLER           VectorF0
+#define RP_POWMAN_IRQ_TIMER_HANDLER         VectorF4
+
+/* Spare interrupts */
+#define RP_SPARE_IRQ_0_HANDLER              VectorF8
+#define RP_SPARE_IRQ_1_HANDLER              VectorFC
+#define RP_SPARE_IRQ_2_HANDLER              Vector100
+#define RP_SPARE_IRQ_3_HANDLER              Vector104
+#define RP_SPARE_IRQ_4_HANDLER              Vector108
+#define RP_SPARE_IRQ_5_HANDLER              Vector10C
+
+/* IRQ numbers */
+#define RP_TIMER0_IRQ0_NUMBER               0
+#define RP_TIMER0_IRQ1_NUMBER               1
+#define RP_TIMER0_IRQ2_NUMBER               2
+#define RP_TIMER0_IRQ3_NUMBER               3
+#define RP_TIMER1_IRQ0_NUMBER               4
+#define RP_TIMER1_IRQ1_NUMBER               5
+#define RP_TIMER1_IRQ2_NUMBER               6
+#define RP_TIMER1_IRQ3_NUMBER               7
+#define RP_PWM_IRQ_WRAP_0_NUMBER            8
+#define RP_PWM_IRQ_WRAP_1_NUMBER            9
+#define RP_DMA_IRQ_0_NUMBER                 10
+#define RP_DMA_IRQ_1_NUMBER                 11
+#define RP_DMA_IRQ_2_NUMBER                 12
+#define RP_DMA_IRQ_3_NUMBER                 13
+#define RP_USBCTRL_IRQ_NUMBER               14
+#define RP_PIO0_IRQ_0_NUMBER                15
+#define RP_PIO0_IRQ_1_NUMBER                16
+#define RP_PIO1_IRQ_0_NUMBER                17
+#define RP_PIO1_IRQ_1_NUMBER                18
+#define RP_PIO2_IRQ_0_NUMBER                19
+#define RP_PIO2_IRQ_1_NUMBER                20
+#define RP_IO_IRQ_BANK0_NUMBER              21
+#define RP_IO_IRQ_BANK0_NS_NUMBER           22
+#define RP_IO_IRQ_QSPI_NUMBER               23
+#define RP_IO_IRQ_QSPI_NS_NUMBER            24
+#define RP_SIO_IRQ_FIFO_NUMBER              25
+#define RP_SIO_IRQ_BELL_NUMBER              26
+#define RP_SIO_IRQ_FIFO_NS_NUMBER           27
+#define RP_SIO_IRQ_BELL_NS_NUMBER           28
+#define RP_SIO_IRQ_MTIMECMP_NUMBER          29
+#define RP_CLOCKS_IRQ_NUMBER                30
+#define RP_SPI0_IRQ_NUMBER                  31
+#define RP_SPI1_IRQ_NUMBER                  32
+#define RP_UART0_IRQ_NUMBER                 33
+#define RP_UART1_IRQ_NUMBER                 34
+#define RP_ADC_IRQ_FIFO_NUMBER              35
+#define RP_I2C0_IRQ_NUMBER                  36
+#define RP_I2C1_IRQ_NUMBER                  37
+#define RP_OTP_IRQ_NUMBER                   38
+#define RP_TRNG_IRQ_NUMBER                  39
+#define RP_PROC0_IRQ_CTI_NUMBER             40
+#define RP_PROC1_IRQ_CTI_NUMBER             41
+#define RP_PLL_SYS_IRQ_NUMBER               42
+#define RP_PLL_USB_IRQ_NUMBER               43
+#define RP_POWMAN_IRQ_POW_NUMBER            44
+#define RP_POWMAN_IRQ_TIMER_NUMBER          45
+#define RP_SPARE_IRQ_0_NUMBER               46
+#define RP_SPARE_IRQ_1_NUMBER               47
+#define RP_SPARE_IRQ_2_NUMBER               48
+#define RP_SPARE_IRQ_3_NUMBER               49
+#define RP_SPARE_IRQ_4_NUMBER               50
+#define RP_SPARE_IRQ_5_NUMBER               51
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void irqInit(void);
+  void irqDeinit(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_ISR_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_pal_lld.h
+++ b/os/xhal/ports/RP/RP2350/rp_pal_lld.h
@@ -1,0 +1,57 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_pal_lld.h
+ * @brief   RP2350-specific PAL low level driver definitions.
+ */
+
+#ifndef RP2350_RP_PAL_LLD_H
+#define RP2350_RP_PAL_LLD_H
+
+/**
+ * @name    RP2350-specific alternate function selectors
+ * @{
+ * @note    Selectors above 7 are RP2350-specific and may map to pin-dependent
+ *          signals. Refer to the RP2350 GPIO function tables when using them.
+ */
+#define PAL_RP_IOCTRL_FUNCSEL_PIO2          PAL_RP_IOCTRL_FUNCSEL(8U)
+#define PAL_RP_IOCTRL_FUNCSEL_XIP           PAL_RP_IOCTRL_FUNCSEL(9U)
+#define PAL_RP_IOCTRL_FUNCSEL_USB           PAL_RP_IOCTRL_FUNCSEL(10U)
+
+#define PAL_MODE_ALTERNATE_PIO2             (PAL_RP_IOCTRL_FUNCSEL_PIO2    | \
+                                             PAL_RP_PAD_IE                 | \
+                                             PAL_RP_PAD_SCHMITT)
+#define PAL_MODE_ALTERNATE_XIP              (PAL_RP_IOCTRL_FUNCSEL_XIP     | \
+                                             PAL_RP_PAD_IE                 | \
+                                             PAL_RP_PAD_SCHMITT)
+#define PAL_MODE_ALTERNATE_USB              (PAL_RP_IOCTRL_FUNCSEL_USB     | \
+                                             PAL_RP_PAD_IE                 | \
+                                             PAL_RP_PAD_SCHMITT)
+/** @} */
+
+/**
+ * @brief   Access a SIO GPIO register by port.
+ * @details Given a register name (field of SIO) and port (0, 1), produce a
+ *          reference to the correct GPIO register for the port. On the RP2350
+ *          every "hi" register immediately follows the "low" register.
+ *
+ * @notapi
+ */
+#define RP_PAL_SIO_REG(reg, port)                                               \
+  ((&SIO->reg)[(port)])
+
+#endif /* RP2350_RP_PAL_LLD_H */

--- a/os/xhal/ports/RP/RP2350/rp_pll.c
+++ b/os/xhal/ports/RP/RP2350/rp_pll.c
@@ -1,0 +1,144 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_pll.c
+ * @brief   RP2350 PLL source.
+ *
+ * @addtogroup RP_PLL
+ * @{
+ */
+
+#include "hal.h"
+#include "hal_safety.h"
+#include "rp_pll.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout for PLL lock in microseconds.
+ * @note    PLL lock typically takes <1 ms. We allow up to 10 ms
+ *          to account for ROSC timing variance during early init.
+ */
+#define RP_PLL_LOCK_TIMEOUT_US          10000U
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes a PLL.
+ *
+ * @param[in] pll       pointer to PLL registers (PLL_SYS or PLL_USB)
+ * @param[in] refdiv    reference divider (1-63)
+ * @param[in] vco_freq  target VCO frequency in Hz (750-1600 MHz)
+ * @param[in] postdiv1  post divider 1 (1-7)
+ * @param[in] postdiv2  post divider 2 (1-7)
+ *
+ * @note    Output frequency = vco_freq / (postdiv1 * postdiv2)
+ * @note    VCO frequency = (XOSC / refdiv) * fbdiv
+ * @note    See RP2350 Datasheet 8.6 PLL
+ */
+void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
+                 uint32_t postdiv1, uint32_t postdiv2) {
+
+  uint32_t ref_freq;
+  uint32_t fbdiv;
+  uint32_t pdiv;
+
+  /* Denominators must be validated before any division uses them. */
+  chDbgAssert((refdiv >= 1U) && (refdiv <= 63U), "invalid REFDIV");
+
+  ref_freq = RP_XOSCCLK / refdiv;
+  chDbgAssert(ref_freq != 0U, "reference frequency is zero");
+  fbdiv = vco_freq / ref_freq;
+  pdiv = PLL_PRIM_POSTDIV1(postdiv1) | PLL_PRIM_POSTDIV2(postdiv2);
+
+  chDbgAssert(vco_freq >= RP_PLL_VCO_MIN_FREQ &&
+              vco_freq <= RP_PLL_VCO_MAX_FREQ,
+              "VCO frequency out of range");
+  chDbgAssert((RP_XOSCCLK % refdiv) == 0U, "XOSC not divisible by REFDIV");
+  chDbgAssert(ref_freq >= 5000000U, "reference frequency below 5 MHz");
+  chDbgAssert(fbdiv >= 16U && fbdiv <= 320U, "FBDIV out of range");
+  chDbgAssert((ref_freq * fbdiv) == vco_freq,
+              "VCO not an integer multiple of reference");
+  chDbgAssert(postdiv1 >= 1U && postdiv1 <= 7U, "POSTDIV1 out of range");
+  chDbgAssert(postdiv2 >= 1U && postdiv2 <= 7U, "POSTDIV2 out of range");
+  chDbgAssert(ref_freq <= (vco_freq / 16U), "Reference frequency too high");
+
+  /* Check if PLL is already configured */
+  if ((pll->CS & PLL_CS_LOCK) &&
+      (refdiv == (pll->CS & PLL_CS_REFDIV_Msk)) &&
+      (fbdiv == (pll->FBDIV_INT & PLL_FBDIV_INT_Msk)) &&
+      (pdiv == (pll->PRIM & (PLL_PRIM_POSTDIV1_Msk | PLL_PRIM_POSTDIV2_Msk)))) {
+    return;
+  }
+
+  /* Reset the PLL */
+  if (pll == PLL_SYS) {
+    rp_peripheral_reset(RESETS_ALLREG_PLL_SYS);
+    rp_peripheral_unreset(RESETS_ALLREG_PLL_SYS);
+  } else {
+    rp_peripheral_reset(RESETS_ALLREG_PLL_USB);
+    rp_peripheral_unreset(RESETS_ALLREG_PLL_USB);
+  }
+
+  /* Set VCO divider */
+  pll->CS = refdiv;
+  pll->FBDIV_INT = fbdiv;
+
+  /* Turn on PLL */
+  pll->CLR.PWR = PLL_PWR_PD | PLL_PWR_VCOPD;
+
+  /* Wait for PLL lock */
+  if (halRegWaitAnySet32X(&pll->CS, PLL_CS_LOCK,
+                          RP_PLL_LOCK_TIMEOUT_US, NULL)) {
+    halSftFail("PLL lock timeout");
+  }
+
+  /* Set post divider */
+  pll->PRIM = pdiv;
+
+  /* Turn on post divider */
+  pll->CLR.PWR = PLL_PWR_POSTDIVPD;
+}
+
+/**
+ * @brief   Deinitialize a PLL.
+ *
+ * @param[in] pll       pointer to PLL register
+ */
+void rp_pll_deinit(PLL_TypeDef *pll) {
+
+  /* Power down the PLL */
+  pll->PWR = PLL_PWR_PD | PLL_PWR_VCOPD | PLL_PWR_POSTDIVPD | PLL_PWR_DSMPD;
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_pll.h
+++ b/os/xhal/ports/RP/RP2350/rp_pll.h
@@ -1,0 +1,74 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_pll.h
+ * @brief   RP2350 PLL header.
+ *
+ * @addtogroup RP_PLL
+ * @{
+ */
+
+#ifndef RP_PLL_H
+#define RP_PLL_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Minimum VCO frequency in Hz.
+ */
+#define RP_PLL_VCO_MIN_FREQ             750000000U
+
+/**
+ * @brief   Maximum VCO frequency in Hz.
+ */
+#define RP_PLL_VCO_MAX_FREQ             1600000000U
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rp_pll_init(PLL_TypeDef *pll, uint32_t refdiv, uint32_t vco_freq,
+                   uint32_t postdiv1, uint32_t postdiv2);
+  void rp_pll_deinit(PLL_TypeDef *pll);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_PLL_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_registry.h
+++ b/os/xhal/ports/RP/RP2350/rp_registry.h
@@ -1,0 +1,155 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_registry.h
+ * @brief   RP2350 capabilities registry.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef RP_REGISTRY_H
+#define RP_REGISTRY_H
+
+/*===========================================================================*/
+/* Platform capabilities.                                                    */
+/*===========================================================================*/
+
+/**
+ * @name    RP2350 capabilities
+ * @{
+ */
+
+/*===========================================================================*/
+/* Common.                                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* RP2350                                                                   */
+/*===========================================================================*/
+
+/* GPIO attributes.
+   RP2350A (QFN-60): GPIO0-29, 4 IO_BANK0 interrupt registers.
+   RP2350B (QFN-80): GPIO0-47, 6 IO_BANK0 interrupt registers.
+   Select QFN-80 variant by defining RP2350B_QFN80 in the board build
+   flags. */
+#if defined(RP2350B_QFN80)
+/* RP2350B QFN-80: GPIO0-47. */
+#define RP_GPIO_NUM_LINES                   48
+#define RP_GPIO_INTR_REGS                   6
+#else
+/* RP2350A QFN-60 (Pico 2): GPIO0-29. */
+#define RP_GPIO_NUM_LINES                   30
+#define RP_GPIO_INTR_REGS                   4
+#endif
+
+/* UART attributes.*/
+#define RP_HAS_UART0                        TRUE
+#define RP_HAS_UART1                        TRUE
+
+/* PIO attributes.*/
+#define RP_HAS_PIO0                         TRUE
+#define RP_HAS_PIO1                         TRUE
+#define RP_HAS_PIO2                         TRUE
+#define RP_PIO_NUM_BLOCKS                   3
+#define RP_PIO_HAS_GPIOBASE                 TRUE
+
+/* TIMER attributes.*/
+#define RP_HAS_TIMER0                       TRUE
+#define RP_HAS_TIMER1                       TRUE
+#define RP_ST_NUM_ALARMS                    4
+
+/* RP2350 has no dedicated RTC peripheral; time-keeping is emulated on
+   the POWMAN Always-On timer (see LLD/RTCv2). */
+#define RP_HAS_RTC                          TRUE
+
+/* SPI attributes.*/
+#define RP_HAS_SPI0                         TRUE
+#define RP_HAS_SPI1                         TRUE
+
+/* I2C attributes.*/
+#define RP_HAS_I2C0                         TRUE
+#define RP_HAS_I2C1                         TRUE
+
+/* DMA attributes.*/
+#define RP_HAS_DMA                          TRUE
+#define RP_DMA_NUM_CHANNELS                 16
+
+/* WDG attributes.*/
+#define RP_HAS_WDG                          TRUE
+#define RP_WDG_STORAGE_SIZE                 32U
+#define RP_PSM_WDSEL_ALL_BITS               0x1FFFFFFU
+#define RP_WDG_HAS_E1_ERRATA                FALSE
+
+/* USB attributes.*/
+#define RP_HAS_USB                          TRUE
+#define USB_ENDPOINTS_NUMBER                15
+
+/* Flash attributes.*/
+#define RP_HAS_FLASH                        TRUE
+
+#define RP_HAS_HSTX                         TRUE
+#define RP_HAS_TRNG                         TRUE
+#define RP_HAS_SHA256                       TRUE
+#define RP_HAS_OTP                          TRUE
+
+/* PWM attributes.*/
+#define RP_HAS_PWM                          TRUE
+#define RP_PWM_NUM_SLICES                   12
+#define RP_HAS_PWM0                         TRUE
+#define RP_HAS_PWM1                         TRUE
+#define RP_HAS_PWM2                         TRUE
+#define RP_HAS_PWM3                         TRUE
+#define RP_HAS_PWM4                         TRUE
+#define RP_HAS_PWM5                         TRUE
+#define RP_HAS_PWM6                         TRUE
+#define RP_HAS_PWM7                         TRUE
+#define RP_HAS_PWM8                         TRUE
+#define RP_HAS_PWM9                         TRUE
+#define RP_HAS_PWM10                        TRUE
+#define RP_HAS_PWM11                        TRUE
+
+/* ADC attributes.
+   RP2350A (QFN-60): 4 external inputs on GPIO26-29 (AINSEL 0-3),
+                     temp on AINSEL 4.
+   RP2350B (QFN-80): 8 external inputs on GPIO40-47 (AINSEL 0-7),
+                     temp on AINSEL 8.
+   Select QFN-80 variant by defining RP2350B_QFN80 in the board build
+   flags. */
+#define RP_HAS_ADC                          TRUE
+#if defined(RP2350B_QFN80)
+/* RP2350B QFN-80: GPIO40-47 = AINSEL 0-7, temp on AINSEL 8. */
+#define RP_ADC_NUM_CHANNELS                 9U
+#define RP_ADC_TEMPERATURE_CHANNEL          8U
+#define RP_ADC_BASE_PIN                     40U
+#else
+/* RP2350A QFN-60 (Pico 2): GPIO26-29 = AINSEL 0-3, temp on AINSEL 4. */
+#define RP_ADC_NUM_CHANNELS                 5U
+#define RP_ADC_TEMPERATURE_CHANNEL          4U
+#define RP_ADC_BASE_PIN                     26U
+#endif
+#define RP_ADC_HAS_TEMPERATURE_SENSOR       TRUE
+#define RP_ADC_FIFO_DEPTH                   8U
+#define RP_ADC_DREQ                         48U
+#define RP_ADC_AINSEL_BITS                  4U
+#define RP_ADC_RROBIN_MASK                  0x01FF0000U
+
+/** @} */
+
+#endif /* RP_REGISTRY_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_xosc.c
+++ b/os/xhal/ports/RP/RP2350/rp_xosc.c
@@ -1,0 +1,89 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_xosc.c
+ * @brief   RP2350 XOSC source.
+ *
+ * @addtogroup RP_XOSC
+ * @{
+ */
+
+#include "hal.h"
+#include "hal_safety.h"
+#include "rp_xosc.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Timeout for XOSC stabilization in microseconds.
+ * @note    Crystal startup typically takes 1-2 ms. We allow up to 100 ms
+ *          to account for slow crystals and ROSC timing variance.
+ */
+#define RP_XOSC_STABLE_TIMEOUT_US       100000U
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes the XOSC
+ * @note    Assumes 1-15 MHz crystal is attached.
+ * @note    See RP2350 Datasheet 8.2 XOSC
+ */
+void rp_xosc_init(void) {
+
+  /* Set frequency range */
+  XOSC->CTRL = XOSC_CTRL_FREQ_RANGE_1_15MHZ;
+
+  /* Set startup delay */
+  XOSC->STARTUP = RP_XOSC_STARTUP_DELAY;
+
+  /* Enable the XOSC */
+  XOSC->SET.CTRL = XOSC_CTRL_ENABLE_ENABLE;
+
+  /* Wait for XOSC to be stable with timeout protection. */
+  if (halRegWaitAnySet32X(&XOSC->STATUS, XOSC_STATUS_STABLE,
+                          RP_XOSC_STABLE_TIMEOUT_US, NULL)) {
+    halSftFail("XOSC stable timeout");
+  }
+}
+
+/**
+ * @brief   Disable the XOSC
+ * @pre     The XOSC must not be the current source for CLK_REF.
+ */
+void rp_xosc_disable(void) {
+
+  /* Disable XOSC */
+  XOSC->XOR.CTRL = (XOSC->CTRL ^ XOSC_CTRL_ENABLE_DISABLE) & XOSC_CTRL_ENABLE_Msk;
+}
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/rp_xosc.h
+++ b/os/xhal/ports/RP/RP2350/rp_xosc.h
@@ -1,0 +1,86 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_xosc.h
+ * @brief   RP2350 XOSC header.
+ *
+ * @addtogroup RP_XOSC
+ * @{
+ */
+
+#ifndef RP_XOSC_H
+#define RP_XOSC_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   XOSC startup delay multiplier.
+ * @note    The base delay is ~1 ms of crystal periods. The default
+ *          multiplier of 6 gives a conservative ~6 ms startup delay
+ *          which accommodates slow-starting crystals. It can be
+ *          overridden from the board file.
+ */
+#if !defined(RP_XOSC_STARTUP_DELAY_MULTIPLIER)
+#define RP_XOSC_STARTUP_DELAY_MULTIPLIER    6U
+#endif
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/**
+ * @brief   XOSC startup delay value.
+ * @note    Delay is in multiples of 256 crystal periods
+ *          For 12MHz, each count is ~21.3us. Default gives 6ms startup.
+ */
+#define RP_XOSC_STARTUP_DELAY               \
+    ((((RP_XOSCCLK / 1000U) + 128U) / 256U) * RP_XOSC_STARTUP_DELAY_MULTIPLIER)
+
+#if RP_XOSC_STARTUP_DELAY > 0x3FFF
+#error "RP_XOSC_STARTUP_DELAY exceeds the 14-bit STARTUP.DELAY register field"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rp_xosc_init(void);
+  void rp_xosc_disable(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RP_XOSC_H */
+
+/** @} */

--- a/os/xhal/ports/RP/rp_bootrom.c
+++ b/os/xhal/ports/RP/rp_bootrom.c
@@ -1,0 +1,267 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rp_bootrom.c
+ * @brief   RP boot ROM access API implementation.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#include "hal.h"
+#include "rp_bootrom.h"
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+#define RP_ROM_BOOTROM_FUNC_TABLE_OFFSET     0x14U
+
+#if defined(RP2040)
+#define RP_ROM_BOOTROM_TABLE_LOOKUP_OFFSET   0x18U
+#define RP_ROM_BOOTROM_DATA_TABLE_OFFSET     0x16U
+#else
+#define RP_ROM_BOOTROM_TABLE_LOOKUP_OFFSET   0x16U
+#endif
+
+static inline void *rp_rom_hword_ptr(uint32_t addr) {
+
+  return (void *)(uintptr_t)(*(uint16_t *)(uintptr_t)(addr));
+}
+
+typedef void *(*rp_rom_table_lookup_2040_fn_t)(uint16_t *table, uint32_t code);
+
+#if defined(RP2350)
+typedef void *(*rp_rom_table_lookup_2350_fn_t)(uint32_t code, uint32_t mask);
+typedef int (*rp_rom_reboot_fn_t)(uint32_t flags, uint32_t delay_ms,
+                                  uint32_t p0, uint32_t p1);
+#endif
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+#if defined(RP2350)
+static uint32_t rp_rom_func_mask_x(void) {
+
+#if defined(__riscv)
+  return RP_ROM_RT_FLAG_FUNC_RISCV;
+#elif defined(PORT_KERNEL_MODE) && (PORT_KERNEL_MODE == PORT_KERNEL_MODE_GUEST)
+  return RP_ROM_RT_FLAG_FUNC_ARM_NONSEC;
+#else
+  return RP_ROM_RT_FLAG_FUNC_ARM_SEC;
+#endif
+}
+#endif
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+void *rpRomFuncLookupX(uint32_t code) {
+
+#if defined(RP2040)
+  rp_rom_table_lookup_2040_fn_t rom_table_lookup;
+  uint16_t *func_table;
+
+  rom_table_lookup =
+      (rp_rom_table_lookup_2040_fn_t)rp_rom_hword_ptr(
+          RP_ROM_BOOTROM_TABLE_LOOKUP_OFFSET);
+  func_table = (uint16_t *)rp_rom_hword_ptr(RP_ROM_BOOTROM_FUNC_TABLE_OFFSET);
+
+  return rom_table_lookup(func_table, code);
+#else
+  rp_rom_table_lookup_2350_fn_t rom_table_lookup;
+
+  rom_table_lookup =
+      (rp_rom_table_lookup_2350_fn_t)rp_rom_hword_ptr(
+          RP_ROM_BOOTROM_TABLE_LOOKUP_OFFSET);
+
+  return rom_table_lookup(code, rp_rom_func_mask_x());
+#endif
+}
+
+void *rpRomDataLookupX(uint32_t code) {
+
+#if defined(RP2040)
+  rp_rom_table_lookup_2040_fn_t rom_table_lookup;
+  uint16_t *data_table;
+
+  rom_table_lookup =
+      (rp_rom_table_lookup_2040_fn_t)rp_rom_hword_ptr(
+          RP_ROM_BOOTROM_TABLE_LOOKUP_OFFSET);
+  data_table = (uint16_t *)rp_rom_hword_ptr(RP_ROM_BOOTROM_DATA_TABLE_OFFSET);
+
+  return rom_table_lookup(data_table, code);
+#else
+  rp_rom_table_lookup_2350_fn_t rom_table_lookup;
+
+  rom_table_lookup =
+      (rp_rom_table_lookup_2350_fn_t)rp_rom_hword_ptr(
+          RP_ROM_BOOTROM_TABLE_LOOKUP_OFFSET);
+
+  return rom_table_lookup(code, RP_ROM_RT_FLAG_DATA);
+#endif
+}
+
+/**
+ * @brief   Batch-resolves ROM function codes into function pointers.
+ * @note    The @p table array is modified in place: each entry must be
+ *          initialized with a ROM table code (via @p RP_ROM_TABLE_CODE)
+ *          stored in a @p uintptr_t slot. On return every entry is
+ *          overwritten with the resolved function pointer (or zero on
+ *          lookup failure).
+ *
+ * @param[in,out] table   array of ROM codes, replaced with pointers
+ * @param[in]     count   number of entries in @p table
+ * @return              @p true if every code resolved successfully
+ */
+bool rpRomFuncsLookupX(uintptr_t *table, unsigned count) {
+  bool ok = true;
+  unsigned i;
+
+  chDbgCheck(table != NULL);
+
+  for (i = 0U; i < count; i++) {
+    table[i] = (uintptr_t)rpRomFuncLookupX((uint32_t)table[i]);
+    if (table[i] == 0U) {
+      ok = false;
+    }
+  }
+
+  return ok;
+}
+
+bool rpRomGetFlashApiX(rp_rom_flash_api_t *apip) {
+  uintptr_t table[] = {
+    RP_ROM_FUNC_CONNECT_INTERNAL_FLASH,
+    RP_ROM_FUNC_FLASH_EXIT_XIP,
+    RP_ROM_FUNC_FLASH_RANGE_ERASE,
+    RP_ROM_FUNC_FLASH_RANGE_PROGRAM,
+    RP_ROM_FUNC_FLASH_FLUSH_CACHE,
+    RP_ROM_FUNC_FLASH_ENTER_CMD_XIP
+  };
+  bool ok;
+
+  chDbgCheck(apip != NULL);
+
+  *apip = (rp_rom_flash_api_t) {0};
+  ok = rpRomFuncsLookupX(table, 6U);
+
+  apip->connect_internal_flash =
+      (rp_rom_connect_internal_flash_fn_t)table[0];
+  apip->flash_exit_xip = (rp_rom_flash_exit_xip_fn_t)table[1];
+  apip->flash_range_erase = (rp_rom_flash_range_erase_fn_t)table[2];
+  apip->flash_range_program = (rp_rom_flash_range_program_fn_t)table[3];
+  apip->flash_flush_cache = (rp_rom_flash_flush_cache_fn_t)table[4];
+  apip->flash_enter_cmd_xip = (rp_rom_flash_enter_cmd_xip_fn_t)table[5];
+
+  return ok;
+}
+
+#if defined(RP2350)
+int rpRomReboot(uint32_t flags, uint32_t delay_ms,
+                uint32_t p0, uint32_t p1) {
+  rp_rom_reboot_fn_t func;
+
+  func = (rp_rom_reboot_fn_t)rpRomFuncLookupX(RP_ROM_FUNC_REBOOT);
+  chDbgAssert(func != NULL, "reboot unavailable");
+
+  return func(flags, delay_ms, p0, p1);
+}
+#endif
+
+void __attribute__((noreturn)) rpRomResetUsbBoot(
+  uint32_t gpio_mask, uint32_t disable_interface_mask) {
+
+  chDbgAssert((gpio_mask == 0U) ||
+              ((gpio_mask & (gpio_mask - 1U)) == 0U),
+              "single GPIO bit required");
+
+#if defined(RP2040)
+  rp_rom_reset_usb_boot_fn_t func;
+
+  func = (rp_rom_reset_usb_boot_fn_t)rpRomFuncLookupX(
+      RP_ROM_FUNC_RESET_USB_BOOT);
+  chDbgAssert(func != NULL, "USB boot reset unavailable");
+
+  func(gpio_mask, disable_interface_mask);
+#else
+  uint32_t flags = disable_interface_mask;
+  uint32_t gpio = 0U;
+
+  if (gpio_mask != 0U) {
+    flags |= RP_ROM_BOOTSEL_GPIO_PIN_SPECIFIED;
+    gpio = (uint32_t)__builtin_ctz(gpio_mask);
+  }
+
+  (void)rpRomReboot(RP_ROM_REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL |
+                     RP_ROM_REBOOT2_FLAG_NO_RETURN_ON_SUCCESS,
+                     10U, flags, gpio);
+#endif
+
+  chSysHalt("bootrom return");
+  __builtin_unreachable();
+}
+
+#if defined(RP2040)
+bool rpRomGetMemApiX(rp_rom_mem_api_t *apip) {
+  uintptr_t table[] = {
+    RP_ROM_FUNC_MEMCPY,
+    RP_ROM_FUNC_MEMCPY44,
+    RP_ROM_FUNC_MEMSET,
+    RP_ROM_FUNC_MEMSET4
+  };
+  bool ok;
+
+  chDbgCheck(apip != NULL);
+
+  *apip = (rp_rom_mem_api_t) {0};
+  ok = rpRomFuncsLookupX(table, 4U);
+
+  apip->memcpy = (rp_rom_memcpy_fn_t)table[0];
+  apip->memcpy44 = (rp_rom_memcpy44_fn_t)table[1];
+  apip->memset = (rp_rom_memset_fn_t)table[2];
+  apip->memset4 = (rp_rom_memset4_fn_t)table[3];
+
+  return ok;
+}
+
+bool rpRomGetBitApiX(rp_rom_bit_api_t *apip) {
+  uintptr_t table[] = {
+    RP_ROM_FUNC_CLZ32,
+    RP_ROM_FUNC_CTZ32,
+    RP_ROM_FUNC_POPCOUNT32,
+    RP_ROM_FUNC_REVERSE32
+  };
+  bool ok;
+
+  chDbgCheck(apip != NULL);
+
+  *apip = (rp_rom_bit_api_t) {0};
+  ok = rpRomFuncsLookupX(table, 4U);
+
+  apip->clz32 = (rp_rom_clz32_fn_t)table[0];
+  apip->ctz32 = (rp_rom_ctz32_fn_t)table[1];
+  apip->popcount32 = (rp_rom_popcount32_fn_t)table[2];
+  apip->reverse32 = (rp_rom_reverse32_fn_t)table[3];
+
+  return ok;
+}
+#endif
+
+/** @} */

--- a/os/xhal/ports/RP/rp_bootrom.h
+++ b/os/xhal/ports/RP/rp_bootrom.h
@@ -1,0 +1,309 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rp_bootrom.h
+ * @brief   RP boot ROM access API header.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef RP_BOOTROM_H
+#define RP_BOOTROM_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Builds a boot ROM lookup code from two ASCII characters.
+ */
+#define RP_ROM_TABLE_CODE(c1, c2) \
+  ((uint32_t)(c1) | ((uint32_t)(c2) << 8))
+
+/**
+ * @name    Boot ROM function codes available on RP2040 and RP2350
+ * @{
+ */
+#define RP_ROM_FUNC_FLASH_ENTER_CMD_XIP \
+  RP_ROM_TABLE_CODE('C', 'X')
+#define RP_ROM_FUNC_FLASH_EXIT_XIP \
+  RP_ROM_TABLE_CODE('E', 'X')
+#define RP_ROM_FUNC_FLASH_FLUSH_CACHE \
+  RP_ROM_TABLE_CODE('F', 'C')
+#define RP_ROM_FUNC_CONNECT_INTERNAL_FLASH \
+  RP_ROM_TABLE_CODE('I', 'F')
+#define RP_ROM_FUNC_FLASH_RANGE_ERASE \
+  RP_ROM_TABLE_CODE('R', 'E')
+#define RP_ROM_FUNC_FLASH_RANGE_PROGRAM \
+  RP_ROM_TABLE_CODE('R', 'P')
+/** @} */
+
+/**
+ * @name    USB BOOTSEL interface flags
+ * @{
+ */
+#define RP_ROM_BOOTSEL_DISABLE_MSD_INTERFACE      0x01U
+#define RP_ROM_BOOTSEL_DISABLE_PICOBOOT_INTERFACE 0x02U
+/** @} */
+
+#if defined(RP2040) || defined(__DOXYGEN__)
+/**
+ * @name    RP2040-only boot ROM function codes
+ * @{
+ */
+#define RP_ROM_FUNC_MEMCPY44      RP_ROM_TABLE_CODE('C', '4')
+#define RP_ROM_FUNC_CLZ32         RP_ROM_TABLE_CODE('L', '3')
+#define RP_ROM_FUNC_MEMCPY        RP_ROM_TABLE_CODE('M', 'C')
+#define RP_ROM_FUNC_MEMSET        RP_ROM_TABLE_CODE('M', 'S')
+#define RP_ROM_FUNC_POPCOUNT32    RP_ROM_TABLE_CODE('P', '3')
+#define RP_ROM_FUNC_REVERSE32     RP_ROM_TABLE_CODE('R', '3')
+#define RP_ROM_FUNC_MEMSET4       RP_ROM_TABLE_CODE('S', '4')
+#define RP_ROM_FUNC_CTZ32         RP_ROM_TABLE_CODE('T', '3')
+#define RP_ROM_FUNC_RESET_USB_BOOT RP_ROM_TABLE_CODE('U', 'B')
+#define RP_ROM_FUNC_WAIT_FOR_VECTOR RP_ROM_TABLE_CODE('W', 'V')
+/** @} */
+
+/**
+ * @name    RP2040-only boot ROM data table codes
+ * @{
+ */
+#define RP_ROM_DATA_COPYRIGHT_STRING  RP_ROM_TABLE_CODE('C', 'R')
+#define RP_ROM_DATA_GIT_REVISION      RP_ROM_TABLE_CODE('G', 'R')
+#define RP_ROM_DATA_SOFT_FLOAT_TABLE  RP_ROM_TABLE_CODE('S', 'F')
+#define RP_ROM_DATA_SOFT_DOUBLE_TABLE RP_ROM_TABLE_CODE('S', 'D')
+#define RP_ROM_DATA_FPLIB_START       RP_ROM_TABLE_CODE('F', 'S')
+#define RP_ROM_DATA_FPLIB_END         RP_ROM_TABLE_CODE('F', 'E')
+#define RP_ROM_DATA_FLOAT_TABLE_SIZE  RP_ROM_TABLE_CODE('F', 'Z')
+/** @} */
+#endif
+
+#if defined(RP2350) || defined(__DOXYGEN__)
+/**
+ * @name    RP2350-only boot ROM function codes
+ * @{
+ */
+#define RP_ROM_FUNC_REBOOT                      \
+  RP_ROM_TABLE_CODE('R', 'B')
+#define RP_ROM_FUNC_FLASH_OP                    \
+  RP_ROM_TABLE_CODE('F', 'O')
+#define RP_ROM_FUNC_FLASH_RUNTIME_TO_STORAGE_ADDR \
+  RP_ROM_TABLE_CODE('F', 'A')
+#define RP_ROM_FUNC_FLASH_RESET_ADDRESS_TRANS   \
+  RP_ROM_TABLE_CODE('R', 'A')
+#define RP_ROM_FUNC_FLASH_SELECT_XIP_READ_MODE  \
+  RP_ROM_TABLE_CODE('X', 'M')
+#define RP_ROM_FUNC_GET_SYS_INFO                \
+  RP_ROM_TABLE_CODE('G', 'S')
+#define RP_ROM_FUNC_GET_PARTITION_TABLE_INFO    \
+  RP_ROM_TABLE_CODE('G', 'P')
+#define RP_ROM_FUNC_PICK_AB_PARTITION           \
+  RP_ROM_TABLE_CODE('A', 'B')
+#define RP_ROM_FUNC_GET_B_PARTITION             \
+  RP_ROM_TABLE_CODE('G', 'B')
+#define RP_ROM_FUNC_GET_UF2_TARGET_PARTITION    \
+  RP_ROM_TABLE_CODE('G', 'U')
+#define RP_ROM_FUNC_LOAD_PARTITION_TABLE        \
+  RP_ROM_TABLE_CODE('L', 'P')
+#define RP_ROM_FUNC_OTP_ACCESS                  \
+  RP_ROM_TABLE_CODE('O', 'A')
+#define RP_ROM_FUNC_CHAIN_IMAGE                 \
+  RP_ROM_TABLE_CODE('C', 'I')
+#define RP_ROM_FUNC_EXPLICIT_BUY                \
+  RP_ROM_TABLE_CODE('E', 'B')
+#define RP_ROM_FUNC_BOOTROM_STATE_RESET         \
+  RP_ROM_TABLE_CODE('S', 'R')
+#define RP_ROM_FUNC_SET_BOOTROM_STACK           \
+  RP_ROM_TABLE_CODE('S', 'S')
+#define RP_ROM_FUNC_SECURE_CALL                 \
+  RP_ROM_TABLE_CODE('S', 'C')
+#define RP_ROM_FUNC_SET_NS_API_PERMISSION       \
+  RP_ROM_TABLE_CODE('S', 'P')
+#define RP_ROM_FUNC_SET_ROM_CALLBACK            \
+  RP_ROM_TABLE_CODE('R', 'C')
+#define RP_ROM_FUNC_VALIDATE_NS_BUFFER          \
+  RP_ROM_TABLE_CODE('V', 'B')
+/** @} */
+
+/**
+ * @name    RP2350-only boot ROM data table codes
+ * @{
+ */
+#define RP_ROM_DATA_SOFTWARE_GIT_REVISION       \
+  RP_ROM_TABLE_CODE('G', 'R')
+#define RP_ROM_DATA_FLASH_DEVINFO16_PTR         \
+  RP_ROM_TABLE_CODE('F', 'D')
+#define RP_ROM_DATA_PARTITION_TABLE_PTR         \
+  RP_ROM_TABLE_CODE('P', 'T')
+#define RP_ROM_DATA_SAVED_XIP_SETUP_FUNC_PTR    \
+  RP_ROM_TABLE_CODE('X', 'F')
+/** @} */
+
+/**
+ * @name    RP2350 ROM table lookup flags
+ * @{
+ */
+#define RP_ROM_RT_FLAG_FUNC_RISCV               0x0001U
+#define RP_ROM_RT_FLAG_FUNC_RISCV_FAR           0x0003U
+#define RP_ROM_RT_FLAG_FUNC_ARM_SEC             0x0004U
+#define RP_ROM_RT_FLAG_FUNC_ARM_NONSEC          0x0010U
+#define RP_ROM_RT_FLAG_DATA                     0x0040U
+/** @} */
+
+/**
+ * @name    RP2350 reboot flags
+ * @{
+ */
+#define RP_ROM_REBOOT2_FLAG_REBOOT_TYPE_NORMAL       0x00U
+#define RP_ROM_REBOOT2_FLAG_REBOOT_TYPE_BOOTSEL      0x02U
+#define RP_ROM_REBOOT2_FLAG_REBOOT_TYPE_RAM_IMAGE    0x03U
+#define RP_ROM_REBOOT2_FLAG_REBOOT_TYPE_FLASH_UPDATE 0x04U
+#define RP_ROM_REBOOT2_FLAG_REBOOT_TYPE_PC_SP        0x0DU
+#define RP_ROM_REBOOT2_FLAG_REBOOT_TO_ARM            0x10U
+#define RP_ROM_REBOOT2_FLAG_REBOOT_TO_RISCV          0x20U
+#define RP_ROM_REBOOT2_FLAG_NO_RETURN_ON_SUCCESS     0x100U
+/** @} */
+
+/**
+ * @name    RP2350 BOOTSEL flags
+ * @{
+ */
+#define RP_ROM_BOOTSEL_GPIO_PIN_ACTIVE_LOW      0x10U
+#define RP_ROM_BOOTSEL_GPIO_PIN_SPECIFIED       0x20U
+/** @} */
+
+/**
+ * @name    RP2350 boot ROM error codes
+ * @{
+ */
+#define RP_ROM_OK                               0
+#define RP_ROM_ERROR_NOT_PERMITTED              (-4)
+#define RP_ROM_ERROR_INVALID_ARG                (-5)
+#define RP_ROM_ERROR_INVALID_ADDRESS            (-10)
+#define RP_ROM_ERROR_BAD_ALIGNMENT              (-11)
+#define RP_ROM_ERROR_INVALID_STATE              (-12)
+#define RP_ROM_ERROR_BUFFER_TOO_SMALL           (-13)
+#define RP_ROM_ERROR_PRECONDITION_NOT_MET       (-14)
+#define RP_ROM_ERROR_MODIFIED_DATA              (-15)
+#define RP_ROM_ERROR_INVALID_DATA               (-16)
+#define RP_ROM_ERROR_NOT_FOUND                  (-17)
+#define RP_ROM_ERROR_UNSUPPORTED_MODIFICATION   (-18)
+#define RP_ROM_ERROR_LOCK_REQUIRED              (-19)
+/** @} */
+#endif
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+#if !defined(__ASSEMBLER__)
+
+typedef void (*rp_rom_connect_internal_flash_fn_t)(void);
+typedef void (*rp_rom_flash_exit_xip_fn_t)(void);
+typedef void (*rp_rom_flash_range_erase_fn_t)(uint32_t offset,
+                                              size_t count,
+                                              uint32_t block_size,
+                                              uint8_t block_cmd);
+typedef void (*rp_rom_flash_range_program_fn_t)(uint32_t offset,
+                                                const uint8_t *data,
+                                                size_t count);
+typedef void (*rp_rom_flash_flush_cache_fn_t)(void);
+typedef void (*rp_rom_flash_enter_cmd_xip_fn_t)(void);
+typedef void __attribute__((noreturn)) (*rp_rom_reset_usb_boot_fn_t)(
+  uint32_t gpio_mask, uint32_t disable_interface_mask);
+
+/**
+ * @brief   Shared RP flash helper functions exported by the boot ROM.
+ */
+typedef struct {
+  rp_rom_connect_internal_flash_fn_t  connect_internal_flash;
+  rp_rom_flash_exit_xip_fn_t          flash_exit_xip;
+  rp_rom_flash_range_erase_fn_t       flash_range_erase;
+  rp_rom_flash_range_program_fn_t     flash_range_program;
+  rp_rom_flash_flush_cache_fn_t       flash_flush_cache;
+  rp_rom_flash_enter_cmd_xip_fn_t     flash_enter_cmd_xip;
+} rp_rom_flash_api_t;
+
+#if defined(RP2040) || defined(__DOXYGEN__)
+typedef uint32_t (*rp_rom_clz32_fn_t)(uint32_t value);
+typedef uint32_t (*rp_rom_ctz32_fn_t)(uint32_t value);
+typedef uint32_t (*rp_rom_popcount32_fn_t)(uint32_t value);
+typedef uint32_t (*rp_rom_reverse32_fn_t)(uint32_t value);
+typedef void *(*rp_rom_memcpy_fn_t)(void *dest, const void *src, size_t n);
+typedef uint32_t *(*rp_rom_memcpy44_fn_t)(uint32_t *dest,
+                                          const uint32_t *src,
+                                          uint32_t n);
+typedef void *(*rp_rom_memset_fn_t)(void *dest, int c, size_t n);
+typedef uint32_t *(*rp_rom_memset4_fn_t)(uint32_t *dest,
+                                         uint8_t value,
+                                         uint32_t n);
+
+/**
+ * @brief   RP2040 memory helper functions exported by the boot ROM.
+ */
+typedef struct {
+  rp_rom_memcpy_fn_t    memcpy;
+  rp_rom_memcpy44_fn_t  memcpy44;
+  rp_rom_memset_fn_t    memset;
+  rp_rom_memset4_fn_t   memset4;
+} rp_rom_mem_api_t;
+
+/**
+ * @brief   RP2040 bit helper functions exported by the boot ROM.
+ */
+typedef struct {
+  rp_rom_clz32_fn_t       clz32;
+  rp_rom_ctz32_fn_t       ctz32;
+  rp_rom_popcount32_fn_t  popcount32;
+  rp_rom_reverse32_fn_t   reverse32;
+} rp_rom_bit_api_t;
+#endif
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void *rpRomFuncLookupX(uint32_t code);
+  void *rpRomDataLookupX(uint32_t code);
+  bool rpRomFuncsLookupX(uintptr_t *table, unsigned count);
+  bool rpRomGetFlashApiX(rp_rom_flash_api_t *apip);
+  void __attribute__((noreturn)) rpRomResetUsbBoot(
+    uint32_t gpio_mask, uint32_t disable_interface_mask);
+#if defined(RP2350) || defined(__DOXYGEN__)
+  int rpRomReboot(uint32_t flags, uint32_t delay_ms,
+                  uint32_t p0, uint32_t p1);
+#endif
+#if defined(RP2040) || defined(__DOXYGEN__)
+  bool rpRomGetMemApiX(rp_rom_mem_api_t *apip);
+  bool rpRomGetBitApiX(rp_rom_bit_api_t *apip);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !__ASSEMBLER__ */
+
+#endif /* RP_BOOTROM_H */
+
+/** @} */


### PR DESCRIPTION
## Summary

First stage of the XHAL port for RP2040/RP2350 — the first non-STM32 (and first SMP-capable) XHAL silicon port.

- `os/xhal/ports/RP`: twin of the classic RP port converted to the XHAL environment (no OSAL, `ch*` primitives directly): platform init (clocks/PLL/XOSC/bootrom), TIMERv1 system-timer LLD (TIMER0, 4 alarms, `ST_LLD_MULTICORE_SUPPORT`), GPIOv1 PAL LLD (`PAL_NEW_INIT`, event support, core-affinity extension), for both RP2040 and RP2350 (ARM).
- `demos/RP/RT-XHAL-RP-MULTI`: multi-target demo (Pico + Pico 2), PAL blinker, tickless, single-core at this stage. SIO console, SMP second core and the remaining drivers land in the next stages (SIO/SPI/WDG+DMA → I2C/ADC/PWM/RTC → USB/EFL → Hazard3).
- Build manifest (`OSAL_REMOVAL_BUILDS.txt`) and `port/RP` labeler globs extended.

Fork provenance: master `0db31951d5`; per-file-group table plus intentional divergences documented in `os/xhal/ports/RP/README.md`. Review aid: `git diff --no-index os/hal/ports/RP/<x> os/xhal/ports/RP/<x>` shows only the conversion delta.

Intentional divergences from classic:
- `hal_lld_init()` calls `stBind()` unconditionally — classic gates it to free-running mode, leaving the periodic SysTick path configured by `st_lld_bind()` but never started (classic has the same latent issue; a classic-side fix can follow separately).
- ST/PAL IRQ priority knobs validated with `CH_IRQ_IS_VALID_KERNEL_PRIORITY` (handlers take kernel locks; classic had no checks).

## Depends on

- #198 (`stBindAlarmN` indexed-alarm assert) — not required for this single-core stage, but required before the Stage-2 SMP demo enables the second core with assertions on.

## Verification

- Build matrix, all clean: rp2040_pico + rp2350_pico2 × {tickless, periodic (`CH_CFG_ST_TIMEDELTA=0`), debug (`CH_DBG_ENABLE_CHECKS/ASSERTS/SYSTEM_STATE_CHECK`)}, plus `USE_SMART_BUILD=no` on both targets (compiles every shared XHAL driver source against the new port).
- `demos/STM32/RT-XHAL-STM32G474RE-NUCLEO64` reference build clean (no shared-code regressions; zero shared XHAL changes in this PR).
- XHAL OSAL lexical gate (per `OSAL_REMOVAL_MIGRATION.md`) clean; `tools/style/stylecheck.py` clean on all new files; `git diff --check` clean.
- codex adversarial review: 5 findings — fixed in this PR: unconditional `stBind()` (periodic-mode start), `CH_IRQ_IS_VALID_KERNEL_PRIORITY` for ST/PAL priority checks, trailing-whitespace cleanup, periodic + full-debug build probes added to the matrix; the `stBindAlarmN` finding is #198.
- coderabbit CLI review: 12 findings, all verified to target code **identical in the classic tree** (e.g. `rp_fifo.h` comment typo, `st_lld_start_alarm` re-arm shape, bootrom NULL-lookup assert, `PAL_MODE_OUTPUT_OPENDRAIN` #undef, analog-mode pad bits). Per the fork-fidelity policy these are untouched here to keep the classic↔XHAL review diff clean; they are candidates for a separate classic-side cleanup PR that this port would then mirror.
- On-hardware validation (LED cadence measurement on Pico/Pico 2) pending — no RP boards currently connected to the bench; will be run before Stage 2 lands.

## Changelog

- XHAL: added RP2040/RP2350 port (stage 1: platform, ST, PAL) with the RT-XHAL-RP-MULTI demo.
