### PR TITLE
RT: record queued thread ownership

### DIFF
--- a/os/rt/include/chobjects.h
+++ b/os/rt/include/chobjects.h
@@ -290,6 +290,12 @@ struct ch_thread {
      */
     void                        *wtobjp;
     /**
+     * @brief   Pointer to a threads queue object.
+     * @note    This field is valid when the thread is in
+     *          @p CH_STATE_QUEUED state.
+     */
+    threads_queue_t             *wtqueuep;
+    /**
      * @brief   Pointer to a generic thread reference object.
      * @note    This field is used to get a pointer to a synchronization
      *          object and is valid when the thread is in @p CH_STATE_SUSPENDED

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -693,6 +693,7 @@ static inline void chThdDoDequeueNextI(threads_queue_t *tqp, msg_t msg) {
   tp = threadref(ch_queue_fifo_remove(&tqp->queue));
 
   chDbgAssert(tp->state == CH_STATE_QUEUED, "invalid state");
+  chDbgAssert(tp->u.wtqueuep == tqp, "invalid queue");
 
   tp->u.rdymsg = msg;
   (void) chSchReadyI(tp);

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -1405,6 +1405,7 @@ msg_t chThdEnqueueTimeoutS(threads_queue_t *tqp, sysinterval_t timeout) {
   }
 
   currtp = chThdGetSelfX();
+  currtp->u.wtqueuep = tqp;
   ch_queue_insert(&tqp->queue, (ch_queue_t *)currtp);
 
   return chSchGoSleepTimeoutS(CH_STATE_QUEUED, timeout);

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -2380,6 +2380,7 @@ chThdQueueObjectDispose(&tq1);]]></value>
             <local_variables>
               <value><![CDATA[msg_t msg;
 bool empty;
+bool owned;
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
 msg_t tracemsg;
@@ -2425,9 +2426,9 @@ test_assert(empty, "queue not empty");]]></value>
             </step>
             <step>
               <description>
-                <value>One queued thread is resumed using
-                  chThdDequeueNextI() and, when enabled, its ready trace
-                  message is tested.</value>
+                <value>One queued thread's queue owner is verified, then
+                  it is resumed using chThdDequeueNextI() and, when
+                  enabled, its ready trace message is tested.</value>
               </description>
               <tags>
                 <value />
@@ -2439,6 +2440,8 @@ threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX(),
 chThdYield();
 chSysLock();
 empty = chThdQueueIsEmptyI(&tq1);
+owned = (threads[0]->state == CH_STATE_QUEUED) &&
+        (threads[0]->u.wtqueuep == &tq1);
 chThdDequeueNextI(&tq1, MSG_RESET);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
@@ -2446,6 +2449,7 @@ found = test_find_ready_trace(threads[0], CH_STATE_QUEUED, &tracemsg);
 #endif
 chSysUnlock();
 test_assert(!empty, "queue empty");
+test_assert(owned, "invalid queue owner");
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
 test_assert(found, "ready trace not found");

--- a/test/rt/source/test/rt_test_sequence_006.c
+++ b/test/rt/source/test/rt_test_sequence_006.c
@@ -181,8 +181,9 @@ static const testcase_t rt_test_006_001 = {
  * - [6.2.1] A threads queue is initialized, tested as empty, then
  *   touched with empty dequeue operations.
  * - [6.2.2] Immediate timeout enqueue is tested on an empty queue.
- * - [6.2.3] One queued thread is resumed using chThdDequeueNextI() and,
- *   when enabled, its ready trace message is tested.
+ * - [6.2.3] One queued thread's queue owner is verified, then it is resumed
+ *   using chThdDequeueNextI() and, when enabled, its ready trace message is
+ *   tested.
  * - [6.2.4] Two queued threads are resumed using chThdDequeueAllI().
  * .
  */
@@ -201,6 +202,7 @@ static void rt_test_006_002_teardown(void) {
 static void rt_test_006_002_execute(void) {
   msg_t msg;
   bool empty;
+  bool owned;
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
   msg_t tracemsg;
@@ -232,8 +234,9 @@ static void rt_test_006_002_execute(void) {
   }
   test_end_step(2);
 
-  /* [6.2.3] One queued thread is resumed using chThdDequeueNextI() and,
-     when enabled, its ready trace message is tested.*/
+  /* [6.2.3] One queued thread's queue owner is verified, then it is resumed
+     using chThdDequeueNextI() and, when enabled, its ready trace message is
+     tested.*/
   test_set_step(3);
   {
     qmsg1 = MSG_OK;
@@ -242,6 +245,8 @@ static void rt_test_006_002_execute(void) {
     chThdYield();
     chSysLock();
     empty = chThdQueueIsEmptyI(&tq1);
+    owned = (threads[0]->state == CH_STATE_QUEUED) &&
+            (threads[0]->u.wtqueuep == &tq1);
     chThdDequeueNextI(&tq1, MSG_RESET);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
@@ -249,6 +254,7 @@ static void rt_test_006_002_execute(void) {
 #endif
     chSysUnlock();
     test_assert(!empty, "queue empty");
+    test_assert(owned, "invalid queue owner");
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
      ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     test_assert(found, "ready trace not found");


### PR DESCRIPTION
## Summary

- add a typed `threads_queue_t *wtqueuep` view to the thread wait-state union
- record the owning queue before a thread enters `CH_STATE_QUEUED`
- assert queue ownership before an explicit dequeue overwrites the wait-state union
- extend the RT queue lifecycle test to verify the owner backlink while queued

## Reason

`u.wtobjp` is documented as identifying a thread's wait object, and context-switch tracing records that value. Generic thread queue waits did not initialize the union, leaving stale state for tracing and diagnostics even though timeout and wake behavior continued to work through the intrusive queue links.

The dedicated typed pointer restores the queued-thread state invariant without casts. It does not change `thread_t` size or scheduling behavior.

## Validation

- RT and OSLIB simulator suites with assertions, system-state checking, full tracing, and thread filling enabled
- `xmllint --noout test/rt/configuration.xml`
- `git diff --check`
