### PR TITLE
OSLIB: honor the revised semaphore contract in guarded pools

### DIFF
--- a/os/oslib/src/chmempools.c
+++ b/os/oslib/src/chmempools.c
@@ -321,11 +321,22 @@ void chGuardedPoolLoadArray(guarded_memory_pool_t *gmp, void *p, size_t n) {
  */
 void *chGuardedPoolAllocTimeoutS(guarded_memory_pool_t *gmp,
                                  sysinterval_t timeout) {
-  msg_t msg;
 
-  msg = chSemWaitTimeoutS(&gmp->sem, timeout);
-  if (msg != MSG_OK) {
-    return NULL;
+  /* Non-wait acquisition is performed directly on the counter, the
+     semaphore wait API no longer accepts TIME_IMMEDIATE.*/
+  if (timeout == TIME_IMMEDIATE) {
+    if (chSemGetCounterI(&gmp->sem) <= (cnt_t)0) {
+      return NULL;
+    }
+    chSemFastWaitI(&gmp->sem);
+  }
+  else {
+    msg_t msg;
+
+    msg = chSemWaitTimeoutS(&gmp->sem, timeout);
+    if (msg != MSG_OK) {
+      return NULL;
+    }
   }
 
   return chPoolAllocI(&gmp->pool);


### PR DESCRIPTION
## Summary

#200 changed the semaphore contract: `chSemWaitTimeoutS()` now rejects `TIME_IMMEDIATE` and directs non-wait acquisition to `chSemFastWaitI()`. `chGuardedPoolAllocTimeoutS()` still forwarded its caller's timeout unmodified, so the documented guarded-pool non-waiting allocation (`chGuardedPoolAllocTimeout(gmp, TIME_IMMEDIATE)`) now stops on the parameter check in any build with `CH_DBG_ENABLE_CHECKS` enabled. The OS library test suite hits this deterministically in test case 7.2 (guarded memory pool without waiting).

This adopts the revised contract in the guarded pool: `TIME_IMMEDIATE` performs the acquisition directly on the counter under the system lock (`chSemGetCounterI` + `chSemFastWaitI`); all other timeouts keep the semaphore wait path. A sweep of `os/oslib/src` shows this is the only call site forwarding caller timeouts into the semaphore wait API.

## How it was found

Running the OSLIB test suite on RP2350 silicon with `CH_DBG_ENABLE_CHECKS`+`ASSERTS` (first hardware validation pass of the XHAL RP port, #199/#201): the suite halts in `chSemWaitTimeoutS` from `chGuardedPoolAllocTimeout`. With this fix the full RT + OSLIB suites pass on the Pico 2 (95 cases, 0 failures).

## Verification

- `test/rt/testbuild` POSIX simulator target builds clean (CI's build check).
- RT + OSLIB suites: Final result SUCCESS for both on RP2350 hardware with checks and assertions enabled.
- stylecheck clean.

## Changelog

- OSLIB: fixed guarded-pool non-waiting allocation stopping on the semaphore TIME_IMMEDIATE check with parameter checks enabled.