### PR TITLE
RT: restore immediate semaphore waits

### DIFF
--- a/os/rt/src/chsem.c
+++ b/os/rt/src/chsem.c
@@ -253,15 +253,17 @@ msg_t chSemWaitS(semaphore_t *sp) {
 
 /**
  * @brief   Performs a wait operation on a semaphore with timeout specification.
- * @note    For a non-waiting acquisition when the counter is known to be
- *          positive, use @p chSemFastWaitI().
- * @pre     Fewer than @p SEMAPHORE_MAX_WAITERS threads may already be waiting
- *          on the semaphore.
+ * @note    When the counter is already known to be positive in a locked
+ *          context, @p chSemFastWaitI() provides a faster non-waiting
+ *          acquisition.
+ * @pre     Unless @p timeout is @p TIME_IMMEDIATE, fewer than
+ *          @p SEMAPHORE_MAX_WAITERS threads may already be waiting on the
+ *          semaphore.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are handled as follows:
- *                      - @a TIME_IMMEDIATE this value is not allowed.
+ *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
  * @return              A message specifying how the invoking thread has been
  *                      released from the semaphore.
@@ -285,15 +287,17 @@ msg_t chSemWaitTimeout(semaphore_t *sp, sysinterval_t timeout) {
 
 /**
  * @brief   Performs a wait operation on a semaphore with timeout specification.
- * @note    For a non-waiting acquisition when the counter is known to be
- *          positive, use @p chSemFastWaitI().
- * @pre     Fewer than @p SEMAPHORE_MAX_WAITERS threads may already be waiting
- *          on the semaphore.
+ * @note    When the counter is already known to be positive in a locked
+ *          context, @p chSemFastWaitI() provides a faster non-waiting
+ *          acquisition.
+ * @pre     Unless @p timeout is @p TIME_IMMEDIATE, fewer than
+ *          @p SEMAPHORE_MAX_WAITERS threads may already be waiting on the
+ *          semaphore.
  *
  * @param[in] sp        pointer to a @p semaphore_t object
  * @param[in] timeout   the number of ticks before the operation times out,
  *                      the following special values are handled as follows:
- *                      - @a TIME_IMMEDIATE this value is not allowed.
+ *                      - @a TIME_IMMEDIATE immediate timeout.
  *                      - @a TIME_INFINITE no timeout.
  * @return              A message specifying how the invoking thread has been
  *                      released from the semaphore.
@@ -308,10 +312,19 @@ msg_t chSemWaitTimeout(semaphore_t *sp, sysinterval_t timeout) {
 msg_t chSemWaitTimeoutS(semaphore_t *sp, sysinterval_t timeout) {
 
   chDbgCheckClassS();
-  chDbgCheck((sp != NULL) && (timeout != TIME_IMMEDIATE));
+  chDbgCheck(sp != NULL);
   chDbgAssert(((sp->cnt >= (cnt_t)0) && ch_queue_isempty(&sp->queue)) ||
               ((sp->cnt < (cnt_t)0) && ch_queue_notempty(&sp->queue)),
               "inconsistent semaphore");
+
+  if (unlikely(TIME_IMMEDIATE == timeout)) {
+    if (sp->cnt <= (cnt_t)0) {
+      return MSG_TIMEOUT;
+    }
+
+    chSemFastWaitI(sp);
+    return MSG_OK;
+  }
 
   chDbgAssert(sp->cnt > SEMAPHORE_MIN_COUNT, "counter underflow");
   if (--sp->cnt < (cnt_t)0) {

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -2726,10 +2726,11 @@ test_assert_sequence("ABCDE", "invalid sequence");]]></value>
             <value>Semaphore timeout test.</value>
           </brief>
           <description>
-            <value>Successful and expired timed semaphore waits are
-              explored. The test expects that the semaphore wait
-              function returns the correct value and that the semaphore
-              structure status is correct after each operation.</value>
+            <value>Immediate, successful, and expired timed semaphore
+              waits are explored. The test expects that the semaphore
+              wait function returns the correct value and that the
+              semaphore structure status is correct after each
+              operation.</value>
           </description>
           <condition>
             <value />
@@ -2748,6 +2749,27 @@ msg_t msg;]]></value>
             </local_variables>
           </various_code>
           <steps>
+            <step>
+              <description>
+                <value>Immediate waits are tested with one available
+                  unit and with an empty semaphore.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chSemSignal(&sem1);
+msg = chSemWaitTimeout(&sem1, TIME_IMMEDIATE);
+test_assert(msg == MSG_OK, "wrong wake-up message");
+test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
+test_assert(sem1.cnt == 0, "counter not zero");
+
+msg = chSemWaitTimeout(&sem1, TIME_IMMEDIATE);
+test_assert(msg == MSG_TIMEOUT, "wrong wake-up message");
+test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
+test_assert(sem1.cnt == 0, "counter not zero");]]></value>
+              </code>
+            </step>
             <step>
               <description>
                 <value>Testing non-timeout condition.</value>

--- a/test/rt/source/test/rt_test_sequence_007.c
+++ b/test/rt/source/test/rt_test_sequence_007.c
@@ -271,13 +271,16 @@ static const testcase_t rt_test_007_002 = {
  * @page rt_test_007_003 [7.3] Semaphore timeout test
  *
  * <h2>Description</h2>
- * Successful and expired timed semaphore waits are explored. The test
- * expects that the semaphore wait function returns the correct value and
- * that the semaphore structure status is correct after each operation.
+ * Immediate, successful, and expired timed semaphore waits are explored.
+ * The test expects that the semaphore wait function returns the correct
+ * value and that the semaphore structure status is correct after each
+ * operation.
  *
  * <h2>Test Steps</h2>
- * - [7.3.1] Testing non-timeout condition.
- * - [7.3.2] Testing timeout condition.
+ * - [7.3.1] Immediate waits are tested with one available unit and with an
+ *   empty semaphore.
+ * - [7.3.2] Testing non-timeout condition.
+ * - [7.3.3] Testing timeout condition.
  * .
  */
 
@@ -294,8 +297,25 @@ static void rt_test_007_003_execute(void) {
   systime_t target_time;
   msg_t msg;
 
-  /* [7.3.1] Testing non-timeout condition.*/
+  /* [7.3.1] Immediate waits are tested with one available unit and with an
+     empty semaphore.*/
   test_set_step(1);
+  {
+    chSemSignal(&sem1);
+    msg = chSemWaitTimeout(&sem1, TIME_IMMEDIATE);
+    test_assert(msg == MSG_OK, "wrong wake-up message");
+    test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
+    test_assert(sem1.cnt == 0, "counter not zero");
+
+    msg = chSemWaitTimeout(&sem1, TIME_IMMEDIATE);
+    test_assert(msg == MSG_TIMEOUT, "wrong wake-up message");
+    test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
+    test_assert(sem1.cnt == 0, "counter not zero");
+  }
+  test_end_step(1);
+
+  /* [7.3.2] Testing non-timeout condition.*/
+  test_set_step(2);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX() - 1,
                                    thread2, 0);
@@ -305,10 +325,10 @@ static void rt_test_007_003_execute(void) {
     test_assert(ch_queue_isempty(&sem1.queue), "queue not empty");
     test_assert(sem1.cnt == 0, "counter not zero");
   }
-  test_end_step(1);
+  test_end_step(2);
 
-  /* [7.3.2] Testing timeout condition.*/
-  test_set_step(2);
+  /* [7.3.3] Testing timeout condition.*/
+  test_set_step(3);
   {
     target_time = chTimeAddX(test_wait_tick(), TIME_MS2I(5 * 50));
     for (i = 0; i < 5; i++) {
@@ -323,7 +343,7 @@ static void rt_test_007_003_execute(void) {
                             chTimeAddX(target_time, ALLOWED_DELAY),
                             "out of time window");
   }
-  test_end_step(2);
+  test_end_step(3);
 }
 
 static const testcase_t rt_test_007_003 = {


### PR DESCRIPTION
## Summary

- restore `TIME_IMMEDIATE` support in `chSemWaitTimeout()` and `chSemWaitTimeoutS()`
- perform immediate acquisition without entering the blocking-wait counter path
- add RT regression coverage for successful and unsuccessful immediate waits

## Rationale

Guarded memory pools and existing callers use `TIME_IMMEDIATE` as the semaphore try-wait operation. Rejecting that value changed the documented API contract and required callers to duplicate semaphore acquisition logic.

The regular timed-wait path decrements the counter before deciding whether to block. That operation is inappropriate for an immediate poll and can cross the signed counter boundary when the semaphore already represents the maximum number of waiters. The restored immediate path instead returns `MSG_TIMEOUT` without changing an unavailable semaphore, or consumes an available unit using `chSemFastWaitI()`.

## Validation

- full RT and OSLIB simulator suites with kernel checks, assertions, state checking, tracing, thread filling, and priority-ordered semaphores enabled
- full RT and OSLIB simulator suites with non-recovering undefined-behavior sanitizer instrumentation
- guarded memory pool non-waiting allocation test in both runs
- `xmllint --noout test/rt/configuration.xml`
- `git diff --check`
