### PR TITLE
XHAL: RP port EFL driver with XIP flash safety

### DIFF
--- a/os/xhal/OSAL_REMOVAL_BUILDS.txt
+++ b/os/xhal/OSAL_REMOVAL_BUILDS.txt
@@ -33,6 +33,8 @@ testxhal/ADC-GPT/make/stm32u575zi_nucleo144.make
 testxhal/ADC-GPT/make/stm32wl55jc_nucleo64.make
 testxhal/DAC-GPT/make/stm32g474re_nucleo64.make
 testxhal/DAC-GPT/make/stm32h563zi_nucleo144.make
+testxhal/EFL-MFS/make/rp2040_pico.make
+testxhal/EFL-MFS/make/rp2350_pico2.make
 testxhal/EFL-MFS/make/stm32g474re_nucleo64.make
 testxhal/EFL-MFS/make/stm32wl55jc_nucleo64.make
 testxhal/I2S/make/stm32g474re_nucleo64.make

--- a/os/xhal/ports/RP/LLD/EFLv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/EFLv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_EFL TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/EFLv1

--- a/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld.c
+++ b/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld.c
@@ -1,0 +1,514 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    EFLv1/rp_efl_lld.c
+ * @brief   RP shared Embedded Flash subsystem low level driver source.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#include <string.h>
+
+#include "hal.h"
+#include "rp_efl_lld.h"
+
+#if (HAL_USE_EFL == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+static const flash_descriptor_t efl_lld_descriptor = {
+  .attributes       = FLASH_ATTR_ERASED_IS_ONE |
+                      FLASH_ATTR_MEMORY_MAPPED |
+                      FLASH_ATTR_REWRITABLE,
+  .page_size        = RP_FLASH_PAGE_SIZE,
+  .sectors_count    = RP_FLASH_SECTORS_COUNT,
+  .sectors          = NULL,
+  .sectors_size     = RP_FLASH_SECTOR_SIZE,
+  .address          = (uint8_t *)RP_FLASH_BASE,
+  .size             = RP_FLASH_SIZE
+};
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level Embedded Flash driver initialization.
+ *
+ * @notapi
+ */
+void efl_lld_init(void) {
+
+  /* Driver initialization. */
+  eflObjectInit(&EFLD1);
+
+  /* The descriptor is served by the base class, it is placed in the
+     driver field read by flsGetDescriptor(). */
+  EFLD1.descriptor = efl_lld_descriptor;
+
+  /* Platform-specific one-time initialization (e.g. RP2040 boot2 copy). */
+  rp_efl_lld_init();
+}
+
+/**
+ * @brief   Configures and activates the Embedded Flash peripheral.
+ *
+ * @param[in,out] self          Pointer to an EFL driver instance.
+ * @return                      The operation status.
+ *
+ * @notapi
+ */
+msg_t efl_lld_start(hal_efl_driver_c *self) {
+
+  return rp_efl_lld_start(self);
+}
+
+/**
+ * @brief   Deactivates the Embedded Flash peripheral.
+ *
+ * @param[in,out] self          Pointer to an EFL driver instance.
+ *
+ * @notapi
+ */
+void efl_lld_stop(hal_efl_driver_c *self) {
+
+  (void)self;
+
+  /* Nothing to do. */
+}
+
+/**
+ * @brief   Read operation.
+ *
+ * @param[in,out] self  pointer to an EFL driver instance
+ * @param[in] offset    offset within full flash address space
+ * @param[in] n         number of bytes to be read
+ * @param[out] rp       pointer to the data buffer
+ * @return              An error code.
+ * @retval FLASH_NO_ERROR           if the read operation succeeded.
+ * @retval FLASH_ERROR_READ         if the read operation failed.
+ * @retval FLASH_ERROR_HW_FAILURE   if access to the memory failed.
+ *
+ * @notapi
+ */
+flash_error_t efl_lld_read(hal_efl_driver_c *self, flash_offset_t offset,
+                           size_t n, uint8_t *rp) {
+
+  chDbgCheck((self != NULL) && (rp != NULL) && (n > 0U));
+  chDbgCheck((size_t)offset + n <= (size_t)self->descriptor.size);
+  chDbgAssert(self->state == FLASH_READ, "invalid state");
+
+  /* Read from memory-mapped XIP region. */
+  memcpy((void *)rp, (const void *)(self->descriptor.address + offset), n);
+
+  return FLASH_NO_ERROR;
+}
+
+/**
+ * @brief   Program operation.
+ *
+ * @param[in,out] self  pointer to an EFL driver instance
+ * @param[in] offset    offset within full flash address space
+ * @param[in] n         number of bytes to be programmed
+ * @param[in] pp        pointer to the data buffer
+ * @return              An error code.
+ * @retval FLASH_NO_ERROR           if the program operation succeeded.
+ * @retval FLASH_ERROR_PROGRAM      if the program operation failed.
+ * @retval FLASH_ERROR_HW_FAILURE   if access to the memory failed.
+ *
+ * @notapi
+ */
+flash_error_t efl_lld_program(hal_efl_driver_c *self, flash_offset_t offset,
+                              size_t n, const uint8_t *pp) {
+  flash_error_t err = FLASH_NO_ERROR;
+  syssts_t sts;
+
+  chDbgCheck((self != NULL) && (pp != NULL) && (n > 0U));
+  chDbgCheck((size_t)offset + n <= (size_t)self->descriptor.size);
+  chDbgAssert(self->state == FLASH_PGM, "invalid state");
+
+  /* Allow the application to prepare for XIP becoming unavailable. */
+  rpEflBeforeXipOff();
+
+  /* Program in page-sized chunks.  The source data copy is intentionally
+   * done outside the system lock while XIP is still enabled; only the
+   * RAM-resident page transaction itself is bracketed by syslock. */
+  while (n > 0U) {
+    uint8_t page_buf[RP_FLASH_PAGE_SIZE];
+    uint32_t page_base = offset & ~(uint32_t)(RP_FLASH_PAGE_SIZE - 1U);
+    size_t page_offset = offset & (RP_FLASH_PAGE_SIZE - 1U);
+    size_t page_remaining = RP_FLASH_PAGE_SIZE - page_offset;
+    size_t chunk = (n < page_remaining) ? n : page_remaining;
+
+    /*
+     * Programming is done page-by-page. Fill the untouched bytes with
+     * 0xFF (all ones) so a partial write still emits a full page.
+     */
+    memset(page_buf, 0xFF, sizeof(page_buf));
+    memcpy(page_buf + page_offset, pp, chunk);
+
+    sts = chSysGetStatusAndLockX();
+
+    /* Program the page. */
+    err = rp_efl_lld_program_page_full(self, page_base, page_buf,
+                                       RP_FLASH_PAGE_SIZE);
+
+    chSysRestoreStatusX(sts);
+
+    /* Stop on the first failing page, the error is reported to the
+     * caller after the XIP-restored notification below. */
+    if (err != FLASH_NO_ERROR) {
+      break;
+    }
+
+    offset += chunk;
+    pp += chunk;
+    n -= chunk;
+  }
+
+  /* Notify the application that XIP is available again. */
+  rpEflAfterXipOn();
+
+  return err;
+}
+
+/**
+ * @brief   Starts a whole-device erase operation.
+ * @note    This is not implemented for safety reasons - erasing the entire
+ *          flash would destroy the running firmware.
+ *
+ * @param[in,out] self  pointer to an EFL driver instance
+ * @return              An error code.
+ *
+ * @notapi
+ */
+flash_error_t efl_lld_start_erase_all(hal_efl_driver_c *self) {
+
+  (void)self;
+
+  return FLASH_ERROR_UNIMPLEMENTED;
+}
+
+/**
+ * @brief   Starts a sector erase operation.
+ * @note    The erase completes synchronously inside this call; the base
+ *          class keeps the driver in the erase state until the following
+ *          @p flashQueryErase() reports completion.
+ *
+ * @param[in,out] self  pointer to an EFL driver instance
+ * @param[in] sector    sector to be erased
+ * @return              An error code.
+ * @retval FLASH_NO_ERROR           if the erase completed.
+ * @retval FLASH_ERROR_ERASE        if the erase operation failed.
+ * @retval FLASH_ERROR_HW_FAILURE   if access to the memory failed.
+ *
+ * @notapi
+ */
+flash_error_t efl_lld_start_erase_sector(hal_efl_driver_c *self,
+                                         flash_sector_t sector) {
+  flash_offset_t offset;
+  flash_error_t err;
+  syssts_t sts;
+
+  chDbgCheck(self != NULL);
+  chDbgCheck(sector < self->descriptor.sectors_count);
+  chDbgAssert(self->state == FLASH_ERASE, "invalid state");
+
+  /* Calculate sector offset. */
+  offset = (flash_offset_t)sector * RP_FLASH_SECTOR_SIZE;
+
+  /* Allow the application to prepare for XIP becoming unavailable. */
+  rpEflBeforeXipOff();
+
+  /* Lock the system around the single RAM-resident erase sequence. */
+  sts = chSysGetStatusAndLockX();
+
+  /* Perform the entire erase sequence in RAM. */
+  err = rp_efl_lld_erase_full(self, RP_FLASH_CMD_SECTOR_ERASE, offset);
+
+  /* Restore system state. */
+  chSysRestoreStatusX(sts);
+
+  /* Notify the application that XIP is available again. */
+  rpEflAfterXipOn();
+
+  return err;
+}
+
+/**
+ * @brief   Queries the driver for erase operation progress.
+ * @note    Erase operations complete synchronously inside
+ *          @p efl_lld_start_erase_sector(), there is nothing left to
+ *          poll: the first query after a successful erase reports
+ *          completion.
+ *
+ * @param[in,out] self  pointer to an EFL driver instance
+ * @param[out] msec     recommended time, in milliseconds, that
+ *                      should be spent before calling this
+ *                      function again, can be @p NULL
+ * @return              An error code.
+ * @retval FLASH_NO_ERROR           if there is no erase operation in progress.
+ *
+ * @notapi
+ */
+flash_error_t efl_lld_query_erase(hal_efl_driver_c *self, unsigned *msec) {
+
+  chDbgCheck(self != NULL);
+  chDbgAssert(self->state == FLASH_ERASE, "invalid state");
+
+  (void)msec;
+
+  return FLASH_NO_ERROR;
+}
+
+/**
+ * @brief   Returns the erase state of a sector.
+ *
+ * @param[in,out] self  pointer to an EFL driver instance
+ * @param[in] sector    sector to be verified
+ * @return              An error code.
+ * @retval FLASH_NO_ERROR           if the sector is erased.
+ * @retval FLASH_ERROR_VERIFY       if the verify operation failed.
+ * @retval FLASH_ERROR_HW_FAILURE   if access to the memory failed.
+ *
+ * @notapi
+ */
+flash_error_t efl_lld_verify_erase(hal_efl_driver_c *self,
+                                   flash_sector_t sector) {
+  const uint32_t *address;
+  flash_error_t err = FLASH_NO_ERROR;
+  unsigned i;
+
+  chDbgCheck(self != NULL);
+  chDbgCheck(sector < self->descriptor.sectors_count);
+  chDbgAssert(self->state == FLASH_READ, "invalid state");
+
+  /* Address of the sector in XIP space. */
+  address = (const uint32_t *)(self->descriptor.address +
+                               flashGetSectorOffset(self, sector));
+
+  /* Scanning the sector space. */
+  for (i = 0U; i < RP_FLASH_SECTOR_SIZE / sizeof(uint32_t); i++) {
+    if (address[i] != 0xFFFFFFFFU) {
+      err = FLASH_ERROR_VERIFY;
+      break;
+    }
+  }
+
+  return err;
+}
+
+/**
+ * @brief   Starts a block erase operation.
+ * @note    RP-local extension, the standard flash interface has no slot
+ *          for block erases with explicit JEDEC commands.  The operation
+ *          completes synchronously inside this call and does not involve
+ *          the base class state machine, the driver state is only read
+ *          to reject calls while a sector erase is pending completion.
+ * @note    The standard flash operations rely on the shared
+ *          @p flsAcquireExclusive() / @p flsReleaseExclusive()
+ *          convention, mutual exclusion is the caller's responsibility
+ *          there.  This extension is not reachable through that
+ *          interface so it self-locks instead: the driver mutex is held
+ *          for the whole operation, including the state validation and
+ *          the XIP-off window.  Do not call it with the driver already
+ *          acquired through @p flsAcquireExclusive().
+ *
+ * @param[in,out] self    pointer to an EFL driver instance
+ * @param[in] cmd         JEDEC erase command byte, one of
+ *                        @p RP_FLASH_CMD_SECTOR_ERASE,
+ *                        @p RP_FLASH_CMD_BLOCK_ERASE_32K or
+ *                        @p RP_FLASH_CMD_BLOCK_ERASE_64K, the erase
+ *                        extent is derived from this value alone
+ * @param[in] block       block number to be erased, in units of the
+ *                        erase extent implied by @p cmd
+ * @return                An error code.
+ * @retval FLASH_NO_ERROR           if the block erase completed.
+ * @retval FLASH_BUSY_ERASING       if there is an erase operation in progress.
+ * @retval FLASH_ERROR_ERASE        if the erase operation failed.
+ * @retval FLASH_ERROR_HW_FAILURE   if @p cmd is not a supported erase
+ *                                  command, if the erase extent falls
+ *                                  outside the device or if access to
+ *                                  the memory failed.
+ *
+ * @api
+ */
+flash_error_t rpEflStartEraseBlock(hal_efl_driver_c *self,
+                                   uint8_t cmd,
+                                   uint32_t block) {
+  flash_offset_t offset;
+  uint32_t erase_size;
+  flash_error_t err;
+  syssts_t sts;
+
+  chDbgCheck(self != NULL);
+
+  /* The erase extent is derived from the command byte alone, unsupported
+     commands are rejected before any size or offset math. */
+  switch (cmd) {
+  case RP_FLASH_CMD_SECTOR_ERASE:
+    erase_size = RP_FLASH_SECTOR_SIZE;
+    break;
+  case RP_FLASH_CMD_BLOCK_ERASE_32K:
+    erase_size = RP_FLASH_BLOCK_32K_SIZE;
+    break;
+  case RP_FLASH_CMD_BLOCK_ERASE_64K:
+    erase_size = RP_FLASH_BLOCK_64K_SIZE;
+    break;
+  default:
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* The whole erase extent must lie inside the device. */
+  if (block >= (RP_FLASH_SIZE / erase_size)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  offset = (flash_offset_t)block * erase_size;
+
+  /* This extension is outside the shared acquire/release convention,
+     the driver mutex is taken for the whole operation. */
+#if HAL_USE_MUTUAL_EXCLUSION == TRUE
+  drvLock(self);
+#endif
+
+  chDbgAssert((self->state == HAL_DRV_STATE_READY) ||
+              (self->state == FLASH_ERASE), "invalid state");
+
+  /* No erasing while a sector erase is pending completion. */
+  if (self->state == FLASH_ERASE) {
+#if HAL_USE_MUTUAL_EXCLUSION == TRUE
+    drvUnlock(self);
+#endif
+    return FLASH_BUSY_ERASING;
+  }
+
+  /* Allow the application to prepare for XIP becoming unavailable. */
+  rpEflBeforeXipOff();
+
+  /* Erase is one uninterrupted RAM-resident XIP-off transaction, so the
+   * whole helper runs under syslock. */
+  sts = chSysGetStatusAndLockX();
+  err = rp_efl_lld_erase_full(self, cmd, offset);
+  chSysRestoreStatusX(sts);
+
+  /* Notify the application that XIP is available again. */
+  rpEflAfterXipOn();
+
+#if HAL_USE_MUTUAL_EXCLUSION == TRUE
+  drvUnlock(self);
+#endif
+
+  return err;
+}
+
+/**
+ * @brief   Reads the flash chip's unique ID.
+ * @note    RP-local extension, the standard flash interface has no slot
+ *          for unique ID reads.  The JEDEC 0x4B command is issued at
+ *          runtime, which requires exiting and re-entering XIP mode.
+ * @note    The standard flash operations rely on the shared
+ *          @p flsAcquireExclusive() / @p flsReleaseExclusive()
+ *          convention, mutual exclusion is the caller's responsibility
+ *          there.  This extension is not reachable through that
+ *          interface so it self-locks instead: the driver mutex is held
+ *          for the whole operation, including the state validation and
+ *          the XIP-off window.  Do not call it with the driver already
+ *          acquired through @p flsAcquireExclusive().
+ *
+ * @param[in,out] self  pointer to an EFL driver instance
+ * @param[out] uid      pointer to an 8-byte buffer for the unique ID
+ * @return              An error code.
+ * @retval FLASH_NO_ERROR           if the unique ID has been read.
+ * @retval FLASH_BUSY_ERASING       if there is an erase operation in progress.
+ * @retval FLASH_ERROR_HW_FAILURE   on communication or controller
+ *                                  failures, including transfer
+ *                                  timeouts and XIP exit/restore
+ *                                  failures propagated from the lower
+ *                                  layer.  No other error codes are
+ *                                  returned by this function.
+ *
+ * @api
+ */
+flash_error_t rpEflReadUniqueId(hal_efl_driver_c *self, uint8_t *uid) {
+  uint8_t rx[4U + RP_FLASH_UNIQUE_ID_SIZE];
+  flash_error_t err;
+  syssts_t sts;
+
+  chDbgCheck((self != NULL) && (uid != NULL));
+
+  /* This extension is outside the shared acquire/release convention,
+     the driver mutex is taken for the whole operation. */
+#if HAL_USE_MUTUAL_EXCLUSION == TRUE
+  drvLock(self);
+#endif
+
+  chDbgAssert((self->state == HAL_DRV_STATE_READY) ||
+              (self->state == FLASH_ERASE), "invalid state");
+
+  /* No flash transactions while a sector erase is pending completion. */
+  if (self->state == FLASH_ERASE) {
+#if HAL_USE_MUTUAL_EXCLUSION == TRUE
+    drvUnlock(self);
+#endif
+    return FLASH_BUSY_ERASING;
+  }
+
+  /* Allow the application to prepare for XIP becoming unavailable. */
+  rpEflBeforeXipOff();
+
+  sts = chSysGetStatusAndLockX();
+  err = rp_efl_lld_read_uid_full(self, rx, sizeof(rx));
+  chSysRestoreStatusX(sts);
+
+  /* Notify the application that XIP is available again. */
+  rpEflAfterXipOn();
+
+#if HAL_USE_MUTUAL_EXCLUSION == TRUE
+  drvUnlock(self);
+#endif
+
+  if (err == FLASH_NO_ERROR) {
+    memcpy(uid, rx + 4U, RP_FLASH_UNIQUE_ID_SIZE);
+  }
+
+  return err;
+}
+
+/**
+ * @brief   Default RP EFL pre-XIP-off hook.
+ * @details Weak no-op implementation applications may override.
+ */
+CC_WEAK void rpEflBeforeXipOff(void) {
+}
+
+/**
+ * @brief   Default RP EFL post-XIP-on hook.
+ * @details Weak no-op implementation applications may override.
+ */
+CC_WEAK void rpEflAfterXipOn(void) {
+}
+
+#endif /* HAL_USE_EFL == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld.h
+++ b/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld.h
@@ -1,0 +1,52 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    EFLv1/rp_efl_lld.h
+ * @brief   RP EFL shared internal interfaces.
+ */
+
+#ifndef RP_EFL_LLD_H
+#define RP_EFL_LLD_H
+
+#if (HAL_USE_EFL == TRUE) || defined(__DOXYGEN__)
+
+#if !defined(__ASSEMBLER__)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rp_efl_lld_init(void);
+  msg_t rp_efl_lld_start(hal_efl_driver_c *eflp);
+  flash_error_t rp_efl_lld_program_page_full(hal_efl_driver_c *eflp,
+                                             uint32_t offset,
+                                             const uint8_t *data,
+                                             size_t len);
+  flash_error_t rp_efl_lld_erase_full(hal_efl_driver_c *eflp,
+                                      uint8_t cmd,
+                                      uint32_t offset);
+  flash_error_t rp_efl_lld_read_uid_full(hal_efl_driver_c *eflp,
+                                         uint8_t *rx,
+                                         size_t count);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !__ASSEMBLER__ */
+
+#endif /* HAL_USE_EFL == TRUE */
+
+#endif /* RP_EFL_LLD_H */

--- a/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld_api.inc
+++ b/os/xhal/ports/RP/LLD/EFLv1/rp_efl_lld_api.inc
@@ -1,0 +1,40 @@
+/**
+ * @brief   Hook invoked immediately before the RP EFL driver disables XIP.
+ * @details Applications may override this weak hook in order to coordinate
+ *          other cores, park threads, or perform any other preparation
+ *          required before flash becomes temporarily unavailable through XIP.
+ * @note    This hook is called in thread context while XIP is still enabled.
+ */
+void rpEflBeforeXipOff(void);
+
+/**
+ * @brief   Hook invoked immediately after the RP EFL driver restores XIP.
+ * @details Applications may override this weak hook in order to resume the
+ *          coordination established by @p rpEflBeforeXipOff().
+ * @note    This hook is called in thread context after XIP has been restored.
+ */
+void rpEflAfterXipOn(void);
+
+void efl_lld_init(void);
+msg_t efl_lld_start(hal_efl_driver_c *self);
+void efl_lld_stop(hal_efl_driver_c *self);
+flash_error_t efl_lld_read(hal_efl_driver_c *self, flash_offset_t offset,
+                           size_t n, uint8_t *rp);
+flash_error_t efl_lld_program(hal_efl_driver_c *self, flash_offset_t offset,
+                              size_t n, const uint8_t *pp);
+flash_error_t efl_lld_start_erase_all(hal_efl_driver_c *self);
+flash_error_t efl_lld_start_erase_sector(hal_efl_driver_c *self,
+                                         flash_sector_t sector);
+flash_error_t efl_lld_query_erase(hal_efl_driver_c *self, unsigned *msec);
+flash_error_t efl_lld_verify_erase(hal_efl_driver_c *self,
+                                   flash_sector_t sector);
+
+/* RP-local extensions, the standard flash interface has no slots for
+   block erases with explicit JEDEC commands or unique ID reads.  Unlike
+   the standard operations, which follow the shared flsAcquireExclusive()
+   convention, these extensions self-lock on the driver mutex and must
+   not be called with the driver already acquired.*/
+flash_error_t rpEflStartEraseBlock(hal_efl_driver_c *self,
+                                   uint8_t cmd,
+                                   uint32_t block);
+flash_error_t rpEflReadUniqueId(hal_efl_driver_c *self, uint8_t *uid);

--- a/os/xhal/ports/RP/RP2040/hal_efl_lld.c
+++ b/os/xhal/ports/RP/RP2040/hal_efl_lld.c
@@ -1,0 +1,917 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/hal_efl_lld.c
+ * @brief   RP2040 Embedded Flash subsystem low level driver source.
+ * @note    This is a self-contained flash driver that directly manipulates
+ *          the SSI peripheral.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#include <string.h>
+
+#include "hal.h"
+#include "rp_efl_lld.h"
+
+#if (HAL_USE_EFL == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Macro to place functions in RAM.
+ */
+#define RAMFUNC __attribute__((noinline, section(".ramtext")))
+
+/**
+ * @name    SSI configuration for direct SPI mode
+ * @{
+ */
+#define SSI_BAUDR_DEFAULT                   6U
+/** @} */
+
+/**
+ * @name    IO QSPI register indexes
+ * @{
+ */
+#define RP2040_IO_QSPI_SS_INDEX             1U
+/** @} */
+
+/**
+ * @name    Standard JEDEC Flash commands
+ * @{
+ */
+#define FLASHCMD_WRITE_ENABLE               0x06U
+#define FLASHCMD_READ_STATUS                0x05U
+#define FLASHCMD_PAGE_PROGRAM               0x02U
+#define FLASHCMD_SECTOR_ERASE               0x20U
+#define FLASHCMD_BLOCK_ERASE_32K            0x52U
+#define FLASHCMD_BLOCK_ERASE_64K            0xD8U
+#define FLASHCMD_READ_UNIQUE_ID             0x4BU
+/** @} */
+
+/**
+ * @name    Flash status register bits
+ * @{
+ */
+#define FLASH_STATUS_BUSY                   (1U << 0)
+#define FLASH_STATUS_WEL                    (1U << 1)
+/** @} */
+
+/**
+ * @name    Page alignment
+ * @{
+ */
+#define RP_FLASH_PAGE_MASK                  (RP_FLASH_PAGE_SIZE - 1U)
+/** @} */
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   EFL1 driver identifier.
+ */
+hal_efl_driver_c EFLD1;
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Copy of boot2 stage2 image for XIP restoration after flash ops.
+ * @details 252 bytes (full 256-byte image minus 4-byte CRC).
+ *          See RP2040 Datasheet 2.8.1.3 and rp_flash_enter_xip().
+ */
+CC_ALIGN_DATA(4) static uint8_t rp_boot2[252];
+
+/**
+ * @brief   PADS_QSPI SCLK, SD0..SD3 and SS values saved before the
+ *          flash operation.
+ * @details rp_flash_connect_internal() hard-resets PADS_QSPI, wiping
+ *          all six QSPI pad controls, so the pre-operation values must
+ *          be captured before that reset and re-applied after boot2
+ *          has reconfigured the pads for XIP.
+ */
+static uint32_t rp_pads_save[6];
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Checks elapsed time against the free-running 1 MHz timer.
+ * @note    This function MUST be in RAM.  TIMER0 is an APB peripheral
+ *          and remains readable while XIP is disabled; TIMERAWL has no
+ *          read side effects.
+ *
+ * @param[in] start       TIMERAWL value sampled when the wait started
+ * @param[in] timeout_us  allowed time in microseconds
+ * @return                true if the timeout expired.
+ */
+RAMFUNC static bool rp_flash_timeout(uint32_t start, uint32_t timeout_us) {
+
+  return (uint32_t)(TIMER0->TIMERAWL - start) > timeout_us;
+}
+
+/**
+ * @brief   Clocks one byte through the SSI and discards the RX byte.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] ssi       pointer to the SSI registers
+ * @param[in] data      data byte to transmit
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_ssi_tx8(SSI_TypeDef *ssi, uint8_t data) {
+  uint32_t start;
+
+  ssi->DR[0] = data;
+  start = TIMER0->TIMERAWL;
+  while (ssi->RXFLR == 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+  (void)ssi->DR[0];
+
+  return true;
+}
+
+/**
+ * @brief   Resynchronization of the SSI FIFOs.
+ * @details After a transfer timeout the engine may still be shifting and
+ *          the RX FIFO may hold residue; without draining, a later
+ *          status poll can consume stale bytes and a BUSY=0 answer need
+ *          not belong to that poll, a false idle would let XIP return
+ *          over a busy device. Deliberately unbounded, matching the
+ *          wait-ready doctrine: no later poll can be trusted until the
+ *          engine is clean; a controller which never recovers leaves the
+ *          system spinning here for a watchdog to catch.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] ssi       pointer to the SSI registers
+ */
+RAMFUNC static void rp_flash_resync(SSI_TypeDef *ssi) {
+
+  while (((ssi->SR & SSI_SR_BUSY) != 0U) || (ssi->RXFLR > 0U)) {
+    if (ssi->RXFLR > 0U) {
+      (void)ssi->DR[0];
+    }
+  }
+}
+
+/**
+ * @brief   Force chip select high or low
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] high      true for CS high (deassert), false for CS low (assert)
+ */
+RAMFUNC static void rp_flash_cs_force(hal_efl_driver_c *eflp, bool high) {
+  (void)eflp;
+  uint32_t val = high ? IOQSPI_CTRL_OUTOVER_HIGH : IOQSPI_CTRL_OUTOVER_LOW;
+
+  IO_QSPI->GPIO[RP2040_IO_QSPI_SS_INDEX].CTRL =
+      (IO_QSPI->GPIO[RP2040_IO_QSPI_SS_INDEX].CTRL &
+       ~IOQSPI_CTRL_OUTOVER_Msk) |
+      IOQSPI_CTRL_OUTOVER(val);
+
+  /* Read back to ensure write is flushed */
+  (void)IO_QSPI->GPIO[RP2040_IO_QSPI_SS_INDEX].CTRL;
+}
+
+/**
+ * @brief   Transfer data to/from flash
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] tx        transmit buffer (NULL to send zeros)
+ * @param[out] rx       receive buffer (NULL to discard)
+ * @param[in] count     number of bytes to transfer
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_put_get(hal_efl_driver_c *eflp, const uint8_t *tx,
+                                     uint8_t *rx, size_t count) {
+  SSI_TypeDef *ssi = eflp->ssi;
+  size_t tx_remaining = count;
+  size_t rx_remaining = count;
+  const size_t max_in_flight = 14U; /* FIFO is 16 deep so we leave a margin */
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((tx_remaining > 0U) || (rx_remaining > 0U)) {
+    size_t in_flight = (count - tx_remaining) - (count - rx_remaining);
+
+    while ((tx_remaining > 0U) && (in_flight < max_in_flight)) {
+      uint8_t data = (tx != NULL) ? *tx++ : 0U;
+      ssi->DR[0] = data;
+      tx_remaining--;
+      in_flight++;
+    }
+
+    while ((rx_remaining > 0U) && (ssi->RXFLR > 0U)) {
+      uint8_t data = (uint8_t)ssi->DR[0];
+      if (rx != NULL) {
+        *rx++ = data;
+      }
+      rx_remaining--;
+    }
+
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Execute a flash command.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] cmd       command byte
+ * @param[in] tx        transmit data after command (NULL if none)
+ * @param[out] rx       receive buffer (NULL to discard)
+ * @param[in] count     number of bytes to transfer after command
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_do_cmd(hal_efl_driver_c *eflp, uint8_t cmd,
+                                    const uint8_t *tx, uint8_t *rx,
+                                    size_t count) {
+  bool ok;
+
+  /* Assert CS. */
+  rp_flash_cs_force(eflp, false);
+
+  /* Send command byte. */
+  ok = rp_flash_ssi_tx8(eflp->ssi, cmd);
+
+  /* Transfer remaining data. */
+  if (ok && (count > 0U)) {
+    ok = rp_flash_put_get(eflp, tx, rx, count);
+  }
+
+  /* A failed transfer can leave the engine shifting and residue in the
+     RX FIFO; resynchronize before the CS edge so the next transaction
+     starts clean and later status polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(eflp->ssi);
+  }
+
+  /* Deassert CS, also on failed transfers. */
+  rp_flash_cs_force(eflp, true);
+
+  return ok;
+}
+
+/**
+ * @brief   Wait for flash to become ready.
+ * @note    This function MUST be in RAM.
+ * @note    Neither a timeout nor a communication failure aborts the wait:
+ *          XIP cannot be restored while the device may still be busy,
+ *          fetches would return garbage and fault. Errors are recorded
+ *          and the polling continues until a successful status read
+ *          reports the device idle; a device or controller which never
+ *          recovers leaves the system spinning here, which is a
+ *          watchdog's job to catch.
+ *
+ * @param[in] eflp        pointer to an EFL driver instance
+ * @param[in] timeout_us  operation timeout in microseconds
+ * @param[in] timeout_err error reported when the operation exceeded the
+ *                        timeout (operation-specific category)
+ * @return                An error code, @p FLASH_ERROR_HW_FAILURE on
+ *                        communication failures.
+ */
+RAMFUNC static flash_error_t rp_flash_wait_ready(hal_efl_driver_c *eflp,
+                                                 uint32_t timeout_us,
+                                                 flash_error_t timeout_err) {
+  uint32_t start = TIMER0->TIMERAWL;
+  bool timed_out = false;
+  bool comm_fail = false;
+  uint8_t status;
+
+  do {
+    if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+      comm_fail = true;
+      status = FLASH_STATUS_BUSY;
+    }
+    if (((status & FLASH_STATUS_BUSY) != 0U) &&
+        rp_flash_timeout(start, timeout_us)) {
+      timed_out = true;
+    }
+  } while ((status & FLASH_STATUS_BUSY) != 0U);
+
+  if (comm_fail) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  if (timed_out) {
+    return timeout_err;
+  }
+  return FLASH_NO_ERROR;
+}
+
+/**
+ * @brief   Send write enable command and verify the WEL latch.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @return              true on success, false on timeout or if the
+ *                      write enable latch did not set.
+ */
+RAMFUNC static bool rp_flash_write_enable(hal_efl_driver_c *eflp) {
+  uint8_t status;
+
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_WRITE_ENABLE, NULL, NULL, 0U)) {
+    return false;
+  }
+
+  /* Read back the status register and verify WEL is set, a device
+     that rejects the command would silently fail later. */
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+    return false;
+  }
+
+  return (status & FLASH_STATUS_WEL) != 0U;
+}
+
+/**
+ * @brief   Flush XIP cache
+ * @note    This function MUST be in RAM.
+ */
+RAMFUNC static void rp_flash_flush_cache(void) {
+  uint32_t ctrl;
+
+  /* Write to flush register to trigger cache flush. */
+  XIP_CTRL->FLUSH = 1U;
+
+  /* Read back blocks until flush is complete. */
+  (void)XIP_CTRL->FLUSH;
+
+  /* Re-enable the cache while preserving the remaining policy bits. */
+  ctrl = XIP_CTRL->CTRL;
+  ctrl |= XIP_CTRL_CTRL_EN;
+  XIP_CTRL->CTRL = ctrl;
+}
+
+/**
+ * @brief   Reset QSPI pads and mux to connect SSI to internal flash.
+ * @note    This function MUST be in RAM.
+ *
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_connect_internal(void) {
+  uint32_t bits = RESETS_ALLREG_IO_QSPI | RESETS_ALLREG_PADS_QSPI;
+  PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
+  uint32_t start;
+  unsigned i;
+
+  /* Save all six QSPI pad controls (SCLK, SD0..SD3, SS) before the
+     hard reset below wipes them, rp_flash_enter_xip() restores them
+     verbatim once boot2 has brought XIP back. */
+  rp_pads_save[0] = pads_qspi->GPIO_QSPI_SCLK;
+  rp_pads_save[1] = pads_qspi->GPIO_QSPI_SD0;
+  rp_pads_save[2] = pads_qspi->GPIO_QSPI_SD1;
+  rp_pads_save[3] = pads_qspi->GPIO_QSPI_SD2;
+  rp_pads_save[4] = pads_qspi->GPIO_QSPI_SD3;
+  rp_pads_save[5] = pads_qspi->GPIO_QSPI_SS;
+
+  /* Hard-reset IO_QSPI and PADS_QSPI. */
+  RESETS->SET.RESET = bits;
+  RESETS->CLR.RESET = bits;
+  start = TIMER0->TIMERAWL;
+  while ((RESETS->RESET_DONE & bits) != bits) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+
+  /* Mux all QSPI GPIOs to function 0 (XIP). */
+  for (i = 0U; i < 6U; i++) {
+    IO_QSPI->GPIO[i].CTRL = 0U;
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Exit XIP mode and configure for direct access.
+ * @note    This function MUST be in RAM.
+ * @note    This follows a similar pattern to the ROM's flash_exit_xip()
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @return              true on success, false on timeout.  Also on
+ *                      failure the caller must re-enter XIP mode.
+ */
+RAMFUNC static bool rp_flash_exit_xip(hal_efl_driver_c *eflp) {
+  SSI_TypeDef *ssi = eflp->ssi;
+  PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
+  uint32_t padctrl_save;
+  uint32_t padctrl_tmp;
+  uint32_t start;
+  unsigned i;
+  volatile unsigned delay;
+  bool ok = true;
+
+  /* Wait for any pending work.*/
+  start = TIMER0->TIMERAWL;
+  while ((ssi->SR & SSI_SR_BUSY) != 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+
+  /* Default non XIP SPI configuration */
+  ssi->SSIENR = 0U;
+  (void)ssi->SR;                    /* Clear sticky errors (clear-on-read). */
+  (void)ssi->ICR;
+  ssi->BAUDR = SSI_BAUDR_DEFAULT;
+  ssi->CTRLR0 = SSI_CTRLR0_SPI_FRF_STD |
+                 SSI_CTRLR0_TMOD_TX_AND_RX |
+                 SSI_CTRLR0_DFS_32(7U);
+  ssi->SER = 1U;
+  ssi->SSIENR = 1U;
+
+  /*
+   * Exit continuous read mode sequence:
+   * 1. CS high 32 clocks with IO pulled down
+   * 2. CS low 32 clocks with IO pulled up
+   * 3. Send 0xFF, 0xFF
+  */
+
+  /* Save pad control and configure with output disabled.*/
+  padctrl_save = pads_qspi->GPIO_QSPI_SD0;
+  padctrl_tmp = (padctrl_save & ~(PADS_QSPI_OD | PADS_QSPI_PUE |
+                                  PADS_QSPI_PDE))
+                | PADS_QSPI_OD | PADS_QSPI_PDE;
+
+  /* 1. CS high */
+  rp_flash_cs_force(eflp, true);
+
+  pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
+  pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
+  pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
+  pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
+
+  /* Delay of ~6000 cycles */
+  for (delay = 0U; delay < 2048U; delay++) {
+  }
+
+  /* Send 4 bytes / 32 clocks */
+  for (i = 0U; ok && (i < 4U); i++) {
+    ok = rp_flash_ssi_tx8(ssi, 0U);
+  }
+
+  if (ok) {
+    padctrl_tmp = (padctrl_tmp & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
+
+    /* 2. CS low */
+    rp_flash_cs_force(eflp, false);
+
+    pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
+
+    /* Delay of ~6000 cycles */
+    for (delay = 0U; delay < 2048U; delay++) {
+    }
+
+    /* Send 4 bytes / 32 clocks */
+    for (i = 0U; ok && (i < 4U); i++) {
+      ok = rp_flash_ssi_tx8(ssi, 0U);
+    }
+  }
+
+  /* Restore pad controls, also on failed sequences. */
+  pads_qspi->GPIO_QSPI_SD0 = padctrl_save;
+  pads_qspi->GPIO_QSPI_SD1 = padctrl_save;
+  padctrl_save = (padctrl_save & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
+  pads_qspi->GPIO_QSPI_SD2 = padctrl_save;
+  pads_qspi->GPIO_QSPI_SD3 = padctrl_save;
+
+  if (!ok) {
+    rp_flash_cs_force(eflp, true);
+    return false;
+  }
+
+  /* 3. Send 0xFF, 0xFF */
+  rp_flash_cs_force(eflp, false);
+  ssi->DR[0] = 0xFFU;
+  ssi->DR[0] = 0xFFU;
+  start = TIMER0->TIMERAWL;
+  while (ssi->RXFLR < 2U) {
+    if (rp_flash_timeout(start, RP_FLASH_SSI_TIMEOUT_US)) {
+      ok = false;
+      break;
+    }
+  }
+  if (ok) {
+    (void)ssi->DR[0];
+    (void)ssi->DR[0];
+  }
+  rp_flash_cs_force(eflp, true);
+
+  return ok;
+}
+
+/**
+ * @brief   Enter XIP mode by re-executing the boot2 stage2 code.
+ * @note    This function MUST be in RAM.
+ * @details The SSI SPI_CTRLR0 register XIP_CMD field (bits 31:24) does
+ *          not read back on RP2040 — it always returns zero regardless
+ *          of the value written.  Because the boot2 stores the QSPI
+ *          continuous-read mode byte (typically 0xA0) in this field,
+ *          a register save/restore approach cannot recover the original
+ *          XIP configuration.
+ *
+ *          Instead, the boot2 stage2 code is copied to RAM during
+ *          driver init and re-executed here.  This is the same technique used
+ *          by the Pico SDK (flash_enable_xip_via_boot2 in
+ *          hardware_flash/flash.c).
+ *
+ *          Per RP2040 Datasheet section 2.8.1.3, the 256-byte boot2
+ *          image is position-independent Thumb code — the bootrom
+ *          copies it to SRAM and calls it during the boot sequence.
+ *          All standard boot2 variants (w25q080, generic_03h,
+ *          at25sf128a, is25lp080) follow the Pico SDK convention of
+ *          checking the saved LR on exit: if non-zero (called from
+ *          user code) the boot2 returns to the caller; if zero (called
+ *          from the bootrom) it jumps to the application entry point.
+ *          Custom boot2 implementations that do not follow this
+ *          convention will not work with this driver.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @return              always @p true, the RP2040 restore sequence has
+ *                      no detectable failure mode. The bool signature
+ *                      mirrors the RP2350 driver, where the final QMI
+ *                      direct-mode idle wait can time out.
+ */
+RAMFUNC static bool rp_flash_enter_xip(hal_efl_driver_c *eflp) {
+  PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
+  (void)eflp;
+
+  /* Reset CS control to normal. */
+  IO_QSPI->GPIO[RP2040_IO_QSPI_SS_INDEX].CTRL =
+      (IO_QSPI->GPIO[RP2040_IO_QSPI_SS_INDEX].CTRL &
+       ~IOQSPI_CTRL_OUTOVER_Msk) |
+      IOQSPI_CTRL_OUTOVER(IOQSPI_CTRL_OUTOVER_NORMAL);
+
+  /* Re-execute the boot2 to fully restore the SSI configuration
+   * including QSPI mode, continuous read, and baud rate.  The OR
+   * with 1 sets the Thumb bit required by BX on ARMv6-M. */
+  ((void (*)(void))((uintptr_t)rp_boot2 | 1U))();
+
+  /* Boot2 reconfigures the pads for XIP; re-applying the values saved
+     in rp_flash_connect_internal() restores any board/application-
+     specific pad tuning that existed before the operation, on all six
+     QSPI pads (SCLK, SD0..SD3, SS). */
+  pads_qspi->GPIO_QSPI_SCLK = rp_pads_save[0];
+  pads_qspi->GPIO_QSPI_SD0  = rp_pads_save[1];
+  pads_qspi->GPIO_QSPI_SD1  = rp_pads_save[2];
+  pads_qspi->GPIO_QSPI_SD2  = rp_pads_save[3];
+  pads_qspi->GPIO_QSPI_SD3  = rp_pads_save[4];
+  pads_qspi->GPIO_QSPI_SS   = rp_pads_save[5];
+
+  rp_flash_flush_cache();
+
+  return true;
+}
+
+/**
+ * @brief   Program a page of flash.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] offset    flash offset (must be page-aligned or within page)
+ * @param[in] data      data to program
+ * @param[in] len       number of bytes (must not cross page boundary)
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_program_page(hal_efl_driver_c *eflp,
+                                                   uint32_t offset,
+                                                   const uint8_t *data,
+                                                   size_t len) {
+  SSI_TypeDef *ssi = eflp->ssi;
+  flash_error_t ready_err;
+  uint8_t addr[3];
+  bool ok;
+
+  /* Send write enable; nothing was launched on failure. */
+  if (!rp_flash_write_enable(eflp)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Prepare 24-bit address (big-endian). */
+  addr[0] = (uint8_t)(offset >> 16);
+  addr[1] = (uint8_t)(offset >> 8);
+  addr[2] = (uint8_t)offset;
+
+  /* Assert CS. */
+  rp_flash_cs_force(eflp, false);
+
+  /* Send page program command. */
+  ok = rp_flash_ssi_tx8(ssi, FLASHCMD_PAGE_PROGRAM);
+
+  /* Send address. */
+  if (ok) {
+    ok = rp_flash_put_get(eflp, addr, NULL, 3U);
+  }
+
+  /* Send data. */
+  if (ok) {
+    ok = rp_flash_put_get(eflp, data, NULL, len);
+  }
+
+  /* A failed transfer can leave engine residue behind; resynchronize
+     before the CS edge so the ready polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(ssi);
+  }
+
+  /* Deassert CS, also on failed transfers. */
+  rp_flash_cs_force(eflp, true);
+
+  /* The CS edge may have launched the program even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US,
+                                  FLASH_ERROR_PROGRAM);
+
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
+}
+
+/**
+ * @brief   Send an erase command to flash.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] cmd       JEDEC erase command byte
+ * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_erase_cmd(hal_efl_driver_c *eflp,
+                                                uint8_t cmd,
+                                                uint32_t offset) {
+  flash_error_t ready_err;
+  uint8_t addr[3];
+  bool ok;
+
+  /* Send write enable; nothing was launched on failure. */
+  if (!rp_flash_write_enable(eflp)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Prepare 24-bit address (big-endian). */
+  addr[0] = (uint8_t)(offset >> 16);
+  addr[1] = (uint8_t)(offset >> 8);
+  addr[2] = (uint8_t)offset;
+
+  /* Send erase command with address. */
+  ok = rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+
+  /* The CS edge may have launched the erase even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US,
+                                  FLASH_ERROR_ERASE);
+
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
+}
+
+/**
+ * @brief   Complete erase operation (runs entirely in RAM).
+ * @note    This function MUST be in RAM. It handles the entire sequence
+ *          from exit XIP to enter XIP so no flash code executes while
+ *          XIP is disabled.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] cmd       JEDEC erase command byte
+ * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_erase_full(hal_efl_driver_c *eflp,
+                                                 uint8_t cmd,
+                                                 uint32_t offset) {
+  flash_error_t err = FLASH_NO_ERROR;
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer interrupts, their handlers may execute from flash.*/
+  __disable_irq();
+
+  /* Connect SSI to flash and exit XIP mode. */
+  if (!rp_flash_connect_internal() || !rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Send erase command and wait for erase to complete. */
+  else {
+    err = rp_flash_erase_cmd(eflp, cmd, offset);
+  }
+
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  __set_PRIMASK(primask);
+
+  return err;
+}
+
+/**
+ * @brief   Single-page program operation that runs entirely in RAM.
+ * @note    This function MUST be in RAM. It handles the entire sequence
+ *          from exit XIP to enter XIP so no flash code executes while
+ *          XIP is disabled.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] offset    flash offset (must not cross page boundary)
+ * @param[in] data      pointer to data in RAM
+ * @param[in] len       number of bytes to program
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_program_page_full(hal_efl_driver_c *eflp,
+                                                        uint32_t offset,
+                                                        const uint8_t *data,
+                                                        size_t len) {
+  flash_error_t err = FLASH_NO_ERROR;
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer interrupts, their handlers may execute from flash.*/
+  __disable_irq();
+
+  /* Connect SSI to flash and exit XIP mode. */
+  if (!rp_flash_connect_internal() || !rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Program the page. */
+  else {
+    err = rp_flash_program_page(eflp, offset, data, len);
+  }
+
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  __set_PRIMASK(primask);
+
+  return err;
+}
+
+/**
+ * @brief   Read flash unique ID (runs entirely in RAM).
+ * @note    This function MUST be in RAM. It handles the entire sequence
+ *          from exit XIP to enter XIP so no flash code executes while
+ *          XIP is disabled.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[out] rx       receive buffer
+ * @param[in] count     number of bytes to transfer after command
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_read_uid_full(hal_efl_driver_c *eflp,
+                                                    uint8_t *rx,
+                                                    size_t count) {
+  flash_error_t err = FLASH_NO_ERROR;
+  uint32_t primask = __get_PRIMASK();
+
+  /* Defer interrupts, their handlers may execute from flash.*/
+  __disable_irq();
+
+  /* Connect SSI to flash and exit XIP mode. */
+  if (!rp_flash_connect_internal() || !rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Send read unique ID command. */
+  else if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_UNIQUE_ID, NULL, rx, count)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  __set_PRIMASK(primask);
+
+  return err;
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+void rp_efl_lld_init(void) {
+
+  EFLD1.ssi = XIP_SSI;
+
+  /* Copy the boot2 stage2 image (first 252 bytes of flash, excluding
+   * the 4-byte CRC) into a RAM buffer while XIP is still functional.
+   * After flash program/erase operations, rp_flash_enter_xip()
+   * re-executes this copy to restore the SSI/XIP configuration.
+   * See RP2040 Datasheet section 2.8.1.3 for boot2 requirements. */
+  memcpy(rp_boot2, (const void *)RP_FLASH_BASE, sizeof(rp_boot2));
+}
+
+msg_t rp_efl_lld_start(hal_efl_driver_c *eflp) {
+
+  (void)eflp;
+
+  /* Nothing to do - boot2 is copied during init. */
+  return HAL_RET_SUCCESS;
+}
+
+flash_error_t rp_efl_lld_program_page_full(hal_efl_driver_c *eflp,
+                                           uint32_t offset,
+                                           const uint8_t *data,
+                                           size_t len) {
+
+  /* Unconditional bounds validation of the program extent, the debug
+     checks in the upper layers are compiled out in release builds. */
+  if ((offset >= RP_FLASH_SIZE) ||
+      ((RP_FLASH_SIZE - offset) < (uint32_t)len)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  return rp_flash_program_page_full(eflp, offset, data, len);
+}
+
+flash_error_t rp_efl_lld_erase_full(hal_efl_driver_c *eflp,
+                                    uint8_t cmd,
+                                    uint32_t offset) {
+  uint32_t esize;
+
+  /* Erase extent per command byte, unknown commands are rejected. */
+  switch (cmd) {
+  case FLASHCMD_SECTOR_ERASE:
+    esize = RP_FLASH_SECTOR_SIZE;
+    break;
+  case FLASHCMD_BLOCK_ERASE_32K:
+    esize = RP_FLASH_BLOCK_32K_SIZE;
+    break;
+  case FLASHCMD_BLOCK_ERASE_64K:
+    esize = RP_FLASH_BLOCK_64K_SIZE;
+    break;
+  default:
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Unconditional bounds validation of the erase extent, the debug
+     checks in the upper layers are compiled out in release builds. */
+  if ((offset >= RP_FLASH_SIZE) || ((RP_FLASH_SIZE - offset) < esize)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* The device aligns erase commands down to the erase unit; an offset
+     that is not aligned to the unit would silently erase data outside
+     the requested extent. */
+  if ((offset & (esize - 1U)) != 0U) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  return rp_flash_erase_full(eflp, cmd, offset);
+}
+
+flash_error_t rp_efl_lld_read_uid_full(hal_efl_driver_c *eflp,
+                                       uint8_t *rx,
+                                       size_t count) {
+
+  return rp_flash_read_uid_full(eflp, rx, count);
+}
+
+#endif /* HAL_USE_EFL == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/hal_efl_lld.h
+++ b/os/xhal/ports/RP/RP2040/hal_efl_lld.h
@@ -1,0 +1,259 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/hal_efl_lld.h
+ * @brief   RP2040 Embedded Flash subsystem low level driver header.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#ifndef HAL_EFL_LLD_H
+#define HAL_EFL_LLD_H
+
+#if (HAL_USE_EFL == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Flash page size (minimum write unit).
+ */
+#define RP_FLASH_PAGE_SIZE                  256U
+
+/**
+ * @brief   Flash sector size (minimum erase unit).
+ */
+#define RP_FLASH_SECTOR_SIZE                4096U
+
+/**
+ * @brief   Flash sector erase command (JEDEC 0x20).
+ */
+#define RP_FLASH_CMD_SECTOR_ERASE          0x20U
+
+/**
+ * @brief   Flash 32KB block erase command (JEDEC 0x52).
+ */
+#define RP_FLASH_CMD_BLOCK_ERASE_32K        0x52U
+
+/**
+ * @brief   Flash 64KB block erase command (JEDEC 0xD8).
+ */
+#define RP_FLASH_CMD_BLOCK_ERASE_64K        0xD8U
+
+/**
+ * @brief   Flash 32KB block size.
+ */
+#define RP_FLASH_BLOCK_32K_SIZE             (32U * 1024U)
+
+/**
+ * @brief   Flash 64KB block size.
+ */
+#define RP_FLASH_BLOCK_64K_SIZE             65536U
+
+/**
+ * @brief   XIP base address.
+ */
+#define RP_FLASH_BASE                       0x10000000U
+
+/**
+ * @brief   SSI base address.
+ */
+#define RP_SSI_BASE                         0x18000000U
+
+/**
+ * @brief   XIP control base address.
+ */
+#define RP_XIP_CTRL_BASE                    0x14000000U
+
+/**
+ * @brief   Flash unique ID size in bytes.
+ */
+#define RP_FLASH_UNIQUE_ID_SIZE             8U
+
+/**
+ * @name    XIP safety strategies
+ * @{
+ */
+/**
+ * @brief   Flash safety left to the application.
+ * @details The application is responsible for providing @p
+ *          rpEflBeforeXipOff() / @p rpEflAfterXipOn() implementations
+ *          which keep the other core and DMA away from XIP while flash
+ *          operations are in progress.
+ */
+#define RP_EFL_XIP_SAFETY_NONE              0
+/**
+ * @brief   Built-in SMP lockout.
+ * @details The port parks the other core in RAM with interrupts masked
+ *          for the duration of each flash operation. DMA reading from the
+ *          XIP window remains an application responsibility.
+ */
+#define RP_EFL_XIP_SAFETY_LOCKOUT           1
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    RP2040 configuration options
+ * @{
+ */
+
+/**
+ * @brief   Total flash size in bytes.
+ * @note    Default is 2MB for standard Raspberry Pi Pico.
+ *          Override in mcuconf.h for boards with different flash sizes.
+ */
+#if !defined(RP_FLASH_SIZE) || defined(__DOXYGEN__)
+#define RP_FLASH_SIZE                       (2U * 1024U * 1024U)
+#endif
+
+/* The driver issues 24-bit (3-byte) JEDEC addresses; larger devices
+   would silently wrap around and corrupt low flash. */
+#if RP_FLASH_SIZE > (16U * 1024U * 1024U)
+#error "RP_FLASH_SIZE exceeds 24-bit flash addressing"
+#endif
+
+/**
+ * @brief   XIP safety strategy used while flash operations run.
+ * @details One of @p RP_EFL_XIP_SAFETY_NONE (application-provided hooks)
+ *          or @p RP_EFL_XIP_SAFETY_LOCKOUT (built-in SMP core lockout).
+ * @note    SMP configurations must select a strategy explicitly in
+ *          mcuconf.h, flash operations are not SMP-safe otherwise.
+ */
+#if !defined(RP_EFL_XIP_SAFETY) || defined(__DOXYGEN__)
+#if defined(CH_CFG_SMP_MODE) && (CH_CFG_SMP_MODE == TRUE)
+#error "SMP EFL requires RP_EFL_XIP_SAFETY in mcuconf.h: select RP_EFL_XIP_SAFETY_LOCKOUT or RP_EFL_XIP_SAFETY_NONE with application hooks"
+#else
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_NONE
+#endif
+#endif
+
+#if (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_NONE) &&                        \
+    (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_LOCKOUT)
+#error "invalid RP_EFL_XIP_SAFETY value"
+#endif
+
+/**
+ * @brief   Suggested wait time during erase operations polling.
+ */
+#if !defined(RP_FLASH_WAIT_TIME_MS) || defined(__DOXYGEN__)
+#define RP_FLASH_WAIT_TIME_MS               1U
+#endif
+
+/**
+ * @brief   Timeout for SSI FIFO/BUSY waits in microseconds.
+ * @details Bounds the individual controller-level waits (FIFO drains,
+ *          SR BUSY polls, QSPI pad reset completion) performed while
+ *          XIP is disabled.
+ */
+#if !defined(RP_FLASH_SSI_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_SSI_TIMEOUT_US             1000U
+#endif
+
+/**
+ * @brief   Timeout for a page program operation in microseconds.
+ */
+#if !defined(RP_FLASH_PROGRAM_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_PROGRAM_TIMEOUT_US         20000U
+#endif
+
+/**
+ * @brief   Timeout for an erase operation in microseconds.
+ * @details Sized for the worst-case 64KB block erase time of common
+ *          QSPI flash devices.
+ */
+#if !defined(RP_FLASH_ERASE_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_ERASE_TIMEOUT_US           4000000U
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness. */
+#if !defined(RP_HAS_FLASH)
+#error "RP_HAS_FLASH not defined in registry"
+#endif
+
+#if RP_HAS_FLASH != TRUE
+#error "RP_HAS_FLASH is not TRUE"
+#endif
+
+/**
+ * @brief   Number of sectors in flash.
+ */
+#define RP_FLASH_SECTORS_COUNT              (RP_FLASH_SIZE / RP_FLASH_SECTOR_SIZE)
+
+/**
+ * @brief   Number of 64KB blocks in flash.
+ */
+#define RP_FLASH_BLOCKS_COUNT               (RP_FLASH_SIZE / RP_FLASH_BLOCK_64K_SIZE)
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+#include "rp_efl_lld.h"
+
+/**
+ * @brief   Low level fields of the embedded flash driver structure.
+ */
+#define efl_lld_driver_fields                                               \
+  /* Pointer to SSI registers. */                                           \
+  SSI_TypeDef                 *ssi
+
+/**
+ * @brief   Low level fields of the embedded flash configuration structure.
+ */
+#define efl_lld_config_fields                                               \
+  /* Dummy configuration, it is not needed.*/                               \
+  uint32_t                    dummy
+
+/*===========================================================================*/
+/* Application hooks.                                                        */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if !defined(__DOXYGEN__)
+extern hal_efl_driver_c EFLD1;
+#endif
+#include "rp_efl_lld_api.inc"
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_EFL == TRUE */
+
+#endif /* HAL_EFL_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/platform.mk
+++ b/os/xhal/ports/RP/RP2040/platform.mk
@@ -26,11 +26,18 @@ endif
 
 HALCONF := $(strip $(shell cat $(HALCONFDIR)/xhalconf.h | grep -E "\#define"))
 
+ifneq ($(findstring HAL_USE_EFL TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/RP2040/hal_efl_lld.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040/rp_flash_safety.c
+endif
 else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/RP2040/hal_efl_lld.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2040/rp_flash_safety.c
 endif
 
 # Drivers compatible with the platform.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/EFLv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk

--- a/os/xhal/ports/RP/RP2040/rp_flash_safety.c
+++ b/os/xhal/ports/RP/RP2040/rp_flash_safety.c
@@ -1,0 +1,72 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2040/rp_flash_safety.c
+ * @brief   Built-in SMP flash safety hooks.
+ * @details Strong implementations of the EFL XIP hooks which park the
+ *          other core in RAM for the duration of flash operations, using
+ *          the RP2 SMP port lockout services.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_EFL == TRUE) && (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT)
+
+#if !defined(CH_CFG_SMP_MODE) || (CH_CFG_SMP_MODE != TRUE)
+#error "RP_EFL_XIP_SAFETY_LOCKOUT requires the RT SMP kernel (CH_CFG_SMP_MODE == TRUE)"
+#endif
+
+/**
+ * @brief   Parks the other core before XIP becomes unavailable.
+ * @note    When the HAL itself started core 1, its readiness is awaited
+ *          before the first lockout: until then the core may be running
+ *          startup code from flash without being parkable yet. A core
+ *          started by other means is the application's responsibility
+ *          (do not perform flash operations before it is ready).
+ */
+void rpEflBeforeXipOff(void) {
+
+#if RP_CORE1_START == TRUE
+  if (!__port_lockout_other_ready()) {
+    uint32_t start = TIMER0->TIMERAWL;
+
+    while (!__port_lockout_other_ready()) {
+      if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+        chSysHalt("core 1 never became parkable");
+      }
+    }
+  }
+#endif
+
+  __port_flash_lockout();
+}
+
+/**
+ * @brief   Releases the other core once XIP is available again.
+ */
+void rpEflAfterXipOn(void) {
+
+  __port_flash_unlockout();
+}
+
+#endif /* (HAL_USE_EFL == TRUE) &&
+          (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT) */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/hal_efl_lld.c
+++ b/os/xhal/ports/RP/RP2350/hal_efl_lld.c
@@ -1,0 +1,1034 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/hal_efl_lld.c
+ * @brief   RP2350 Embedded Flash subsystem low level driver source.
+ * @note    This is a self-contained flash driver that directly manipulates
+ *          the QMI peripheral.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#include <string.h>
+
+#include "hal.h"
+#include "rp_efl_lld.h"
+
+#if defined(__riscv)
+/* Hazard3 mstatus.MIE mask/restore primitives, not in the general HAL
+   include chain.*/
+#include "hazard3_irq.h"
+#endif
+
+#if (HAL_USE_EFL == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Macro to place functions in RAM.
+ */
+#define RAMFUNC __attribute__((noinline, section(".ramtext")))
+
+/* QMI DIRECT_CSR and DIRECT_TX bit definitions are in rp2350.h. */
+
+/**
+ * @name    XIP cache constants
+ * @{
+ */
+#define RP_XIP_MAINTENANCE_BASE             0x18000000U
+#define RP_XIP_CACHE_LINE_SIZE              8U
+#define RP_XIP_CACHE_SIZE                   (16U * 1024U)
+#define RP_XIP_ADDRESS_SPACE_SIZE           0x04000000U
+#define RP_XIP_SET_WAY_BASE                 (RP_XIP_ADDRESS_SPACE_SIZE - RP_XIP_CACHE_SIZE)
+/** @} */
+
+/**
+ * @name    XIP cache maintenance operations
+ * @{
+ */
+#define RP_XIP_CACHE_INVALIDATE_BY_SET_WAY  0U
+#define RP_XIP_CACHE_CLEAN_BY_SET_WAY       1U
+/** @} */
+
+/**
+ * @name    Standard JEDEC Flash commands
+ * @{
+ */
+#define FLASHCMD_WRITE_ENABLE               0x06U
+#define FLASHCMD_READ_STATUS                0x05U
+#define FLASHCMD_PAGE_PROGRAM               0x02U
+#define FLASHCMD_SECTOR_ERASE               0x20U
+#define FLASHCMD_BLOCK_ERASE_32K            0x52U
+#define FLASHCMD_BLOCK_ERASE_64K            0xD8U
+#define FLASHCMD_READ_UNIQUE_ID             0x4BU
+/** @} */
+
+/**
+ * @name    Flash status register bits
+ * @{
+ */
+#define FLASH_STATUS_BUSY                   (1U << 0)
+#define FLASH_STATUS_WEL                    (1U << 1)
+/** @} */
+
+/**
+ * @name    Page alignment
+ * @{
+ */
+#define RP_FLASH_PAGE_MASK                  (RP_FLASH_PAGE_SIZE - 1U)
+/** @} */
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   EFL1 driver identifier.
+ */
+hal_efl_driver_c EFLD1;
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Checks elapsed time against the free-running 1 MHz timer.
+ * @note    This function MUST be in RAM.  TIMER0 is an APB peripheral
+ *          and remains readable while XIP is disabled; TIMERAWL has no
+ *          read side effects.
+ *
+ * @param[in] start       TIMERAWL value sampled when the wait started
+ * @param[in] timeout_us  allowed time in microseconds
+ * @return                true if the timeout expired.
+ */
+RAMFUNC static bool rp_flash_timeout(uint32_t start, uint32_t timeout_us) {
+
+  return (uint32_t)(TIMER0->TIMERAWL - start) > timeout_us;
+}
+
+/**
+ * @brief   Waits for the QMI direct-mode interface to become idle.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_direct_wait_idle(QMI_TypeDef *qmi) {
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Clocks one direct-mode TX word and discards the RX byte.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ * @param[in] data      DIRECT_TX value (data byte plus control bits)
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_direct_tx8(QMI_TypeDef *qmi, uint32_t data) {
+  uint32_t start;
+
+  qmi->DIRECT_TX = data;
+  start = TIMER0->TIMERAWL;
+  while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) != 0U) {
+    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+  (void)qmi->DIRECT_RX;
+
+  return true;
+}
+
+/**
+ * @brief   Resynchronization of the direct-mode FIFOs.
+ * @details After a transfer timeout the engine may still be shifting and
+ *          the RX FIFO may hold residue; without draining, a later
+ *          status poll can consume stale bytes and a BUSY=0 answer need
+ *          not belong to that poll, a false idle would let XIP return
+ *          over a busy device. Deliberately unbounded, matching the
+ *          wait-ready doctrine: no later poll can be trusted until the
+ *          engine is clean, and the CS edge that follows is only legal
+ *          with the engine idle; a controller which never recovers
+ *          leaves the system spinning here for a watchdog to catch.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ */
+RAMFUNC static void rp_flash_resync(QMI_TypeDef *qmi) {
+
+  while (((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) ||
+         ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U)) {
+    if ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
+      (void)qmi->DIRECT_RX;
+    }
+  }
+}
+
+/**
+ * @brief   Force chip select high or low
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] high      true for CS high (deassert), false for CS low (assert)
+ */
+RAMFUNC static void rp_flash_cs_force(hal_efl_driver_c *eflp, bool high) {
+  QMI_TypeDef *qmi = eflp->qmi;
+
+  if (high) {
+    qmi->DIRECT_CSR &= ~QMI_DIRECT_CSR_ASSERT_CS0N;
+  } else {
+    qmi->DIRECT_CSR |= QMI_DIRECT_CSR_ASSERT_CS0N;
+  }
+
+  /* Read back to ensure write is flushed */
+  (void)qmi->DIRECT_CSR;
+}
+
+/**
+ * @brief   Transfer data to/from flash
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] tx        transmit buffer (NULL to send zeros)
+ * @param[out] rx       receive buffer (NULL to discard)
+ * @param[in] count     number of bytes to transfer
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_put_get(hal_efl_driver_c *eflp, const uint8_t *tx,
+                                     uint8_t *rx, size_t count) {
+  QMI_TypeDef *qmi = eflp->qmi;
+  size_t tx_remaining = count;
+  size_t rx_remaining = count;
+  uint32_t start = TIMER0->TIMERAWL;
+
+  while ((tx_remaining > 0U) || (rx_remaining > 0U)) {
+    uint32_t csr = qmi->DIRECT_CSR;
+
+    /* Send if TX FIFO not full and data remaining. */
+    if ((tx_remaining > 0U) && ((csr & QMI_DIRECT_CSR_TXFULL) == 0U)) {
+      uint8_t data = (tx != NULL) ? *tx++ : 0U;
+      qmi->DIRECT_TX = data;
+      tx_remaining--;
+    }
+
+    if ((rx_remaining > 0U) && ((csr & QMI_DIRECT_CSR_RXEMPTY) == 0U)) {
+      uint8_t data = (uint8_t)qmi->DIRECT_RX;
+      if (rx != NULL) {
+        *rx++ = data;
+      }
+      rx_remaining--;
+    }
+
+    if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief   Execute a flash command.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] cmd       command byte
+ * @param[in] tx        transmit data after command (NULL if none)
+ * @param[out] rx       receive buffer (NULL to discard)
+ * @param[in] count     number of bytes to transfer after command
+ * @return              true on success, false on timeout.
+ */
+RAMFUNC static bool rp_flash_do_cmd(hal_efl_driver_c *eflp, uint8_t cmd,
+                                    const uint8_t *tx, uint8_t *rx,
+                                    size_t count) {
+  QMI_TypeDef *qmi = eflp->qmi;
+  bool ok;
+
+  /* Assert CS. */
+  rp_flash_cs_force(eflp, false);
+
+  /* Send command byte. */
+  ok = rp_flash_direct_tx8(qmi, cmd);
+
+  /* Transfer remaining data. */
+  if (ok && (count > 0U)) {
+    ok = rp_flash_put_get(eflp, tx, rx, count);
+  }
+
+  /* A failed transfer can leave the engine shifting and residue in the
+     RX FIFO; resynchronize before the CS edge so the next transaction
+     starts clean and later status polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(qmi);
+  }
+
+  /* Deassert CS, also on failed transfers. */
+  rp_flash_cs_force(eflp, true);
+
+  return ok;
+}
+
+/**
+ * @brief   Wait for flash to become ready.
+ * @note    This function MUST be in RAM.
+ * @note    Neither a timeout nor a communication failure aborts the wait:
+ *          XIP cannot be restored while the device may still be busy,
+ *          fetches would return garbage and fault. Errors are recorded
+ *          and the polling continues until a successful status read
+ *          reports the device idle; a device or controller which never
+ *          recovers leaves the system spinning here, which is a
+ *          watchdog's job to catch.
+ *
+ * @param[in] eflp        pointer to an EFL driver instance
+ * @param[in] timeout_us  operation timeout in microseconds
+ * @param[in] timeout_err error reported when the operation exceeded the
+ *                        timeout (operation-specific category)
+ * @return                An error code, @p FLASH_ERROR_HW_FAILURE on
+ *                        communication failures.
+ */
+RAMFUNC static flash_error_t rp_flash_wait_ready(hal_efl_driver_c *eflp,
+                                                 uint32_t timeout_us,
+                                                 flash_error_t timeout_err) {
+  uint32_t start = TIMER0->TIMERAWL;
+  bool timed_out = false;
+  bool comm_fail = false;
+  uint8_t status;
+
+  do {
+    if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+      comm_fail = true;
+      status = FLASH_STATUS_BUSY;
+    }
+    if (((status & FLASH_STATUS_BUSY) != 0U) &&
+        rp_flash_timeout(start, timeout_us)) {
+      timed_out = true;
+    }
+  } while ((status & FLASH_STATUS_BUSY) != 0U);
+
+  if (comm_fail) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  if (timed_out) {
+    return timeout_err;
+  }
+  return FLASH_NO_ERROR;
+}
+
+/**
+ * @brief   Send write enable command and verify the WEL latch.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @return              true on success, false on timeout or if the
+ *                      write enable latch did not set.
+ */
+RAMFUNC static bool rp_flash_write_enable(hal_efl_driver_c *eflp) {
+  uint8_t status;
+
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_WRITE_ENABLE, NULL, NULL, 0U)) {
+    return false;
+  }
+
+  /* Read back the status register and verify WEL is set, a device
+     that rejects the command would silently fail later. */
+  if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_STATUS, NULL, &status, 1U)) {
+    return false;
+  }
+
+  return (status & FLASH_STATUS_WEL) != 0U;
+}
+
+/**
+ * @brief   Flush XIP cache and restore cache policy.
+ * @note    This function MUST be in RAM.
+ */
+RAMFUNC static void rp_flash_flush_cache(hal_efl_driver_c *eflp) {
+  volatile uint8_t *maint = (volatile uint8_t *)RP_XIP_MAINTENANCE_BASE;
+  XIP_CTRL_TypeDef *xip_ctrl = XIP_CTRL;
+  uint32_t offset;
+
+  for (offset = RP_XIP_SET_WAY_BASE;
+       offset < RP_XIP_ADDRESS_SPACE_SIZE;
+       offset += RP_XIP_CACHE_LINE_SIZE) {
+#if RP_EFL_HAS_PSRAM == TRUE
+    /*
+     * Write back dirty PSRAM (CS1) cache lines before invalidating.
+     * The XIP cache is shared between CS0 (flash, read-only) and
+     * CS1 (PSRAM, write-back). Without this clean step, cached
+     * PSRAM writes would be lost on invalidation.
+     *
+     * The clean and invalidate must be adjacent per-line: clean-by-
+     * set/way corrupts the cache tag, so a cleaned-but-not-yet-
+     * invalidated line can cause spurious cache hits.
+     */
+    maint[offset + RP_XIP_CACHE_CLEAN_BY_SET_WAY] = 0U;
+    __DSB();
+#endif
+    maint[offset + RP_XIP_CACHE_INVALIDATE_BY_SET_WAY] = 0U;
+  }
+
+  __DSB();
+  __ISB();
+
+  /* Restore the saved cache policy after maintenance. */
+  xip_ctrl->CTRL = eflp->xip_ctrl;
+}
+
+/**
+ * @brief   Exit XIP mode and configure for direct access.
+ * @note    This function MUST be in RAM.
+ * @note    This follows a similar pattern to the ROM's flash_exit_xip()
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @return              true on success, false on timeout.  Also on
+ *                      failure the caller must re-enter XIP mode, the
+ *                      saved configuration is valid in both cases.
+ */
+RAMFUNC static bool rp_flash_exit_xip(hal_efl_driver_c *eflp) {
+  QMI_TypeDef *qmi = eflp->qmi;
+  XIP_CTRL_TypeDef *xip_ctrl = XIP_CTRL;
+  PADS_QSPI_TypeDef *pads_qspi = PADS_QSPI;
+  uint32_t padctrl_save[4];
+  uint32_t padctrl_tmp;
+  unsigned i;
+  volatile unsigned delay;
+  bool ok = true;
+
+  /* Save current XIP configuration (CS0 and CS1) before switching
+   * to direct mode. */
+  eflp->xip_ctrl       = xip_ctrl->CTRL;
+  eflp->xip_timing     = qmi->M0_TIMING;
+  eflp->xip_rfmt       = qmi->M0_RFMT;
+  eflp->xip_rcmd       = qmi->M0_RCMD;
+  eflp->xip_m1_timing  = qmi->M1_TIMING;
+  eflp->xip_m1_rfmt    = qmi->M1_RFMT;
+  eflp->xip_m1_rcmd    = qmi->M1_RCMD;
+  eflp->xip_m1_wfmt    = qmi->M1_WFMT;
+  eflp->xip_m1_wcmd    = qmi->M1_WCMD;
+
+  /* Wait for any pending work.*/
+  if (!rp_flash_direct_wait_idle(qmi)) {
+    return false;
+  }
+
+  /* Default non XIP SPI configuration */
+  qmi->DIRECT_CSR = QMI_DIRECT_CSR_EN | QMI_DIRECT_CSR_CLKDIV(6U);
+
+  /* Wait for the direct-mode interface to settle after enabling it
+     while draining stale RX data: a full RX FIFO can itself stall the
+     serial engine and hold BUSY high, so the drain must happen inside
+     the wait (matches the bootrom's entry sequence). */
+  {
+    uint32_t start = TIMER0->TIMERAWL;
+
+    while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_BUSY) != 0U) {
+      if ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
+        (void)qmi->DIRECT_RX;
+      }
+      if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+        return false;
+      }
+    }
+    while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_RXEMPTY) == 0U) {
+      (void)qmi->DIRECT_RX;
+    }
+  }
+
+  /*
+   * Exit continuous read / QPI mode sequence:
+   * 1. CS high 32 clocks with IO pulled down
+   * 2. CS low 32 clocks with IO pulled up
+   * 3. F5h QPI exit in quad width, 16x NOP ones, FFh QPI exit in quad width
+  */
+
+  /* Save all four data pad controls and configure with output
+     disabled.  Each pad is restored verbatim afterwards, SD2/SD3 may
+     be configured differently from SD0/SD1 (e.g. /WP and /HOLD
+     pull-ups on single-SPI boards). */
+  padctrl_save[0] = pads_qspi->GPIO_QSPI_SD0;
+  padctrl_save[1] = pads_qspi->GPIO_QSPI_SD1;
+  padctrl_save[2] = pads_qspi->GPIO_QSPI_SD2;
+  padctrl_save[3] = pads_qspi->GPIO_QSPI_SD3;
+  padctrl_tmp = (padctrl_save[0] & ~(PADS_QSPI_OD | PADS_QSPI_PUE |
+                                     PADS_QSPI_PDE))
+                | PADS_QSPI_OD | PADS_QSPI_PDE;
+
+  /* 1. CS high */
+  rp_flash_cs_force(eflp, true);
+
+  pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
+  pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
+  pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
+  pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
+
+  /* Delay of ~6000 cycles */
+  for (delay = 0U; delay < 2048U; delay++) {
+  }
+
+  /* Send 4 bytes / 32 clocks */
+  for (i = 0U; ok && (i < 4U); i++) {
+    ok = rp_flash_direct_tx8(qmi, 0U);
+  }
+
+  if (ok) {
+    padctrl_tmp = (padctrl_tmp & ~PADS_QSPI_PDE) | PADS_QSPI_PUE;
+
+    /* 2. CS low */
+    rp_flash_cs_force(eflp, false);
+
+    pads_qspi->GPIO_QSPI_SD0 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD1 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD2 = padctrl_tmp;
+    pads_qspi->GPIO_QSPI_SD3 = padctrl_tmp;
+
+    /* Delay of ~6000 cycles */
+    for (delay = 0U; delay < 2048U; delay++) {
+    }
+
+    /* Send 4 bytes / 32 clocks */
+    for (i = 0U; ok && (i < 4U); i++) {
+      ok = rp_flash_direct_tx8(qmi, 0U);
+    }
+  }
+
+  /* Restore all pad controls verbatim, also on failed sequences. */
+  pads_qspi->GPIO_QSPI_SD0 = padctrl_save[0];
+  pads_qspi->GPIO_QSPI_SD1 = padctrl_save[1];
+  pads_qspi->GPIO_QSPI_SD2 = padctrl_save[2];
+  pads_qspi->GPIO_QSPI_SD3 = padctrl_save[3];
+
+  if (!ok) {
+    rp_flash_cs_force(eflp, true);
+    return false;
+  }
+
+  /* 3. QPI exit: F5h in quad width on CS0. Exits flash chips that use
+   *    this command to leave QPI mode (e.g. some Winbond, ISSI parts).
+   *    PSRAM on CS1 is unaffected — its CS is not asserted here and its
+   *    QPI state is preserved across the flash operation via M1
+   *    save/restore.
+   *
+   *    CS is still asserted from phase 2; a real deassert/reassert edge
+   *    is required so F5h starts a fresh transaction (the bootrom does
+   *    the same). */
+  rp_flash_cs_force(eflp, true);
+  for (delay = 0U; delay < 64U; delay++) {
+  }
+  rp_flash_cs_force(eflp, false);
+  qmi->DIRECT_TX = 0xF5U | QMI_DIRECT_TX_IWIDTH(QMI_DIRECT_TX_IWIDTH_Q) |
+                   QMI_DIRECT_TX_OE | QMI_DIRECT_TX_NOPUSH;
+  ok = rp_flash_direct_wait_idle(qmi);
+  rp_flash_cs_force(eflp, true);
+
+  /* Continuous-read recovery: CSn=0, MOSI=1, all other IOs Hi-Z, 16
+   * clocks in single-width (Hardware Design with RP2350: Section 3.3,
+   * RP2350 Datasheet: 5.4.8.7). Exits devices stuck in continuous-read
+   * mode; QPI exit is handled separately by the FFh quad command below. */
+  if (ok) {
+    rp_flash_cs_force(eflp, false);
+    for (i = 0U; ok && (i < 2U); i++) {
+      uint32_t start = TIMER0->TIMERAWL;
+
+      while ((qmi->DIRECT_CSR & QMI_DIRECT_CSR_TXFULL) != 0U) {
+        if (rp_flash_timeout(start, RP_FLASH_QMI_TIMEOUT_US)) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) {
+        qmi->DIRECT_TX = 0xFFU | QMI_DIRECT_TX_NOPUSH;
+      }
+    }
+    if (ok) {
+      ok = rp_flash_direct_wait_idle(qmi);
+    }
+    rp_flash_cs_force(eflp, true);
+  }
+
+  /* QPI exit: FFh in quad width (catches devices that ignore F5h). */
+  if (ok) {
+    rp_flash_cs_force(eflp, false);
+    qmi->DIRECT_TX = 0xFFU | QMI_DIRECT_TX_IWIDTH(QMI_DIRECT_TX_IWIDTH_Q) |
+                     QMI_DIRECT_TX_OE | QMI_DIRECT_TX_NOPUSH;
+    ok = rp_flash_direct_wait_idle(qmi);
+    rp_flash_cs_force(eflp, true);
+  }
+
+  return ok;
+}
+
+/**
+ * @brief   Enter XIP mode
+ * @note    This function MUST be in RAM.
+ * @note    Restores the XIP configuration that was saved when exit_xip
+ *          was called, preserving whatever mode the bootrom configured
+ *          (e.g. QSPI fast read).
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @return              @p true on success, @p false when the final idle
+ *                      wait timed out (the restore still proceeds, XIP
+ *                      must come back no matter what).
+ */
+RAMFUNC static bool rp_flash_enter_xip(hal_efl_driver_c *eflp) {
+  QMI_TypeDef *qmi = eflp->qmi;
+  bool ok;
+
+  /* Wait for transfers to complete.  On timeout the restore proceeds
+     anyway, XIP must come back no matter what. */
+  ok = rp_flash_direct_wait_idle(qmi);
+
+  /* Disable direct mode and restore saved XIP configuration (CS0 and CS1). */
+  qmi->DIRECT_CSR = 0U;
+  qmi->M0_TIMING  = eflp->xip_timing;
+  qmi->M0_RFMT    = eflp->xip_rfmt;
+  qmi->M0_RCMD    = eflp->xip_rcmd;
+  qmi->M1_TIMING  = eflp->xip_m1_timing;
+  qmi->M1_RFMT    = eflp->xip_m1_rfmt;
+  qmi->M1_RCMD    = eflp->xip_m1_rcmd;
+  qmi->M1_WFMT    = eflp->xip_m1_wfmt;
+  qmi->M1_WCMD    = eflp->xip_m1_wcmd;
+
+  rp_flash_flush_cache(eflp);
+
+  return ok;
+}
+
+/**
+ * @brief   Program a page of flash.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] offset    flash offset (must be page-aligned or within page)
+ * @param[in] data      data to program
+ * @param[in] len       number of bytes (must not cross page boundary)
+ * @return              true on success, false on timeout or
+ *                      communication failure.
+ */
+RAMFUNC static flash_error_t rp_flash_program_page(hal_efl_driver_c *eflp,
+                                                   uint32_t offset,
+                                                   const uint8_t *data,
+                                                   size_t len) {
+  QMI_TypeDef *qmi = eflp->qmi;
+  flash_error_t ready_err;
+  uint8_t addr[3];
+  bool ok;
+
+  /* Send write enable; nothing was launched on failure. */
+  if (!rp_flash_write_enable(eflp)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Prepare 24-bit address (big-endian). */
+  addr[0] = (uint8_t)(offset >> 16);
+  addr[1] = (uint8_t)(offset >> 8);
+  addr[2] = (uint8_t)offset;
+
+  /* Assert CS. */
+  rp_flash_cs_force(eflp, false);
+
+  /* Send page program command. */
+  ok = rp_flash_direct_tx8(qmi, FLASHCMD_PAGE_PROGRAM);
+
+  /* Send address. */
+  if (ok) {
+    ok = rp_flash_put_get(eflp, addr, NULL, 3U);
+  }
+
+  /* Send data. */
+  if (ok) {
+    ok = rp_flash_put_get(eflp, data, NULL, len);
+  }
+
+  /* A failed transfer can leave engine residue behind; resynchronize
+     before the CS edge so the ready polls read their own responses. */
+  if (!ok) {
+    rp_flash_resync(qmi);
+  }
+
+  /* Deassert CS, also on failed transfers. */
+  rp_flash_cs_force(eflp, true);
+
+  /* The CS edge may have launched the program even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_PROGRAM_TIMEOUT_US,
+                                  FLASH_ERROR_PROGRAM);
+
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
+}
+
+/**
+ * @brief   Send an erase command to flash.
+ * @note    This function MUST be in RAM.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] cmd       JEDEC erase command byte
+ * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              true on success, false on timeout or
+ *                      communication failure.
+ */
+RAMFUNC static flash_error_t rp_flash_erase_cmd(hal_efl_driver_c *eflp,
+                                                uint8_t cmd,
+                                                uint32_t offset) {
+  flash_error_t ready_err;
+  uint8_t addr[3];
+  bool ok;
+
+  /* Send write enable; nothing was launched on failure. */
+  if (!rp_flash_write_enable(eflp)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Prepare 24-bit address (big-endian). */
+  addr[0] = (uint8_t)(offset >> 16);
+  addr[1] = (uint8_t)(offset >> 8);
+  addr[2] = (uint8_t)offset;
+
+  /* Send erase command with address. */
+  ok = rp_flash_do_cmd(eflp, cmd, addr, NULL, 3U);
+
+  /* The CS edge may have launched the erase even after a partial
+     transfer; the device must be drained to idle in every case before
+     XIP can come back. */
+  ready_err = rp_flash_wait_ready(eflp, RP_FLASH_ERASE_TIMEOUT_US,
+                                  FLASH_ERROR_ERASE);
+
+  if (!ok) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+  return ready_err;
+}
+
+/**
+ * @brief   Masks all maskable interrupts at the architecture level.
+ * @details While XIP is disabled every handler is unreachable, including
+ *          fast interrupts above the kernel priority ceiling which a
+ *          BASEPRI-based lock would leave enabled. PRIMASK is used on ARM
+ *          and mstatus.MIE on RISC-V; NMI and fault-class exceptions
+ *          remain unmasked on both architectures.
+ * @note    Forced inline so the masking code is guaranteed to reside in
+ *          the RAMFUNC callers.
+ *
+ * @return              An opaque, architecture-specific mask state (the
+ *                      PRIMASK value on ARM, the saved mstatus.MIE bit
+ *                      on RISC-V), only meaningful as the argument to
+ *                      @p rp_flash_restore_irqs().
+ */
+CC_FORCE_INLINE static inline uint32_t rp_flash_mask_irqs(void) {
+#if defined(__riscv)
+  return hazard3_irq_disable_save();
+#else
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+  return primask;
+#endif
+}
+
+/**
+ * @brief   Restores the interrupt enable state saved by
+ *          @p rp_flash_mask_irqs().
+ *
+ * @param[in] state     opaque mask state returned by
+ *                      @p rp_flash_mask_irqs(), not interpretable by the
+ *                      caller
+ */
+CC_FORCE_INLINE static inline void rp_flash_restore_irqs(uint32_t state) {
+#if defined(__riscv)
+  hazard3_irq_restore(state);
+#else
+  __set_PRIMASK(state);
+#endif
+}
+
+/**
+ * @brief   Complete erase operation (runs entirely in RAM).
+ * @note    This function MUST be in RAM. It handles the entire sequence
+ *          from exit XIP to enter XIP so no flash code executes while
+ *          XIP is disabled.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] cmd       JEDEC erase command byte
+ * @param[in] offset    flash offset (must be aligned to erase unit)
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_erase_full(hal_efl_driver_c *eflp,
+                                                 uint8_t cmd,
+                                                 uint32_t offset) {
+  flash_error_t err = FLASH_NO_ERROR;
+  uint32_t irqs;
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  irqs = rp_flash_mask_irqs();
+
+  /* Exit XIP mode. */
+  if (!rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Send erase command and wait for erase to complete. */
+  else {
+    err = rp_flash_erase_cmd(eflp, cmd, offset);
+  }
+
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  rp_flash_restore_irqs(irqs);
+
+  return err;
+}
+
+/**
+ * @brief   Single-page program operation that runs entirely in RAM.
+ * @note    This function MUST be in RAM. It handles the entire sequence
+ *          from exit XIP to enter XIP so no flash code executes while
+ *          XIP is disabled.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[in] offset    flash offset (must not cross page boundary)
+ * @param[in] data      pointer to data in RAM
+ * @param[in] len       number of bytes to program
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_program_page_full(hal_efl_driver_c *eflp,
+                                                        uint32_t offset,
+                                                        const uint8_t *data,
+                                                        size_t len) {
+  flash_error_t err = FLASH_NO_ERROR;
+  uint32_t irqs;
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  irqs = rp_flash_mask_irqs();
+
+  /* Exit XIP mode. */
+  if (!rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Program the page. */
+  else {
+    err = rp_flash_program_page(eflp, offset, data, len);
+  }
+
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  rp_flash_restore_irqs(irqs);
+
+  return err;
+}
+
+/**
+ * @brief   Read flash unique ID (runs entirely in RAM).
+ * @note    This function MUST be in RAM. It handles the entire sequence
+ *          from exit XIP to enter XIP so no flash code executes while
+ *          XIP is disabled.
+ *
+ * @param[in] eflp      pointer to an EFL driver instance
+ * @param[out] rx       receive buffer
+ * @param[in] count     number of bytes to transfer after command
+ * @return              An error code.
+ */
+RAMFUNC static flash_error_t rp_flash_read_uid_full(hal_efl_driver_c *eflp,
+                                                    uint8_t *rx,
+                                                    size_t count) {
+  flash_error_t err = FLASH_NO_ERROR;
+  uint32_t irqs;
+
+  /* Defer fast interrupts too, their handlers may execute from flash.*/
+  irqs = rp_flash_mask_irqs();
+
+  /* Exit XIP mode. */
+  if (!rp_flash_exit_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+  /* Send read unique ID command. */
+  else if (!rp_flash_do_cmd(eflp, FLASHCMD_READ_UNIQUE_ID, NULL, rx, count)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Re-enter XIP mode unconditionally, the system cannot continue
+     without XIP restored. A controller failure here outranks any
+     device-level error already recorded. */
+  if (!rp_flash_enter_xip(eflp)) {
+    err = FLASH_ERROR_HW_FAILURE;
+  }
+
+  rp_flash_restore_irqs(irqs);
+
+  return err;
+}
+
+/**
+ * @brief   Translates a logical XIP offset through the QMI address
+ *          translation registers.
+ * @details Program and erase commands are issued with physical flash
+ *          addresses while XIP reads go through the ATRANS windows.
+ *          With a non-identity mapping (e.g. bootrom-packaged images,
+ *          A/B partitions) the logical offset must be translated
+ *          before it is sent to the device.  The boot default is an
+ *          identity mapping, so behavior is unchanged on stock
+ *          systems.
+ * @note    Runs from flash while XIP is still enabled, must be called
+ *          before the RAM-resident sequence.
+ *
+ * @param[in] qmi       pointer to the QMI registers
+ * @param[in] offset    logical offset within the XIP address space
+ * @param[in] length    length of the operation starting at @p offset
+ * @param[out] physp    translated physical flash offset
+ * @return              true on success, false if any part of the
+ *                      [offset, offset + length) extent falls outside
+ *                      the mapped size of its 4 MiB window.
+ */
+static bool rp_flash_translate(QMI_TypeDef *qmi, uint32_t offset,
+                               uint32_t length, uint32_t *physp) {
+  uint32_t at    = qmi->ATRANS[(offset >> 22) & 7U];
+  uint32_t base  = ((at & QMI_ATRANS_BASE_Msk) >> QMI_ATRANS_BASE_Pos) << 12;
+  uint32_t size  = ((at & QMI_ATRANS_SIZE_Msk) >> QMI_ATRANS_SIZE_Pos) << 12;
+  uint32_t off4m = offset & 0x3FFFFFU;
+
+  /* The whole extent must lie inside the window's mapped size, the
+     SIZE granularity (4 KiB) is finer than the large erase units. */
+  if ((off4m >= size) || ((size - off4m) < length)) {
+    return false;
+  }
+  *physp = base + off4m;
+
+  return true;
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+void rp_efl_lld_init(void) {
+
+  /* RP2350 uses QMI register save/restore, no boot2 copy is needed. */
+  EFLD1.qmi = QMI;
+}
+
+msg_t rp_efl_lld_start(hal_efl_driver_c *eflp) {
+
+  (void)eflp;
+
+  /* Nothing to do - flash is always accessible via XIP. */
+  return HAL_RET_SUCCESS;
+}
+
+flash_error_t rp_efl_lld_program_page_full(hal_efl_driver_c *eflp,
+                                           uint32_t offset,
+                                           const uint8_t *data,
+                                           size_t len) {
+  uint32_t phys;
+
+  /* Unconditional bounds validation of the logical extent, the debug
+     checks in the upper layers are compiled out in release builds and
+     the ATRANS windows can map more than the configured flash size. */
+  if ((offset >= RP_FLASH_SIZE) ||
+      ((RP_FLASH_SIZE - offset) < (uint32_t)len)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Translate through ATRANS while XIP still works, validating the
+     whole page extent. */
+  if (!rp_flash_translate(eflp->qmi, offset, (uint32_t)len, &phys)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  return rp_flash_program_page_full(eflp, phys, data, len);
+}
+
+flash_error_t rp_efl_lld_erase_full(hal_efl_driver_c *eflp,
+                                    uint8_t cmd,
+                                    uint32_t offset) {
+  uint32_t phys;
+  uint32_t esize;
+
+  /* Erase extent per command byte, unknown commands are rejected. */
+  switch (cmd) {
+  case FLASHCMD_SECTOR_ERASE:
+    esize = RP_FLASH_SECTOR_SIZE;
+    break;
+  case FLASHCMD_BLOCK_ERASE_32K:
+    esize = RP_FLASH_BLOCK_32K_SIZE;
+    break;
+  case FLASHCMD_BLOCK_ERASE_64K:
+    esize = RP_FLASH_BLOCK_64K_SIZE;
+    break;
+  default:
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Unconditional bounds validation of the logical extent, the debug
+     checks in the upper layers are compiled out in release builds and
+     the ATRANS windows can map more than the configured flash size. */
+  if ((offset >= RP_FLASH_SIZE) || ((RP_FLASH_SIZE - offset) < esize)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* Translate through ATRANS while XIP still works, validating the
+     whole erase extent: the SIZE field is 4 KiB-granular so a large
+     erase can start inside a window yet overrun its mapped tail. */
+  if (!rp_flash_translate(eflp->qmi, offset, esize, &phys)) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  /* The device aligns erase commands down to the erase unit; a BASE
+     that is not aligned to the unit would silently erase physical data
+     outside the translated extent. */
+  if ((phys & (esize - 1U)) != 0U) {
+    return FLASH_ERROR_HW_FAILURE;
+  }
+
+  return rp_flash_erase_full(eflp, cmd, phys);
+}
+
+flash_error_t rp_efl_lld_read_uid_full(hal_efl_driver_c *eflp,
+                                       uint8_t *rx,
+                                       size_t count) {
+
+  return rp_flash_read_uid_full(eflp, rx, count);
+}
+
+#endif /* HAL_USE_EFL == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/hal_efl_lld.h
+++ b/os/xhal/ports/RP/RP2350/hal_efl_lld.h
@@ -1,0 +1,287 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/hal_efl_lld.h
+ * @brief   RP2350 Embedded Flash subsystem low level driver header.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#ifndef HAL_EFL_LLD_H
+#define HAL_EFL_LLD_H
+
+#if (HAL_USE_EFL == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Flash page size (minimum write unit).
+ */
+#define RP_FLASH_PAGE_SIZE                  256U
+
+/**
+ * @brief   Flash sector size (minimum erase unit).
+ */
+#define RP_FLASH_SECTOR_SIZE                4096U
+
+/**
+ * @brief   Flash sector erase command (JEDEC 0x20).
+ */
+#define RP_FLASH_CMD_SECTOR_ERASE          0x20U
+
+/**
+ * @brief   Flash 32KB block erase command (JEDEC 0x52).
+ */
+#define RP_FLASH_CMD_BLOCK_ERASE_32K        0x52U
+
+/**
+ * @brief   Flash 64KB block erase command (JEDEC 0xD8).
+ */
+#define RP_FLASH_CMD_BLOCK_ERASE_64K        0xD8U
+
+/**
+ * @brief   Flash 32KB block size.
+ */
+#define RP_FLASH_BLOCK_32K_SIZE             (32U * 1024U)
+
+/**
+ * @brief   Flash 64KB block size.
+ */
+#define RP_FLASH_BLOCK_64K_SIZE             65536U
+
+/**
+ * @brief   XIP base address.
+ */
+#define RP_FLASH_BASE                       0x10000000U
+
+/**
+ * @brief   QMI base address.
+ */
+#define RP_QMI_BASE                         0x400D0000U
+
+/**
+ * @brief   XIP control base address.
+ */
+#define RP_XIP_CTRL_BASE                    0x400C8000U
+
+/**
+ * @brief   Flash unique ID size in bytes.
+ */
+#define RP_FLASH_UNIQUE_ID_SIZE             8U
+
+/**
+ * @name    XIP safety strategies
+ * @{
+ */
+/**
+ * @brief   Flash safety left to the application.
+ * @details The application is responsible for providing @p
+ *          rpEflBeforeXipOff() / @p rpEflAfterXipOn() implementations
+ *          which keep the other core, fast interrupts and DMA away from
+ *          XIP while flash operations are in progress.
+ */
+#define RP_EFL_XIP_SAFETY_NONE              0
+/**
+ * @brief   Built-in SMP lockout.
+ * @details The port parks the other core in RAM with interrupts masked
+ *          for the duration of each flash operation. DMA reading from the
+ *          XIP window remains an application responsibility.
+ */
+#define RP_EFL_XIP_SAFETY_LOCKOUT           1
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    RP2350 configuration options
+ * @{
+ */
+
+/**
+ * @brief   Total flash size in bytes.
+ * @note    Default is 4MB for standard Raspberry Pi Pico 2.
+ *          Override in mcuconf.h for boards with different flash sizes.
+ */
+#if !defined(RP_FLASH_SIZE) || defined(__DOXYGEN__)
+#define RP_FLASH_SIZE                       (4U * 1024U * 1024U)
+#endif
+
+/* The driver issues 24-bit (3-byte) JEDEC addresses; larger devices
+   would silently wrap around and corrupt low flash. */
+#if RP_FLASH_SIZE > (16U * 1024U * 1024U)
+#error "RP_FLASH_SIZE exceeds 24-bit flash addressing"
+#endif
+
+/**
+ * @brief   XIP safety strategy used while flash operations run.
+ * @details One of @p RP_EFL_XIP_SAFETY_NONE (application-provided hooks)
+ *          or @p RP_EFL_XIP_SAFETY_LOCKOUT (built-in SMP core lockout).
+ * @note    SMP configurations must select a strategy explicitly in
+ *          mcuconf.h, flash operations are not SMP-safe otherwise.
+ */
+#if !defined(RP_EFL_XIP_SAFETY) || defined(__DOXYGEN__)
+#if defined(CH_CFG_SMP_MODE) && (CH_CFG_SMP_MODE == TRUE)
+#error "SMP EFL requires RP_EFL_XIP_SAFETY in mcuconf.h: select RP_EFL_XIP_SAFETY_LOCKOUT or RP_EFL_XIP_SAFETY_NONE with application hooks"
+#else
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_NONE
+#endif
+#endif
+
+#if (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_NONE) &&                        \
+    (RP_EFL_XIP_SAFETY != RP_EFL_XIP_SAFETY_LOCKOUT)
+#error "invalid RP_EFL_XIP_SAFETY value"
+#endif
+
+/**
+ * @brief   Suggested wait time during erase operations polling.
+ */
+#if !defined(RP_FLASH_WAIT_TIME_MS) || defined(__DOXYGEN__)
+#define RP_FLASH_WAIT_TIME_MS               1U
+#endif
+
+/**
+ * @brief   Timeout for QMI direct-mode FIFO/BUSY waits in microseconds.
+ * @details Bounds the individual controller-level waits (FIFO drains,
+ *          DIRECT_CSR BUSY polls) performed while XIP is disabled.
+ */
+#if !defined(RP_FLASH_QMI_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_QMI_TIMEOUT_US             1000U
+#endif
+
+/**
+ * @brief   Timeout for a page program operation in microseconds.
+ */
+#if !defined(RP_FLASH_PROGRAM_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_PROGRAM_TIMEOUT_US         20000U
+#endif
+
+/**
+ * @brief   Timeout for an erase operation in microseconds.
+ * @details Sized for the worst-case 64KB block erase time of common
+ *          QSPI flash devices.
+ */
+#if !defined(RP_FLASH_ERASE_TIMEOUT_US) || defined(__DOXYGEN__)
+#define RP_FLASH_ERASE_TIMEOUT_US           4000000U
+#endif
+
+/**
+ * @brief   Enables PSRAM (CS1) cache handling in the EFL driver.
+ * @details When enabled, the XIP cache flush performs a clean-before-
+ *          invalidate sequence to write back dirty PSRAM cache lines
+ *          before invalidation. When disabled, only invalidation is
+ *          performed (flash cache lines are never dirty).
+ * @note    Set to @p TRUE in mcuconf.h for boards with PSRAM on QMI CS1.
+ * @note    PSRAM must be initialized (QMI M1 registers configured,
+ *          XIP_CTRL WRITABLE_M1 set) before the first EFL operation.
+ *          The EFL driver saves XIP_CTRL on entry to flash operations
+ *          and restores it on exit; if WRITABLE_M1 is not yet set at
+ *          the time of the first save, it will be cleared on restore.
+ */
+#if !defined(RP_EFL_HAS_PSRAM) || defined(__DOXYGEN__)
+#define RP_EFL_HAS_PSRAM                    FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness. */
+#if !defined(RP_HAS_FLASH)
+#error "RP_HAS_FLASH not defined in registry"
+#endif
+
+#if RP_HAS_FLASH != TRUE
+#error "RP_HAS_FLASH is not TRUE"
+#endif
+
+/**
+ * @brief   Number of sectors in flash.
+ */
+#define RP_FLASH_SECTORS_COUNT              (RP_FLASH_SIZE / RP_FLASH_SECTOR_SIZE)
+
+/**
+ * @brief   Number of 64KB blocks in flash.
+ */
+#define RP_FLASH_BLOCKS_COUNT               (RP_FLASH_SIZE / RP_FLASH_BLOCK_64K_SIZE)
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+#include "rp_efl_lld.h"
+
+/**
+ * @brief   Low level fields of the embedded flash driver structure.
+ */
+#define efl_lld_driver_fields                                               \
+  /* Pointer to QMI registers. */                                           \
+  QMI_TypeDef                 *qmi;                                         \
+  /* Saved XIP control register. */                                         \
+  uint32_t                    xip_ctrl;                                     \
+  /* Saved CS0 (flash) XIP configuration registers. */                       \
+  uint32_t                    xip_timing;                                   \
+  uint32_t                    xip_rfmt;                                     \
+  uint32_t                    xip_rcmd;                                     \
+  /* Saved CS1 (PSRAM) XIP configuration registers. */                      \
+  uint32_t                    xip_m1_timing;                                \
+  uint32_t                    xip_m1_rfmt;                                  \
+  uint32_t                    xip_m1_rcmd;                                  \
+  uint32_t                    xip_m1_wfmt;                                  \
+  uint32_t                    xip_m1_wcmd
+
+/**
+ * @brief   Low level fields of the embedded flash configuration structure.
+ */
+#define efl_lld_config_fields                                               \
+  /* Dummy configuration, it is not needed.*/                               \
+  uint32_t                    dummy
+
+/*===========================================================================*/
+/* Application hooks.                                                        */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if !defined(__DOXYGEN__)
+extern hal_efl_driver_c EFLD1;
+#endif
+#include "rp_efl_lld_api.inc"
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_EFL == TRUE */
+
+#endif /* HAL_EFL_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2350/platform.mk
+++ b/os/xhal/ports/RP/RP2350/platform.mk
@@ -26,11 +26,18 @@ endif
 
 HALCONF := $(strip $(shell cat $(HALCONFDIR)/xhalconf.h | grep -E "\#define"))
 
+ifneq ($(findstring HAL_USE_EFL TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/RP2350/hal_efl_lld.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350/rp_flash_safety.c
+endif
 else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/RP2350/hal_efl_lld.c \
+               $(CHIBIOS)/os/xhal/ports/RP/RP2350/rp_flash_safety.c
 endif
 
 # Drivers compatible with the platform.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/EFLv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk

--- a/os/xhal/ports/RP/RP2350/rp_flash_safety.c
+++ b/os/xhal/ports/RP/RP2350/rp_flash_safety.c
@@ -1,0 +1,72 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RP2350/rp_flash_safety.c
+ * @brief   Built-in SMP flash safety hooks.
+ * @details Strong implementations of the EFL XIP hooks which park the
+ *          other core in RAM for the duration of flash operations, using
+ *          the RP2 SMP port lockout services.
+ *
+ * @addtogroup HAL_EFL
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_EFL == TRUE) && (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT)
+
+#if !defined(CH_CFG_SMP_MODE) || (CH_CFG_SMP_MODE != TRUE)
+#error "RP_EFL_XIP_SAFETY_LOCKOUT requires the RT SMP kernel (CH_CFG_SMP_MODE == TRUE)"
+#endif
+
+/**
+ * @brief   Parks the other core before XIP becomes unavailable.
+ * @note    When the HAL itself started core 1, its readiness is awaited
+ *          before the first lockout: until then the core may be running
+ *          startup code from flash without being parkable yet. A core
+ *          started by other means is the application's responsibility
+ *          (do not perform flash operations before it is ready).
+ */
+void rpEflBeforeXipOff(void) {
+
+#if RP_CORE1_START == TRUE
+  if (!__port_lockout_other_ready()) {
+    uint32_t start = TIMER0->TIMERAWL;
+
+    while (!__port_lockout_other_ready()) {
+      if ((TIMER0->TIMERAWL - start) > PORT_LOCKOUT_TIMEOUT_US) {
+        chSysHalt("core 1 never became parkable");
+      }
+    }
+  }
+#endif
+
+  __port_flash_lockout();
+}
+
+/**
+ * @brief   Releases the other core once XIP is available again.
+ */
+void rpEflAfterXipOn(void) {
+
+  __port_flash_unlockout();
+}
+
+#endif /* (HAL_USE_EFL == TRUE) &&
+          (RP_EFL_XIP_SAFETY == RP_EFL_XIP_SAFETY_LOCKOUT) */
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2040_pico/chconf.h
+++ b/testxhal/EFL-MFS/cfg/rp2040_pico/chconf.h
@@ -1,0 +1,857 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Disabled because the non-SMP ARMv6-M port has no realtime
+ *          counter support.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2040_pico/portab.c
+++ b/testxhal/EFL-MFS/cfg/rp2040_pico/portab.c
@@ -1,0 +1,51 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.c
+ * @brief   Application portability module code.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#include "hal.h"
+
+#include "portab.h"
+
+void portab_setup(void) {
+
+  /*
+   * UART0 I/O pins setup.
+   */
+  palSetLineMode(PORTAB_UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(PORTAB_UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+
+  /*
+   * LED line as output.
+   */
+  palSetLineMode(PORTAB_LINE_LED1, PAL_MODE_OUTPUT_PUSHPULL |
+                                   PAL_RP_PAD_DRIVE12);
+  palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_OFF);
+
+  /*
+   * Button replacement line as pulled-down input, it reads as not pressed
+   * unless externally driven high.
+   */
+  palSetLineMode(PORTAB_LINE_BUTTON, PAL_MODE_INPUT_PULLDOWN);
+}
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2040_pico/portab.h
+++ b/testxhal/EFL-MFS/cfg/rp2040_pico/portab.h
@@ -1,0 +1,63 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.h
+ * @brief   Application portability macros and structures.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+#define PORTAB_LINE_LED1            25U
+#define PORTAB_LED_OFF              PAL_LOW
+#define PORTAB_LED_ON               PAL_HIGH
+
+/* The Pico board has no user button, GP22 is configured as a pulled-down
+   input by portab_setup() so the line reads as not pressed unless it is
+   externally driven high.*/
+#define PORTAB_LINE_BUTTON          22U
+#define PORTAB_BUTTON_PRESSED       PAL_HIGH
+
+#define PORTAB_SIO1                 SIOD0
+#define PORTAB_UART_TX_PIN          0U
+#define PORTAB_UART_RX_PIN          1U
+
+/*
+ * The RP2040 external QSPI flash on the 2MB Pico is uniform 4KB sectors
+ * (512 in total), reserve the final two sectors of the device for the two
+ * 4KB MFS banks used by the test suite.
+ */
+#define MFS_BANK_SIZE               4096U
+#define MFS_BANK0_START             (RP_FLASH_SECTORS_COUNT - 2U)
+#define MFS_BANK0_SECTORS           1U
+#define MFS_BANK1_START             (RP_FLASH_SECTORS_COUNT - 1U)
+#define MFS_BANK1_SECTORS           1U
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTAB_H */
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2040_pico/xhalconf.h
+++ b/testxhal/EFL-MFS/cfg/rp2040_pico/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         TRUE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         TRUE
+#define HAL_USE_SPI                         FALSE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         FALSE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   TRUE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              TRUE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               FALSE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2040_pico/xmcuconf.h
+++ b/testxhal/EFL-MFS/cfg/rp2040_pico/xmcuconf.h
@@ -1,0 +1,75 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2040 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2040_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * EFL driver system settings.
+ * Single-core configuration, no XIP safety strategy is required and the
+ * default no-op coordination callbacks are used.
+ */
+#define RP_FLASH_SIZE                       (2U * 1024U * 1024U)
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_NONE
+#define RP_FLASH_WAIT_TIME_MS               1U
+#define RP_FLASH_SSI_TIMEOUT_US             1000U
+#define RP_FLASH_PROGRAM_TIMEOUT_US         20000U
+#define RP_FLASH_ERASE_TIMEOUT_US           4000000U
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+#endif /* XMCUCONF_H */

--- a/testxhal/EFL-MFS/cfg/rp2350_pico2/chconf.h
+++ b/testxhal/EFL-MFS/cfg/rp2350_pico2/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2350_pico2/portab.c
+++ b/testxhal/EFL-MFS/cfg/rp2350_pico2/portab.c
@@ -1,0 +1,51 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.c
+ * @brief   Application portability module code.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#include "hal.h"
+
+#include "portab.h"
+
+void portab_setup(void) {
+
+  /*
+   * UART0 I/O pins setup.
+   */
+  palSetLineMode(PORTAB_UART_TX_PIN, PAL_MODE_ALTERNATE_UART);
+  palSetLineMode(PORTAB_UART_RX_PIN, PAL_MODE_ALTERNATE_UART);
+
+  /*
+   * LED line as output.
+   */
+  palSetLineMode(PORTAB_LINE_LED1, PAL_MODE_OUTPUT_PUSHPULL |
+                                   PAL_RP_PAD_DRIVE12);
+  palWriteLine(PORTAB_LINE_LED1, PORTAB_LED_OFF);
+
+  /*
+   * Button replacement line as pulled-down input, it reads as not pressed
+   * unless externally driven high.
+   */
+  palSetLineMode(PORTAB_LINE_BUTTON, PAL_MODE_INPUT_PULLDOWN);
+}
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2350_pico2/portab.h
+++ b/testxhal/EFL-MFS/cfg/rp2350_pico2/portab.h
@@ -1,0 +1,63 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    portab.h
+ * @brief   Application portability macros and structures.
+ *
+ * @addtogroup application_portability
+ * @{
+ */
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+#define PORTAB_LINE_LED1            25U
+#define PORTAB_LED_OFF              PAL_LOW
+#define PORTAB_LED_ON               PAL_HIGH
+
+/* The Pico 2 board has no user button, GP22 is configured as a pulled-down
+   input by portab_setup() so the line reads as not pressed unless it is
+   externally driven high.*/
+#define PORTAB_LINE_BUTTON          22U
+#define PORTAB_BUTTON_PRESSED       PAL_HIGH
+
+#define PORTAB_SIO1                 SIOD0
+#define PORTAB_UART_TX_PIN          0U
+#define PORTAB_UART_RX_PIN          1U
+
+/*
+ * The RP2350 external QSPI flash on the 4MB Pico 2 is uniform 4KB sectors
+ * (1024 in total), reserve the final two sectors of the device for the two
+ * 4KB MFS banks used by the test suite.
+ */
+#define MFS_BANK_SIZE               4096U
+#define MFS_BANK0_START             (RP_FLASH_SECTORS_COUNT - 2U)
+#define MFS_BANK0_SECTORS           1U
+#define MFS_BANK1_START             (RP_FLASH_SECTORS_COUNT - 1U)
+#define MFS_BANK1_SECTORS           1U
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTAB_H */
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2350_pico2/xhalconf.h
+++ b/testxhal/EFL-MFS/cfg/rp2350_pico2/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         TRUE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         TRUE
+#define HAL_USE_SPI                         FALSE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         FALSE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   TRUE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              TRUE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               FALSE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/testxhal/EFL-MFS/cfg/rp2350_pico2/xmcuconf.h
+++ b/testxhal/EFL-MFS/cfg/rp2350_pico2/xmcuconf.h
@@ -1,0 +1,77 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest (4 bits on Cortex-M33).
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2350_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CLOCK_DYNAMIC                    FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_UART0_PRIORITY               3
+#define RP_IRQ_UART1_PRIORITY               3
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * EFL driver system settings.
+ * Single-core configuration, no XIP safety strategy is required and the
+ * default no-op coordination callbacks are used.
+ */
+#define RP_FLASH_SIZE                       (4U * 1024U * 1024U)
+#define RP_EFL_XIP_SAFETY                   RP_EFL_XIP_SAFETY_NONE
+#define RP_FLASH_WAIT_TIME_MS               1U
+#define RP_FLASH_QMI_TIMEOUT_US             1000U
+#define RP_FLASH_PROGRAM_TIMEOUT_US         20000U
+#define RP_FLASH_ERASE_TIMEOUT_US           4000000U
+#define RP_EFL_HAS_PSRAM                    FALSE
+
+/*
+ * SIO driver system settings.
+ */
+#define RP_SIO_USE_UART0                    TRUE
+#define RP_SIO_USE_UART1                    FALSE
+
+#endif /* XMCUCONF_H */

--- a/testxhal/EFL-MFS/make/rp2040_pico.make
+++ b/testxhal/EFL-MFS/make/rp2040_pico.make
@@ -1,0 +1,193 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+# NOTE: FLASH_LEN shrinks the linkable XIP region to 2040KB so the image
+#       can never overlap the two 4KB MFS bank sectors at the end of the
+#       2MB device (offsets 0x1FE000 and 0x1FF000).
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT = --defsym=FLASH_LEN=2088960
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m0plus
+
+# Imported source files and paths.
+CHIBIOS  := ../../
+CONFDIR  := ./cfg/rp2040_pico
+BUILDDIR := ./build/rp2040_pico
+DEPDIR   := ./.dep/rp2040_pico
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv6-M/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/test/test.mk
+include $(CHIBIOS)/test/mfs/mfs_test.mk
+include $(CHIBIOS)/os/xhal/lib/complex/mfs/hal_mfs.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2040_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(TESTSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC) $(TESTINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1 -DOOP_USE_LEGACY
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/testxhal/EFL-MFS/make/rp2350_pico2.make
+++ b/testxhal/EFL-MFS/make/rp2350_pico2.make
@@ -1,0 +1,198 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+# NOTE: FLASH_LEN shrinks the linkable XIP region to 4088KB so the image
+#       can never overlap the two 4KB MFS bank sectors at the end of the
+#       4MB device (offsets 0x3FE000 and 0x3FF000).
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT = --defsym=FLASH_LEN=4186112
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = softfp
+endif
+
+# FPU-related options.
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-sp-d16
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../
+CONFDIR  := ./cfg/rp2350_pico2
+BUILDDIR := ./build/rp2350_pico2
+DEPDIR   := ./.dep/rp2350_pico2
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/test/test.mk
+include $(CHIBIOS)/test/mfs/mfs_test.mk
+include $(CHIBIOS)/os/xhal/lib/complex/mfs/hal_mfs.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(TESTSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC) $(TESTINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS = -DCRT0_VTOR_INIT=1 -DOOP_USE_LEGACY
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################


### PR DESCRIPTION
## Summary

Stage 4a of the RP2040/RP2350 XHAL port: the embedded-flash (EFL) stack with XIP flash safety, plus RP targets for `testxhal/EFL-MFS`.

- The XHAL flash base class now owns the state machine: all ten classic driver-side state writes are removed, along with the entry-state gates the base now provides; the descriptor is served through the driver object per the STM32G4xx model; erase queries return immediately reflecting the synchronous RP erase (with `flashWaitErase()` semantics documented).
- The RP-local block-erase and unique-id operations become `rpEfl`-prefixed extensions with a hardened surface: extent derived exclusively from a validated command (the redundant size parameter is gone), self-locking via the driver mutex across their whole operation including the XIP window (documented as differing from the vmt ops' caller-side `flsAcquireExclusive()` convention), and a busy-gate on both.
- Family plumbing hardened symmetrically beyond the review findings: RP2040's low-level erase had no command validation at all (raw byte forwarded to the flash device) and gained the validated switch plus alignment checks; RP2350 gained logical-offset bounds (its address-translation windows can map more than the configured size); both families unconditionally bound offset+extent against `RP_FLASH_SIZE`.
- XIP-window discipline verified by section inspection on both families: every helper in `.ramtext` with zero branch targets into the XIP range; the QMI nine-register save/restore (with the WRITABLE_M1 ordering note), PSRAM cache sequence, timeouts, and the three-level `RP_EFL_XIP_SAFETY` policy carry over unchanged.
- `testxhal/EFL-MFS` gains both RP targets using the classic flash-bank offsets, with the MFS bank sectors now **reserved from the image via `FLASH_LEN`** (map-verified: flash length 0x1FE000 / 0x3FE000) — closing a weakness the classic precedent also has.

## Review triage

- codex adversarial review: central conversion verdict **clean** (state ownership, both XIP chains, QMI/PSRAM/lockout, and an explicit argument that single-core `SAFETY_NONE` is honest — the executing core masks interrupts inside RAM while XIP is down). Findings fixed: MFS-bank reservation (above), block-erase parameter API collapsed to a validated command, extension serialization + documentation, UID state gate.
- coderabbit CLI: 4 findings (extension mutex coverage, unknown-command rejection, command-derived extent, unconditional offset validation) — all fixed, with the symmetric-family sweep as a bonus.
- Follow-up candidates (not this PR): porting the classic `XIP-VALIDATION` and `EFL-SMP-LOCKOUT` testhal scenarios to XHAL so SMP lockout, ATRANS non-identity, PSRAM writeback and timeout recovery get dedicated runtime coverage.

## Verification

- Build matrix, all clean: testxhal/EFL-MFS rp2040+rp2350 × {default, +`CH_DBG_ENABLE_CHECKS/ASSERTS`}; `USE_SMART_BUILD=no` demo leg; untouched STM32 EFL-MFS leg; scratch link-tests across four configurations including SMP+LOCKOUT and PSRAM-enabled.
- OSAL lexical gate, per-file stylecheck, `git diff --check`: clean. Zero shared XHAL changes.
- On-hardware validation (MFS store/erase cycles on both chips) queued for the batched multi-stage bench pass before the stage drafts leave review.

## Changelog

- XHAL: RP port gains the EFL driver with XIP flash safety; testxhal/EFL-MFS gains RP2040/RP2350 targets.
