### PR TITLE
XHAL: RP port PWM and ADC drivers

### DIFF
--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.c
@@ -34,6 +34,54 @@
 /* Module exported variables.                                                */
 /*===========================================================================*/
 
+/**
+ * @brief   PWM configuration for the LED slice.
+ * @details The slice counts at 1MHz over a 1000 ticks period giving a
+ *          1kHz PWM frequency, the LED on GP25 is driven by the B
+ *          channel. Events are enabled at runtime by the application.
+ */
+const hal_pwm_config_t portab_pwm_config = {
+  .frequency      = 1000000U,
+  .period         = 1000U,
+  .enabled_events = 0U,
+  .channels       = {
+    {
+      .mode       = PWM_OUTPUT_DISABLED
+    },
+    {
+      .mode       = PWM_OUTPUT_ACTIVE_HIGH
+    }
+  },
+  .dummy          = 0U
+};
+
+/**
+ * @brief   Conversion groups of the portability ADC configuration.
+ * @details A single conversion group sampling the on-die temperature
+ *          sensor at the free-running rate, the sensor bias is enabled
+ *          by the driver for the duration of the conversion.
+ */
+static const adc_conversion_groups_t portab_adc_groups = {
+  .grpsnum        = 1U,
+  .grps           = {
+    {
+      .num_channels = 1U,
+      .channel      = ADC_CHANNEL_TEMPSENSOR,
+      .rrobin       = 0U,
+      .div          = 0U,
+      .ts_enabled   = true
+    }
+  }
+};
+
+/**
+ * @brief   ADC configuration carrying the temperature sensor group.
+ */
+const hal_adc_config_t portab_adc_config = {
+  .grps           = &portab_adc_groups,
+  .dummy          = 0U
+};
+
 /*===========================================================================*/
 /* Module local types.                                                       */
 /*===========================================================================*/
@@ -53,11 +101,11 @@
 void portab_setup(void) {
 
   /*
-   * LED line as output.
+   * LED line on the PWM function, the pad is driven by slice 4
+   * channel B.
    */
-  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_OUTPUT_PUSHPULL |
+  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_ALTERNATE_PWM |
                                   PAL_RP_PAD_DRIVE12);
-  palWriteLine(PORTAB_LINE_LED, PORTAB_LED_OFF);
 
   /*
    * UART0 console pads, TX on GP0 and RX on GP1.

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
@@ -35,6 +35,15 @@
 
 #define PORTAB_SIO_CONSOLE          SIOD0
 
+/* The board LED on GP25 is served by PWM slice 4 channel B.*/
+#define PORTAB_PWM                  PWMD4
+#define PORTAB_PWM_CHANNEL          1U
+
+/* ADC instance and index of the temperature sensor conversion group
+   within the portability ADC configuration.*/
+#define PORTAB_ADC                  ADCD1
+#define PORTAB_ADC_TEMP_GRP         0U
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -54,6 +63,9 @@
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/
+
+extern const hal_pwm_config_t portab_pwm_config;
+extern const hal_adc_config_t portab_adc_config;
 
 #ifdef __cplusplus
 extern "C" {

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
@@ -45,7 +45,7 @@
 /*===========================================================================*/
 
 #define HAL_USE_PAL                         TRUE
-#define HAL_USE_ADC                         FALSE
+#define HAL_USE_ADC                         TRUE
 #define HAL_USE_DAC                         FALSE
 #define HAL_USE_CAN                         FALSE
 #define HAL_USE_EFL                         FALSE
@@ -55,7 +55,7 @@
 #define HAL_USE_I2S                         FALSE
 #define HAL_USE_ICU                         FALSE
 #define HAL_USE_MMC_SPI                     FALSE
-#define HAL_USE_PWM                         FALSE
+#define HAL_USE_PWM                         TRUE
 #define HAL_USE_RTC                         FALSE
 #define HAL_USE_SDC                         FALSE
 #define HAL_USE_SIO                         TRUE

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
@@ -60,4 +60,25 @@
 #define RP_SIO_USE_UART0                    TRUE
 #define RP_SIO_USE_UART1                    FALSE
 
+/*
+ * ADC driver system settings.
+ */
+#define RP_ADC_USE_ADC1                     TRUE
+#define RP_ADC_ADC1_DMA_CHANNEL             RP_DMA_CHANNEL_ID_ANY
+#define RP_ADC_ADC1_DMA_PRIORITY            0
+#define RP_ADC_ADC1_DMA_IRQ_PRIORITY        3
+
+/*
+ * PWM driver system settings.
+ */
+#define RP_PWM_USE_PWM0                     FALSE
+#define RP_PWM_USE_PWM1                     FALSE
+#define RP_PWM_USE_PWM2                     FALSE
+#define RP_PWM_USE_PWM3                     FALSE
+#define RP_PWM_USE_PWM4                     TRUE
+#define RP_PWM_USE_PWM5                     FALSE
+#define RP_PWM_USE_PWM6                     FALSE
+#define RP_PWM_USE_PWM7                     FALSE
+#define RP_PWM_IRQ_WRAP_NUMBER_PRIORITY     3
+
 #endif /* XMCUCONF_H */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.c
@@ -34,6 +34,54 @@
 /* Module exported variables.                                                */
 /*===========================================================================*/
 
+/**
+ * @brief   PWM configuration for the LED slice.
+ * @details The slice counts at 1MHz over a 1000 ticks period giving a
+ *          1kHz PWM frequency, the LED on GP25 is driven by the B
+ *          channel. Events are enabled at runtime by the application.
+ */
+const hal_pwm_config_t portab_pwm_config = {
+  .frequency      = 1000000U,
+  .period         = 1000U,
+  .enabled_events = 0U,
+  .channels       = {
+    {
+      .mode       = PWM_OUTPUT_DISABLED
+    },
+    {
+      .mode       = PWM_OUTPUT_ACTIVE_HIGH
+    }
+  },
+  .dummy          = 0U
+};
+
+/**
+ * @brief   Conversion groups of the portability ADC configuration.
+ * @details A single conversion group sampling the on-die temperature
+ *          sensor at the free-running rate, the sensor bias is enabled
+ *          by the driver for the duration of the conversion.
+ */
+static const adc_conversion_groups_t portab_adc_groups = {
+  .grpsnum        = 1U,
+  .grps           = {
+    {
+      .num_channels = 1U,
+      .channel      = ADC_CHANNEL_TEMPSENSOR,
+      .rrobin       = 0U,
+      .div          = 0U,
+      .ts_enabled   = true
+    }
+  }
+};
+
+/**
+ * @brief   ADC configuration carrying the temperature sensor group.
+ */
+const hal_adc_config_t portab_adc_config = {
+  .grps           = &portab_adc_groups,
+  .dummy          = 0U
+};
+
 /*===========================================================================*/
 /* Module local types.                                                       */
 /*===========================================================================*/
@@ -53,11 +101,11 @@
 void portab_setup(void) {
 
   /*
-   * LED line as output.
+   * LED line on the PWM function, the pad is driven by slice 4
+   * channel B.
    */
-  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_OUTPUT_PUSHPULL |
+  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_ALTERNATE_PWM |
                                   PAL_RP_PAD_DRIVE12);
-  palWriteLine(PORTAB_LINE_LED, PORTAB_LED_OFF);
 
   /*
    * UART0 console pads, TX on GP0 and RX on GP1.

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
@@ -35,6 +35,15 @@
 
 #define PORTAB_SIO_CONSOLE          SIOD0
 
+/* The board LED on GP25 is served by PWM slice 4 channel B.*/
+#define PORTAB_PWM                  PWMD4
+#define PORTAB_PWM_CHANNEL          1U
+
+/* ADC instance and index of the temperature sensor conversion group
+   within the portability ADC configuration.*/
+#define PORTAB_ADC                  ADCD1
+#define PORTAB_ADC_TEMP_GRP         0U
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -54,6 +63,9 @@
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/
+
+extern const hal_pwm_config_t portab_pwm_config;
+extern const hal_adc_config_t portab_adc_config;
 
 #ifdef __cplusplus
 extern "C" {

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
@@ -45,7 +45,7 @@
 /*===========================================================================*/
 
 #define HAL_USE_PAL                         TRUE
-#define HAL_USE_ADC                         FALSE
+#define HAL_USE_ADC                         TRUE
 #define HAL_USE_DAC                         FALSE
 #define HAL_USE_CAN                         FALSE
 #define HAL_USE_EFL                         FALSE
@@ -55,7 +55,7 @@
 #define HAL_USE_I2S                         FALSE
 #define HAL_USE_ICU                         FALSE
 #define HAL_USE_MMC_SPI                     FALSE
-#define HAL_USE_PWM                         FALSE
+#define HAL_USE_PWM                         TRUE
 #define HAL_USE_RTC                         FALSE
 #define HAL_USE_SDC                         FALSE
 #define HAL_USE_SIO                         TRUE

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
@@ -61,4 +61,29 @@
 #define RP_SIO_USE_UART0                    TRUE
 #define RP_SIO_USE_UART1                    FALSE
 
+/*
+ * ADC driver system settings.
+ */
+#define RP_ADC_USE_ADC1                     TRUE
+#define RP_ADC_ADC1_DMA_CHANNEL             RP_DMA_CHANNEL_ID_ANY
+#define RP_ADC_ADC1_DMA_PRIORITY            0
+#define RP_ADC_ADC1_DMA_IRQ_PRIORITY        3
+
+/*
+ * PWM driver system settings.
+ */
+#define RP_PWM_USE_PWM0                     FALSE
+#define RP_PWM_USE_PWM1                     FALSE
+#define RP_PWM_USE_PWM2                     FALSE
+#define RP_PWM_USE_PWM3                     FALSE
+#define RP_PWM_USE_PWM4                     TRUE
+#define RP_PWM_USE_PWM5                     FALSE
+#define RP_PWM_USE_PWM6                     FALSE
+#define RP_PWM_USE_PWM7                     FALSE
+#define RP_PWM_USE_PWM8                     FALSE
+#define RP_PWM_USE_PWM9                     FALSE
+#define RP_PWM_USE_PWM10                    FALSE
+#define RP_PWM_USE_PWM11                    FALSE
+#define RP_PWM_IRQ_WRAP_NUMBER_PRIORITY     3
+
 #endif /* XMCUCONF_H */

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -14,6 +14,8 @@
     limitations under the License.
 */
 
+#include <string.h>
+
 #include "ch.h"
 #include "hal.h"
 #include "rt_test_root.h"
@@ -25,8 +27,79 @@ static hal_buffered_sio_c bsio1;
 static uint8_t rxbuf[32];
 static uint8_t txbuf[32];
 
+/*
+ * PWM period (wrap) events counted by the PWM callback, read by the
+ * main loop for the periodic report.
+ */
+static volatile uint32_t pwm_wraps;
+
+/*
+ * Buffer receiving the temperature sensor samples via DMA.
+ */
+static adcsample_t temp_sample[1];
+
 static const char banner[] = "\r\n" BOARD_NAME " -- ChibiOS/RT "
                              CH_KERNEL_VERSION "\r\n";
+
+/*
+ * PWM driver callback, invoked in ISR context outside any critical
+ * section. Only the period (wrap) event is enabled by this demo, the
+ * cached event flags are consumed and the wrap counter is advanced.
+ */
+static void pwm_wrap_cb(void *ip) {
+
+  (void)pwmGetAndClearEventsX(ip, PWM_EVENT_PERIOD);
+  pwm_wraps++;
+}
+
+/*
+ * Writes a zero-terminated string on the stream.
+ */
+static void print_str(BaseSequentialStream *stream, const char *s) {
+
+  stmWrite(stream, (const uint8_t *)s, strlen(s));
+}
+
+/*
+ * Writes a signed decimal number on the stream.
+ */
+static void print_dec(BaseSequentialStream *stream, int32_t value) {
+  char buf[12];
+  size_t i;
+  uint32_t u;
+
+  i = sizeof buf;
+  if (value < 0) {
+    u = (uint32_t)(-value);
+  }
+  else {
+    u = (uint32_t)value;
+  }
+  do {
+    i--;
+    buf[i] = (char)('0' + (char)(u % 10U));
+    u = u / 10U;
+  } while (u > 0U);
+  if (value < 0) {
+    i--;
+    buf[i] = '-';
+  }
+  stmWrite(stream, (const uint8_t *)&buf[i], sizeof buf - i);
+}
+
+/*
+ * Converts a raw temperature sensor sample into tenths of Celsius
+ * degree. The RP conversion formula is T = 27 - (V - 0.706) / 0.001721
+ * with the sample scaled against the 3.3V ADC reference, it is
+ * evaluated here in microvolts using integer arithmetic.
+ */
+static int32_t temp_raw_to_dc(adcsample_t raw) {
+  int32_t uv;
+
+  uv = (int32_t)(((uint64_t)raw * 3300000ULL) >> 12U);
+
+  return 270 - (((uv - 706000) * 10) / 1721);
+}
 
 /*
  * Application entry point.
@@ -34,6 +107,10 @@ static const char banner[] = "\r\n" BOARD_NAME " -- ChibiOS/RT "
 int main(void) {
   BaseSequentialStream *stream;
   msg_t msg;
+  pwmcnt_t width;
+  unsigned i;
+  int32_t tdc;
+  int32_t frac;
 
   /*
    * System initializations.
@@ -70,11 +147,66 @@ int main(void) {
   test_execute(stream, &oslib_test_suite);
 
   /*
-   * Normal main() thread activity, in this demo it toggles the board LED
-   * in a loop.
+   * Activates the PWM driver on the LED slice using the portability
+   * configuration then enables the period (wrap) event notification,
+   * the callback counts the slice wraps from ISR context.
+   */
+  msg = drvStart(&PORTAB_PWM, &portab_pwm_config);
+  chDbgAssert(msg == HAL_RET_SUCCESS, "PWM start failed");
+  drvSetCallbackX(&PORTAB_PWM, pwm_wrap_cb);
+  pwmEnableEvents(&PORTAB_PWM, PWM_EVENT_PERIOD);
+
+  /*
+   * Activates the ADC driver using the portability configuration which
+   * carries the temperature sensor conversion group.
+   */
+  msg = drvStart(&PORTAB_ADC, &portab_adc_config);
+  chDbgAssert(msg == HAL_RET_SUCCESS, "ADC start failed");
+
+  /*
+   * Normal main() thread activity, in this demo it fades the board LED
+   * through the PWM channel and, once per fade cycle, performs a
+   * synchronous conversion of the on-die temperature sensor printing
+   * the result together with the wrap events counter.
    */
   while (true) {
-    palToggleLine(PORTAB_LINE_LED);
-    chThdSleepMilliseconds(500);
+    /* One triangular fade cycle, one percent duty step every 10ms for
+       a two seconds cycle at a visibly smooth 1kHz PWM frequency.*/
+    for (i = 0U; i < 200U; i++) {
+      if (i < 100U) {
+        width = PWM_PERCENTAGE_TO_WIDTH(&PORTAB_PWM, i * 100U);
+      }
+      else {
+        width = PWM_PERCENTAGE_TO_WIDTH(&PORTAB_PWM, (200U - i) * 100U);
+      }
+      pwmEnableChannel(&PORTAB_PWM, PORTAB_PWM_CHANNEL, width);
+      chThdSleepMilliseconds(10);
+    }
+
+    /* Synchronous linear conversion of the temperature sensor group,
+       one sample per conversion.*/
+    msg = adcConvert(&PORTAB_ADC, PORTAB_ADC_TEMP_GRP, temp_sample, 1U);
+    if (msg == MSG_OK) {
+      tdc = temp_raw_to_dc(temp_sample[0]);
+      frac = tdc % 10;
+      if (frac < 0) {
+        frac = -frac;
+      }
+      print_str(stream, "temp raw=");
+      print_dec(stream, (int32_t)temp_sample[0]);
+      print_str(stream, " temp=");
+      if ((tdc < 0) && (tdc / 10 == 0)) {
+        print_str(stream, "-");
+      }
+      print_dec(stream, tdc / 10);
+      print_str(stream, ".");
+      print_dec(stream, frac);
+      print_str(stream, "C wraps=");
+      print_dec(stream, (int32_t)pwm_wraps);
+      print_str(stream, "\r\n");
+    }
+    else {
+      print_str(stream, "temp conversion failed\r\n");
+    }
   }
 }

--- a/os/xhal/ports/RP/LLD/ADCv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/ADCv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_ADC TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1/hal_adc_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1/hal_adc_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1

--- a/os/xhal/ports/RP/LLD/ADCv1/hal_adc_lld.c
+++ b/os/xhal/ports/RP/LLD/ADCv1/hal_adc_lld.c
@@ -1,0 +1,771 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ADCv1/hal_adc_lld.c
+ * @brief   RP ADC subsystem low level driver source.
+ *
+ * @addtogroup ADC
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_ADC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @name    PAD control register bits
+ * @{
+ */
+#define PADS_GPIO_IE                        (1U << 6)
+#define PADS_GPIO_OD                        (1U << 7)
+#define PADS_GPIO_PUE                       (1U << 3)
+#define PADS_GPIO_PDE                       (1U << 2)
+/** @} */
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/** @brief ADC1 driver identifier.*/
+#if (RP_ADC_USE_ADC1 == TRUE) || defined(__DOXYGEN__)
+hal_adc_driver_c ADCD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Conversion groups of the default configuration.
+ * @details A single conversion group sampling the on-die temperature
+ *          sensor at the free-running rate, one sample per buffer row.
+ */
+static const adc_conversion_groups_t adc_default_groups = {
+  .grpsnum      = 1U,
+  .grps         = {
+    {
+      .num_channels = 1U,
+      .channel      = ADC_CHANNEL_TEMPSENSOR,
+      .rrobin       = 0U,
+      .div          = 0U,
+      .ts_enabled   = true
+    }
+  }
+};
+
+/**
+ * @brief   Driver default configuration.
+ */
+static const hal_adc_config_t adc_default_config = {
+  .grps         = &adc_default_groups,
+  .dummy        = 0U
+};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Validates an ADC configuration.
+ * @details Every conversion group in the configuration is checked
+ *          against the channel complement and the register field
+ *          widths of the device. A configuration without conversion
+ *          groups is accepted, conversion starts are then rejected by
+ *          the group number guard.
+ *
+ * @param[in] config    pointer to the @p hal_adc_config_t structure
+ * @return              Configuration validity.
+ */
+static bool adc_lld_validate_config(const hal_adc_config_t *config) {
+  const adc_conversion_group_t *grpp;
+  unsigned i;
+
+  if (config->grps == NULL) {
+    return true;
+  }
+
+  for (i = 0U; i < config->grps->grpsnum; i++) {
+    grpp = &config->grps->grps[i];
+
+    /* At least one sample per buffer row.*/
+    if (grpp->num_channels == 0U) {
+      return false;
+    }
+
+    /* The first (or only) channel must exist on the device.*/
+    if (grpp->channel >= RP_ADC_NUM_CHANNELS) {
+      return false;
+    }
+
+    /* The round-robin mask must only select channels usable on the
+       device, checked unshifted so bits beyond the hardware field
+       cannot be discarded by the shift. The register field is wider
+       than the channel complement on some variants.*/
+    if ((grpp->rrobin & ~((1U << RP_ADC_NUM_CHANNELS) - 1U)) != 0U) {
+      return false;
+    }
+
+    if (grpp->rrobin == 0U) {
+      /* Single-channel mode, exactly one sample per buffer row.*/
+      if (grpp->num_channels != 1U) {
+        return false;
+      }
+    }
+    else {
+      /* Round-robin mode, one sample per selected channel: the FIFO
+         carries no channel tag so buffer positions can only be
+         attributed by the scan order, see the fields note in the
+         driver header.*/
+      if ((unsigned)grpp->num_channels !=
+          (unsigned)__builtin_popcount(grpp->rrobin)) {
+        return false;
+      }
+
+      /* The scan starts from the first channel which must therefore
+         be part of the selection.*/
+      if ((grpp->rrobin & (1U << grpp->channel)) == 0U) {
+        return false;
+      }
+    }
+
+    /* The divisor must fit the DIV integer and fractional fields.*/
+    if ((grpp->div & ~(ADC_DIV_INT_MASK | ADC_DIV_FRAC_MASK)) != 0U) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Drains the ADC FIFO.
+ * @note    Waits for any in-progress conversion to complete before draining.
+ *
+ * @param[in] adc       pointer to the ADC registers block
+ */
+static void adc_lld_drain_fifo(ADC_TypeDef *adc) {
+
+  /* Wait for any in-progress conversion to complete.*/
+  while ((adc->CS & ADC_CS_READY) == 0U) {
+  }
+
+  /* Drain all samples from FIFO.*/
+  while ((adc->FCS & ADC_FCS_EMPTY) == 0U) {
+    (void)adc->FIFO;
+  }
+}
+
+/**
+ * @brief   Common DMA channel service routine.
+ * @details Terminal events are mapped onto the shared ISR macros. In
+ *          circular mode the buffer is covered by two DMA channels
+ *          chained to each other, each owning one half (or the whole
+ *          single-row buffer when the depth is one): on completion the
+ *          hardware chain trigger starts the partner channel
+ *          immediately, without any re-arm dependency on this routine,
+ *          which only reprograms the just-completed channel for its
+ *          next turn and then invokes @p _adc_isr_half_code() or
+ *          @p _adc_isr_full_code(). In linear mode the completion of
+ *          the single channel invokes @p _adc_isr_full_code() which
+ *          terminates the conversion.
+ * @note    The reprogramming of a completed channel must happen before
+ *          the partner channel completion chains back into it, that is
+ *          within one half-buffer period instead of the FIFO depth
+ *          which bounded the classic re-arm scheme.
+ * @note    The DMA service dispatching the completions rewrites the
+ *          channel control register at dispatch time, the control word
+ *          is therefore fully re-established here. The @p AL1_CTRL
+ *          alias is not a trigger register so the channel can be
+ *          re-armed enabled without being started, only the partner
+ *          chain event starts it. There is no rp_dma helper accepting
+ *          a chain target, @p dmaChannelSetModeX() enforces
+ *          self-chaining, hence the direct register access through the
+ *          channel pointer.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ * @param[in] ct        content of the CTRL_TRIG register
+ * @param[in] second    true if the served channel is the second one of
+ *                      the circular ping-pong pair
+ */
+static void adc_lld_serve_channel_interrupt(hal_adc_driver_c *adcp,
+                                            uint32_t ct,
+                                            bool second) {
+
+  /* DMA errors handling.*/
+  if ((ct & (DMA_CTRL_TRIG_READ_ERROR | DMA_CTRL_TRIG_WRITE_ERROR)) != 0U) {
+    _adc_isr_error_code(adcp, ADC_ERR_DMAFAILURE);
+  }
+  else {
+    /* Conversion group may have been reset by error handler.*/
+    if (adcp->grpp != NULL) {
+      /* Checking for DMA transfer complete.*/
+      if ((ct & DMA_CTRL_TRIG_BUSY) == 0U) {
+        /* Check for ADC-level errors during transfer.*/
+        adcerror_t emask = 0U;
+        if ((adcp->adc->FCS & ADC_FCS_OVER) != 0U) {
+          emask |= ADC_ERR_OVERFLOW;
+        }
+        if ((adcp->adc->CS & ADC_CS_ERR_STICKY) != 0U) {
+          emask |= ADC_ERR_CONVERSION;
+        }
+        if (emask != 0U) {
+          _adc_isr_error_code(adcp, emask);
+        }
+        else if (adcp->state == ADC_ACTIVE_CIRCULAR) {
+          /* Geometry of the completed channel, with a single row
+             buffer both channels cover the whole buffer.*/
+          size_t total = (size_t)adcp->grpp->num_channels * adcp->depth;
+          size_t count = (adcp->depth > 1U) ? (total / 2U) : total;
+          const rp_dma_channel_t *dmachp = second ? adcp->dma2 : adcp->dma;
+          const rp_dma_channel_t *partner = second ? adcp->dma : adcp->dma2;
+          adcsample_t *base = adcp->samples;
+
+          if (second && (adcp->depth > 1U)) {
+            base = base + count;
+          }
+
+          /* Rewinding the write address of the just-completed channel
+             and re-arming it for its next turn, see the notes above.*/
+          dmaChannelSetDestinationX(dmachp, (uint32_t)base);
+          dmaChannelSetCounterX(dmachp, (uint32_t)count);
+          dmachp->channel->AL1_CTRL =
+            (adcp->dmamode & ~DMA_CTRL_TRIG_CHAIN_TO_Msk) |
+            DMA_CTRL_TRIG_CHAIN_TO(partner->chnidx) |
+            DMA_CTRL_TRIG_EN;
+
+          if (second || (adcp->depth == 1U)) {
+            _adc_isr_full_code(adcp);
+          }
+          else {
+            _adc_isr_half_code(adcp);
+          }
+        }
+        else {
+          /* Linear mode: transfer complete.*/
+          _adc_isr_full_code(adcp);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief   Main DMA channel service routine.
+ * @details Serves the completions of linear conversions and, in
+ *          circular mode, of the channel covering the first buffer
+ *          half.
+ *
+ * @param[in] p         parameter for the registered function
+ * @param[in] ct        content of the CTRL_TRIG register
+ */
+static void adc_lld_serve_dma_interrupt(void *p, uint32_t ct) {
+
+  adc_lld_serve_channel_interrupt((hal_adc_driver_c *)p, ct, false);
+}
+
+/**
+ * @brief   Second DMA channel service routine.
+ * @details Serves the completions of the channel covering the second
+ *          buffer half of circular conversions.
+ *
+ * @param[in] p         parameter for the registered function
+ * @param[in] ct        content of the CTRL_TRIG register
+ */
+static void adc_lld_serve_dma2_interrupt(void *p, uint32_t ct) {
+
+  adc_lld_serve_channel_interrupt((hal_adc_driver_c *)p, ct, true);
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level ADC driver initialization.
+ *
+ * @notapi
+ */
+void adc_lld_init(void) {
+
+#if RP_ADC_USE_ADC1 == TRUE
+  /* Driver initialization.*/
+  adcObjectInit(&ADCD1);
+  ADCD1.adc      = ADC;
+  ADCD1.dma      = NULL;
+  ADCD1.dma2     = NULL;
+  ADCD1.dmamode  = DMA_CTRL_TRIG_DATA_SIZE_HWORD |
+                   DMA_CTRL_TRIG_INCR_WRITE      |
+                   DMA_CTRL_TRIG_TREQ_ADC        |
+                   DMA_CTRL_TRIG_PRIORITY(RP_ADC_ADC1_DMA_PRIORITY);
+  ADCD1.ts_owned = false;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the ADC peripheral.
+ * @details The DMA channel is claimed and the ADC is taken out of reset
+ *          and enabled. Conversion parameters are programmed for each
+ *          conversion by @p adc_lld_start_conversion(), the associated
+ *          configuration only carries the conversion groups table.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t adc_lld_start(hal_adc_driver_c *adcp) {
+
+  /* Resources claim and peripheral activation.*/
+  if (false) {
+  }
+#if RP_ADC_USE_ADC1 == TRUE
+  else if (&ADCD1 == adcp) {
+    /* DMA channel allocation, the associated interrupt vector is
+       enabled by the allocator.*/
+    adcp->dma = dmaChannelAlloc(RP_ADC_ADC1_DMA_CHANNEL,
+                                RP_ADC_ADC1_DMA_IRQ_PRIORITY,
+                                adc_lld_serve_dma_interrupt,
+                                (void *)adcp);
+    if (adcp->dma == NULL) {
+      return HAL_RET_NO_RESOURCE;
+    }
+
+    /* Reset ADC peripheral.*/
+    rp_peripheral_reset(RESETS_ALLREG_ADC);
+    rp_peripheral_unreset(RESETS_ALLREG_ADC);
+  }
+#endif
+  else {
+    chDbgAssert(false, "invalid ADC instance");
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  /* Enable ADC and wait for readiness.*/
+  adcp->adc->CS = ADC_CS_EN;
+  while ((adcp->adc->CS & ADC_CS_READY) == 0U) {
+  }
+
+  /* Clear any pending FIFO errors and drain any samples in FIFO.*/
+  adcp->adc->FCS = ADC_FCS_UNDER | ADC_FCS_OVER;
+  adc_lld_drain_fifo(adcp->adc);
+
+  /* Set DMA source to ADC FIFO (constant across conversions).*/
+  dmaChannelSetSourceX(adcp->dma, (uint32_t)&adcp->adc->FIFO);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the ADC peripheral.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ *
+ * @notapi
+ */
+void adc_lld_stop(hal_adc_driver_c *adcp) {
+
+  /* If stopping then disables the ADC and releases the DMA channel.*/
+  if (adcp->state == HAL_DRV_STATE_STOPPING) {
+    /* Stop conversions. NOTE: CLR alias may also clear W1C ERR_STICKY
+       as a side-effect; acceptable during shutdown.*/
+    adcp->adc->CLR.CS = ADC_CS_START_MANY | ADC_CS_TS_EN;
+    adcp->ts_owned = false;
+
+    /* Quiesce the DMA channels, also in case this has been called
+       uncleanly. The second channel only exists while a circular
+       conversion is active, it is disabled first so that a completion
+       of the main channel cannot chain into it.*/
+    if (adcp->dma2 != NULL) {
+      syssts_t sts;
+
+      dmaChannelDisableX(adcp->dma2);
+      dmaChannelDisableInterruptX(adcp->dma2);
+      sts = chSysGetStatusAndLockX();
+      dmaChannelFreeI(adcp->dma2);
+      chSysRestoreStatusX(sts);
+      adcp->dma2 = NULL;
+    }
+    dmaChannelDisableX(adcp->dma);
+
+    /* Disable FIFO and DMA requests.*/
+    adcp->adc->FCS = 0U;
+
+    /* Drain FIFO.*/
+    adc_lld_drain_fifo(adcp->adc);
+
+    /* Disable ADC.*/
+    adcp->adc->CS = 0U;
+
+    /* Release DMA channel.*/
+    dmaChannelFree(adcp->dma);
+    adcp->dma = NULL;
+
+    /* Hold ADC in reset to gate the peripheral clock.*/
+    rp_peripheral_reset(RESETS_ALLREG_ADC);
+  }
+}
+
+/**
+ * @brief   ADC configuration.
+ * @details No hardware is programmed at configuration time, the
+ *          conversion groups carried by the configuration are validated
+ *          and programmed for each conversion start.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ * @param[in] config    pointer to the @p hal_adc_config_t structure
+ * @return              A pointer to the current configuration structure.
+ * @retval NULL         if the configuration failed.
+ *
+ * @notapi
+ */
+const hal_adc_config_t *adc_lld_setcfg(hal_adc_driver_c *adcp,
+                                       const hal_adc_config_t *config) {
+
+  (void)adcp;
+
+  if (config == NULL) {
+    config = &adc_default_config;
+  }
+
+  if (!adc_lld_validate_config(config)) {
+    return NULL;
+  }
+
+  return config;
+}
+
+/**
+ * @brief   Selects one of the pre-defined ADC configurations.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ * @param[in] cfgnum    driver configuration number
+ * @return              The configuration pointer.
+ *
+ * @notapi
+ */
+const hal_adc_config_t *adc_lld_selcfg(hal_adc_driver_c *adcp,
+                                       unsigned cfgnum) {
+#if ADC_USE_CONFIGURATIONS == TRUE
+  extern const adc_configurations_t adc_configurations;
+
+  if (cfgnum >= adc_configurations.cfgsnum) {
+    return NULL;
+  }
+
+  return adc_lld_setcfg(adcp, &adc_configurations.cfgs[cfgnum]);
+#else
+
+  if (cfgnum > 0U) {
+    return NULL;
+  }
+
+  return adc_lld_setcfg(adcp, NULL);
+#endif
+}
+
+/**
+ * @brief   ADC callback setting.
+ * @note    The callback is stored by the base class, it is invoked by
+ *          the shared ISR macros, nothing to do here.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ * @param[in] cb        callback function to be associated
+ *
+ * @notapi
+ */
+void adc_lld_set_callback(hal_adc_driver_c *adcp, drv_cb_t cb) {
+
+  (void)adcp;
+  (void)cb;
+}
+
+/**
+ * @brief   Starts an ADC conversion.
+ * @details Circular conversions claim a second DMA channel and chain
+ *          the two channels to each other in a ping-pong over the
+ *          buffer halves, see @p adc_lld_serve_channel_interrupt().
+ *          Linear conversions use the single allocated channel over
+ *          the full buffer.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ * @param[in] grpnum    conversion group number
+ * @param[out] samples  samples buffer
+ * @param[in] depth     buffer depth
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t adc_lld_start_conversion(hal_adc_driver_c *adcp, unsigned grpnum,
+                               adcsample_t *samples, size_t depth) {
+  const hal_adc_config_t *config = (const hal_adc_config_t *)adcp->config;
+  const adc_conversion_group_t *grpp;
+  bool circular = (adcp->state == ADC_ACTIVE_CIRCULAR);
+  uint32_t cs_val;
+  size_t total;
+
+  if ((config == NULL) || (config->grps == NULL) ||
+      (grpnum >= config->grps->grpsnum)) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  /* The half and full buffer events are defined over buffer halves,
+     circular buffers deeper than one row must therefore have an even
+     depth, matching the shared driver contract.*/
+  if (circular && (depth > 1U) && ((depth & 1U) != 0U)) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  grpp = &config->grps->grps[grpnum];
+  adcp->grpp = grpp;
+
+  /* Circular conversions use a second chained DMA channel, claimed
+     for the duration of the conversion only.*/
+  if (circular) {
+    syssts_t sts;
+
+    sts = chSysGetStatusAndLockX();
+    adcp->dma2 = dmaChannelAllocI(RP_DMA_CHANNEL_ID_ANY,
+                                  RP_ADC_ADC1_DMA_IRQ_PRIORITY,
+                                  adc_lld_serve_dma2_interrupt,
+                                  (void *)adcp);
+    chSysRestoreStatusX(sts);
+    if (adcp->dma2 == NULL) {
+      adcp->grpp = NULL;
+      return HAL_RET_NO_RESOURCE;
+    }
+    dmaChannelSetSourceX(adcp->dma2, (uint32_t)&adcp->adc->FIFO);
+  }
+
+  /* Clear any previous errors (SET alias writes 1 to W1C bits).*/
+  adcp->adc->SET.CS = ADC_CS_ERR_STICKY;
+  adcp->adc->FCS = ADC_FCS_UNDER | ADC_FCS_OVER;
+
+  /* Drain FIFO.*/
+  adc_lld_drain_fifo(adcp->adc);
+
+  /* Build CS register value.*/
+  cs_val = ADC_CS_EN |
+           ((grpp->channel << ADC_CS_AINSEL_POS) & ADC_CS_AINSEL_MASK);
+
+  /* Enable temperature sensor if needed, the bias is kept enabled only
+     while this group is converting, see adc_lld_stop_conversion().*/
+  if (grpp->ts_enabled) {
+    cs_val |= ADC_CS_TS_EN;
+  }
+  adcp->ts_owned = grpp->ts_enabled;
+
+  /* Configure round-robin if multiple channels.*/
+  if (grpp->rrobin != 0U) {
+    cs_val |= (grpp->rrobin << ADC_CS_RROBIN_POS) & RP_ADC_RROBIN_MASK;
+  }
+
+  /* Write CS without START_MANY first. AINSEL must be stable when
+     START_MANY transitions 0->1 to set the round-robin starting channel.*/
+  adcp->adc->CS = cs_val;
+
+  /* Configure clock divisor.*/
+  adcp->adc->DIV = grpp->div;
+
+  /* Configure FIFO: enable, DMA request, threshold = 1.*/
+  adcp->adc->FCS = ADC_FCS_EN | ADC_FCS_DREQ_EN | (1U << ADC_FCS_THRESH_POS);
+
+  /* DMA setup, the source addresses have been programmed at channel
+     claim time.*/
+  total = (size_t)grpp->num_channels * depth;
+  if (circular) {
+    size_t count;
+    adcsample_t *base2;
+
+    /* Each channel covers one buffer half, with a single row buffer
+       both cover the whole buffer.*/
+    if (depth > 1U) {
+      count = total / 2U;
+      base2 = samples + count;
+    }
+    else {
+      count = total;
+      base2 = samples;
+    }
+
+    /* NOTE: rp_dma.h offers no helper accepting a chain target,
+       dmaChannelSetModeX() enforces self-chaining, the control
+       registers are therefore programmed directly through the channel
+       pointers. The AL1_CTRL alias is not a trigger register so the
+       second channel can be armed enabled without being started, only
+       the chain event raised by the main channel completion starts
+       it.*/
+    dmaChannelSetDestinationX(adcp->dma, (uint32_t)samples);
+    dmaChannelSetCounterX(adcp->dma, (uint32_t)count);
+    adcp->dma->channel->AL1_CTRL =
+      (adcp->dmamode & ~DMA_CTRL_TRIG_CHAIN_TO_Msk) |
+      DMA_CTRL_TRIG_CHAIN_TO(adcp->dma2->chnidx);
+
+    dmaChannelSetDestinationX(adcp->dma2, (uint32_t)base2);
+    dmaChannelSetCounterX(adcp->dma2, (uint32_t)count);
+    adcp->dma2->channel->AL1_CTRL =
+      (adcp->dmamode & ~DMA_CTRL_TRIG_CHAIN_TO_Msk) |
+      DMA_CTRL_TRIG_CHAIN_TO(adcp->dma->chnidx) |
+      DMA_CTRL_TRIG_EN;
+
+    /* Enable DMA channel interrupts.*/
+    dmaChannelEnableInterruptX(adcp->dma);
+    dmaChannelEnableInterruptX(adcp->dma2);
+
+    /* Triggering the main channel, it starts on the first FIFO
+       request.*/
+    dmaChannelEnableX(adcp->dma);
+  }
+  else {
+    /* Linear conversion, single channel over the full buffer.*/
+    dmaChannelSetDestinationX(adcp->dma, (uint32_t)samples);
+    dmaChannelSetCounterX(adcp->dma, (uint32_t)total);
+    dmaChannelSetModeX(adcp->dma, adcp->dmamode);
+
+    /* Enable DMA channel interrupt.*/
+    dmaChannelEnableInterruptX(adcp->dma);
+
+    /* Enable DMA channel.*/
+    dmaChannelEnableX(adcp->dma);
+  }
+
+  /* Wait for ADC ready before starting conversion.*/
+  while ((adcp->adc->CS & ADC_CS_READY) == 0U) {
+  }
+
+  /* Start continuous conversion (second step: add START_MANY).*/
+  adcp->adc->CS = cs_val | ADC_CS_START_MANY;
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Stops an ongoing conversion.
+ * @details The second channel of a circular ping-pong, when present,
+ *          is quiesced and released and the temperature sensor bias is
+ *          disabled when it had been enabled on behalf of the group,
+ *          this also covers the terminal error paths which stop the
+ *          conversion from the ISR.
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ *
+ * @notapi
+ */
+void adc_lld_stop_conversion(hal_adc_driver_c *adcp) {
+
+  /* Stop conversions. Using CLR alias for atomic bit clear.*/
+  adcp->adc->CLR.CS = ADC_CS_START_MANY;
+
+  /* The second channel is disabled first so that a completion of the
+     main channel cannot chain into it during the teardown.*/
+  if (adcp->dma2 != NULL) {
+    dmaChannelDisableX(adcp->dma2);
+    dmaChannelDisableInterruptX(adcp->dma2);
+  }
+
+  /* Disable DMA channel.*/
+  dmaChannelDisableX(adcp->dma);
+  dmaChannelDisableInterruptX(adcp->dma);
+
+  /* Release the circular ping-pong channel.*/
+  if (adcp->dma2 != NULL) {
+    syssts_t sts;
+
+    sts = chSysGetStatusAndLockX();
+    dmaChannelFreeI(adcp->dma2);
+    chSysRestoreStatusX(sts);
+    adcp->dma2 = NULL;
+  }
+
+  /* The temperature sensor bias is kept enabled only while its group
+     is converting.*/
+  if (adcp->ts_owned) {
+    adcp->adc->CLR.CS = ADC_CS_TS_EN;
+    adcp->ts_owned = false;
+  }
+
+  /* Disable FIFO.*/
+  adcp->adc->FCS = 0U;
+
+  /* Drain FIFO.*/
+  adc_lld_drain_fifo(adcp->adc);
+}
+
+/**
+ * @brief   Enables the temperature sensor.
+ * @note    This is an RP-only functionality.
+ * @note    This function is meant to be called after @p drvStart().
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ *
+ * @notapi
+ */
+void adcRPEnableTS(hal_adc_driver_c *adcp) {
+
+  adcp->adc->SET.CS = ADC_CS_TS_EN;
+}
+
+/**
+ * @brief   Disables the temperature sensor.
+ * @note    This is an RP-only functionality.
+ * @note    This function is meant to be called after @p drvStart().
+ *
+ * @param[in] adcp      pointer to the @p hal_adc_driver_c object
+ *
+ * @notapi
+ */
+void adcRPDisableTS(hal_adc_driver_c *adcp) {
+
+  adcp->adc->CLR.CS = ADC_CS_TS_EN;
+}
+
+/**
+ * @brief   Configures a GPIO pin for ADC input.
+ * @note    Disables digital I/O and pulls for proper analog operation.
+ *
+ * @param[in] gpio      GPIO pin number (26-29 RP2040, 26-29/40-47 RP2350)
+ *
+ * @api
+ */
+void adcRPGpioInit(uint32_t gpio) {
+  uint32_t padbits;
+
+  /* Validate GPIO range. NUM_CHANNELS includes the temperature sensor
+     which has no GPIO pin, hence the -1.*/
+  chDbgCheck(gpio >= RP_ADC_BASE_PIN);
+  chDbgCheck(gpio < (RP_ADC_BASE_PIN + RP_ADC_NUM_CHANNELS - 1U));
+
+  /* FUNCSEL = NULL (31): disconnect digital output driver.*/
+  IO_BANK0->GPIO[gpio].CTRL = 31U;
+
+  /* Disable pulls and digital input, enable output disable.*/
+  padbits = PADS_BANK0->GPIO[gpio];
+  padbits &= ~(PADS_GPIO_PUE | PADS_GPIO_PDE | PADS_GPIO_IE);
+  padbits |= PADS_GPIO_OD;
+  PADS_BANK0->GPIO[gpio] = padbits;
+}
+
+#endif /* HAL_USE_ADC == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/ADCv1/hal_adc_lld.h
+++ b/os/xhal/ports/RP/LLD/ADCv1/hal_adc_lld.h
@@ -1,0 +1,349 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ADCv1/hal_adc_lld.h
+ * @brief   RP ADC subsystem low level driver header.
+ *
+ * @addtogroup ADC
+ * @{
+ */
+
+#ifndef HAL_ADC_LLD_H
+#define HAL_ADC_LLD_H
+
+#if (HAL_USE_ADC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    ADC CS register bits
+ * @{
+ */
+#define ADC_CS_EN                           (1U << 0)
+#define ADC_CS_TS_EN                        (1U << 1)
+#define ADC_CS_START_ONCE                   (1U << 2)
+#define ADC_CS_START_MANY                   (1U << 3)
+#define ADC_CS_READY                        (1U << 8)
+#define ADC_CS_ERR                          (1U << 9)
+#define ADC_CS_ERR_STICKY                   (1U << 10)
+#define ADC_CS_AINSEL_POS                   12U
+#define ADC_CS_AINSEL_MASK                  (((1U << RP_ADC_AINSEL_BITS) - 1U) \
+                                             << ADC_CS_AINSEL_POS)
+#define ADC_CS_RROBIN_POS                   16U
+/** @} */
+
+/**
+ * @name    ADC FCS register bits
+ * @{
+ */
+#define ADC_FCS_EN                          (1U << 0)
+#define ADC_FCS_SHIFT                       (1U << 1)
+#define ADC_FCS_ERR                         (1U << 2)
+#define ADC_FCS_DREQ_EN                     (1U << 3)
+#define ADC_FCS_EMPTY                       (1U << 8)
+#define ADC_FCS_FULL                        (1U << 9)
+#define ADC_FCS_UNDER                       (1U << 10)
+#define ADC_FCS_OVER                        (1U << 11)
+#define ADC_FCS_LEVEL_POS                   16U
+#define ADC_FCS_LEVEL_MASK                  (0xFU << ADC_FCS_LEVEL_POS)
+#define ADC_FCS_THRESH_POS                  24U
+#define ADC_FCS_THRESH_MASK                 (0xFU << ADC_FCS_THRESH_POS)
+/** @} */
+
+/**
+ * @name    ADC DIV register bits
+ * @{
+ */
+#define ADC_DIV_FRAC_POS                    0U
+#define ADC_DIV_FRAC_MASK                   (0xFFU << ADC_DIV_FRAC_POS)
+#define ADC_DIV_INT_POS                     8U
+#define ADC_DIV_INT_MASK                    (0xFFFFU << ADC_DIV_INT_POS)
+/** @} */
+
+/**
+ * @name    ADC FIFO register bits
+ * @{
+ */
+#define ADC_FIFO_VAL_MASK                   0x0FFFU
+#define ADC_FIFO_ERR                        (1U << 15)
+/** @} */
+
+/**
+ * @name    Possible ADC errors mask bits
+ * @{
+ */
+#define ADC_ERR_DMAFAILURE                  1U  /**< DMA operations failure.  */
+#define ADC_ERR_OVERFLOW                    2U  /**< ADC FIFO overflow.       */
+#define ADC_ERR_UNDERFLOW                   4U  /**< ADC FIFO underflow.      */
+#define ADC_ERR_CONVERSION                  8U  /**< ADC conversion error.    */
+/** @} */
+
+/**
+ * @name    ADC channel definitions
+ * @{
+ */
+#define ADC_CHANNEL_IN0                     0U
+#define ADC_CHANNEL_IN1                     1U
+#define ADC_CHANNEL_IN2                     2U
+#define ADC_CHANNEL_IN3                     3U
+#define ADC_CHANNEL_TEMPSENSOR              RP_ADC_TEMPERATURE_CHANNEL
+
+#if (RP_ADC_NUM_CHANNELS > 5U) || defined(__DOXYGEN__)
+#define ADC_CHANNEL_IN4                     4U
+#define ADC_CHANNEL_IN5                     5U
+#define ADC_CHANNEL_IN6                     6U
+#define ADC_CHANNEL_IN7                     7U
+#endif
+/** @} */
+
+/**
+ * @name    Channel selection helper macros
+ * @{
+ */
+#define ADC_CHSELR_CHSEL(n)                 (1U << (n))
+#define ADC_CHSELR_CHSEL0                   (1U << 0)
+#define ADC_CHSELR_CHSEL1                   (1U << 1)
+#define ADC_CHSELR_CHSEL2                   (1U << 2)
+#define ADC_CHSELR_CHSEL3                   (1U << 3)
+#define ADC_CHSELR_CHSEL4                   (1U << 4)
+
+#if (RP_ADC_NUM_CHANNELS > 5U) || defined(__DOXYGEN__)
+#define ADC_CHSELR_CHSEL5                   (1U << 5)
+#define ADC_CHSELR_CHSEL6                   (1U << 6)
+#define ADC_CHSELR_CHSEL7                   (1U << 7)
+#define ADC_CHSELR_CHSEL8                   (1U << 8)
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   ADC1 driver enable switch.
+ * @details If set to @p TRUE the support for ADC1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_ADC_USE_ADC1) || defined(__DOXYGEN__)
+#define RP_ADC_USE_ADC1                     FALSE
+#endif
+
+/**
+ * @brief   ADC1 DMA channel setting.
+ * @note    Circular conversions additionally claim a second,
+ *          dynamically selected DMA channel for the duration of the
+ *          conversion, see the ping-pong notes in the driver source.
+ */
+#if !defined(RP_ADC_ADC1_DMA_CHANNEL) || defined(__DOXYGEN__)
+#define RP_ADC_ADC1_DMA_CHANNEL             RP_DMA_CHANNEL_ID_ANY
+#endif
+
+/**
+ * @brief   ADC1 DMA priority (0..1).
+ */
+#if !defined(RP_ADC_ADC1_DMA_PRIORITY) || defined(__DOXYGEN__)
+#define RP_ADC_ADC1_DMA_PRIORITY            0
+#endif
+
+/**
+ * @brief   ADC1 DMA interrupt priority level setting.
+ */
+#if !defined(RP_ADC_ADC1_DMA_IRQ_PRIORITY) || defined(__DOXYGEN__)
+#define RP_ADC_ADC1_DMA_IRQ_PRIORITY        3
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness.*/
+#if !defined(RP_HAS_ADC)
+#error "RP_HAS_ADC not defined in registry"
+#endif
+
+#if !defined(RP_ADC_NUM_CHANNELS)
+#error "RP_ADC_NUM_CHANNELS not defined in registry"
+#endif
+
+#if !defined(RP_ADC_TEMPERATURE_CHANNEL)
+#error "RP_ADC_TEMPERATURE_CHANNEL not defined in registry"
+#endif
+
+#if !defined(RP_ADC_AINSEL_BITS)
+#error "RP_ADC_AINSEL_BITS not defined in registry"
+#endif
+
+#if !defined(RP_ADC_RROBIN_MASK)
+#error "RP_ADC_RROBIN_MASK not defined in registry"
+#endif
+
+/* Device selection checks.*/
+#if RP_ADC_USE_ADC1 && !RP_HAS_ADC
+#error "ADC1 not present in the selected device"
+#endif
+
+/* At least one ADC must be assigned.*/
+#if !RP_ADC_USE_ADC1
+#error "ADC driver activated but no ADC peripheral assigned"
+#endif
+
+/* DMA priority checks.*/
+#if RP_ADC_USE_ADC1 &&                                                      \
+    !RP_DMA_IS_VALID_PRIORITY(RP_ADC_ADC1_DMA_PRIORITY)
+#error "Invalid DMA priority assigned to ADC1"
+#endif
+
+/* DMA channel checks.*/
+#if RP_ADC_USE_ADC1 &&                                                      \
+    !RP_DMA_IS_VALID_CHANNEL(RP_ADC_ADC1_DMA_CHANNEL)
+#error "Invalid DMA channel assigned to ADC1"
+#endif
+
+/* IRQ priority checks. The priority is used for the DMA channels vector
+   whose handler interacts with the kernel, therefore a kernel-compatible
+   priority is required.*/
+#if RP_ADC_USE_ADC1 &&                                                      \
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_ADC_ADC1_DMA_IRQ_PRIORITY)
+#error "Invalid IRQ priority assigned to ADC1"
+#endif
+
+/* Forcing inclusion of the DMA support driver.*/
+#if !defined(RP_DMA_REQUIRED)
+#define RP_DMA_REQUIRED
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   ADC sample data type.
+ */
+typedef uint16_t adcsample_t;
+
+/**
+ * @brief   Channels number in a conversion group.
+ */
+typedef uint16_t adc_channels_num_t;
+
+/**
+ * @brief   Type of an ADC error mask.
+ */
+typedef uint32_t adcerror_t;
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level fields of the ADC driver structure.
+ */
+#define adc_lld_driver_fields                                               \
+  /* Pointer to the ADC registers block.*/                                  \
+  ADC_TypeDef               *adc;                                           \
+  /* Pointer to associated DMA channel.*/                                   \
+  const rp_dma_channel_t    *dma;                                           \
+  /* Pointer to the second DMA channel chained to the first one by         \
+     circular conversions, NULL when no circular conversion is             \
+     active.*/                                                              \
+  const rp_dma_channel_t    *dma2;                                          \
+  /* DMA mode bit mask.*/                                                   \
+  uint32_t                  dmamode;                                        \
+  /* True while the temperature sensor bias is enabled on behalf of        \
+     the active conversion group.*/                                         \
+  bool                      ts_owned
+
+/**
+ * @brief   Low level fields of the ADC configuration structure.
+ */
+#define adc_lld_config_fields                                               \
+  /* Dummy configuration, it is not needed.*/                               \
+  uint32_t                  dummy
+
+/**
+ * @brief   Low level fields of the ADC configuration group structure.
+ *
+ * @note    The ADC FIFO carries no channel tag: samples land in the
+ *          buffer in round-robin scan order, ascending channel index
+ *          starting from @p channel and wrapping over the @p rrobin
+ *          selection. Buffer positions can only be attributed to
+ *          channels through this ordering, see the field comments.
+ */
+#define adc_lld_configuration_group_fields                                  \
+  /* ADC channel number (0-4 RP2040, 0-8 RP2350B).                          \
+     Single-channel: the channel to sample. Round-robin: first channel.*/   \
+  uint32_t                  channel;                                        \
+  /* Round-robin channel mask (0 = single-channel mode, num_channels        \
+     must then be 1). Channels are sampled in ascending bit order,          \
+     e.g. 0x0F = ch0-3. A non-zero mask must select exactly                 \
+     num_channels channels and must include the first channel.*/            \
+  uint32_t                  rrobin;                                         \
+  /* Clock divisor: 0 = free-running 500 kS/s, else                         \
+     rate = 48 MHz / (1 + INT + FRAC/256). Use @p ADC_DIV(i, f).*/          \
+  uint32_t                  div;                                            \
+  /* Enable temperature sensor (set to true when using temp sensor ch).*/   \
+  bool                      ts_enabled
+
+/**
+ * @brief   Macro to build clock divisor value.
+ *
+ * @param[in] i         integer part of divisor (0-65535)
+ * @param[in] f         fractional part of divisor (0-255)
+ */
+#define ADC_DIV(i, f)                       (((uint32_t)(i) << 8U) | (uint32_t)(f))
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (RP_ADC_USE_ADC1 == TRUE) && !defined(__DOXYGEN__)
+extern hal_adc_driver_c ADCD1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void adc_lld_init(void);
+  msg_t adc_lld_start(hal_adc_driver_c *adcp);
+  void adc_lld_stop(hal_adc_driver_c *adcp);
+  const hal_adc_config_t *adc_lld_setcfg(hal_adc_driver_c *adcp,
+                                         const hal_adc_config_t *config);
+  const hal_adc_config_t *adc_lld_selcfg(hal_adc_driver_c *adcp,
+                                         unsigned cfgnum);
+  void adc_lld_set_callback(hal_adc_driver_c *adcp, drv_cb_t cb);
+  msg_t adc_lld_start_conversion(hal_adc_driver_c *adcp, unsigned grpnum,
+                                 adcsample_t *samples, size_t depth);
+  void adc_lld_stop_conversion(hal_adc_driver_c *adcp);
+  void adcRPEnableTS(hal_adc_driver_c *adcp);
+  void adcRPDisableTS(hal_adc_driver_c *adcp);
+  void adcRPGpioInit(uint32_t gpio);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_ADC == TRUE */
+
+#endif /* HAL_ADC_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/PWMv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/PWMv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_PWM TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1

--- a/os/xhal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
+++ b/os/xhal/ports/RP/LLD/PWMv1/hal_pwm_lld.c
@@ -1,0 +1,872 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    PWMv1/hal_pwm_lld.c
+ * @brief   RP PWM subsystem low level driver source.
+ *
+ * @addtogroup PWM
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_PWM == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   PWMD0 driver identifier.
+ * @note    The driver PWMD0 allocates the PWM slice 0 when enabled.
+ */
+#if (RP_PWM_USE_PWM0 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD0;
+#endif
+
+/**
+ * @brief   PWMD1 driver identifier.
+ * @note    The driver PWMD1 allocates the PWM slice 1 when enabled.
+ */
+#if (RP_PWM_USE_PWM1 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD1;
+#endif
+
+/**
+ * @brief   PWMD2 driver identifier.
+ * @note    The driver PWMD2 allocates the PWM slice 2 when enabled.
+ */
+#if (RP_PWM_USE_PWM2 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD2;
+#endif
+
+/**
+ * @brief   PWMD3 driver identifier.
+ * @note    The driver PWMD3 allocates the PWM slice 3 when enabled.
+ */
+#if (RP_PWM_USE_PWM3 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD3;
+#endif
+
+/**
+ * @brief   PWMD4 driver identifier.
+ * @note    The driver PWMD4 allocates the PWM slice 4 when enabled.
+ */
+#if (RP_PWM_USE_PWM4 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD4;
+#endif
+
+/**
+ * @brief   PWMD5 driver identifier.
+ * @note    The driver PWMD5 allocates the PWM slice 5 when enabled.
+ */
+#if (RP_PWM_USE_PWM5 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD5;
+#endif
+
+/**
+ * @brief   PWMD6 driver identifier.
+ * @note    The driver PWMD6 allocates the PWM slice 6 when enabled.
+ */
+#if (RP_PWM_USE_PWM6 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD6;
+#endif
+
+/**
+ * @brief   PWMD7 driver identifier.
+ * @note    The driver PWMD7 allocates the PWM slice 7 when enabled.
+ */
+#if (RP_PWM_USE_PWM7 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD7;
+#endif
+
+/**
+ * @brief   PWMD8 driver identifier.
+ * @note    The driver PWMD8 allocates the PWM slice 8 when enabled.
+ */
+#if (RP_PWM_USE_PWM8 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD8;
+#endif
+
+/**
+ * @brief   PWMD9 driver identifier.
+ * @note    The driver PWMD9 allocates the PWM slice 9 when enabled.
+ */
+#if (RP_PWM_USE_PWM9 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD9;
+#endif
+
+/**
+ * @brief   PWMD10 driver identifier.
+ * @note    The driver PWMD10 allocates the PWM slice 10 when enabled.
+ */
+#if (RP_PWM_USE_PWM10 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD10;
+#endif
+
+/**
+ * @brief   PWMD11 driver identifier.
+ * @note    The driver PWMD11 allocates the PWM slice 11 when enabled.
+ */
+#if (RP_PWM_USE_PWM11 == TRUE) || defined(__DOXYGEN__)
+hal_pwm_driver_c PWMD11;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver default configuration.
+ * @note    A 1MHz counter clock over the full 16-bit counter range, both
+ *          channel outputs disabled and no events initially enabled.
+ */
+static const hal_pwm_config_t pwm_default_config = {
+  .frequency      = 1000000U,
+  .period         = 65536U,
+  .enabled_events = 0U,
+  .channels       = {
+    { .mode = PWM_OUTPUT_DISABLED },
+    { .mode = PWM_OUTPUT_DISABLED }
+  },
+  .dummy          = 0U
+};
+
+/**
+ * @brief   Lifecycle state of the shared PWM block.
+ * @details The reset line and the wrap interrupt vector are shared by
+ *          all slices, the masks below arbitrate the first-user
+ *          activation and the last-user teardown of those resources in
+ *          software. The hardware @p EN register cannot be used for
+ *          this purpose because a stopping slice could reset the block
+ *          while another slice start is between the block unreset and
+ *          its counter enable.
+ * @note    All transitions are performed within critical sections, the
+ *          system lock is cross-core on SMP configurations so starts
+ *          and stops performed by both cores are serialized.
+ */
+static struct {
+  /**
+   * @brief   Mask of the slices currently owning the shared block.
+   */
+  uint32_t                  active_mask;
+  /**
+   * @brief   Mask of the slices with a start in progress.
+   * @details A starting slice references the shared block before its
+   *          registers are programmed so that a concurrent last-user
+   *          stop cannot reset the block nor disable the vector while
+   *          the activation is in progress.
+   */
+  uint32_t                  starting_mask;
+  /**
+   * @brief   Core owning the wrap interrupt vector.
+   * @details Only meaningful while at least one of the masks above is
+   *          not empty, see the SMP notes in the driver header.
+   */
+  uint32_t                  irq_core;
+} pwm_lld_lifecycle;
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Computes the divider register value for a configuration.
+ * @details The counter clock divider is an 8.4 fixed point value,
+ *          computed in 64 bits in order not to overflow at high system
+ *          clocks.
+ *
+ * @param[in] config    pointer to the @p hal_pwm_config_t structure
+ * @return              The divider register value.
+ * @retval 0            if the frequency is zero or the required divider
+ *                      falls outside the 1.0 to 255+15/16 hardware
+ *                      range.
+ */
+static uint32_t pwm_lld_get_divider(const hal_pwm_config_t *config) {
+  halfreq_t sys_clk;
+  uint32_t div_fp4;
+
+  /* A zero frequency cannot be represented by the divider and would
+     make the division below meaningless.*/
+  if (config->frequency == 0U) {
+    return 0U;
+  }
+
+  sys_clk = halClockGetPointX(RP_CLK_SYS);
+  div_fp4 = (uint32_t)(((uint64_t)sys_clk << 4) / config->frequency);
+  if ((div_fp4 < 0x010U) || (div_fp4 > 0xFFFU)) {
+    return 0U;
+  }
+
+  return div_fp4;
+}
+
+/**
+ * @brief   Validates a PWM configuration.
+ * @details No hardware is accessed, the configuration can be validated
+ *          while the shared block is still in reset.
+ *
+ * @param[in] config    pointer to the @p hal_pwm_config_t structure
+ * @return              Configuration validity.
+ */
+static bool pwm_lld_is_valid_config(const hal_pwm_config_t *config) {
+  unsigned i;
+
+  /* The counter counts from zero to TOP included, valid periods span
+     one tick to the full 16-bit range plus one.*/
+  if ((config->period < 1U) || (config->period > 65536U)) {
+    return false;
+  }
+
+  /* Only the period event exists on this hardware, see the events
+     limitation note in the driver header.*/
+  if ((config->enabled_events & ~(pwm_events_t)PWM_EVENT_PERIOD) != 0U) {
+    return false;
+  }
+
+  /* Only the known channel output modes are accepted, unknown modes
+     are rejected instead of being silently treated as disabled.*/
+  for (i = 0U; i < (unsigned)PWM_CHANNELS; i++) {
+    switch (config->channels[i].mode & PWM_OUTPUT_MASK) {
+    case PWM_OUTPUT_DISABLED:
+    case PWM_OUTPUT_ACTIVE_HIGH:
+    case PWM_OUTPUT_ACTIVE_LOW:
+      break;
+    default:
+      return false;
+    }
+  }
+
+  /* The divider must be representable.*/
+  if (pwm_lld_get_divider(config) == 0U) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Applies a validated configuration to a slice.
+ * @details The slice is quiesced during the divider and top changes:
+ *          the enable bit is dropped, the wrap event for this slice is
+ *          masked and any latched request is discarded, then the
+ *          counter and the compares are cleared before reprogramming.
+ *          This is the classic driver re-configuration sequence, active
+ *          channels do not survive a reconfiguration.
+ * @pre     The configuration has been validated by
+ *          @p pwm_lld_is_valid_config() and the shared block is out of
+ *          reset.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] config    pointer to the @p hal_pwm_config_t structure
+ */
+static void pwm_lld_apply_config(hal_pwm_driver_c *pwmp,
+                                 const hal_pwm_config_t *config) {
+  PWM_TypeDef *p = pwmp->pwm;
+  uint32_t csr;
+
+  /* Quiescing the slice, see the details in the function description.*/
+  p->CLR.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
+  p->CH[pwmp->timer_id].CSR = 0U;
+  p->CH[pwmp->timer_id].CTR = 0U;
+  p->CH[pwmp->timer_id].CC  = 0U;
+  p->INTR = PWM_INTR_CH(pwmp->timer_id);
+
+  p->CH[pwmp->timer_id].DIV = pwm_lld_get_divider(config);
+
+  /* The counter counts from zero to TOP included so the register must
+     be programmed with one count less than the requested period.*/
+  p->CH[pwmp->timer_id].TOP = (uint32_t)(config->period - 1U);
+
+  /* Free-running trailing-edge modulation, phase-correct mode is not
+     used by this driver. Only the active low modes invert the outputs,
+     the channel modes have been validated already.*/
+  csr = PWM_CSR_EN | PWM_CSR_DIVMODE_FREE;
+  if ((config->channels[0].mode & PWM_OUTPUT_MASK) == PWM_OUTPUT_ACTIVE_LOW) {
+    csr |= PWM_CSR_A_INV;
+  }
+  if ((config->channels[1].mode & PWM_OUTPUT_MASK) == PWM_OUTPUT_ACTIVE_LOW) {
+    csr |= PWM_CSR_B_INV;
+  }
+  p->CH[pwmp->timer_id].CSR = csr;
+
+  /* Bookkeeping fields of the upper driver, on this platform the low
+     level driver owns the register programming and keeps these
+     consistent also on live reconfigurations.*/
+  pwmp->period         = config->period;
+  pwmp->enabled        = 0U;
+  pwmp->enabled_events = config->enabled_events;
+
+  /* Initially enabled events, only the period event can get here.*/
+  if ((config->enabled_events & PWM_EVENT_PERIOD) != 0U) {
+    p->SET.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
+  }
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if (RP_PWM_USE_PWM0 == TRUE) || (RP_PWM_USE_PWM1 == TRUE) || \
+    (RP_PWM_USE_PWM2 == TRUE) || (RP_PWM_USE_PWM3 == TRUE) || \
+    (RP_PWM_USE_PWM4 == TRUE) || (RP_PWM_USE_PWM5 == TRUE) || \
+    (RP_PWM_USE_PWM6 == TRUE) || (RP_PWM_USE_PWM7 == TRUE) || \
+    defined(__DOXYGEN__)
+#define RP_PWM_USE_ANY_PWM07 TRUE
+#else
+#define RP_PWM_USE_ANY_PWM07 FALSE
+#endif
+
+#if (RP_HAS_PWM8 == TRUE)
+#if (RP_PWM_USE_PWM8 == TRUE)  || (RP_PWM_USE_PWM9 == TRUE) || \
+    (RP_PWM_USE_PWM10 == TRUE) || (RP_PWM_USE_PWM11 == TRUE)
+#define RP_PWM_USE_ANY_PWM811 TRUE
+#else
+#define RP_PWM_USE_ANY_PWM811 FALSE
+#endif
+#else
+#define RP_PWM_USE_ANY_PWM811 FALSE
+#endif
+
+#if (RP_PWM_USE_ANY_PWM07 == TRUE) || (RP_PWM_USE_ANY_PWM811 == TRUE) || \
+    defined(__DOXYGEN__)
+/**
+ * @brief   PWM wrap 0 interrupt handler.
+ * @note    The vector is shared by all slices, on the RP2350 all slice
+ *          wrap events are kept routed to this vector as in the classic
+ *          driver and the wrap 1 vector is not used.
+ * @note    The masked status is read once and dispatched per-slice, the
+ *          vector is enabled on a single core only so no concurrent
+ *          dispatch can consume the snapshot, see the SMP notes in the
+ *          driver header.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_PWM_IRQ_WRAP_0_HANDLER) {
+  uint32_t ints;
+
+  CH_IRQ_PROLOGUE();
+
+  ints = PWM->IRQ0_INTS;
+
+#if RP_PWM_USE_PWM0 == TRUE
+  if ((ints & PWM_INTS_CH(0)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD0);
+  }
+#endif
+
+#if RP_PWM_USE_PWM1 == TRUE
+  if ((ints & PWM_INTS_CH(1)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD1);
+  }
+#endif
+
+#if RP_PWM_USE_PWM2 == TRUE
+  if ((ints & PWM_INTS_CH(2)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD2);
+  }
+#endif
+
+#if RP_PWM_USE_PWM3 == TRUE
+  if ((ints & PWM_INTS_CH(3)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD3);
+  }
+#endif
+
+#if RP_PWM_USE_PWM4 == TRUE
+  if ((ints & PWM_INTS_CH(4)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD4);
+  }
+#endif
+
+#if RP_PWM_USE_PWM5 == TRUE
+  if ((ints & PWM_INTS_CH(5)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD5);
+  }
+#endif
+
+#if RP_PWM_USE_PWM6 == TRUE
+  if ((ints & PWM_INTS_CH(6)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD6);
+  }
+#endif
+
+#if RP_PWM_USE_PWM7 == TRUE
+  if ((ints & PWM_INTS_CH(7)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD7);
+  }
+#endif
+
+#if RP_PWM_USE_PWM8 == TRUE
+  if ((ints & PWM_INTS_CH(8)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD8);
+  }
+#endif
+
+#if RP_PWM_USE_PWM9 == TRUE
+  if ((ints & PWM_INTS_CH(9)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD9);
+  }
+#endif
+
+#if RP_PWM_USE_PWM10 == TRUE
+  if ((ints & PWM_INTS_CH(10)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD10);
+  }
+#endif
+
+#if RP_PWM_USE_PWM11 == TRUE
+  if ((ints & PWM_INTS_CH(11)) != 0U) {
+    pwm_lld_serve_interrupt(&PWMD11);
+  }
+#endif
+
+  CH_IRQ_EPILOGUE();
+}
+
+#endif
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level PWM driver initialization.
+ *
+ * @notapi
+ */
+void pwm_lld_init(void) {
+
+  /* Reset PWM peripheral once for all slices. */
+  rp_peripheral_reset(RESETS_ALLREG_PWM);
+
+#if RP_PWM_USE_PWM0 == TRUE
+  pwmObjectInit(&PWMD0);
+  PWMD0.pwm = PWM;
+  PWMD0.timer_id = 0;
+  PWMD0.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM1 == TRUE
+  pwmObjectInit(&PWMD1);
+  PWMD1.pwm = PWM;
+  PWMD1.timer_id = 1;
+  PWMD1.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM2 == TRUE
+  pwmObjectInit(&PWMD2);
+  PWMD2.pwm = PWM;
+  PWMD2.timer_id = 2;
+  PWMD2.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM3 == TRUE
+  pwmObjectInit(&PWMD3);
+  PWMD3.pwm = PWM;
+  PWMD3.timer_id = 3;
+  PWMD3.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM4 == TRUE
+  pwmObjectInit(&PWMD4);
+  PWMD4.pwm = PWM;
+  PWMD4.timer_id = 4;
+  PWMD4.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM5 == TRUE
+  pwmObjectInit(&PWMD5);
+  PWMD5.pwm = PWM;
+  PWMD5.timer_id = 5;
+  PWMD5.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM6 == TRUE
+  pwmObjectInit(&PWMD6);
+  PWMD6.pwm = PWM;
+  PWMD6.timer_id = 6;
+  PWMD6.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM7 == TRUE
+  pwmObjectInit(&PWMD7);
+  PWMD7.pwm = PWM;
+  PWMD7.timer_id = 7;
+  PWMD7.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM8 == TRUE
+  pwmObjectInit(&PWMD8);
+  PWMD8.pwm = PWM;
+  PWMD8.timer_id = 8;
+  PWMD8.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM9 == TRUE
+  pwmObjectInit(&PWMD9);
+  PWMD9.pwm = PWM;
+  PWMD9.timer_id = 9;
+  PWMD9.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM10 == TRUE
+  pwmObjectInit(&PWMD10);
+  PWMD10.pwm = PWM;
+  PWMD10.timer_id = 10;
+  PWMD10.channels = PWM_CHANNELS;
+#endif
+
+#if RP_PWM_USE_PWM11 == TRUE
+  pwmObjectInit(&PWMD11);
+  PWMD11.pwm = PWM;
+  PWMD11.timer_id = 11;
+  PWMD11.channels = PWM_CHANNELS;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the PWM peripheral.
+ * @details The retained configuration is validated first, then the
+ *          shared block is acquired: the first user takes it out of
+ *          reset and enables the wrap vector on the calling core, which
+ *          becomes the vector owner, see the SMP notes in the driver
+ *          header. The slice is programmed only after the acquisition
+ *          so its registers, including the wrap interrupt enable, are
+ *          never touched while the block can be in reset.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t pwm_lld_start(hal_pwm_driver_c *pwmp) {
+  const hal_pwm_config_t *config;
+  uint32_t slice_mask;
+  syssts_t sts;
+
+  /* Validation of the retained configuration, a NULL configuration
+     selects the driver default. In the STARTING state the
+     configuration method performs no hardware access so the shared
+     block can still be in reset here.*/
+  config = pwm_lld_setcfg(pwmp, (const hal_pwm_config_t *)pwmp->config);
+  if (config == NULL) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+  pwmp->config = config;
+
+  /* Shared resources acquisition, the whole transition is performed
+     inside a critical section so a concurrent transition from the
+     other core cannot interleave with it.*/
+  slice_mask = 1U << pwmp->timer_id;
+  sts = chSysGetStatusAndLockX();
+  if ((pwm_lld_lifecycle.active_mask | pwm_lld_lifecycle.starting_mask)
+      == 0U) {
+    rp_peripheral_unreset(RESETS_ALLREG_PWM);
+    nvicEnableVector(RP_PWM_IRQ_WRAP_0_NUMBER,
+                     RP_PWM_IRQ_WRAP_NUMBER_PRIORITY);
+    pwm_lld_lifecycle.irq_core = SIO->CPUID;
+  }
+  pwm_lld_lifecycle.starting_mask |= slice_mask;
+  chSysRestoreStatusX(sts);
+
+  /* Programming the slice, the block is out of reset and referenced by
+     this slice so a concurrent last-user stop cannot reset it.*/
+  pwm_lld_apply_config(pwmp, config);
+
+  /* The slice becomes an active user of the shared block.*/
+  sts = chSysGetStatusAndLockX();
+  pwm_lld_lifecycle.starting_mask &= ~slice_mask;
+  pwm_lld_lifecycle.active_mask   |= slice_mask;
+  chSysRestoreStatusX(sts);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the PWM peripheral.
+ * @details The slice is quiesced, then the shared block is released:
+ *          the last user disables the wrap vector and resets the block
+ *          within a critical section, serialized against concurrent
+ *          slice starts on the other core. The last-user stop must be
+ *          performed on the vector owner core, see the SMP notes in the
+ *          driver header.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ *
+ * @notapi
+ */
+void pwm_lld_stop(hal_pwm_driver_c *pwmp) {
+  PWM_TypeDef *p = pwmp->pwm;
+  uint32_t slice_mask;
+  syssts_t sts;
+
+  /* Disabling this slice wrap interrupt first, the vector is shared
+     among all slices and must not be able to fire for a stopped
+     driver.*/
+  p->CLR.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
+
+  p->CH[pwmp->timer_id].CSR = 0U;
+  p->CH[pwmp->timer_id].CTR = 0U;
+  p->CH[pwmp->timer_id].CC  = 0U;
+  p->CH[pwmp->timer_id].DIV = 1U;
+  p->CH[pwmp->timer_id].TOP = 0xFFFF;
+
+  /* Clearing any interrupt request still latched for this slice.*/
+  p->INTR = PWM_INTR_CH(pwmp->timer_id);
+
+  /* Shared resources release, starts in progress on the other core
+     hold a reference through the starting mask so the teardown cannot
+     happen under them.*/
+  slice_mask = 1U << pwmp->timer_id;
+  sts = chSysGetStatusAndLockX();
+  pwm_lld_lifecycle.active_mask &= ~slice_mask;
+  if ((pwm_lld_lifecycle.active_mask | pwm_lld_lifecycle.starting_mask)
+      == 0U) {
+    /* The vector can only be disabled on the core owning it, see the
+       SMP notes in the driver header.*/
+    chDbgAssert(pwm_lld_lifecycle.irq_core == SIO->CPUID,
+                "wrap vector owned by the other core");
+    nvicDisableVector(RP_PWM_IRQ_WRAP_0_NUMBER);
+    rp_peripheral_reset(RESETS_ALLREG_PWM);
+  }
+  chSysRestoreStatusX(sts);
+}
+
+/**
+ * @brief   PWM slice configuration.
+ * @details In the STARTING driver state the configuration is only
+ *          validated: the shared PWM block may still be in reset and
+ *          the slice does not own the shared resources yet, so
+ *          @p pwm_lld_start() applies the returned configuration after
+ *          the resources acquisition. In the READY state the
+ *          configuration is validated and applied to the slice, active
+ *          channels do not survive a live reconfiguration.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] config    pointer to the @p hal_pwm_config_t structure
+ * @return              A pointer to the current configuration structure.
+ * @retval NULL         if the configuration failed.
+ *
+ * @notapi
+ */
+const hal_pwm_config_t *pwm_lld_setcfg(hal_pwm_driver_c *pwmp,
+                                       const hal_pwm_config_t *config) {
+
+  if (config == NULL) {
+    config = &pwm_default_config;
+  }
+
+  if (!pwm_lld_is_valid_config(config)) {
+    return NULL;
+  }
+
+  /* Initial start path, no hardware access, see the description.*/
+  if (drvGetStateX(pwmp) == HAL_DRV_STATE_STARTING) {
+    return config;
+  }
+
+  /* Live reconfiguration of a started driver.*/
+  pwm_lld_apply_config(pwmp, config);
+
+  return config;
+}
+
+/**
+ * @brief   Selects one of the pre-defined PWM configurations.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] cfgnum    driver configuration number
+ * @return              The configuration pointer.
+ *
+ * @notapi
+ */
+const hal_pwm_config_t *pwm_lld_selcfg(hal_pwm_driver_c *pwmp,
+                                       unsigned cfgnum) {
+
+#if PWM_USE_CONFIGURATIONS == TRUE
+  extern const pwm_configurations_t pwm_configurations;
+
+  if (cfgnum >= pwm_configurations.cfgsnum) {
+    return NULL;
+  }
+
+  return pwm_lld_setcfg(pwmp, &pwm_configurations.cfgs[cfgnum]);
+#else
+
+  if (cfgnum > 0U) {
+    return NULL;
+  }
+
+  return pwm_lld_setcfg(pwmp, NULL);
+#endif
+}
+
+/**
+ * @brief   Callback change notification.
+ * @note    The callback is stored in the base class, no low level
+ *          action is required.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] cb        callback function to be associated
+ *
+ * @notapi
+ */
+void pwm_lld_set_callback(hal_pwm_driver_c *pwmp, drv_cb_t cb) {
+
+  (void)pwmp;
+  (void)cb;
+}
+
+/**
+ * @brief   Enables a PWM channel.
+ * @pre     The PWM unit must have been activated using @p pwmStart().
+ * @post    The channel is active using the specified configuration.
+ * @note    The function has effect at the next cycle start.
+ * @note    The compare registers are 16 bits wide, widths above 65535
+ *          fail a debug assertion and are clamped in release builds.
+ *          A full 100% duty (width equal to the period) is therefore
+ *          not achievable when the period is 65536 ticks.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] channel   PWM channel identifier (0...channels-1)
+ * @param[in] width     PWM pulse width as clock pulses number
+ *
+ * @notapi
+ */
+void pwm_lld_enable_channel(hal_pwm_driver_c *pwmp,
+                            pwmchannel_t channel,
+                            pwmcnt_t width) {
+  uint32_t current_cc = pwmp->pwm->CH[pwmp->timer_id].CC;
+
+  chDbgAssert(width <= (pwmcnt_t)0xFFFF, "width exceeds compare range");
+  if (width > (pwmcnt_t)0xFFFF) {
+    width = (pwmcnt_t)0xFFFF;
+  }
+
+  if (channel == 0U) {
+    pwmp->pwm->CH[pwmp->timer_id].CC = (current_cc & PWM_CC_B) |
+                                       ((width << PWM_CC_A_Pos) & PWM_CC_A);
+  }
+  else {
+    pwmp->pwm->CH[pwmp->timer_id].CC = (current_cc & PWM_CC_A) |
+                                       ((width << PWM_CC_B_Pos) & PWM_CC_B);
+  }
+}
+
+/**
+ * @brief   Disables a PWM channel and its notification.
+ * @pre     The PWM unit must have been activated using @p pwmStart().
+ * @post    The channel is disabled and its output line returned to the
+ *          idle state.
+ * @note    The function has effect at the next cycle start.
+ * @note    There is no channel notification to disable on this hardware,
+ *          see the events limitation note in the driver header.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] channel   PWM channel identifier (0...channels-1)
+ *
+ * @notapi
+ */
+void pwm_lld_disable_channel(hal_pwm_driver_c *pwmp, pwmchannel_t channel) {
+
+  if (channel == 0U) {
+    pwmp->pwm->CH[pwmp->timer_id].CC &= ~PWM_CC_A;
+  }
+  else {
+    pwmp->pwm->CH[pwmp->timer_id].CC &= ~PWM_CC_B;
+  }
+}
+
+/**
+ * @brief   Enables PWM event notifications.
+ * @note    RP LIMITATION: only @p PWM_EVENT_PERIOD is supported, the
+ *          slices have no compare interrupt. Channel event bits fail a
+ *          debug assertion and are silently ignored in release builds.
+ * @note    The shared driver caches the requested events before this
+ *          call, channel events can never be delivered by this hardware
+ *          so they are stripped back out of the cache: on this platform
+ *          the @p enabled_events field only ever contains
+ *          @p PWM_EVENT_PERIOD, see the events limitation note in the
+ *          driver header.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] events    events mask
+ *
+ * @notapi
+ */
+void pwm_lld_enable_events(hal_pwm_driver_c *pwmp, pwm_events_t events) {
+
+  chDbgAssert((events & ~(pwm_events_t)PWM_EVENT_PERIOD) == 0U,
+              "channel events not supported");
+
+  /* Correcting the enabled events cache, see the notes above.*/
+  pwmp->enabled_events &= (pwm_events_t)PWM_EVENT_PERIOD;
+
+  if ((events & PWM_EVENT_PERIOD) != 0U) {
+    /* Discarding a wrap possibly latched while the event was disabled,
+       notifications start from the next wrap.*/
+    pwmp->pwm->INTR = PWM_INTR_CH(pwmp->timer_id);
+    pwmp->pwm->SET.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
+  }
+}
+
+/**
+ * @brief   Disables PWM event notifications.
+ * @note    Channel event bits are ignored, they can never be enabled on
+ *          this hardware.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] events    events mask
+ *
+ * @notapi
+ */
+void pwm_lld_disable_events(hal_pwm_driver_c *pwmp, pwm_events_t events) {
+
+  if ((events & PWM_EVENT_PERIOD) != 0U) {
+    pwmp->pwm->CLR.IRQ0_INTE = PWM_INTE_CH(pwmp->timer_id);
+  }
+}
+
+/**
+ * @brief   Serves a slice wrap event.
+ * @details The latched request of the slice is cleared and the period
+ *          event callback is invoked outside of any critical section.
+ * @pre     The wrap status bit of this slice is set in the
+ *          @p IRQ0_INTS register.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ *
+ * @notapi
+ */
+void pwm_lld_serve_interrupt(hal_pwm_driver_c *pwmp) {
+  pwm_events_t events;
+
+  /* Clearing the latched request for this slice only.*/
+  pwmp->pwm->INTR = PWM_INTR_CH(pwmp->timer_id);
+
+  events = PWM_EVENT_PERIOD;
+  _pwm_isr_invoke_cb(pwmp, events);
+}
+
+#endif /* HAL_USE_PWM == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
+++ b/os/xhal/ports/RP/LLD/PWMv1/hal_pwm_lld.h
@@ -1,0 +1,448 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    PWMv1/hal_pwm_lld.h
+ * @brief   RP PWM subsystem low level driver header.
+ *
+ * @note    RP LIMITATION, PWM events: the PWM slices of the RP2040 and
+ *          of the RP2350 expose a single interrupt source, the counter
+ *          wrap. There is no compare interrupt on the A/B channels,
+ *          therefore only @p PWM_EVENT_PERIOD is supported by this
+ *          driver. Requesting any @p PWM_EVENT_CHANNEL(n) bit through
+ *          @p pwm_lld_enable_events() fails a debug assertion; in
+ *          release builds the channel event bits are silently ignored.
+ *          Configurations carrying channel bits in the
+ *          @p enabled_events field are rejected.
+ * @note    All slice wrap events are routed through the wrap 0 vector
+ *          (the @p IRQ0_INTE / @p IRQ0_INTS block) on both families.
+ *          The second RP2350 wrap interrupt (wrap 1, @p IRQ1_*) is left
+ *          untouched, this matches the classic driver routing.
+ * @note    RP LIMITATION, enabled events cache: as a consequence of the
+ *          missing channel events the @p enabled_events field of the
+ *          driver structure only ever contains @p PWM_EVENT_PERIOD on
+ *          this platform, channel bits cached by the shared driver
+ *          before the low level call are stripped back out by
+ *          @p pwm_lld_enable_events().
+ * @note    SMP constraints of the shared PWM block: all slices share
+ *          the block reset line and the wrap interrupt vector, both are
+ *          managed through a first-user/last-user software lifecycle
+ *          whose transitions are performed within cross-core critical
+ *          sections. RP devices have one NVIC per core and the wrap
+ *          vector is enabled only on the core performing the first-user
+ *          activation: that core owns the vector and every PWM callback
+ *          of every slice executes on it until the last-user teardown.
+ *          The stop performing the last-user teardown must be invoked
+ *          on the owner core because the per-core NVIC cannot be
+ *          disabled from the other core, the constraint is checked by a
+ *          debug assertion.
+ *
+ * @addtogroup PWM
+ * @{
+ */
+
+#ifndef HAL_PWM_LLD_H
+#define HAL_PWM_LLD_H
+
+#if (HAL_USE_PWM == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Number of PWM channels per PWM driver.
+ */
+#define PWM_CHANNELS                            2
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    RP configuration options
+ * @{
+ */
+
+/**
+ * @brief   PWMD0 driver enable switch.
+ * @details If set to @p TRUE the support for PWM0 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM0) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM0                  FALSE
+#endif
+
+/**
+ * @brief   PWMD1 driver enable switch.
+ * @details If set to @p TRUE the support for PWM1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM1) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM1                  FALSE
+#endif
+
+/**
+ * @brief   PWMD2 driver enable switch.
+ * @details If set to @p TRUE the support for PWM2 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM2) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM2                  FALSE
+#endif
+
+/**
+ * @brief   PWMD3 driver enable switch.
+ * @details If set to @p TRUE the support for PWM3 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM3) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM3                  FALSE
+#endif
+
+/**
+ * @brief   PWMD4 driver enable switch.
+ * @details If set to @p TRUE the support for PWM4 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM4) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM4                  FALSE
+#endif
+
+/**
+ * @brief   PWMD5 driver enable switch.
+ * @details If set to @p TRUE the support for PWM5 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM5) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM5                  FALSE
+#endif
+
+/**
+ * @brief   PWMD6 driver enable switch.
+ * @details If set to @p TRUE the support for PWM6 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM6) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM6                  FALSE
+#endif
+
+/**
+ * @brief   PWMD7 driver enable switch.
+ * @details If set to @p TRUE the support for PWM7 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM7) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM7                  FALSE
+#endif
+
+/**
+ * @brief   PWMD8 driver enable switch.
+ * @details If set to @p TRUE the support for PWM8 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM8) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM8                  FALSE
+#endif
+
+/**
+ * @brief   PWMD9 driver enable switch.
+ * @details If set to @p TRUE the support for PWM9 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM9) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM9                  FALSE
+#endif
+
+/**
+ * @brief   PWMD10 driver enable switch.
+ * @details If set to @p TRUE the support for PWM10 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM10) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM10                 FALSE
+#endif
+
+/**
+ * @brief   PWMD11 driver enable switch.
+ * @details If set to @p TRUE the support for PWM11 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_PWM_USE_PWM11) || defined(__DOXYGEN__)
+#define RP_PWM_USE_PWM11                 FALSE
+#endif
+
+/**
+ * @brief   PWM wrap interrupt priority level setting.
+ */
+#if !defined(RP_PWM_IRQ_WRAP_NUMBER_PRIORITY) || defined(__DOXYGEN__)
+#define RP_PWM_IRQ_WRAP_NUMBER_PRIORITY   3
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/* Configuration checks.                                                     */
+/*===========================================================================*/
+
+/* Registry checks for robustness. */
+#if !defined(RP_HAS_PWM)
+#error "RP_HAS_PWM not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM0)
+#error "RP_HAS_PWM0 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM1)
+#error "RP_HAS_PWM1 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM2)
+#error "RP_HAS_PWM2 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM3)
+#error "RP_HAS_PWM3 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM4)
+#error "RP_HAS_PWM4 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM5)
+#error "RP_HAS_PWM5 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM6)
+#error "RP_HAS_PWM6 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM7)
+#error "RP_HAS_PWM7 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM8)
+#error "RP_HAS_PWM8 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM9)
+#error "RP_HAS_PWM9 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM10)
+#error "RP_HAS_PWM10 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_PWM11)
+#error "RP_HAS_PWM11 not defined in registry"
+#endif
+
+#if (RP_PWM_USE_PWM0 == TRUE) && (RP_HAS_PWM0 != TRUE)
+#error "PWM0 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM1 == TRUE) && (RP_HAS_PWM1 != TRUE)
+#error "PWM1 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM2 == TRUE) && (RP_HAS_PWM2 != TRUE)
+#error "PWM2 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM3 == TRUE) && (RP_HAS_PWM3 != TRUE)
+#error "PWM3 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM4 == TRUE) && (RP_HAS_PWM4 != TRUE)
+#error "PWM4 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM5 == TRUE) && (RP_HAS_PWM5 != TRUE)
+#error "PWM5 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM6 == TRUE) && (RP_HAS_PWM6 != TRUE)
+#error "PWM6 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM7 == TRUE) && (RP_HAS_PWM7 != TRUE)
+#error "PWM7 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM8 == TRUE) && (RP_HAS_PWM8 != TRUE)
+#error "PWM8 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM9 == TRUE) && (RP_HAS_PWM9 != TRUE)
+#error "PWM9 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM10 == TRUE) && (RP_HAS_PWM10 != TRUE)
+#error "PWM10 not present in the selected device"
+#endif
+
+#if (RP_PWM_USE_PWM11 == TRUE) && (RP_HAS_PWM11 != TRUE)
+#error "PWM11 not present in the selected device"
+#endif
+
+/* IRQ priority checks.*/
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_PWM_IRQ_WRAP_NUMBER_PRIORITY)
+#error "Invalid IRQ priority assigned to RP_PWM_IRQ_WRAP_NUMBER_PRIORITY"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level fields of the PWM driver structure.
+ */
+#define pwm_lld_driver_fields                                               \
+  /* Pointer to the shared PWM registers block.*/                           \
+  PWM_TypeDef               *pwm;                                           \
+  /* Index of the PWM slice associated to this driver.*/                    \
+  pwmchannel_t              timer_id
+
+/**
+ * @brief   Low level fields of the PWM configuration structure.
+ */
+#define pwm_lld_config_fields                                               \
+  /* Dummy configuration field, the RP slice has no additional              \
+     configuration registers.*/                                             \
+  uint32_t                  dummy
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Changes the period the PWM peripheral.
+ * @details This function changes the period of a PWM unit that has already
+ *          been activated using @p pwmStart().
+ * @pre     The PWM unit must have been activated using @p pwmStart().
+ * @post    The PWM unit period is changed to the new value.
+ * @note    The function has effect at the next cycle start.
+ * @note    If a period is specified that is shorter than the pulse width
+ *          programmed in one of the channels then the behavior is not
+ *          guaranteed.
+ * @note    Periods outside the 1 to 65536 ticks range supported by the
+ *          16-bit slice counter fail a debug assertion, in release
+ *          builds they are clamped to the nearest valid value. The
+ *          shared driver caches the requested period before this call,
+ *          the clamped value is written back into the cache so that
+ *          the cached period and the hardware always agree.
+ *
+ * @param[in] pwmp      pointer to a @p hal_pwm_driver_c object
+ * @param[in] period    new cycle time in ticks
+ *
+ * @notapi
+ */
+#define pwm_lld_change_period(pwmp, period)                                 \
+  do {                                                                      \
+    pwmcnt_t newp = (pwmcnt_t)(period);                                     \
+                                                                            \
+    chDbgAssert((newp >= (pwmcnt_t)1) && (newp <= (pwmcnt_t)65536),         \
+                "period out of range");                                     \
+    if (newp < (pwmcnt_t)1) {                                               \
+      newp = (pwmcnt_t)1;                                                   \
+    }                                                                       \
+    if (newp > (pwmcnt_t)65536) {                                           \
+      newp = (pwmcnt_t)65536;                                               \
+    }                                                                       \
+    (pwmp)->period = newp;                                                  \
+    (pwmp)->pwm->CH[(pwmp)->timer_id].TOP = (uint32_t)(newp - 1U);          \
+  } while (false)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (RP_PWM_USE_PWM0 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD0;
+#endif
+
+#if (RP_PWM_USE_PWM1 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD1;
+#endif
+
+#if (RP_PWM_USE_PWM2 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD2;
+#endif
+
+#if (RP_PWM_USE_PWM3 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD3;
+#endif
+
+#if (RP_PWM_USE_PWM4 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD4;
+#endif
+
+#if (RP_PWM_USE_PWM5 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD5;
+#endif
+
+#if (RP_PWM_USE_PWM6 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD6;
+#endif
+
+#if (RP_PWM_USE_PWM7 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD7;
+#endif
+
+#if (RP_PWM_USE_PWM8 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD8;
+#endif
+
+#if (RP_PWM_USE_PWM9 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD9;
+#endif
+
+#if (RP_PWM_USE_PWM10 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD10;
+#endif
+
+#if (RP_PWM_USE_PWM11 == TRUE) && !defined(__DOXYGEN__)
+extern hal_pwm_driver_c PWMD11;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void pwm_lld_init(void);
+  msg_t pwm_lld_start(hal_pwm_driver_c *pwmp);
+  void pwm_lld_stop(hal_pwm_driver_c *pwmp);
+  const hal_pwm_config_t *pwm_lld_setcfg(hal_pwm_driver_c *pwmp,
+                                         const hal_pwm_config_t *config);
+  const hal_pwm_config_t *pwm_lld_selcfg(hal_pwm_driver_c *pwmp,
+                                         unsigned cfgnum);
+  void pwm_lld_set_callback(hal_pwm_driver_c *pwmp, drv_cb_t cb);
+  void pwm_lld_enable_channel(hal_pwm_driver_c *pwmp,
+                              pwmchannel_t channel,
+                              pwmcnt_t width);
+  void pwm_lld_disable_channel(hal_pwm_driver_c *pwmp, pwmchannel_t channel);
+  void pwm_lld_enable_events(hal_pwm_driver_c *pwmp, pwm_events_t events);
+  void pwm_lld_disable_events(hal_pwm_driver_c *pwmp, pwm_events_t events);
+  void pwm_lld_serve_interrupt(hal_pwm_driver_c *pwmp);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_PWM == TRUE */
+
+#endif /* HAL_PWM_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/platform.mk
+++ b/os/xhal/ports/RP/RP2040/platform.mk
@@ -30,8 +30,10 @@ else
 endif
 
 # Drivers compatible with the platform.
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk

--- a/os/xhal/ports/RP/RP2350/platform.mk
+++ b/os/xhal/ports/RP/RP2350/platform.mk
@@ -30,8 +30,10 @@ else
 endif
 
 # Drivers compatible with the platform.
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk


### PR DESCRIPTION
## Summary

Stage 3a of the RP2040/RP2350 XHAL port: the PWM and ADC drivers, plus live driver exercise in the RT-XHAL-RP-MULTI demo.

**PWM** (`LLD/PWMv1`): per-slice drivers (`PWMD0..11`, classic numbering kept) on the XHAL contract. RP slices expose only the wrap interrupt, so `PWM_EVENT_PERIOD` is the sole supported notification — channel event bits assert in debug builds, are stripped from the enabled-events cache in release builds, and configurations carrying them are rejected (the classic per-channel compare callback machinery was verified dead code — no compare interrupt exists, nothing ever invoked it — and is dropped). The shared PWM block's lifecycle is managed by a software refcount (active + start-in-progress masks, all transitions under the cross-core system lock) with the shared wrap vector owned by the first-user core — the base driver drops the lock before physical start/stop, so `PWM->EN` alone cannot arbitrate first-user/last-user transitions safely on SMP. Initial configuration is validate-only until the shared block is acquired; live reconfiguration keeps the quiesce-then-apply path. Stale wrap latches are cleared before unmasking.

**ADC** (`LLD/ADCv1`): the XHAL group model — conversion groups live in the configuration, selected by index with bounds/consistency validation (per-variant channel range, round-robin popcount vs `num_channels`, mask-includes-first-channel). The DMA-paced FIFO engine is retained for linear conversions; **circular conversions use two chained DMA channels in ping-pong**, eliminating the CPU re-arm window entirely (the classic single-channel re-arm would have had only a FIFO-depth deadline, ~8–16 µs at 500 kS/s; the deadline is now one half-buffer period). Temperature-sensor bias is owned per group and dropped at conversion stop, including the error path. Default configuration samples the on-die temperature channel.

**Demo**: after the test suites, the LED fades under PWM with a period-event counter and the on-die temperature prints periodically on the console — live silicon exercise of both drivers' full paths.

## Review triage

- codex adversarial review: 1 BLOCKER (PWM shared-resource lifecycle races on SMP) and 4 MAJOR (config-before-start hardware touch, channel-event cache lie, ADC validation holes, circular sample-loss window) — all redesigned/fixed as described above; 4 MINOR fixed (TS_EN lifetime, DMA-channel knob validation, `pwmChangePeriod` cache/hardware desync via clamp-writeback, negative-temperature print).
- coderabbit CLI: 2 findings (unshifted round-robin validation, negative-temperature sign) — both fixed.

## Verification

- Build matrix, all clean: demo rp2040+rp2350 × {default, +`CH_DBG_ENABLE_CHECKS/ASSERTS`}, `USE_SMART_BUILD=no`, testxhal/SPI regression leg. OSAL lexical gate, per-file stylecheck, `git diff --check` clean. Zero shared XHAL changes.
- On-hardware validation to follow before this leaves draft: LED fade + wrap-counter + temperature telemetry on both chips via the probe rig (unattended, using the established virtual-button technique).

## Changelog

- XHAL: RP port gains the PWM and ADC drivers; RT-XHAL-RP-MULTI exercises them live.
