### PR TITLE
Kernel: validate thread queue operations

### DIFF
--- a/os/nil/src/ch.c
+++ b/os/nil/src/ch.c
@@ -1013,8 +1013,8 @@ void chThdSleepUntil(systime_t abstime) {
  *                      handled as follows:
  *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
- * @return              The message from @p osalQueueWakeupOneI() or
- *                      @p osalQueueWakeupAllI() functions.
+ * @return              The message passed to @p chThdDequeueNextI() or
+ *                      @p chThdDequeueAllI().
  * @retval MSG_TIMEOUT  if the thread has not been dequeued within the
  *                      specified timeout or if the function has been
  *                      invoked with @p TIME_IMMEDIATE as timeout

--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -668,6 +668,7 @@ static inline void chThdSleepS(sysinterval_t ticks) {
 static inline bool chThdQueueIsEmptyI(threads_queue_t *tqp) {
 
   chDbgCheckClassI();
+  chDbgCheck(tqp != NULL);
 
   return ch_queue_isempty(&tqp->queue);
 }
@@ -687,6 +688,7 @@ static inline void chThdDoDequeueNextI(threads_queue_t *tqp, msg_t msg) {
   thread_t *tp;
 
   chDbgCheckClassI();
+  chDbgCheck(tqp != NULL);
 
   chDbgAssert(ch_queue_notempty(&tqp->queue), "empty queue");
 

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -1386,8 +1386,8 @@ void chThdQueueObjectDispose(threads_queue_t *tqp) {
  *                      - @a TIME_IMMEDIATE the thread is not enqueued and
  *                        the function returns @p MSG_TIMEOUT as if a timeout
  *                        occurred.
- * @return              The message from @p osalQueueWakeupOneI() or
- *                      @p osalQueueWakeupAllI() functions.
+ * @return              The message passed to @p chThdDequeueNextI() or
+ *                      @p chThdDequeueAllI().
  * @retval MSG_TIMEOUT  if the thread has not been dequeued within the
  *                      specified timeout or if the function has been
  *                      invoked with @p TIME_IMMEDIATE as timeout
@@ -1399,6 +1399,7 @@ msg_t chThdEnqueueTimeoutS(threads_queue_t *tqp, sysinterval_t timeout) {
   thread_t *currtp;
 
   chDbgCheckClassS();
+  chDbgCheck(tqp != NULL);
 
   if (unlikely(TIME_IMMEDIATE == timeout)) {
     return MSG_TIMEOUT;
@@ -1423,6 +1424,7 @@ msg_t chThdEnqueueTimeoutS(threads_queue_t *tqp, sysinterval_t timeout) {
 void chThdDequeueNextI(threads_queue_t *tqp, msg_t msg) {
 
   chDbgCheckClassI();
+  chDbgCheck(tqp != NULL);
 
   if (ch_queue_notempty(&tqp->queue)) {
     chThdDoDequeueNextI(tqp, msg);
@@ -1440,6 +1442,7 @@ void chThdDequeueNextI(threads_queue_t *tqp, msg_t msg) {
 void chThdDequeueAllI(threads_queue_t *tqp, msg_t msg) {
 
   chDbgCheckClassI();
+  chDbgCheck(tqp != NULL);
 
   while (ch_queue_notempty(&tqp->queue)) {
     chThdDoDequeueNextI(tqp, msg);


### PR DESCRIPTION
## Summary

- add null-object parameter checks to all RT generic thread-queue operations
- make the immediate-timeout enqueue path diagnose a null queue consistently with normal enqueue paths
- correct RT and NIL enqueue documentation to name the kernel dequeue APIs that supply wake messages

## Reason

Thread queue initialization and disposal already validate their object pointer, but the operational APIs did not. With checks enabled, most null pointers became uncontrolled dereferences, while an immediate enqueue silently returned `MSG_TIMEOUT` without validating the queue. The enqueue return documentation also referred to OSAL adapter names instead of the public kernel APIs.

The new checks compile out when parameter checking is disabled and do not alter valid queue behavior.

## Validation

- RT and OSLIB simulator suites with assertions, parameter checks, system-state checking, full tracing, and thread filling enabled
- `git diff --check`

No regression test intentionally triggers a kernel check, because the standard suite cannot continue after the expected halt.
