### PR TITLE
RT: bound semaphore counter arithmetic

### DIFF
--- a/os/rt/include/chsem.h
+++ b/os/rt/include/chsem.h
@@ -33,6 +33,20 @@
 /* Module constants.                                                         */
 /*===========================================================================*/
 
+/**
+ * @brief   Maximum semaphore counter value.
+ * @details This is the maximum number of available units that can be
+ *          represented by a semaphore.
+ */
+#define SEMAPHORE_MAX_COUNT                                                \
+  ((cnt_t)(((ucnt_t)-1) / (ucnt_t)2))
+
+/**
+ * @brief   Maximum number of threads waiting on a semaphore.
+ */
+#define SEMAPHORE_MAX_WAITERS                                              \
+  ((ucnt_t)SEMAPHORE_MAX_COUNT + (ucnt_t)1)
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -51,7 +65,11 @@
 typedef struct ch_semaphore {
   ch_queue_t            queue;      /**< @brief Queue of the threads sleeping
                                                 on this semaphore.          */
-  cnt_t                 cnt;        /**< @brief The semaphore counter.      */
+  cnt_t                 cnt;        /**< @brief The semaphore counter, up to
+                                                @p SEMAPHORE_MAX_COUNT
+                                                available units or
+                                                @p SEMAPHORE_MAX_WAITERS
+                                                waiting threads.            */
 } semaphore_t;
 
 /*===========================================================================*/
@@ -150,6 +168,7 @@ static inline void chSemResetI(semaphore_t *sp, cnt_t n) {
 /**
  * @brief   Decreases the semaphore counter.
  * @details This macro can be used when the counter is known to be positive.
+ * @pre     The semaphore counter must be positive.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  *
@@ -158,14 +177,17 @@ static inline void chSemResetI(semaphore_t *sp, cnt_t n) {
 static inline void chSemFastWaitI(semaphore_t *sp) {
 
   chDbgCheckClassI();
+  chDbgAssert(sp->cnt > (cnt_t)0, "counter is not positive");
 
   sp->cnt--;
 }
 
 /**
  * @brief   Increases the semaphore counter.
- * @details This macro can be used when the counter is known to be not
- *          negative.
+ * @details This function can be used when incrementing the counter does not
+ *          require dequeuing a waiting thread.
+ * @pre     The semaphore counter must be lower than
+ *          @p SEMAPHORE_MAX_COUNT.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  *
@@ -174,6 +196,8 @@ static inline void chSemFastWaitI(semaphore_t *sp) {
 static inline void chSemFastSignalI(semaphore_t *sp) {
 
   chDbgCheckClassI();
+  chDbgAssert(sp->cnt < SEMAPHORE_MAX_COUNT,
+              "counter overflow");
 
   sp->cnt++;
 }

--- a/os/rt/src/chsem.c
+++ b/os/rt/src/chsem.c
@@ -49,6 +49,8 @@
  *          Semaphores usually use a FIFO queuing strategy but it is possible
  *          to make them order threads by priority by enabling
  *          @p CH_CFG_USE_SEMAPHORES_PRIORITY in @p chconf.h.
+ *          A semaphore can represent up to @p SEMAPHORE_MAX_COUNT available
+ *          units or @p SEMAPHORE_MAX_WAITERS waiting threads.
  * @pre     In order to use the semaphore APIs the @p CH_CFG_USE_SEMAPHORES
  *          option must be enabled in @p chconf.h.
  * @{
@@ -75,6 +77,9 @@
 /*===========================================================================*/
 /* Module local functions.                                                   */
 /*===========================================================================*/
+
+#define SEMAPHORE_MIN_COUNT                                                \
+  ((cnt_t)(-SEMAPHORE_MAX_COUNT - (cnt_t)1))
 
 #if CH_CFG_USE_SEMAPHORES_PRIORITY == TRUE
 #define sem_insert(qp, tp) ch_sch_prio_insert(qp, &tp->hdr.queue)
@@ -189,6 +194,8 @@ void chSemResetWithMessageI(semaphore_t *sp, cnt_t n, msg_t msg) {
 
 /**
  * @brief   Performs a wait operation on a semaphore.
+ * @pre     Fewer than @p SEMAPHORE_MAX_WAITERS threads may already be waiting
+ *          on the semaphore.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  * @return              A message specifying how the invoking thread has been
@@ -211,6 +218,8 @@ msg_t chSemWait(semaphore_t *sp) {
 
 /**
  * @brief   Performs a wait operation on a semaphore.
+ * @pre     Fewer than @p SEMAPHORE_MAX_WAITERS threads may already be waiting
+ *          on the semaphore.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  * @return              A message specifying how the invoking thread has been
@@ -228,6 +237,7 @@ msg_t chSemWaitS(semaphore_t *sp) {
   chDbgAssert(((sp->cnt >= (cnt_t)0) && ch_queue_isempty(&sp->queue)) ||
               ((sp->cnt < (cnt_t)0) && ch_queue_notempty(&sp->queue)),
               "inconsistent semaphore");
+  chDbgAssert(sp->cnt > SEMAPHORE_MIN_COUNT, "counter underflow");
 
   if (--sp->cnt < (cnt_t)0) {
     thread_t *currtp = chThdGetSelfX();
@@ -243,11 +253,15 @@ msg_t chSemWaitS(semaphore_t *sp) {
 
 /**
  * @brief   Performs a wait operation on a semaphore with timeout specification.
+ * @note    For a non-waiting acquisition when the counter is known to be
+ *          positive, use @p chSemFastWaitI().
+ * @pre     Fewer than @p SEMAPHORE_MAX_WAITERS threads may already be waiting
+ *          on the semaphore.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  * @param[in] timeout   the number of ticks before the operation times out,
- *                      the following special values are allowed:
- *                      - @a TIME_IMMEDIATE immediate timeout.
+ *                      the following special values are handled as follows:
+ *                      - @a TIME_IMMEDIATE this value is not allowed.
  *                      - @a TIME_INFINITE no timeout.
  * @return              A message specifying how the invoking thread has been
  *                      released from the semaphore.
@@ -271,11 +285,15 @@ msg_t chSemWaitTimeout(semaphore_t *sp, sysinterval_t timeout) {
 
 /**
  * @brief   Performs a wait operation on a semaphore with timeout specification.
+ * @note    For a non-waiting acquisition when the counter is known to be
+ *          positive, use @p chSemFastWaitI().
+ * @pre     Fewer than @p SEMAPHORE_MAX_WAITERS threads may already be waiting
+ *          on the semaphore.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  * @param[in] timeout   the number of ticks before the operation times out,
- *                      the following special values are allowed:
- *                      - @a TIME_IMMEDIATE immediate timeout.
+ *                      the following special values are handled as follows:
+ *                      - @a TIME_IMMEDIATE this value is not allowed.
  *                      - @a TIME_INFINITE no timeout.
  * @return              A message specifying how the invoking thread has been
  *                      released from the semaphore.
@@ -290,17 +308,13 @@ msg_t chSemWaitTimeout(semaphore_t *sp, sysinterval_t timeout) {
 msg_t chSemWaitTimeoutS(semaphore_t *sp, sysinterval_t timeout) {
 
   chDbgCheckClassS();
-  chDbgCheck(sp != NULL);
+  chDbgCheck((sp != NULL) && (timeout != TIME_IMMEDIATE));
   chDbgAssert(((sp->cnt >= (cnt_t)0) && ch_queue_isempty(&sp->queue)) ||
               ((sp->cnt < (cnt_t)0) && ch_queue_notempty(&sp->queue)),
               "inconsistent semaphore");
 
+  chDbgAssert(sp->cnt > SEMAPHORE_MIN_COUNT, "counter underflow");
   if (--sp->cnt < (cnt_t)0) {
-    if (unlikely(TIME_IMMEDIATE == timeout)) {
-      sp->cnt++;
-
-      return MSG_TIMEOUT;
-    }
     thread_t *currtp = chThdGetSelfX();
     currtp->u.wtsemp = sp;
     sem_insert(&sp->queue, currtp);
@@ -313,6 +327,8 @@ msg_t chSemWaitTimeoutS(semaphore_t *sp, sysinterval_t timeout) {
 
 /**
  * @brief   Performs a signal operation on a semaphore.
+ * @pre     The semaphore counter must be lower than
+ *          @p SEMAPHORE_MAX_COUNT.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  *
@@ -326,6 +342,7 @@ void chSemSignal(semaphore_t *sp) {
   chDbgAssert(((sp->cnt >= (cnt_t)0) && ch_queue_isempty(&sp->queue)) ||
               ((sp->cnt < (cnt_t)0) && ch_queue_notempty(&sp->queue)),
               "inconsistent semaphore");
+  chDbgAssert(sp->cnt < SEMAPHORE_MAX_COUNT, "counter overflow");
   if (++sp->cnt <= (cnt_t)0) {
     chSchWakeupS(threadref(ch_queue_fifo_remove(&sp->queue)), MSG_OK);
   }
@@ -334,6 +351,8 @@ void chSemSignal(semaphore_t *sp) {
 
 /**
  * @brief   Performs a signal operation on a semaphore.
+ * @pre     The semaphore counter must be lower than
+ *          @p SEMAPHORE_MAX_COUNT.
  * @post    This function does not reschedule so a call to a rescheduling
  *          function must be performed before unlocking the kernel. Note that
  *          interrupt handlers always reschedule on exit so an explicit
@@ -350,6 +369,7 @@ void chSemSignalI(semaphore_t *sp) {
   chDbgAssert(((sp->cnt >= (cnt_t)0) && ch_queue_isempty(&sp->queue)) ||
               ((sp->cnt < (cnt_t)0) && ch_queue_notempty(&sp->queue)),
               "inconsistent semaphore");
+  chDbgAssert(sp->cnt < SEMAPHORE_MAX_COUNT, "counter overflow");
 
   if (++sp->cnt <= (cnt_t)0) {
     /* Note, it is done this way in order to allow a tail call on
@@ -362,6 +382,8 @@ void chSemSignalI(semaphore_t *sp) {
 
 /**
  * @brief   Adds the specified value to the semaphore counter.
+ * @pre     The resulting counter value must not exceed
+ *          @p SEMAPHORE_MAX_COUNT.
  * @post    This function does not reschedule so a call to a rescheduling
  *          function must be performed before unlocking the kernel. Note that
  *          interrupt handlers always reschedule on exit so an explicit
@@ -381,6 +403,9 @@ void chSemAddCounterI(semaphore_t *sp, cnt_t n) {
   chDbgAssert(((sp->cnt >= (cnt_t)0) && ch_queue_isempty(&sp->queue)) ||
               ((sp->cnt < (cnt_t)0) && ch_queue_notempty(&sp->queue)),
               "inconsistent semaphore");
+  chDbgAssert((sp->cnt <= (cnt_t)0) ||
+              (n <= SEMAPHORE_MAX_COUNT - sp->cnt),
+              "counter overflow");
 
   while (n > (cnt_t)0) {
     if (++sp->cnt <= (cnt_t)0) {
@@ -394,6 +419,11 @@ void chSemAddCounterI(semaphore_t *sp, cnt_t n) {
 
 /**
  * @brief   Performs atomic signal and wait operations on two semaphores.
+ * @pre     The signal and wait semaphores must be different objects.
+ * @pre     The signal semaphore counter must be lower than
+ *          @p SEMAPHORE_MAX_COUNT and fewer than
+ *          @p SEMAPHORE_MAX_WAITERS threads may already be waiting on the
+ *          wait semaphore.
  *
  * @param[in] sps       pointer to a @p semaphore_t object to be signaled
  * @param[in] spw       pointer to a @p semaphore_t object to wait on
@@ -410,6 +440,7 @@ msg_t chSemSignalWait(semaphore_t *sps, semaphore_t *spw) {
   msg_t msg;
 
   chDbgCheck((sps != NULL) && (spw != NULL));
+  chDbgAssert(sps != spw, "same semaphore");
 
   chSysLock();
   chDbgAssert(((sps->cnt >= (cnt_t)0) && ch_queue_isempty(&sps->queue)) ||
@@ -418,6 +449,9 @@ msg_t chSemSignalWait(semaphore_t *sps, semaphore_t *spw) {
   chDbgAssert(((spw->cnt >= (cnt_t)0) && ch_queue_isempty(&spw->queue)) ||
               ((spw->cnt < (cnt_t)0) && ch_queue_notempty(&spw->queue)),
               "inconsistent semaphore");
+
+  chDbgAssert(sps->cnt < SEMAPHORE_MAX_COUNT, "counter overflow");
+  chDbgAssert(spw->cnt > SEMAPHORE_MIN_COUNT, "counter underflow");
   if (++sps->cnt <= (cnt_t)0) {
     tp = threadref(ch_queue_fifo_remove(&sps->queue));
     tp->u.rdymsg = MSG_OK;

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -2505,6 +2505,7 @@ test_assert_sequence("DE", "invalid sequence");]]></value>
         <value><![CDATA[#include "ch.h"
 
 static semaphore_t sem1;
+static semaphore_t sem2;
 
 static THD_FUNCTION(thread1, p) {
 
@@ -2526,7 +2527,7 @@ static THD_FUNCTION(thread3, p) {
 
   (void)p;
   chSemWait(&sem1);
-  chSemSignal(&sem1);
+  chSemSignal(&sem2);
 }
 
 static THD_FUNCTION(thread4, p) {
@@ -2721,12 +2722,10 @@ test_assert_sequence("ABCDE", "invalid sequence");]]></value>
             <value>Semaphore timeout test.</value>
           </brief>
           <description>
-            <value>The three possible semaphore waiting modes (do not
-              wait, wait with timeout, wait without timeout) are
+            <value>Successful and expired timed semaphore waits are
               explored. The test expects that the semaphore wait
-              function returns the correct value in each of the above
-              scenario and that the semaphore structure status is
-              correct after each operation.</value>
+              function returns the correct value and that the semaphore
+              structure status is correct after each operation.</value>
           </description>
           <condition>
             <value />
@@ -2745,20 +2744,6 @@ msg_t msg;]]></value>
             </local_variables>
           </various_code>
           <steps>
-            <step>
-              <description>
-                <value>Testing special case TIME_IMMEDIATE.</value>
-              </description>
-              <tags>
-                <value />
-              </tags>
-              <code>
-                <value><![CDATA[msg = chSemWaitTimeout(&sem1, TIME_IMMEDIATE);
-test_assert(msg == MSG_TIMEOUT, "wrong wake-up message");
-test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
-test_assert(sem1.cnt == 0, "counter not zero");]]></value>
-              </code>
-            </step>
             <step>
               <description>
                 <value>Testing non-timeout condition.</value>
@@ -2877,26 +2862,29 @@ test_assert_sequence("A", "invalid sequence");]]></value>
           <description>
             <value>This test case explicitly addresses the @p
               chSemWaitSignal() function. A thread is created that
-              performs a wait and a signal operations. The tester thread
-              is awakened from an atomic wait/signal operation. The test
-              expects that the semaphore wait function returns the
-              correct value in each of the above scenario and that the
-              semaphore structure status is correct after each
-              operation.</value>
+              performs a wait on the signal semaphore then signals the
+              wait semaphore. The tester thread is awakened from an
+              atomic wait/signal operation. The test expects that the
+              semaphore wait function returns the correct value and that
+              both semaphore structures are correct after each operation.
+            </value>
           </description>
           <condition>
             <value />
           </condition>
           <various_code>
             <setup_code>
-              <value><![CDATA[chSemObjectInit(&sem1, 0);]]></value>
+              <value><![CDATA[chSemObjectInit(&sem1, 0);
+chSemObjectInit(&sem2, 0);]]></value>
             </setup_code>
             <teardown_code>
               <value><![CDATA[test_wait_threads();
-chSemObjectDispose(&sem1);]]></value>
+chSemObjectDispose(&sem1);
+chSemObjectDispose(&sem2);]]></value>
             </teardown_code>
             <local_variables>
-              <value><![CDATA[#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
+              <value><![CDATA[msg_t msg;
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
 msg_t tracemsg;
 bool found;
@@ -2906,9 +2894,9 @@ bool found;
           <steps>
             <step>
               <description>
-                <value>An higher priority thread is created that
-                  performs non-atomical wait and signal operations on a
-                  semaphore.</value>
+                <value>A higher priority thread is created that waits on
+                  the signal semaphore then signals the wait semaphore.
+                </value>
               </description>
               <tags>
                 <value />
@@ -2919,17 +2907,16 @@ bool found;
             </step>
             <step>
               <description>
-                <value>The function chSemSignalWait() is invoked by
-                  specifying the same semaphore for the wait and signal
-                  phases. The counter value and, when enabled, the
-                  signaled thread's ready trace message are tested on
-                  exit.</value>
+                <value>The function chSemSignalWait() is invoked with
+                  distinct signal and wait semaphores. Their counters
+                  and, when enabled, the signaled thread's ready trace
+                  message are tested on exit.</value>
               </description>
               <tags>
                 <value />
               </tags>
               <code>
-                <value><![CDATA[chSemSignalWait(&sem1, &sem1);
+                <value><![CDATA[msg = chSemSignalWait(&sem1, &sem2);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
 chSysLock();
@@ -2938,24 +2925,28 @@ chSysUnlock();
 test_assert(found, "ready trace not found");
 test_assert(tracemsg == MSG_OK, "invalid ready trace message");
 #endif
+test_assert(msg == MSG_OK, "wrong returned message");
 test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
-test_assert(sem1.cnt == 0, "counter not zero");]]></value>
+test_assert(ch_queue_isempty(&sem2.queue), "queue not empty");
+test_assert((sem1.cnt == 0) && (sem2.cnt == 0), "counter not zero");]]></value>
               </code>
             </step>
             <step>
               <description>
-                <value>The function chSemSignalWait() is invoked again
-                  by specifying the same semaphore for the wait and
-                  signal phases. The counter value must be one on exit.
-                </value>
+                <value>The wait semaphore is pre-signaled, then
+                  chSemSignalWait() is invoked again and verified to
+                  complete without blocking.</value>
               </description>
               <tags>
                 <value />
               </tags>
               <code>
-                <value><![CDATA[chSemSignalWait(&sem1, &sem1);
+                <value><![CDATA[chSemSignal(&sem2);
+msg = chSemSignalWait(&sem1, &sem2);
+test_assert(msg == MSG_OK, "wrong returned message");
 test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
-test_assert(sem1.cnt == 0, "counter not zero");]]></value>
+test_assert(ch_queue_isempty(&sem2.queue), "queue not empty");
+test_assert((sem1.cnt == 1) && (sem2.cnt == 0), "invalid counter");]]></value>
               </code>
             </step>
           </steps>
@@ -3068,6 +3059,115 @@ test_assert_lock(chSemGetCounterI(&bsem.sem) == 1, "unexpected counter");]]></va
                 <value><![CDATA[chBSemSignal(&bsem);
 test_assert_lock(chBSemGetStateI(&bsem) == false, "taken");
 test_assert_lock(chSemGetCounterI(&bsem.sem) == 1, "unexpected counter");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Semaphore counter boundaries.</value>
+          </brief>
+          <description>
+            <value>The representable semaphore counter boundaries and
+              the operations that can validly reach them are tested.
+            </value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value><![CDATA[chSemObjectInit(&sem1, 0);
+chSemObjectInit(&sem2, 0);]]></value>
+            </setup_code>
+            <teardown_code>
+              <value><![CDATA[chSemObjectDispose(&sem1);
+chSemObjectDispose(&sem2);]]></value>
+            </teardown_code>
+            <local_variables>
+              <value><![CDATA[cnt_t cnt;
+msg_t msg;
+bool empty;]]></value>
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>The public counter and waiter limits are checked.
+                </value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[test_assert(SEMAPHORE_MAX_COUNT > (cnt_t)0,
+            "invalid maximum counter");
+test_assert(SEMAPHORE_MAX_WAITERS ==
+            (ucnt_t)SEMAPHORE_MAX_COUNT + (ucnt_t)1,
+            "invalid maximum waiters");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Signal, add-counter, and fast operations are
+                  exercised up to the maximum counter value.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+chSemSignal(&sem1);
+test_assert_lock(chSemGetCounterI(&sem1) == SEMAPHORE_MAX_COUNT,
+                 "signal boundary failed");
+
+chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+chSysLock();
+chSemSignalI(&sem1);
+cnt = chSemGetCounterI(&sem1);
+chSysUnlock();
+test_assert(cnt == SEMAPHORE_MAX_COUNT,
+            "I-class signal boundary failed");
+
+chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)2);
+chSysLock();
+chSemAddCounterI(&sem1, (cnt_t)2);
+cnt = chSemGetCounterI(&sem1);
+chSysUnlock();
+test_assert(cnt == SEMAPHORE_MAX_COUNT,
+            "add-counter boundary failed");
+
+chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+chSysLock();
+chSemFastSignalI(&sem1);
+cnt = chSemGetCounterI(&sem1);
+chSemFastWaitI(&sem1);
+chSysUnlock();
+test_assert(cnt == SEMAPHORE_MAX_COUNT,
+            "fast signal boundary failed");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A distinct-object signal/wait operation is
+                  verified at the maximum signal counter value.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+chSemReset(&sem2, 1);
+msg = chSemSignalWait(&sem1, &sem2);
+chSysLock();
+cnt = chSemGetCounterI(&sem1);
+empty = ch_queue_isempty(&sem1.queue) &&
+        ch_queue_isempty(&sem2.queue) &&
+        (chSemGetCounterI(&sem2) == (cnt_t)0);
+chSysUnlock();
+test_assert(msg == MSG_OK, "wrong returned message");
+test_assert(cnt == SEMAPHORE_MAX_COUNT, "invalid signal counter");
+test_assert(empty, "invalid wait semaphore");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_sequence_007.c
+++ b/test/rt/source/test/rt_test_sequence_007.c
@@ -42,6 +42,7 @@
  * - @subpage rt_test_007_004
  * - @subpage rt_test_007_005
  * - @subpage rt_test_007_006
+ * - @subpage rt_test_007_007
  * .
  */
 
@@ -54,6 +55,7 @@
 #include "ch.h"
 
 static semaphore_t sem1;
+static semaphore_t sem2;
 
 static THD_FUNCTION(thread1, p) {
 
@@ -75,7 +77,7 @@ static THD_FUNCTION(thread3, p) {
 
   (void)p;
   chSemWait(&sem1);
-  chSemSignal(&sem1);
+  chSemSignal(&sem2);
 }
 
 static THD_FUNCTION(thread4, p) {
@@ -269,16 +271,13 @@ static const testcase_t rt_test_007_002 = {
  * @page rt_test_007_003 [7.3] Semaphore timeout test
  *
  * <h2>Description</h2>
- * The three possible semaphore waiting modes (do not wait, wait with
- * timeout, wait without timeout) are explored. The test expects that
- * the semaphore wait function returns the correct value in each of the
- * above scenario and that the semaphore structure status is correct
- * after each operation.
+ * Successful and expired timed semaphore waits are explored. The test
+ * expects that the semaphore wait function returns the correct value and
+ * that the semaphore structure status is correct after each operation.
  *
  * <h2>Test Steps</h2>
- * - [7.3.1] Testing special case TIME_IMMEDIATE.
- * - [7.3.2] Testing non-timeout condition.
- * - [7.3.3] Testing timeout condition.
+ * - [7.3.1] Testing non-timeout condition.
+ * - [7.3.2] Testing timeout condition.
  * .
  */
 
@@ -295,18 +294,8 @@ static void rt_test_007_003_execute(void) {
   systime_t target_time;
   msg_t msg;
 
-  /* [7.3.1] Testing special case TIME_IMMEDIATE.*/
+  /* [7.3.1] Testing non-timeout condition.*/
   test_set_step(1);
-  {
-    msg = chSemWaitTimeout(&sem1, TIME_IMMEDIATE);
-    test_assert(msg == MSG_TIMEOUT, "wrong wake-up message");
-    test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
-    test_assert(sem1.cnt == 0, "counter not zero");
-  }
-  test_end_step(1);
-
-  /* [7.3.2] Testing non-timeout condition.*/
-  test_set_step(2);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() - 1,
                                    thread2, 0);
@@ -316,10 +305,10 @@ static void rt_test_007_003_execute(void) {
     test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
     test_assert(sem1.cnt == 0, "counter not zero");
   }
-  test_end_step(2);
+  test_end_step(1);
 
-  /* [7.3.3] Testing timeout condition.*/
-  test_set_step(3);
+  /* [7.3.2] Testing timeout condition.*/
+  test_set_step(2);
   {
     target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(5 * 50));
     for (i = 0; i < 5; i++) {
@@ -334,7 +323,7 @@ static void rt_test_007_003_execute(void) {
                             chTimeAddX(target_time, ALLOWED_DELAY),
                             "out of time window");
   }
-  test_end_step(3);
+  test_end_step(2);
 }
 
 static const testcase_t rt_test_007_003 = {
@@ -418,56 +407,56 @@ static const testcase_t rt_test_007_004 = {
  *
  * <h2>Description</h2>
  * This test case explicitly addresses the @p chSemWaitSignal()
- * function. A thread is created that performs a wait and a signal
- * operations. The tester thread is awakened from an atomic wait/signal
- * operation. The test expects that the semaphore wait function returns
- * the correct value in each of the above scenario and that the
- * semaphore structure status is correct after each operation.
+ * function. A thread is created that performs a wait on the signal
+ * semaphore then signals the wait semaphore. The tester thread is awakened
+ * from an atomic wait/signal operation. The test expects that the semaphore
+ * wait function returns the correct value and that both semaphore structures
+ * are correct after each operation.
  *
  * <h2>Test Steps</h2>
- * - [7.5.1] An higher priority thread is created that performs
- *   non-atomical wait and signal operations on a semaphore.
- * - [7.5.2] The function chSemSignalWait() is invoked by specifying
- *   the same semaphore for the wait and signal phases. The counter
- *   value and, when enabled, the signaled thread's ready trace message
- *   are tested on exit.
- * - [7.5.3] The function chSemSignalWait() is invoked again by
- *   specifying the same semaphore for the wait and signal phases. The
- *   counter value must be one on exit.
+ * - [7.5.1] A higher priority thread is created that waits on the signal
+ *   semaphore then signals the wait semaphore.
+ * - [7.5.2] The function chSemSignalWait() is invoked with distinct signal
+ *   and wait semaphores. Their counters and, when enabled, the signaled
+ *   thread's ready trace message are tested on exit.
+ * - [7.5.3] The wait semaphore is pre-signaled, then chSemSignalWait() is
+ *   invoked again and verified to complete without blocking.
  * .
  */
 
 static void rt_test_007_005_setup(void) {
   chSemObjectInit(&sem1, 0);
+  chSemObjectInit(&sem2, 0);
 }
 
 static void rt_test_007_005_teardown(void) {
   test_wait_threads();
   chSemObjectDispose(&sem1);
+  chSemObjectDispose(&sem2);
 }
 
 static void rt_test_007_005_execute(void) {
+  msg_t msg;
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
   msg_t tracemsg;
   bool found;
 #endif
 
-  /* [7.5.1] An higher priority thread is created that performs
-     non-atomical wait and signal operations on a semaphore.*/
+  /* [7.5.1] A higher priority thread is created that waits on the signal
+     semaphore then signals the wait semaphore.*/
   test_set_step(1);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()+1, thread3, 0);
   }
   test_end_step(1);
 
-  /* [7.5.2] The function chSemSignalWait() is invoked by specifying
-     the same semaphore for the wait and signal phases. The counter
-     value and, when enabled, the signaled thread's ready trace message
-     are tested on exit.*/
+  /* [7.5.2] The function chSemSignalWait() is invoked with distinct signal
+     and wait semaphores. Their counters and, when enabled, the signaled
+     thread's ready trace message are tested on exit.*/
   test_set_step(2);
   {
-    chSemSignalWait(&sem1, &sem1);
+    msg = chSemSignalWait(&sem1, &sem2);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     chSysLock();
@@ -476,19 +465,23 @@ static void rt_test_007_005_execute(void) {
     test_assert(found, "ready trace not found");
     test_assert(tracemsg == MSG_OK, "invalid ready trace message");
 #endif
+    test_assert(msg == MSG_OK, "wrong returned message");
     test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
-    test_assert(sem1.cnt == 0, "counter not zero");
+    test_assert(ch_queue_isempty(&sem2.queue), "queue not empty");
+    test_assert((sem1.cnt == 0) && (sem2.cnt == 0), "counter not zero");
   }
   test_end_step(2);
 
-  /* [7.5.3] The function chSemSignalWait() is invoked again by
-     specifying the same semaphore for the wait and signal phases. The
-     counter value must be one on exit.*/
+  /* [7.5.3] The wait semaphore is pre-signaled, then chSemSignalWait() is
+     invoked again and verified to complete without blocking.*/
   test_set_step(3);
   {
-    chSemSignalWait(&sem1, &sem1);
+    chSemSignal(&sem2);
+    msg = chSemSignalWait(&sem1, &sem2);
+    test_assert(msg == MSG_OK, "wrong returned message");
     test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
-    test_assert(sem1.cnt == 0, "counter not zero");
+    test_assert(ch_queue_isempty(&sem2.queue), "queue not empty");
+    test_assert((sem1.cnt == 1) && (sem2.cnt == 0), "invalid counter");
   }
   test_end_step(3);
 }
@@ -597,6 +590,111 @@ static const testcase_t rt_test_007_006 = {
   rt_test_007_006_execute
 };
 
+/**
+ * @page rt_test_007_007 [7.7] Semaphore counter boundaries
+ *
+ * <h2>Description</h2>
+ * The representable semaphore counter boundaries and the operations that
+ * can validly reach them are tested.
+ *
+ * <h2>Test Steps</h2>
+ * - [7.7.1] The public counter and waiter limits are checked.
+ * - [7.7.2] Signal, add-counter, and fast operations are exercised up to
+ *   the maximum counter value.
+ * - [7.7.3] A distinct-object signal/wait operation is verified at the
+ *   maximum signal counter value.
+ * .
+ */
+
+static void rt_test_007_007_setup(void) {
+  chSemObjectInit(&sem1, 0);
+  chSemObjectInit(&sem2, 0);
+}
+
+static void rt_test_007_007_teardown(void) {
+  chSemObjectDispose(&sem1);
+  chSemObjectDispose(&sem2);
+}
+
+static void rt_test_007_007_execute(void) {
+  cnt_t cnt;
+  msg_t msg;
+  bool empty;
+
+  /* [7.7.1] The public counter and waiter limits are checked.*/
+  test_set_step(1);
+  {
+    test_assert(SEMAPHORE_MAX_COUNT > (cnt_t)0,
+                "invalid maximum counter");
+    test_assert(SEMAPHORE_MAX_WAITERS ==
+                (ucnt_t)SEMAPHORE_MAX_COUNT + (ucnt_t)1,
+                "invalid maximum waiters");
+  }
+  test_end_step(1);
+
+  /* [7.7.2] Signal, add-counter, and fast operations are exercised up to
+     the maximum counter value.*/
+  test_set_step(2);
+  {
+    chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+    chSemSignal(&sem1);
+    test_assert_lock(chSemGetCounterI(&sem1) == SEMAPHORE_MAX_COUNT,
+                     "signal boundary failed");
+
+    chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+    chSysLock();
+    chSemSignalI(&sem1);
+    cnt = chSemGetCounterI(&sem1);
+    chSysUnlock();
+    test_assert(cnt == SEMAPHORE_MAX_COUNT,
+                "I-class signal boundary failed");
+
+    chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)2);
+    chSysLock();
+    chSemAddCounterI(&sem1, (cnt_t)2);
+    cnt = chSemGetCounterI(&sem1);
+    chSysUnlock();
+    test_assert(cnt == SEMAPHORE_MAX_COUNT,
+                "add-counter boundary failed");
+
+    chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+    chSysLock();
+    chSemFastSignalI(&sem1);
+    cnt = chSemGetCounterI(&sem1);
+    chSemFastWaitI(&sem1);
+    chSysUnlock();
+    test_assert(cnt == SEMAPHORE_MAX_COUNT,
+                "fast signal boundary failed");
+  }
+  test_end_step(2);
+
+  /* [7.7.3] A distinct-object signal/wait operation is verified at the
+     maximum signal counter value.*/
+  test_set_step(3);
+  {
+    chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);
+    chSemReset(&sem2, 1);
+    msg = chSemSignalWait(&sem1, &sem2);
+    chSysLock();
+    cnt = chSemGetCounterI(&sem1);
+    empty = ch_queue_isempty(&sem1.queue) &&
+            ch_queue_isempty(&sem2.queue) &&
+            (chSemGetCounterI(&sem2) == (cnt_t)0);
+    chSysUnlock();
+    test_assert(msg == MSG_OK, "wrong returned message");
+    test_assert(cnt == SEMAPHORE_MAX_COUNT, "invalid signal counter");
+    test_assert(empty, "invalid wait semaphore");
+  }
+  test_end_step(3);
+}
+
+static const testcase_t rt_test_007_007 = {
+  "Semaphore counter boundaries",
+  rt_test_007_007_setup,
+  rt_test_007_007_teardown,
+  rt_test_007_007_execute
+};
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -611,6 +709,7 @@ const testcase_t * const rt_test_sequence_007_array[] = {
   &rt_test_007_004,
   &rt_test_007_005,
   &rt_test_007_006,
+  &rt_test_007_007,
   NULL
 };
 

--- a/testhal/RP/RP2040/ST-VALIDATION/main.c
+++ b/testhal/RP/RP2040/ST-VALIDATION/main.c
@@ -245,10 +245,10 @@ static bool vt_iteration(unsigned i, uint32_t *latp) {
   d2_fired = false;
 
   /* Draining any stale semaphore signal.*/
-  while (chSemWaitTimeout(&d2_sem, TIME_IMMEDIATE) == MSG_OK) {
-  }
-
   chSysLock();
+  while (chSemGetCounterI(&d2_sem) > (cnt_t)0) {
+    chSemFastWaitI(&d2_sem);
+  }
 
   /* Arming both one-shot timers.*/
   start = (uint32_t)chVTGetSystemTimeX();

--- a/testhal/RP/RP2350/ST-VALIDATION/main.c
+++ b/testhal/RP/RP2350/ST-VALIDATION/main.c
@@ -245,10 +245,10 @@ static bool vt_iteration(unsigned i, uint32_t *latp) {
   d2_fired = false;
 
   /* Draining any stale semaphore signal.*/
-  while (chSemWaitTimeout(&d2_sem, TIME_IMMEDIATE) == MSG_OK) {
-  }
-
   chSysLock();
+  while (chSemGetCounterI(&d2_sem) > (cnt_t)0) {
+    chSemFastWaitI(&d2_sem);
+  }
 
   /* Arming both one-shot timers.*/
   start = (uint32_t)chVTGetSystemTimeX();


### PR DESCRIPTION
## Summary

- define and document representable semaphore counter and waiter limits
- assert semaphore wait, signal, add-counter, fast-signal, and signal/wait arithmetic boundaries
- require distinct semaphore objects in `chSemSignalWait()`
- reject `TIME_IMMEDIATE` in timed semaphore waits and direct non-wait acquisition to `chSemFastWaitI()`
- update RT coverage and the RP2040/RP2350 validation users for the revised contract

## Reason

The semaphore counter uses the signed `cnt_t` type. Operations at its representable boundaries could cross that range, breaking the relationship between the counter and the wait queue. The previous same-object signal/wait and immediate-timeout behavior also created intermediate arithmetic outside the intended semaphore contract.

Invalid boundary operations now stop at kernel assertions. Valid operations may reach the documented maximum without overflowing, and non-wait acquisition is performed explicitly under the system lock.

## Validation

- RT simulator suite with assertions, state checking, full tracing, and priority-ordered semaphores
- RT simulator suite with non-recovering undefined-behavior instrumentation
- RP2040 ST-VALIDATION build
- RP2350 ST-VALIDATION build
- `xmllint --noout test/rt/configuration.xml`
- `git diff --check`
