### PR TITLE
XHAL: RP port SPI driver with testxhal targets

### DIFF
--- a/os/xhal/OSAL_REMOVAL_BUILDS.txt
+++ b/os/xhal/OSAL_REMOVAL_BUILDS.txt
@@ -39,6 +39,8 @@ testxhal/I2S/make/stm32g474re_nucleo64.make
 testxhal/MMC-SPI/make/stm32g474re_nucleo64.make
 testxhal/RTC/make/stm32g474re_nucleo64.make
 testxhal/RTC/make/stm32wl55jc_nucleo64.make
+testxhal/SPI/make/rp2040_pico.make
+testxhal/SPI/make/rp2350_pico2.make
 testxhal/SPI/make/stm32g474re_nucleo64.make
 testxhal/SPI/make/stm32wl55jc_nucleo64.make
 testxhal/TRNG/make/stm32g474re_nucleo64.make

--- a/os/xhal/ports/RP/LLD/SPIv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/SPIv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_SPI TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/hal_spi_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/hal_spi_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1

--- a/os/xhal/ports/RP/LLD/SPIv1/hal_spi_lld.c
+++ b/os/xhal/ports/RP/LLD/SPIv1/hal_spi_lld.c
@@ -1,0 +1,763 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    SPIv1/hal_spi_lld.c
+ * @brief   RP SPI subsystem low level driver source.
+ *
+ * @addtogroup SPI
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_SPI == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   SPI0 driver identifier.
+ */
+#if (RP_SPI_USE_SPI0 == TRUE) || defined(__DOXYGEN__)
+SPIDriver SPID0;
+#endif
+
+/**
+ * @brief   SPI1 driver identifier.
+ */
+#if (RP_SPI_USE_SPI1 == TRUE) || defined(__DOXYGEN__)
+SPIDriver SPID1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver default configuration.
+ */
+static const hal_spi_config_t spi_default_config = SPI_DEFAULT_CONFIGURATION;
+
+static const uint16_t dummytx = 0xFFFFU;
+static uint16_t dummyrx;
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Validates a SPI configuration.
+ * @details The SSPCR0 DSS field is derived from the frame size in the
+ *          @p mode field, frame sizes the PL022 cannot handle and
+ *          prescale divisors outside the PL022 range are rejected.
+ *          SSPCR0 values with bits outside the documented DSS, FRF,
+ *          SPO, SPH and SCR fields or using the reserved FRF encoding
+ *          are rejected as well.
+ *
+ * @param[in] config    pointer to the @p hal_spi_config_t structure
+ * @param[out] dssp     pointer to the derived SSPCR0 DSS field value
+ * @param[out] dsizep   pointer to the derived DMA data size mode
+ * @return              Configuration validity.
+ */
+static bool spi_lld_validate_config(const hal_spi_config_t *config,
+                                    uint32_t *dssp, uint32_t *dsizep) {
+
+  /* Circular and slave modes are not supported by this driver.*/
+  if ((config->mode & (SPI_MODE_CIRCULAR | SPI_MODE_SLAVE)) != 0U) {
+    return false;
+  }
+
+  /* Only the documented SSPCR0 fields are accepted, all other bits are
+     reserved on the PL022 and must be zero. The DSS field is accepted
+     here but enforced from the frame size when programmed.*/
+  if ((config->SSPCR0 & ~(SPI_SSPCR0_DSS_Msk | SPI_SSPCR0_FRF_Msk |
+                          SPI_SSPCR0_SPO | SPI_SSPCR0_SPH |
+                          SPI_SSPCR0_SCR_Msk)) != 0U) {
+    return false;
+  }
+
+  /* The FRF value 3 is a reserved frame format encoding.*/
+  if ((config->SSPCR0 & SPI_SSPCR0_FRF_Msk) == SPI_SSPCR0_FRF(3U)) {
+    return false;
+  }
+
+  /* The PL022 clock prescale divisor must be an even value in the
+     2..254 range.*/
+  if ((config->SSPCPSR < 2U) || (config->SSPCPSR > 254U) ||
+      ((config->SSPCPSR & 1U) != 0U)) {
+    return false;
+  }
+
+  switch (config->mode & SPI_MODE_FSIZE_MASK) {
+  case SPI_MODE_FSIZE_8:
+    *dssp   = SPI_SSPCR0_DSS_8BIT;
+    *dsizep = DMA_CTRL_TRIG_DATA_SIZE_BYTE;
+    return true;
+  case SPI_MODE_FSIZE_16:
+    *dssp   = SPI_SSPCR0_DSS_16BIT;
+    *dsizep = DMA_CTRL_TRIG_DATA_SIZE_HWORD;
+    return true;
+  default:
+    return false;
+  }
+}
+
+/**
+ * @brief   Shared end-of-rx service routine.
+ * @details The terminal event is claimed against the transfer generation
+ *          counter before any driver state transition, see the notes in
+ *          the driver header. A completion or error made stale by a
+ *          concurrent abort, by a previously served TX error or by a
+ *          transfer restarted from the other core loses the claim and
+ *          is discarded without side effects.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] ct        content of the CTRL_TRIG register
+ */
+static void spi_lld_serve_rx_interrupt(SPIDriver *spip, uint32_t ct) {
+  uint32_t gen;
+  bool claimed;
+
+  /* Transfer generation sampled at service entry, the service body runs
+     outside the system lock and can race the other terminal paths.*/
+  gen = spip->tgen;
+
+  /* DMA errors handling.*/
+  if ((ct & DMA_CTRL_TRIG_AHB_ERROR) != 0U) {
+    chSysLockFromISR();
+    claimed = ((gen & 1U) != 0U) && (gen == spip->tgen);
+    if (claimed) {
+      spip->tgen++;
+
+      /* Stopping DMAs within the claim critical section, the channels
+         cannot belong to a transfer started concurrently by the other
+         core because a start changes the generation under the same
+         lock.*/
+      dmaChannelDisableX(spip->dmatx);
+      dmaChannelDisableX(spip->dmarx);
+    }
+    chSysUnlockFromISR();
+
+    if (claimed) {
+#if defined(RP_SPI_DMA_ERROR_HOOK)
+      /* Hook first, if defined.*/
+      RP_SPI_DMA_ERROR_HOOK(spip);
+#endif
+      /* Reporting the failure.*/
+      _spi_isr_error_code(spip);
+    }
+  }
+  else {
+    /* Operation finished interrupt. The end of the RX sequence marks
+       the end of the whole transfer, the DMA service has already
+       cleared this channel control register. The additional checks on
+       the channel enable bit and on the residual counter reject a stale
+       completion dispatched from an old interrupts snapshot after the
+       channel has been re-armed by a new transfer carrying a matching
+       generation.*/
+    chSysLockFromISR();
+    claimed = ((gen & 1U) != 0U) && (gen == spip->tgen) &&
+              ((spip->dmarx->channel->CTRL_TRIG & DMA_CTRL_TRIG_EN) == 0U) &&
+              (dmaChannelGetCounterX(spip->dmarx) == 0U);
+    if (claimed) {
+      spip->tgen++;
+    }
+    chSysUnlockFromISR();
+
+    if (claimed) {
+      _spi_isr_complete_code(spip);
+    }
+  }
+}
+
+/**
+ * @brief   Shared end-of-tx service routine.
+ * @details The terminal event is claimed against the transfer generation
+ *          counter before any driver state transition, see the notes in
+ *          the driver header. An error made stale by a concurrent abort
+ *          loses the claim and is discarded without side effects.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] ct        content of the CTRL_TRIG register
+ */
+static void spi_lld_serve_tx_interrupt(SPIDriver *spip, uint32_t ct) {
+  uint32_t gen;
+  bool claimed;
+
+  /* Transfer generation sampled at service entry, the service body runs
+     outside the system lock and can race the other terminal paths.*/
+  gen = spip->tgen;
+
+  /* DMA errors handling.*/
+  if ((ct & DMA_CTRL_TRIG_AHB_ERROR) != 0U) {
+    chSysLockFromISR();
+    claimed = ((gen & 1U) != 0U) && (gen == spip->tgen);
+    if (claimed) {
+      spip->tgen++;
+
+      /* Stopping DMAs within the claim critical section, the channels
+         cannot belong to a transfer started concurrently by the other
+         core because a start changes the generation under the same
+         lock.*/
+      dmaChannelDisableX(spip->dmatx);
+      dmaChannelDisableX(spip->dmarx);
+    }
+    chSysUnlockFromISR();
+
+    if (claimed) {
+#if defined(RP_SPI_DMA_ERROR_HOOK)
+      /* Hook first, if defined.*/
+      RP_SPI_DMA_ERROR_HOOK(spip);
+#endif
+      /* A TX failure makes the RX completion impossible, reporting the
+         failure here also terminates the transfer. The RX completion
+         bit possibly pending in the same interrupts snapshot is served
+         after this routine, it loses the claim and is discarded.*/
+      _spi_isr_error_code(spip);
+    }
+  }
+}
+
+/**
+ * @brief   Opens a new transfer generation.
+ * @details The generation counter becomes odd, marking a transfer in
+ *          flight with an unclaimed terminal event.
+ * @note    Must be called with the system lock held, the transfer start
+ *          methods are invoked in I-class context by the shared driver.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ */
+static void spi_lld_tgen_open(SPIDriver *spip) {
+
+  chDbgAssert((spip->tgen & 1U) == 0U, "transfer already in flight");
+
+  spip->tgen++;
+}
+
+/**
+ * @brief   DMA channels allocation.
+ * @note    TX is allocated first: the shared DMA handler scans channels
+ *          in ascending index order within a single interrupts snapshot,
+ *          so with @p RP_DMA_CHANNEL_ID_ANY the TX channel gets the
+ *          lower index and its end-of-sequence service is consumed
+ *          before the RX completion wakes up a thread which, on the
+ *          other core, could immediately reprogram the channels.
+ * @note    An explicit or mixed channel assignment yielding an RX index
+ *          lower than the TX one is rejected, see the notes in the
+ *          driver header.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] rxchn     channel to be allocated for RX
+ * @param[in] txchn     channel to be allocated for TX
+ * @param[in] priority  channels IRQ priority
+ * @return              The operation status.
+ */
+static msg_t spi_lld_get_dma(SPIDriver *spip, uint32_t rxchn,
+                             uint32_t txchn, uint32_t priority) {
+
+  spip->dmatx = dmaChannelAlloc(txchn, priority,
+                                (rp_dmaisr_t)spi_lld_serve_tx_interrupt,
+                                (void *)spip);
+  if (spip->dmatx == NULL) {
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  spip->dmarx = dmaChannelAlloc(rxchn, priority,
+                                (rp_dmaisr_t)spi_lld_serve_rx_interrupt,
+                                (void *)spip);
+  if (spip->dmarx == NULL) {
+    dmaChannelFree(spip->dmatx);
+    spip->dmatx = NULL;
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  /* Enforcing the TX before RX service order, terminal events are
+     arbitrated through the transfer generation counter anyway but the
+     ordering removes stale service windows at the source.*/
+  if (spip->dmarx->chnidx < spip->dmatx->chnidx) {
+    dmaChannelFree(spip->dmarx);
+    dmaChannelFree(spip->dmatx);
+    spip->dmarx = NULL;
+    spip->dmatx = NULL;
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  dmaChannelEnableInterruptX(spip->dmarx);
+  dmaChannelEnableInterruptX(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   SPI deactivation.
+ * @details Stops any DMA activity, disables the SSP, releases the DMA
+ *          channels and finally puts the peripheral back in reset.
+ *          Shared by the stop path and by the start failure rollback.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ */
+static void spi_lld_deactivate(SPIDriver *spip) {
+
+  /* Stopping any ongoing DMA activity first, the channels must be idle
+     before being released.*/
+  dmaChannelDisableX(spip->dmatx);
+  dmaChannelDisableX(spip->dmarx);
+
+  /* SSP disable.*/
+  spip->spi->SSPCR1   = 0U;
+  spip->spi->SSPDMACR = 0U;
+
+  /* DMA channels release before the peripheral reset.*/
+  dmaChannelFree(spip->dmatx);
+  dmaChannelFree(spip->dmarx);
+  spip->dmarx = NULL;
+  spip->dmatx = NULL;
+
+  if (false) {
+  }
+#if RP_SPI_USE_SPI0 == TRUE
+  else if (&SPID0 == spip) {
+    rp_peripheral_reset(RESETS_ALLREG_SPI0);
+  }
+#endif
+#if RP_SPI_USE_SPI1 == TRUE
+  else if (&SPID1 == spip) {
+    rp_peripheral_reset(RESETS_ALLREG_SPI1);
+  }
+#endif
+  else {
+    chDbgAssert(false, "invalid SPI instance");
+  }
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level SPI driver initialization.
+ *
+ * @notapi
+ */
+void spi_lld_init(void) {
+
+#if RP_SPI_USE_SPI0 == TRUE
+  /* Driver initialization.*/
+  spiObjectInit(&SPID0);
+  SPID0.spi       = SPI0;
+  SPID0.dmarx     = NULL;
+  SPID0.dmatx     = NULL;
+  SPID0.tgen      = 0U;
+  SPID0.rxdmamode = DMA_CTRL_TRIG_TREQ_SPI0_RX |
+                    DMA_CTRL_TRIG_PRIORITY(RP_SPI_SPI0_DMA_PRIORITY);
+  SPID0.txdmamode = DMA_CTRL_TRIG_TREQ_SPI0_TX |
+                    DMA_CTRL_TRIG_PRIORITY(RP_SPI_SPI0_DMA_PRIORITY);
+#endif
+#if RP_SPI_USE_SPI1 == TRUE
+  /* Driver initialization.*/
+  spiObjectInit(&SPID1);
+  SPID1.spi       = SPI1;
+  SPID1.dmarx     = NULL;
+  SPID1.dmatx     = NULL;
+  SPID1.tgen      = 0U;
+  SPID1.rxdmamode = DMA_CTRL_TRIG_TREQ_SPI1_RX |
+                    DMA_CTRL_TRIG_PRIORITY(RP_SPI_SPI1_DMA_PRIORITY);
+  SPID1.txdmamode = DMA_CTRL_TRIG_TREQ_SPI1_TX |
+                    DMA_CTRL_TRIG_PRIORITY(RP_SPI_SPI1_DMA_PRIORITY);
+#endif
+}
+
+/**
+ * @brief   Configures and activates the SPI peripheral.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_start(SPIDriver *spip) {
+  msg_t msg;
+
+  /* Resources claim and peripheral activation.*/
+  if (false) {
+  }
+#if RP_SPI_USE_SPI0 == TRUE
+  else if (&SPID0 == spip) {
+    msg = spi_lld_get_dma(spip,
+                          RP_SPI_SPI0_RX_DMA_CHANNEL,
+                          RP_SPI_SPI0_TX_DMA_CHANNEL,
+                          RP_IRQ_SPI0_PRIORITY);
+    if (msg != HAL_RET_SUCCESS) {
+      return msg;
+    }
+    rp_peripheral_unreset(RESETS_ALLREG_SPI0);
+  }
+#endif
+#if RP_SPI_USE_SPI1 == TRUE
+  else if (&SPID1 == spip) {
+    msg = spi_lld_get_dma(spip,
+                          RP_SPI_SPI1_RX_DMA_CHANNEL,
+                          RP_SPI_SPI1_TX_DMA_CHANNEL,
+                          RP_IRQ_SPI1_PRIORITY);
+    if (msg != HAL_RET_SUCCESS) {
+      return msg;
+    }
+    rp_peripheral_unreset(RESETS_ALLREG_SPI1);
+  }
+#endif
+  else {
+    chDbgAssert(false, "invalid SPI instance");
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  /* Static DMA setup, the SSP data register is the fixed endpoint of
+     both channels.*/
+  dmaChannelSetSourceX(spip->dmarx, (uint32_t)&spip->spi->SSPDR);
+  dmaChannelSetDestinationX(spip->dmatx, (uint32_t)&spip->spi->SSPDR);
+
+  /* Register programming is delegated to the configuration method, a
+     NULL configuration selects the driver default.*/
+  spip->config = spi_lld_setcfg(spip, (const hal_spi_config_t *)spip->config);
+  if (spip->config == NULL) {
+    /* A rejected configuration must not leave the peripheral active,
+       the activation performed above is undone so that the shared
+       driver returns to the stop state cleanly.*/
+    spi_lld_deactivate(spip);
+
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the SPI peripheral.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ *
+ * @notapi
+ */
+void spi_lld_stop(SPIDriver *spip) {
+
+  /* Also quiesces any ongoing activity, in case this has been called
+     uncleanly.*/
+  spi_lld_deactivate(spip);
+}
+
+/**
+ * @brief   SPI configuration.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] config    pointer to the @p hal_spi_config_t structure
+ * @return              A pointer to the current configuration structure.
+ * @retval NULL         if the configuration failed.
+ *
+ * @notapi
+ */
+const hal_spi_config_t *spi_lld_setcfg(SPIDriver *spip,
+                                       const hal_spi_config_t *config) {
+  uint32_t dss, dsize;
+
+  if (config == NULL) {
+    config = &spi_default_config;
+  }
+
+  if (!spi_lld_validate_config(config, &dss, &dsize)) {
+    return NULL;
+  }
+
+  /* Configuration-dependent DMA settings.*/
+  spip->rxdmamode = (spip->rxdmamode & ~DMA_CTRL_TRIG_DATA_SIZE_Msk) | dsize;
+  spip->txdmamode = (spip->txdmamode & ~DMA_CTRL_TRIG_DATA_SIZE_Msk) | dsize;
+
+  /* The PL022 requires SSE to be zero while SSPCR0 and SSPCPSR are
+     written. On a live reconfiguration the frame in progress is
+     allowed to complete before the SSP is disabled.*/
+  if ((spip->spi->SSPCR1 & SPI_SSPCR1_SSE) != 0U) {
+    while ((spip->spi->SSPSR & SPI_SSPSR_BSY) != 0U) {
+    }
+    spip->spi->SSPCR1 = 0U;
+  }
+
+  /* SPI setup and enable, master mode only. The DSS field is enforced
+     from the frame size in the mode field.*/
+  spip->spi->SSPCR0   = (config->SSPCR0 & ~SPI_SSPCR0_DSS_Msk) | dss;
+  spip->spi->SSPCPSR  = config->SSPCPSR;
+  spip->spi->SSPDMACR = SPI_SSPDMACR_RXDMAE | SPI_SSPDMACR_TXDMAE;
+  spip->spi->SSPCR1   = SPI_SSPCR1_SSE;
+
+  return config;
+}
+
+/**
+ * @brief       Selects one of the pre-defined SPI configurations.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] cfgnum    driver configuration number
+ * @return              The configuration pointer.
+ *
+ * @notapi
+ */
+const hal_spi_config_t *spi_lld_selcfg(SPIDriver *spip,
+                                       unsigned cfgnum) {
+#if SPI_USE_CONFIGURATIONS == TRUE
+  extern const spi_configurations_t spi_configurations;
+
+  if (cfgnum >= spi_configurations.cfgsnum) {
+    return NULL;
+  }
+
+  return (const void *)spi_lld_setcfg(spip, &spi_configurations.cfgs[cfgnum]);
+#else
+
+  if (cfgnum > 0U) {
+    return NULL;
+  }
+
+  return (const void *)spi_lld_setcfg(spip, NULL);
+#endif
+}
+
+/**
+ * @brief   Ignores data on the SPI bus.
+ * @details This asynchronous function starts the transmission of a series of
+ *          idle words on the SPI bus and ignores the received data.
+ * @post    At the end of the operation the configured callback is invoked.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to be ignored
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_ignore(SPIDriver *spip, size_t n) {
+
+  spi_lld_tgen_open(spip);
+
+  dmaChannelSetDestinationX(spip->dmarx, (uint32_t)&dummyrx);
+  dmaChannelSetCounterX(spip->dmarx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmarx, spip->rxdmamode);
+
+  dmaChannelSetSourceX(spip->dmatx, (uint32_t)&dummytx);
+  dmaChannelSetCounterX(spip->dmatx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmatx, spip->txdmamode);
+
+  dmaChannelEnableX(spip->dmarx);
+  dmaChannelEnableX(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Exchanges data on the SPI bus.
+ * @details This asynchronous function starts a simultaneous transmit/receive
+ *          operation.
+ * @post    At the end of the operation the configured callback is invoked.
+ * @note    The buffers are organized as uint8_t arrays for data sizes below or
+ *          equal to 8 bits else it is organized as uint16_t arrays.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to be exchanged
+ * @param[in] txbuf     the pointer to the transmit buffer
+ * @param[out] rxbuf    the pointer to the receive buffer
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_exchange(SPIDriver *spip, size_t n,
+                       const void *txbuf, void *rxbuf) {
+
+  spi_lld_tgen_open(spip);
+
+  dmaChannelSetDestinationX(spip->dmarx, (uint32_t)rxbuf);
+  dmaChannelSetCounterX(spip->dmarx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmarx, spip->rxdmamode | DMA_CTRL_TRIG_INCR_WRITE);
+
+  dmaChannelSetSourceX(spip->dmatx, (uint32_t)txbuf);
+  dmaChannelSetCounterX(spip->dmatx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmatx, spip->txdmamode | DMA_CTRL_TRIG_INCR_READ);
+
+  dmaChannelEnableX(spip->dmarx);
+  dmaChannelEnableX(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Sends data over the SPI bus.
+ * @details This asynchronous function starts a transmit operation.
+ * @post    At the end of the operation the configured callback is invoked.
+ * @note    The buffers are organized as uint8_t arrays for data sizes below or
+ *          equal to 8 bits else it is organized as uint16_t arrays.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to send
+ * @param[in] txbuf     the pointer to the transmit buffer
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_send(SPIDriver *spip, size_t n, const void *txbuf) {
+
+  spi_lld_tgen_open(spip);
+
+  dmaChannelSetDestinationX(spip->dmarx, (uint32_t)&dummyrx);
+  dmaChannelSetCounterX(spip->dmarx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmarx, spip->rxdmamode);
+
+  dmaChannelSetSourceX(spip->dmatx, (uint32_t)txbuf);
+  dmaChannelSetCounterX(spip->dmatx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmatx, spip->txdmamode | DMA_CTRL_TRIG_INCR_READ);
+
+  dmaChannelEnableX(spip->dmarx);
+  dmaChannelEnableX(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Receives data from the SPI bus.
+ * @details This asynchronous function starts a receive operation.
+ * @post    At the end of the operation the configured callback is invoked.
+ * @note    The buffers are organized as uint8_t arrays for data sizes below or
+ *          equal to 8 bits else it is organized as uint16_t arrays.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] n         number of words to receive
+ * @param[out] rxbuf    the pointer to the receive buffer
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_receive(SPIDriver *spip, size_t n, void *rxbuf) {
+
+  spi_lld_tgen_open(spip);
+
+  dmaChannelSetDestinationX(spip->dmarx, (uint32_t)rxbuf);
+  dmaChannelSetCounterX(spip->dmarx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmarx, spip->rxdmamode | DMA_CTRL_TRIG_INCR_WRITE);
+
+  dmaChannelSetSourceX(spip->dmatx, (uint32_t)&dummytx);
+  dmaChannelSetCounterX(spip->dmatx, (uint32_t)n);
+  dmaChannelSetModeX(spip->dmatx, spip->txdmamode);
+
+  dmaChannelEnableX(spip->dmarx);
+  dmaChannelEnableX(spip->dmatx);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Aborts the ongoing SPI operation, if any.
+ * @note    This function is invoked with the system lock held, the
+ *          terminal event claim is therefore atomic with respect to the
+ *          claims performed by the DMA services on either core.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[out] sizep    pointer to the counter of frames not yet transferred
+ *                      or @p NULL
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t spi_lld_stop_transfer(SPIDriver *spip, size_t *sizep) {
+
+  /* Claiming the terminal event: with an odd generation the transfer is
+     still in flight, the abort takes the event and any completion or
+     error service racing on the other core observes a changed
+     generation and performs no state transition. With an even
+     generation the transfer already terminated, the quiescing below is
+     still performed because it is idempotent on idle channels and,
+     after a DMA error, it is the only path draining the SSP FIFOs.*/
+  if ((spip->tgen & 1U) != 0U) {
+    spip->tgen++;
+  }
+
+  /* No new data requests from the SSP while aborting, the abort
+     sequence requires quiescent request lines.*/
+  spip->spi->SSPDMACR = 0U;
+
+  /* Stopping the DMA channels, the abort waits out any transfer in
+     flight and discards the spurious completion it may raise
+     (RP2040-E13).*/
+  dmaChannelDisableX(spip->dmatx);
+  dmaChannelDisableX(spip->dmarx);
+
+  /* Counter of frames not yet transferred to memory by the RX channel,
+     on the RP2350 the TRANS_COUNT MODE field is masked off by the
+     getter. Frames aborted in the SSP FIFOs are included because they
+     never reach the receive buffer.
+     The counter is read after the abort with the claim held under the
+     system lock: a losing completion service cannot have consumed the
+     terminal event, on a completed transfer the counter reads zero and
+     after a DMA error it holds the frozen residual.*/
+  if (sizep != NULL) {
+    *sizep = (size_t)dmaChannelGetCounterX(spip->dmarx);
+  }
+
+  /* Draining the SSP: frames already queued in the TX FIFO keep being
+     clocked out, the RX FIFO is read until the SSP goes idle, then any
+     leftover frame is discarded.*/
+  while ((spip->spi->SSPSR & SPI_SSPSR_BSY) != 0U) {
+    if ((spip->spi->SSPSR & SPI_SSPSR_RNE) != 0U) {
+      (void)spip->spi->SSPDR;
+    }
+  }
+  while ((spip->spi->SSPSR & SPI_SSPSR_RNE) != 0U) {
+    (void)spip->spi->SSPDR;
+  }
+
+  /* Data requests enabled again for the next transfer.*/
+  spip->spi->SSPDMACR = SPI_SSPDMACR_RXDMAE | SPI_SSPDMACR_TXDMAE;
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Exchanges one frame using a polled wait.
+ * @details This synchronous function exchanges one frame using a polled
+ *          synchronization method. This function is useful when exchanging
+ *          small amount of data on high speed channels, usually in this
+ *          situation is much more efficient just wait for completion using
+ *          polling than suspending the thread waiting for an interrupt.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ * @param[in] frame     the data frame to send over the SPI bus
+ * @return              The received data frame from the SPI bus.
+ *
+ * @notapi
+ */
+uint16_t spi_lld_polled_exchange(SPIDriver *spip, uint16_t frame) {
+
+  spip->spi->SSPDR = (uint32_t)frame;
+  while ((spip->spi->SSPSR & SPI_SSPSR_RNE) == 0U)
+    ;
+  return (uint16_t)spip->spi->SSPDR;
+}
+
+#endif /* HAL_USE_SPI == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/SPIv1/hal_spi_lld.h
+++ b/os/xhal/ports/RP/LLD/SPIv1/hal_spi_lld.h
@@ -1,0 +1,404 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    SPIv1/hal_spi_lld.h
+ * @brief   RP SPI subsystem low level driver header.
+ *
+ * @addtogroup SPI
+ * @{
+ */
+
+#ifndef HAL_SPI_LLD_H
+#define HAL_SPI_LLD_H
+
+#if (HAL_USE_SPI == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Circular mode support flag.
+ */
+#define SPI_SUPPORTS_CIRCULAR               FALSE
+
+/**
+ * @brief   Slave mode support flag.
+ */
+#define SPI_SUPPORTS_SLAVE_MODE             FALSE
+
+/**
+ * @name    SPI CS modes
+ * @{
+ */
+/**
+ * @brief       Selection by PAL line identifier.
+ */
+#define RP_SPI_SELECT_MODE_LINE             0
+
+/**
+ * @brief       Selection by PAL port and pad number.
+ */
+#define RP_SPI_SELECT_MODE_PAD              1
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   Handling method for SPI CS line.
+ */
+#if !defined(RP_SPI_SELECT_MODE) || defined(__DOXYGEN__)
+#define RP_SPI_SELECT_MODE                  RP_SPI_SELECT_MODE_LINE
+#endif
+
+/**
+ * @brief   Default PAL port for Chip Select line.
+ */
+#if !defined(RP_SPI_DEFAULT_PORT) || defined(__DOXYGEN__)
+#define RP_SPI_DEFAULT_PORT                 IOPORT1
+#endif
+
+/**
+ * @brief   Default PAL pad for Chip Select line.
+ */
+#if !defined(RP_SPI_DEFAULT_PAD) || defined(__DOXYGEN__)
+#define RP_SPI_DEFAULT_PAD                  0U
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness.*/
+#if !defined(RP_HAS_SPI0)
+#error "RP_HAS_SPI0 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_SPI1)
+#error "RP_HAS_SPI1 not defined in registry"
+#endif
+
+/* Mcuconf.h checks.*/
+#if !defined(RP_SPI_USE_SPI0)
+#error "RP_SPI_USE_SPI0 not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_SPI_USE_SPI1)
+#error "RP_SPI_USE_SPI1 not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_IRQ_SPI0_PRIORITY)
+#error "RP_IRQ_SPI0_PRIORITY not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_IRQ_SPI1_PRIORITY)
+#error "RP_IRQ_SPI1_PRIORITY not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_SPI_SPI0_RX_DMA_CHANNEL)
+#error "RP_SPI_SPI0_RX_DMA_CHANNEL not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_SPI_SPI0_TX_DMA_CHANNEL)
+#error "RP_SPI_SPI0_TX_DMA_CHANNEL not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_SPI_SPI1_RX_DMA_CHANNEL)
+#error "RP_SPI_SPI1_RX_DMA_CHANNEL not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_SPI_SPI1_TX_DMA_CHANNEL)
+#error "RP_SPI_SPI1_TX_DMA_CHANNEL not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_SPI_SPI0_DMA_PRIORITY)
+#error "RP_SPI_SPI0_DMA_PRIORITY not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_SPI_SPI1_DMA_PRIORITY)
+#error "RP_SPI_SPI1_DMA_PRIORITY not defined in mcuconf.h"
+#endif
+
+/* Device selection checks.*/
+#if RP_SPI_USE_SPI0 && !RP_HAS_SPI0
+#error "SPI0 not present in the selected device"
+#endif
+
+#if RP_SPI_USE_SPI1 && !RP_HAS_SPI1
+#error "SPI1 not present in the selected device"
+#endif
+
+#if !RP_SPI_USE_SPI0 && !RP_SPI_USE_SPI1
+#error "SPI driver activated but no SPI peripheral assigned"
+#endif
+
+#if (RP_SPI_SELECT_MODE != RP_SPI_SELECT_MODE_LINE) &&                      \
+    (RP_SPI_SELECT_MODE != RP_SPI_SELECT_MODE_PAD)
+#error "invalid RP_SPI_SELECT_MODE value"
+#endif
+
+#if HAL_USE_PAL != TRUE
+#error "HAL_USE_SPI requires HAL_USE_PAL"
+#endif
+
+/* IRQ and DMA settings checks. The IRQ priority is used for the DMA
+   channels vector whose handler interacts with the kernel, therefore a
+   kernel-compatible priority is required.*/
+#if RP_SPI_USE_SPI0 &&                                                      \
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_SPI0_PRIORITY)
+#error "Invalid IRQ priority assigned to SPI0"
+#endif
+
+#if RP_SPI_USE_SPI1 &&                                                      \
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_SPI1_PRIORITY)
+#error "Invalid IRQ priority assigned to SPI1"
+#endif
+
+#if RP_SPI_USE_SPI0 &&                                                      \
+    !RP_DMA_IS_VALID_PRIORITY(RP_SPI_SPI0_DMA_PRIORITY)
+#error "Invalid DMA priority assigned to SPI0"
+#endif
+
+#if RP_SPI_USE_SPI1 &&                                                      \
+    !RP_DMA_IS_VALID_PRIORITY(RP_SPI_SPI1_DMA_PRIORITY)
+#error "Invalid DMA priority assigned to SPI1"
+#endif
+
+/* Explicitly assigned RX and TX DMA channels must differ, the check is
+   skipped when RP_DMA_CHANNEL_ID_ANY is used because equal sentinel
+   values are legitimate.
+   The TX channel index is also required to be lower than the RX one:
+   the shared DMA handler scans channels in ascending index order within
+   a single interrupts snapshot, servicing the TX end-of-sequence before
+   the RX completion keeps a stale TX service from trailing the RX
+   completion which releases the waiting thread, a thread which could
+   immediately reprogram the channels from the other core. Terminal
+   events are additionally arbitrated through the per-driver transfer
+   generation counter so correctness no longer depends on the service
+   order, the ordering is enforced as a defensive measure anyway:
+   spi_lld_start() fails with HAL_RET_NO_RESOURCE when the allocated RX
+   channel index is lower than the TX one. With RP_DMA_CHANNEL_ID_ANY
+   on both the order is always satisfied because TX is allocated
+   first.*/
+#if RP_SPI_USE_SPI0 &&                                                      \
+    (RP_SPI_SPI0_RX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI0_TX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI0_RX_DMA_CHANNEL == RP_SPI_SPI0_TX_DMA_CHANNEL)
+#error "SPI0 RX and TX assigned to the same DMA channel"
+#endif
+
+#if RP_SPI_USE_SPI1 &&                                                      \
+    (RP_SPI_SPI1_RX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI1_TX_DMA_CHANNEL != RP_DMA_CHANNEL_ID_ANY) &&                \
+    (RP_SPI_SPI1_RX_DMA_CHANNEL == RP_SPI_SPI1_TX_DMA_CHANNEL)
+#error "SPI1 RX and TX assigned to the same DMA channel"
+#endif
+
+/**
+ * @brief   SSPCR0 SCR field value for the default configuration.
+ * @details Combined with the fixed clock prescale divisor of 2 used by
+ *          the default configuration the resulting bit rate is roughly
+ *          1 MHz from the peripheral clock, following the PL022 rate
+ *          formula peri_clk / (CPSDVSR * (1 + SCR)).
+ */
+#define RP_SPI_DEFAULT_SCR                                                  \
+  ((RP_CLK_PERI_FREQ / (2U * 1000000U)) - 1U)
+
+#if RP_CLK_PERI_FREQ < 2000000U
+#error "RP_CLK_PERI_FREQ too low for the default SPI configuration"
+#endif
+
+#if RP_SPI_DEFAULT_SCR > 255U
+#error "RP_CLK_PERI_FREQ too high for the default SPI configuration"
+#endif
+
+/**
+ * @brief   Default SPI configuration.
+ * @details Motorola frame format, clock polarity and phase zero, 8 bits
+ *          per frame, roughly 1 MHz bit rate.
+ */
+#if (RP_SPI_SELECT_MODE == RP_SPI_SELECT_MODE_LINE) || defined(__DOXYGEN__)
+#define SPI_DEFAULT_CONFIGURATION                                           \
+{                                                                           \
+  .mode             = SPI_MODE_FSIZE_8,                                     \
+  .ssline           = PAL_LINE(RP_SPI_DEFAULT_PORT, RP_SPI_DEFAULT_PAD),    \
+  .SSPCR0           = SPI_SSPCR0_FRF_MOTOROLA | SPI_SSPCR0_DSS_8BIT |       \
+                      SPI_SSPCR0_SCR(RP_SPI_DEFAULT_SCR),                   \
+  .SSPCPSR          = SPI_SSPCPSR_CPSDVSR(2U)                               \
+}
+#elif RP_SPI_SELECT_MODE == RP_SPI_SELECT_MODE_PAD
+#define SPI_DEFAULT_CONFIGURATION                                           \
+{                                                                           \
+  .mode             = SPI_MODE_FSIZE_8,                                     \
+  .ssport           = RP_SPI_DEFAULT_PORT,                                  \
+  .sspad            = RP_SPI_DEFAULT_PAD,                                   \
+  .SSPCR0           = SPI_SSPCR0_FRF_MOTOROLA | SPI_SSPCR0_DSS_8BIT |       \
+                      SPI_SSPCR0_SCR(RP_SPI_DEFAULT_SCR),                   \
+  .SSPCPSR          = SPI_SSPCPSR_CPSDVSR(2U)                               \
+}
+#endif
+
+/* Forcing inclusion of the DMA support driver.*/
+#if !defined(RP_DMA_REQUIRED)
+#define RP_DMA_REQUIRED
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level fields of the SPI driver structure.
+ * @note    The @p tgen field is the transfer generation counter: it is
+ *          incremented under the system lock when a transfer starts and
+ *          again when the transfer terminal event is claimed, its value
+ *          is therefore odd exactly while a transfer is in flight with
+ *          an unclaimed terminal event. Every terminal path (RX
+ *          completion, DMA error, transfer stop) claims the event in a
+ *          critical section by checking the generation it sampled at
+ *          entry against the live value, only the single winner performs
+ *          the driver state transition. This serializes completions,
+ *          errors and aborts across both cores.
+ */
+#define spi_lld_driver_fields                                               \
+  /* Pointer to the SPIx registers block.*/                                 \
+  SPI_TypeDef               *spi;                                           \
+  /* Receive DMA stream.*/                                                  \
+  const rp_dma_channel_t    *dmarx;                                         \
+  /* Transmit DMA stream.*/                                                 \
+  const rp_dma_channel_t    *dmatx;                                         \
+  /* RX DMA mode bit mask.*/                                                \
+  uint32_t                  rxdmamode;                                      \
+  /* TX DMA mode bit mask.*/                                                \
+  uint32_t                  txdmamode;                                      \
+  /* Transfer generation counter, see the structure notes.*/                \
+  uint32_t                  tgen
+
+/**
+ * @brief   Low level fields of the SPI configuration structure.
+ */
+#if (RP_SPI_SELECT_MODE == RP_SPI_SELECT_MODE_LINE) || defined(__DOXYGEN__)
+#define spi_lld_config_fields                                               \
+  /* The chip select line.*/                                                \
+  ioline_t                  ssline;                                         \
+  /* SSPCR0 register initialization data.*/                                 \
+  uint32_t                  SSPCR0;                                         \
+  /* SSPCPSR register initialization data.*/                                \
+  uint32_t                  SSPCPSR
+#elif RP_SPI_SELECT_MODE == RP_SPI_SELECT_MODE_PAD
+#define spi_lld_config_fields                                               \
+  /* The chip select port.*/                                                \
+  ioportid_t                ssport;                                         \
+  /* The chip select pad number.*/                                          \
+  uint_fast8_t              sspad;                                          \
+  /* SSPCR0 register initialization data.*/                                 \
+  uint32_t                  SSPCR0;                                         \
+  /* SSPCPSR register initialization data.*/                                \
+  uint32_t                  SSPCPSR
+#endif
+
+#if (RP_SPI_SELECT_MODE == RP_SPI_SELECT_MODE_LINE) || defined(__DOXYGEN__)
+/**
+ * @brief   Asserts the slave select signal and prepares for transfers.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ *
+ * @notapi
+ */
+#define spi_lld_select(spip) do {                                           \
+                                                                            \
+  palClearLine(__spi_getfield(spip, ssline));                               \
+} while (0)
+
+/**
+ * @brief   Deasserts the slave select signal.
+ * @details The previously selected peripheral is unselected.
+ *
+ * @param[in] spip      pointer to the @p SPIDriver object
+ *
+ * @notapi
+ */
+#define spi_lld_unselect(spip) do {                                         \
+                                                                            \
+  palSetLine(__spi_getfield(spip, ssline));                                 \
+} while (0)
+
+#elif RP_SPI_SELECT_MODE == RP_SPI_SELECT_MODE_PAD
+#define spi_lld_select(spip) do {                                           \
+                                                                            \
+  palClearPad(__spi_getfield(spip, ssport), __spi_getfield(spip, sspad));   \
+} while (0)
+
+#define spi_lld_unselect(spip) do {                                         \
+                                                                            \
+  palSetPad(__spi_getfield(spip, ssport), __spi_getfield(spip, sspad));     \
+} while (0)
+#endif
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (RP_SPI_USE_SPI0 == TRUE) && !defined(__DOXYGEN__)
+extern SPIDriver SPID0;
+#endif
+
+#if (RP_SPI_USE_SPI1 == TRUE) && !defined(__DOXYGEN__)
+extern SPIDriver SPID1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void spi_lld_init(void);
+  msg_t spi_lld_start(SPIDriver *spip);
+  void spi_lld_stop(SPIDriver *spip);
+  const hal_spi_config_t *spi_lld_setcfg(SPIDriver *spip,
+                                         const hal_spi_config_t *config);
+  const hal_spi_config_t *spi_lld_selcfg(SPIDriver *spip,
+                                         unsigned cfgnum);
+  msg_t spi_lld_ignore(SPIDriver *spip, size_t n);
+  msg_t spi_lld_exchange(SPIDriver *spip, size_t n,
+                         const void *txbuf, void *rxbuf);
+  msg_t spi_lld_send(SPIDriver *spip, size_t n, const void *txbuf);
+  msg_t spi_lld_receive(SPIDriver *spip, size_t n, void *rxbuf);
+  msg_t spi_lld_stop_transfer(SPIDriver *spip, size_t *sizep);
+  uint16_t spi_lld_polled_exchange(SPIDriver *spip, uint16_t frame);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+#endif /* HAL_USE_SPI == TRUE */
+
+#endif /* HAL_SPI_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/platform.mk
+++ b/os/xhal/ports/RP/RP2040/platform.mk
@@ -32,6 +32,7 @@ endif
 # Drivers compatible with the platform.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/WDGv1/driver.mk

--- a/os/xhal/ports/RP/RP2350/platform.mk
+++ b/os/xhal/ports/RP/RP2350/platform.mk
@@ -32,6 +32,7 @@ endif
 # Drivers compatible with the platform.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/WDGv1/driver.mk

--- a/testxhal/SPI/cfg/rp2040_pico/chconf.h
+++ b/testxhal/SPI/cfg/rp2040_pico/chconf.h
@@ -1,0 +1,857 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Disabled because the non-SMP ARMv6-M port has no realtime
+ *          counter support.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2040_pico/portab.c
+++ b/testxhal/SPI/cfg/rp2040_pico/portab.c
@@ -1,0 +1,110 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.c
+ * @brief   Application portability module code.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#include "hal.h"
+
+#include "portab.h"
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported variables.                                                */
+/*===========================================================================*/
+
+/*
+ * The PL022 bit rate is SSPCLK / (CPSDVSR * (1 + SCR)), SSPCLK is clk_peri
+ * running at 125MHz on this target. Circular and slave configurations are
+ * not provided because the RP SPI driver supports neither mode.
+ */
+const spi_configurations_t spi_configurations = {
+  .cfgsnum          = 2U,
+  .cfgs = {
+    /*
+     * High speed SPI configuration (3.90625MHz, CPHA=0, CPOL=0, MSb first).
+     */
+    [0] = {
+      .mode         = SPI_MODE_FSIZE_8,
+      .ssline       = 17U,
+      .SSPCR0       = SPI_SSPCR0_SCR(15U) | SPI_SSPCR0_DSS_8BIT,
+      .SSPCPSR      = 2U
+    },
+    /*
+     * Low speed SPI configuration (500kHz, CPHA=0, CPOL=0, MSb first).
+     */
+    [1] = {
+      .mode         = SPI_MODE_FSIZE_8,
+      .ssline       = 17U,
+      .SSPCR0       = SPI_SSPCR0_SCR(124U) | SPI_SSPCR0_DSS_8BIT,
+      .SSPCPSR      = 2U
+    },
+  }
+};
+
+/*===========================================================================*/
+/* Module local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+void portab_setup(void) {
+
+  /*
+   * SPI0 I/O pins setup, chip select is a software-driven PAL line. For
+   * bench validation without an external device a GP19-GP16 jumper loops
+   * MOSI back into MISO.
+   */
+  palSetLineMode(16U, PAL_MODE_ALTERNATE_SPI);            /* SPI0 MISO (RX).*/
+  palSetLineMode(18U, PAL_MODE_ALTERNATE_SPI);            /* SPI0 SCK.      */
+  palSetLineMode(19U, PAL_MODE_ALTERNATE_SPI);            /* SPI0 MOSI (TX).*/
+  palSetLine(17U);
+  palSetLineMode(17U, PAL_MODE_OUTPUT_PUSHPULL |
+                      PAL_RP_PAD_DRIVE12);                /* SPI0 CS.       */
+
+  /*
+   * LED line as output.
+   */
+  palSetLineMode(PORTAB_LINE_LED1, PAL_MODE_OUTPUT_PUSHPULL |
+                                   PAL_RP_PAD_DRIVE12);
+  palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_OFF);
+
+  /*
+   * Button replacement line as pulled-down input, it reads as not pressed
+   * unless externally driven high.
+   */
+  palSetLineMode(PORTAB_LINE_BUTTON, PAL_MODE_INPUT_PULLDOWN);
+}
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2040_pico/portab.h
+++ b/testxhal/SPI/cfg/rp2040_pico/portab.h
@@ -1,0 +1,87 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.h
+ * @brief   Application portability macros and structures.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+#define PORTAB_LINE_LED1            25U
+#define PORTAB_LED_OFF              PAL_LOW
+#define PORTAB_LED_ON               PAL_HIGH
+
+/* The Pico board has no user button, GP22 is configured as a pulled-down
+   input by portab_setup() so the line reads as not pressed unless it is
+   externally driven high.*/
+#define PORTAB_LINE_BUTTON          22U
+#define PORTAB_BUTTON_PRESSED       PAL_HIGH
+
+/* Single SPI instance, the RP SPI driver supports neither slave mode nor
+   circular mode so no PORTAB_SPI2 is provided and the related test code
+   compiles out.*/
+#define PORTAB_SPI1                 SPID0
+
+/* Required SPI configurations, indices into spi_configurations. Circular
+   and slave entries are not provided, the code paths consuming them are
+   disabled by SPI_SUPPORTS_CIRCULAR and SPI_SUPPORTS_SLAVE_MODE.*/
+#define SPI_CFG_HIGH_SPEED          0U
+#define SPI_CFG_LOW_SPEED           1U
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+#endif /* PORTAB_H */
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2040_pico/xhalconf.h
+++ b/testxhal/SPI/cfg/rp2040_pico/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         FALSE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         FALSE
+#define HAL_USE_SPI                         TRUE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         FALSE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   FALSE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              TRUE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               FALSE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2040_pico/xmcuconf.h
+++ b/testxhal/SPI/cfg/rp2040_pico/xmcuconf.h
@@ -1,0 +1,70 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2040 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2040_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     TRUE
+#define RP_SPI_USE_SPI1                     FALSE
+#define RP_SPI_SPI0_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_DMA_PRIORITY            1
+#define RP_SPI_SPI1_DMA_PRIORITY            1
+#define RP_SPI_DMA_ERROR_HOOK(spip)
+
+#endif /* XMCUCONF_H */

--- a/testxhal/SPI/cfg/rp2350_pico2/chconf.h
+++ b/testxhal/SPI/cfg/rp2350_pico2/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2350_pico2/portab.c
+++ b/testxhal/SPI/cfg/rp2350_pico2/portab.c
@@ -1,0 +1,110 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.c
+ * @brief   Application portability module code.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#include "hal.h"
+
+#include "portab.h"
+
+/*===========================================================================*/
+/* Module local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported variables.                                                */
+/*===========================================================================*/
+
+/*
+ * The PL022 bit rate is SSPCLK / (CPSDVSR * (1 + SCR)), SSPCLK is clk_peri
+ * running at 150MHz on this target. Circular and slave configurations are
+ * not provided because the RP SPI driver supports neither mode.
+ */
+const spi_configurations_t spi_configurations = {
+  .cfgsnum          = 2U,
+  .cfgs = {
+    /*
+     * High speed SPI configuration (3.947MHz, CPHA=0, CPOL=0, MSb first).
+     */
+    [0] = {
+      .mode         = SPI_MODE_FSIZE_8,
+      .ssline       = 17U,
+      .SSPCR0       = SPI_SSPCR0_SCR(18U) | SPI_SSPCR0_DSS_8BIT,
+      .SSPCPSR      = 2U
+    },
+    /*
+     * Low speed SPI configuration (500kHz, CPHA=0, CPOL=0, MSb first).
+     */
+    [1] = {
+      .mode         = SPI_MODE_FSIZE_8,
+      .ssline       = 17U,
+      .SSPCR0       = SPI_SSPCR0_SCR(149U) | SPI_SSPCR0_DSS_8BIT,
+      .SSPCPSR      = 2U
+    },
+  }
+};
+
+/*===========================================================================*/
+/* Module local types.                                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local variables.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module local functions.                                                   */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module exported functions.                                                */
+/*===========================================================================*/
+
+void portab_setup(void) {
+
+  /*
+   * SPI0 I/O pins setup, chip select is a software-driven PAL line. For
+   * bench validation without an external device a GP19-GP16 jumper loops
+   * MOSI back into MISO.
+   */
+  palSetLineMode(16U, PAL_MODE_ALTERNATE_SPI);            /* SPI0 MISO (RX).*/
+  palSetLineMode(18U, PAL_MODE_ALTERNATE_SPI);            /* SPI0 SCK.      */
+  palSetLineMode(19U, PAL_MODE_ALTERNATE_SPI);            /* SPI0 MOSI (TX).*/
+  palSetLine(17U);
+  palSetLineMode(17U, PAL_MODE_OUTPUT_PUSHPULL |
+                      PAL_RP_PAD_DRIVE12);                /* SPI0 CS.       */
+
+  /*
+   * LED line as output.
+   */
+  palSetLineMode(PORTAB_LINE_LED1, PAL_MODE_OUTPUT_PUSHPULL |
+                                   PAL_RP_PAD_DRIVE12);
+  palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_OFF);
+
+  /*
+   * Button replacement line as pulled-down input, it reads as not pressed
+   * unless externally driven high.
+   */
+  palSetLineMode(PORTAB_LINE_BUTTON, PAL_MODE_INPUT_PULLDOWN);
+}
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2350_pico2/portab.h
+++ b/testxhal/SPI/cfg/rp2350_pico2/portab.h
@@ -1,0 +1,87 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.h
+ * @brief   Application portability macros and structures.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+#define PORTAB_LINE_LED1            25U
+#define PORTAB_LED_OFF              PAL_LOW
+#define PORTAB_LED_ON               PAL_HIGH
+
+/* The Pico 2 board has no user button, GP22 is configured as a pulled-down
+   input by portab_setup() so the line reads as not pressed unless it is
+   externally driven high.*/
+#define PORTAB_LINE_BUTTON          22U
+#define PORTAB_BUTTON_PRESSED       PAL_HIGH
+
+/* Single SPI instance, the RP SPI driver supports neither slave mode nor
+   circular mode so no PORTAB_SPI2 is provided and the related test code
+   compiles out.*/
+#define PORTAB_SPI1                 SPID0
+
+/* Required SPI configurations, indices into spi_configurations. Circular
+   and slave entries are not provided, the code paths consuming them are
+   disabled by SPI_SUPPORTS_CIRCULAR and SPI_SUPPORTS_SLAVE_MODE.*/
+#define SPI_CFG_HIGH_SPEED          0U
+#define SPI_CFG_LOW_SPEED           1U
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Module inline functions.                                                  */
+/*===========================================================================*/
+
+#endif /* PORTAB_H */
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2350_pico2/xhalconf.h
+++ b/testxhal/SPI/cfg/rp2350_pico2/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         FALSE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         FALSE
+#define HAL_USE_SPI                         TRUE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         FALSE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   FALSE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              TRUE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               FALSE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/testxhal/SPI/cfg/rp2350_pico2/xmcuconf.h
+++ b/testxhal/SPI/cfg/rp2350_pico2/xmcuconf.h
@@ -1,0 +1,71 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest (4 bits on Cortex-M33).
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2350_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CLOCK_DYNAMIC                    FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_SPI0_PRIORITY                2
+#define RP_IRQ_SPI1_PRIORITY                2
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * SPI driver system settings.
+ */
+#define RP_SPI_USE_SPI0                     TRUE
+#define RP_SPI_USE_SPI1                     FALSE
+#define RP_SPI_SPI0_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_RX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI1_TX_DMA_CHANNEL          RP_DMA_CHANNEL_ID_ANY
+#define RP_SPI_SPI0_DMA_PRIORITY            1
+#define RP_SPI_SPI1_DMA_PRIORITY            1
+#define RP_SPI_DMA_ERROR_HOOK(spip)
+
+#endif /* XMCUCONF_H */

--- a/testxhal/SPI/make/rp2040_pico.make
+++ b/testxhal/SPI/make/rp2040_pico.make
@@ -1,0 +1,185 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m0plus
+
+# Imported source files and paths.
+CHIBIOS  := ../../
+CONFDIR  := ./cfg/rp2040_pico
+BUILDDIR := ./build/rp2040_pico
+DEPDIR   := ./.dep/rp2040_pico
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv6-M/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2040_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/testxhal/SPI/make/rp2350_pico2.make
+++ b/testxhal/SPI/make/rp2350_pico2.make
@@ -1,0 +1,190 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = softfp
+endif
+
+# FPU-related options.
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-sp-d16
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../
+CONFDIR  := ./cfg/rp2350_pico2
+BUILDDIR := ./build/rp2350_pico2
+DEPDIR   := ./.dep/rp2350_pico2
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################


### PR DESCRIPTION
## Summary

Stage 2b of the RP2040/RP2350 XHAL port: the PL022 SPI driver, converted from the classic LLD to the XHAL contract, plus RP2040/RP2350 targets for `testxhal/SPI`.

- `msg_t` operation returns; `setcfg`/`selcfg` with a static default configuration (Motorola, mode 0, 8-bit, ~1 MHz from the peripheral clock: SCR 61 @125 MHz, SCR 74 @150 MHz, compile-time guarded); frame size enforced from the mandatory `mode` field (8/16-bit, larger rejected); `SSPCR0` reserved encodings rejected (FRF=3, out-of-mask bits); live reconfiguration quiesces the PL022 (BSY wait, SSE off) before touching CR0/CPSR.
- **New `spi_lld_stop_transfer`**: `SSPDMACR` quiesce → erratum-safe abort of both DMA channels (RP2040-E13/RP2350-E5 path in the shared service) → residual frames from the RX channel counter (RP2350 `TRANS_COUNT` MODE field masked) → FIFO drain while BSY → DMACR restore.
- **Terminal-event arbitration** (from adversarial review): a per-driver transfer generation with parity semantics makes completion, DMA error, and abort single-winner across cores — an in-flight completion on the other core arbitrates atomically against `spiStopTransferI`; a stale RX-completion dispatched from the same DMA-IRQ snapshot as a TX error loses the claim (plus hardware guards: RX EN clear, `TRANS_COUNT`==0); channel-index ordering no longer affects correctness, and inverted explicit channel assignments are additionally rejected at start (`HAL_RET_NO_RESOURCE`).
- Completion maps to the COMPLETE transition (per SPIv2 precedent); DMA errors keep classic's force-completion behavior through the error path, with `RP_SPI_DMA_ERROR_HOOK` fired only by the winning claim.
- `SPI_SUPPORTS_CIRCULAR FALSE`, `SPI_SUPPORTS_SLAVE_MODE FALSE` (classic parity; circular is a candidate follow-up). Select mode: `RP_SPI_SELECT_MODE` (LINE default / PAD) mirroring the STM32 knob.
- `testxhal/SPI`: both RP targets (SPI0 on GP16/17/18/19, CS preset high before pad-mode switch), shared `main.c` untouched; recipes registered in the OSAL-removal manifest.

## Review triage

- codex adversarial review: 3 MAJOR cross-core race findings — all fixed by the generation/claim design above; 1 MINOR (reserved SSPCR0 encodings) fixed; 1 MINOR (CS setup glitch) fixed; 1 coverage note (the shared testxhal/SPI `main.c` compiles out `spiStopTransfer` sites when circular/slave are unsupported, so the new abort path needs dedicated bench coverage — see validation notes below).
- coderabbit CLI: 1 finding (CS glitch, same as above) — fixed.
- Review byproduct for a separate DMAv1 look (inherited shape, classic has it too): `rp_dma` `serve_interrupt()` writes `CTRL_TRIG` error-clear bits unconditionally before the callback, which can clobber a channel re-armed cross-core from a stale INTS snapshot; the SPI claim guards make this benign for SPI (no false terminal event), but a SET/CLR-alias or busy-skip hardening in the service would remove the hang window.

## Verification

- Build matrix, all clean: testxhal/SPI rp2040+rp2350 × {default, +`CH_DBG_ENABLE_CHECKS/ASSERTS`}; demo unaffected (smart-build isolation confirmed, `USE_SMART_BUILD=no` leg compiles the shared SPI driver against the new LLD); untouched STM32 testxhal/SPI leg still green.
- OSAL lexical gate, per-file stylecheck, `git diff --check`: clean. Zero shared XHAL changes.
- On-hardware validation to follow on the bench (Pico/Pico 2 via the probe rig): transfer/abort residual behavior and loopback data checks; will be posted here before this leaves draft.

## Changelog

- XHAL: RP port gains the SPI driver; testxhal/SPI gains RP2040/RP2350 targets.
