### PR TITLE
XHAL: RP port RTC drivers with absolute-time alarms

### DIFF
--- a/os/xhal/ports/RP/LLD/RTCv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/RTCv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_RTC TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv1

--- a/os/xhal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
+++ b/os/xhal/ports/RP/LLD/RTCv1/hal_rtc_lld.c
@@ -1,0 +1,582 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RTCv1/hal_rtc_lld.c
+ * @brief   RP2040 RTC subsystem low level driver source.
+ * @note    The alarm representation used by this driver is documented
+ *          in the driver header.
+ *
+ * @addtogroup HAL_RTC
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/* First Unix second outside the supported range, 2100-03-01T00:00:00Z.
+   The RP2040 RTC hardware applies the every-four-years leap rule to
+   all years, diverging from the Gregorian calendar at that instant,
+   see the driver header notes.*/
+#define RP_RTC_RANGE_END_SEC            4107542400UL
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   RTC driver identifier.
+ */
+hal_rtc_driver_c RTCD1;
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver default configuration.
+ * @note    The shared configuration fields are STM32 register images
+ *          with no meaning on this port, the default configuration is
+ *          intentionally empty.
+ */
+static const hal_rtc_config_t rtc_default_config = {
+  .cr                       = 0U,
+  .prer                     = 0U
+};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Enables alarm matching.
+ *
+ * @param[in] rtcp      pointer to the @p hal_rtc_driver_c object
+ *
+ * @notapi
+ */
+static void rtc_enable_alarm(hal_rtc_driver_c *rtcp) {
+
+  /* Enable matching and wait for it to be activated.*/
+  rtcp->rtc->IRQSETUP0 |= RTC_IRQ_SETUP_0_MATCH_ENA;
+  while ((rtcp->rtc->IRQSETUP0 & RTC_IRQ_SETUP_0_MATCH_ACTIVE) == 0U) {
+  }
+}
+
+/**
+ * @brief   Disables alarm matching.
+ *
+ * @param[in] rtcp      pointer to the @p hal_rtc_driver_c object
+ *
+ * @notapi
+ */
+static void rtc_disable_alarm(hal_rtc_driver_c *rtcp) {
+
+  /* Disable alarm matching and wait until deactivated.*/
+  rtcp->rtc->IRQSETUP0 &= ~RTC_IRQ_SETUP_0_MATCH_ENA;
+  while ((rtcp->rtc->IRQSETUP0 & RTC_IRQ_SETUP_0_MATCH_ACTIVE) != 0U) {
+  }
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   RTC alarm interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_RTC_IRQ_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  rtc_lld_serve_interrupt();
+
+  CH_IRQ_EPILOGUE();
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Shared interrupt service routine.
+ * @details The routine resolves the @p RTCD1 singleton, the RP2040 RTC
+ *          block is unique. The alarm event flag is published under
+ *          lock before the callback is invoked; the callback runs in
+ *          ISR context outside the system lock.
+ *
+ * @notapi
+ */
+void rtc_lld_serve_interrupt(void) {
+  syssts_t sts;
+  bool armed;
+
+  /* The interrupt is level-based on the match condition, matching must
+     be disabled in order to clear it. The alarm is single-shot through
+     the portable API so matching is not re-enabled.*/
+  rtc_disable_alarm(&RTCD1);
+
+  /* A stale pending interrupt taken after the alarm has been disarmed
+     must not publish the event nor invoke the callback. The fired
+     one-shot alarm reads back as disarmed from here on.*/
+  sts = chSysGetStatusAndLockX();
+  armed = (RTCD1.alrmr != 0U);
+  RTCD1.alrmr = 0U;
+  if (armed) {
+    RTCD1.events |= RTC_FLAGS_ALARM_A;
+  }
+  chSysRestoreStatusX(sts);
+
+  if (armed && (RTCD1.cb != NULL)) {
+    RTCD1.cb(&RTCD1);
+  }
+}
+
+/**
+ * @brief   Low level RTC driver initialization.
+ *
+ * @notapi
+ */
+void rtc_lld_init(void) {
+
+  /* RTC object initialization.*/
+  rtcObjectInit(&RTCD1);
+
+  /* RTC register bank pointer initialization.*/
+  RTCD1.rtc = RTC;
+
+  /* No alarm armed initially.*/
+  RTCD1.alrmr = 0U;
+}
+
+/**
+ * @brief   Configures and activates the RTC peripheral.
+ * @note    Starting the driver does not start time counting, the RTC
+ *          begins counting when a date/time is set. An RTC already
+ *          counting keeps its time through a driver restart.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @return                      The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_start(hal_rtc_driver_c *rtcp) {
+  const hal_rtc_config_t *cfg;
+  uint32_t clock, divider, ctrl;
+
+  cfg = (const hal_rtc_config_t *)rtcp->config;
+  if (cfg == NULL) {
+    cfg = rtc_lld_selcfg(rtcp, 0U);
+  }
+  if (cfg == NULL) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+  rtcp->config = cfg;
+
+  /* The RTC block is clocked by clk_rtc, the divider brings it down to
+     the 1Hz reference.*/
+  clock = hal_lld_get_clock_point(RP_CLK_RTC);
+  if ((clock == 0U) || ((clock - 1U) > RTC_CLKDIV_M1)) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  /* Take RTC out of reset.*/
+  rp_peripheral_unreset(RESETS_ALLREG_RTC);
+
+  /* The divider is rewritten only when it does not match, the RTC may
+     be counting through a driver restart and the divider may only be
+     changed while the RTC is disabled. The counted date/time survives
+     the controlled disable, the counters are only paused; the enable
+     state is restored afterwards.*/
+  divider = clock - 1U;
+  if (rtcp->rtc->CLKDIVM1 != divider) {
+    ctrl = rtcp->rtc->CTRL;
+    rtcp->rtc->CTRL = 0U;
+    while ((rtcp->rtc->CTRL & RTC_CTRL_RTC_ACTIVE) != 0U) {
+    }
+    rtcp->rtc->CLKDIVM1 = divider;
+    if ((ctrl & RTC_CTRL_RTC_ENABLE) != 0U) {
+      rtcp->rtc->CTRL = RTC_CTRL_RTC_ENABLE;
+      while ((rtcp->rtc->CTRL & RTC_CTRL_RTC_ACTIVE) == 0U) {
+      }
+    }
+  }
+
+  /* Start from a disarmed alarm state and enable the RTC vector.*/
+  rtc_disable_alarm(rtcp);
+  rtcp->rtc->INTE &= ~RTC_INTE_RTC;
+  rtcp->alrmr = 0U;
+  rtcp->events = 0U;
+  nvicEnableVector(RP_RTC_IRQ_NUMBER, RP_IRQ_RTC_PRIORITY);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the RTC peripheral.
+ * @note    The RTC keeps counting after a driver stop, time is not
+ *          lost; only the alarm and its interrupt are disabled.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ *
+ * @notapi
+ */
+void rtc_lld_stop(hal_rtc_driver_c *rtcp) {
+
+  rtc_disable_alarm(rtcp);
+  rtcp->rtc->INTE &= ~RTC_INTE_RTC;
+  nvicDisableVector(RP_RTC_IRQ_NUMBER);
+  rtcp->alrmr = 0U;
+  rtcp->cb = NULL;
+  rtcp->events = 0U;
+}
+
+/**
+ * @brief   Applies a configuration.
+ * @note    The @p cr and @p prer fields are accepted and ignored, see
+ *          the driver header notes.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @param[in]     config        Pointer to the configuration structure.
+ * @return                      The accepted configuration or @p NULL.
+ *
+ * @notapi
+ */
+const hal_rtc_config_t *rtc_lld_setcfg(hal_rtc_driver_c *rtcp,
+                                       const hal_rtc_config_t *config) {
+
+  /* A missing configuration is replaced with the default one.*/
+  if (config == NULL) {
+    return rtc_lld_selcfg(rtcp, 0U);
+  }
+
+  return config;
+}
+
+/**
+ * @brief   Selects one of the predefined configurations.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @param[in]     cfgnum        Configuration selector.
+ * @return                      The selected configuration or @p NULL.
+ *
+ * @notapi
+ */
+const hal_rtc_config_t *rtc_lld_selcfg(hal_rtc_driver_c *rtcp,
+                                       unsigned cfgnum) {
+
+  (void)rtcp;
+
+  if (cfgnum != 0U) {
+    return NULL;
+  }
+
+  return &rtc_default_config;
+}
+
+/**
+ * @brief   Driver callback setting hook.
+ * @note    The callback pointer is stored by the base class and the
+ *          alarm interrupt source is managed by @p rtc_lld_set_alarm(),
+ *          no low level action is required.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @param         cb            Callback function or @p NULL.
+ *
+ * @notapi
+ */
+void rtc_lld_set_callback(hal_rtc_driver_c *rtcp, drv_cb_t cb) {
+
+  (void)rtcp;
+  (void)cb;
+}
+
+/**
+ * @brief   Sets the current date/time.
+ * @note    Fractional seconds part will be silently ignored. There is
+ *          no possibility to set it on the RP2040 platform.
+ * @note    The RP2040 treats every year evenly divisible by 4 as a
+ *          leap year, therefore date/times at or after 2100-03-01 are
+ *          rejected with @p HAL_RET_CONFIG_ERROR, see the driver
+ *          header notes.
+ * @note    The function can be called from any context.
+ *
+ * @param[in] rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[in] timespec  pointer to a @p rtc_datetime_t structure
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_set_datetime(hal_rtc_driver_c *rtcp,
+                           const rtc_datetime_t *timespec) {
+  rtc_time64_t tv;
+  uint32_t sec, min, hour, setup0, setup1;
+  syssts_t sts;
+
+  /* Date/times at/after 2100-03-01 are outside the range where the
+     hardware every-four-years leap rule matches the Gregorian
+     calendar.*/
+  if (rtcConvertDateTimeToTime64(timespec, &tv) != HAL_RET_SUCCESS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+  if (tv.tv_sec >= (int64_t)RP_RTC_RANGE_END_SEC) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  sec = timespec->millisecond / 1000U;
+  hour = sec / 3600U;
+  sec %= 3600U;
+  min = sec / 60U;
+  sec %= 60U;
+
+  /* Setup register data.*/
+  setup0 = (RTC_SETUP_0_YEAR((uint32_t)timespec->year + RTC_BASE_YEAR))     |
+           (RTC_SETUP_0_MONTH(timespec->month))                             |
+           (RTC_SETUP_0_DAY(timespec->day));
+  setup1 = (RTC_SETUP_1_DOTW(timespec->dayofweek > 0U ?
+                             (uint32_t)timespec->dayofweek - 1U : 0U)
+                             & RTC_SETUP_1_DOTW_Msk)                        |
+           (RTC_SETUP_1_HOUR(hour) & RTC_SETUP_1_HOUR_Msk)                  |
+           (RTC_SETUP_1_MIN(min) & RTC_SETUP_1_MIN_Msk)                     |
+           (RTC_SETUP_1_SEC(sec) & RTC_SETUP_1_SEC_Msk);
+
+  /* Entering a reentrant critical zone.*/
+  sts = chSysGetStatusAndLockX();
+
+  /* Disable RTC.*/
+  rtcp->rtc->CTRL = 0U;
+
+  /* Wait for RTC to go inactive.*/
+  while ((rtcp->rtc->CTRL & RTC_CTRL_RTC_ACTIVE) != 0U) {
+  }
+
+  /* Write setup to pre-load registers.*/
+  rtcp->rtc->SETUP0 = setup0;
+  rtcp->rtc->SETUP1 = setup1;
+
+  /* Move the setup values into the RTC clock domain and re-enable the
+     RTC in one write. Writing LOAD and RTC_ENABLE as two separate
+     writes races the slower RTC clock domain: the second write clears
+     the pending LOAD strobe before the date counter has sampled it, so
+     the time of day would take the new value while the date kept the
+     old one.*/
+  rtcp->rtc->CTRL = RTC_CTRL_LOAD | RTC_CTRL_RTC_ENABLE;
+
+  /* Leaving a reentrant critical zone.*/
+  chSysRestoreStatusX(sts);
+
+  /* Wait for RTC to go active.*/
+  while ((rtcp->rtc->CTRL & RTC_CTRL_RTC_ACTIVE) == 0U) {
+  }
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Gets the current date/time.
+ * @note    The function can be called from any context.
+ *
+ * @param[in]  rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[out] timespec  pointer to a @p rtc_datetime_t structure
+ * @return               The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_get_datetime(hal_rtc_driver_c *rtcp,
+                           rtc_datetime_t *timespec) {
+  uint32_t rtc_0, rtc_1;
+  syssts_t sts;
+
+  /* Entering a reentrant critical zone.*/
+  sts = chSysGetStatusAndLockX();
+
+  /* Read RTC0 first then RTC1.*/
+  rtc_0 = rtcp->rtc->RTC0;
+  rtc_1 = rtcp->rtc->RTC1;
+
+  /* Leaving a reentrant critical zone.*/
+  chSysRestoreStatusX(sts);
+
+  /* Calculate and set milliseconds since midnight field.*/
+  timespec->millisecond = ((RTC_RTC_0_HOUR(rtc_0) * 3600U) +
+                           (RTC_RTC_0_MIN(rtc_0) * 60U) +
+                           (RTC_RTC_0_SEC(rtc_0))) * 1000U;
+
+  /* Set rtc_datetime_t fields with adjustments from RTC data.*/
+  timespec->dayofweek = (uint8_t)(RTC_RTC_0_DOTW(rtc_0) + 1U);
+  timespec->year      = (uint16_t)(RTC_RTC_1_YEAR(rtc_1) - RTC_BASE_YEAR);
+  timespec->month     = (uint8_t)RTC_RTC_1_MONTH(rtc_1);
+  timespec->day       = (uint8_t)RTC_RTC_1_DAY(rtc_1);
+  timespec->dstflag   = 0U;
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Sets an alarm.
+ * @details The @p alrmr word of the alarm specification is an absolute
+ *          time in seconds since the Unix epoch, see the driver header
+ *          notes; it is expanded into a full broken-down date/time and
+ *          programmed as a one-shot full-field match. The day-of-week
+ *          field is written but not matched.
+ * @note    A @p NULL alarm specification disables the alarm.
+ * @note    Alarm times at or after 2100-03-01 are rejected with
+ *          @p HAL_RET_CONFIG_ERROR, see the driver header notes.
+ * @note    The function can be called from any context.
+ *
+ * @param[in] rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[in] alarm     alarm identifier
+ * @param[in] alarmspec pointer to a @p rtc_alarm_t structure or @p NULL
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_set_alarm(hal_rtc_driver_c *rtcp,
+                        rtcalarm_t alarm,
+                        const rtc_alarm_t *alarmspec) {
+  rtc_time64_t tv;
+  rtc_datetime_t dt;
+  uint32_t sec, min, hour, setup0, setup1;
+  syssts_t sts;
+
+  if (alarm >= (rtcalarm_t)RTC_ALARMS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  if (alarmspec == NULL) {
+    /* Entering a reentrant critical zone.*/
+    sts = chSysGetStatusAndLockX();
+
+    /* Disable matching and the alarm interrupt; the level interrupt
+       deasserts when matching deactivates.*/
+    rtc_disable_alarm(rtcp);
+    rtcp->rtc->INTE &= ~RTC_INTE_RTC;
+
+    /* The alarm reads back as disarmed.*/
+    rtcp->alrmr = 0U;
+
+    /* Leaving a reentrant critical zone.*/
+    chSysRestoreStatusX(sts);
+
+    return HAL_RET_SUCCESS;
+  }
+
+  /* Alarm times at/after 2100-03-01 are outside the range where the
+     hardware every-four-years leap rule matches the Gregorian
+     calendar.*/
+  if (alarmspec->alrmr >= RP_RTC_RANGE_END_SEC) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  /* Expanding the seconds count into a broken-down date/time using the
+     shared conversion helper, times before 1980-01-01 are rejected by
+     the conversion.*/
+  tv.tv_sec = (int64_t)alarmspec->alrmr;
+  tv.tv_nsec = 0U;
+  if (rtcConvertTime64ToDateTime(&tv, &dt) != HAL_RET_SUCCESS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  /* Setup date/time fields.*/
+  sec = dt.millisecond / 1000U;
+  hour = sec / 3600U;
+  sec %= 3600U;
+  min = sec / 60U;
+  sec %= 60U;
+
+  /* Setup register data, all calendar fields are match-enabled making
+     the alarm a one-shot full date/time comparison.*/
+  setup0 = (RTC_IRQ_SETUP_0_YEAR((uint32_t)dt.year + RTC_BASE_YEAR)
+               & RTC_IRQ_SETUP_0_YEAR_Msk)                                  |
+           (RTC_IRQ_SETUP_0_MONTH(dt.month) & RTC_IRQ_SETUP_0_MONTH_Msk)    |
+           (RTC_IRQ_SETUP_0_DAY(dt.day) & RTC_IRQ_SETUP_0_DAY_Msk)          |
+           RTC_IRQ_SETUP_0_YEAR_ENA                                         |
+           RTC_IRQ_SETUP_0_MONTH_ENA                                        |
+           RTC_IRQ_SETUP_0_DAY_ENA;
+  setup1 = (RTC_IRQ_SETUP_1_DOTW(dt.dayofweek > 0U ?
+                                 (uint32_t)dt.dayofweek - 1U : 0U)
+               & RTC_IRQ_SETUP_1_DOTW_Msk)                                  |
+           (RTC_IRQ_SETUP_1_HOUR(hour) & RTC_IRQ_SETUP_1_HOUR_Msk)          |
+           (RTC_IRQ_SETUP_1_MIN(min) & RTC_IRQ_SETUP_1_MIN_Msk)             |
+           (RTC_IRQ_SETUP_1_SEC(sec) & RTC_IRQ_SETUP_1_SEC_Msk)             |
+           RTC_IRQ_SETUP_1_HOUR_ENA                                         |
+           RTC_IRQ_SETUP_1_MIN_ENA                                          |
+           RTC_IRQ_SETUP_1_SEC_ENA;
+
+  /* Entering a reentrant critical zone.*/
+  sts = chSysGetStatusAndLockX();
+
+  /* Disable matching and load the alarm time.*/
+  rtc_disable_alarm(rtcp);
+  rtcp->rtc->IRQSETUP0 = setup0;
+  rtcp->rtc->IRQSETUP1 = setup1;
+
+  /* An interrupt pended by a previous alarm must not be misattributed
+     to the new one, pending state is cleared before enabling so that
+     an intentionally-past alarm time still fires.*/
+  nvicClearPending(RP_RTC_IRQ_NUMBER);
+
+  /* Enable the interrupt and the matching.*/
+  rtcp->rtc->INTE |= RTC_INTE_RTC;
+  rtc_enable_alarm(rtcp);
+
+  /* Save the alarm settings.*/
+  rtcp->alrmr = alarmspec->alrmr;
+
+  /* Leaving a reentrant critical zone.*/
+  chSysRestoreStatusX(sts);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Gets an alarm.
+ * @note    The returned @p alrmr word is the stored alarm time in
+ *          seconds since the Unix epoch, zero when the alarm is
+ *          disarmed.
+ * @note    The function can be called from any context.
+ *
+ * @param[in]  rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[in]  alarm     alarm identifier
+ * @param[out] alarmspec pointer to a @p rtc_alarm_t structure
+ * @return               The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_get_alarm(hal_rtc_driver_c *rtcp,
+                        rtcalarm_t alarm,
+                        rtc_alarm_t *alarmspec) {
+
+  if (alarm >= (rtcalarm_t)RTC_ALARMS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  /* TODO: Read back from the RTC registers (to reduce RTCDriver size). */
+  alarmspec->alrmr = rtcp->alrmr;
+
+  return HAL_RET_SUCCESS;
+}
+
+#endif /* HAL_USE_RTC */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/RTCv1/hal_rtc_lld.h
+++ b/os/xhal/ports/RP/LLD/RTCv1/hal_rtc_lld.h
@@ -1,0 +1,171 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RTCv1/hal_rtc_lld.h
+ * @brief   RP2040 RTC subsystem low level driver header.
+ *
+ * @section rtcv1_alarm_representation Alarm representation
+ *
+ * The portable @p rtc_alarm_t type carries a single 32-bit @p alrmr
+ * word which, on STM32 parts, is an ALRMR register image. On this port
+ * @p alrmr is NOT a register image: it is an ABSOLUTE alarm time
+ * expressed in SECONDS since the Unix epoch (1970-01-01 00:00:00 UTC),
+ * the same timescale carried by @p rtc_time64_t::tv_sec and used by
+ * @p rtcSetTime64() and @p rtcGetTime64(), i.e. the timescale the
+ * application uses when it sets the date/time. The driver expands
+ * @p alrmr into a full broken-down date/time and programs a one-shot,
+ * full-field date/time match in the RTC block.
+ *
+ * @note    The supported range ends on 2100-02-28T23:59:59Z: the
+ *          RP2040 RTC hardware treats every year evenly divisible by
+ *          4 as a leap year, including 2100 which is not leap in the
+ *          Gregorian calendar. Date/times and alarm times at or after
+ *          2100-03-01 are rejected with @p HAL_RET_CONFIG_ERROR; the
+ *          @p CTRL.FORCE_NOTLEAPYEAR feature is kept cleared, which is
+ *          correct within the supported range. The classic driver in
+ *          os/hal/ports/RP/LLD/RTCv1 shares this hardware behavior.
+ *          Alarm times before 1980-01-01 (the floor of the shared
+ *          date/time representation) are also rejected with
+ *          @p HAL_RET_CONFIG_ERROR.
+ * @note    Repeating and field-masked alarms are not available through
+ *          the portable API even though the RP2040 RTC block supports
+ *          per-field match enables; see the classic driver in
+ *          os/hal/ports/RP/LLD/RTCv1 for what the silicon can do.
+ *          Dedicated rtcRP* extension functions are possible future
+ *          work.
+ * @note    The @p cr and @p prer fields of the shared
+ *          @p hal_rtc_config_t are STM32 register images with no
+ *          meaning on this port, they are accepted and ignored.
+ *
+ * @addtogroup HAL_RTC
+ * @{
+ */
+
+#ifndef HAL_RTC_LLD_H
+#define HAL_RTC_LLD_H
+
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Implementation capabilities
+ * @{
+ */
+/**
+ * @brief   Callback support in the driver.
+ * @note    Kept for parity with the classic RP2040 driver which also
+ *          supports alarm callbacks.
+ */
+#define RTC_SUPPORTS_CALLBACKS      TRUE
+
+/**
+ * @brief   Number of alarms available.
+ */
+#define RTC_ALARMS                  1
+
+/**
+ * @brief   Presence of a local persistent storage.
+ */
+#define RTC_HAS_STORAGE             FALSE
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/* Priority settings checks.*/
+#if !defined(RP_IRQ_RTC_PRIORITY)
+#error "RP_IRQ_RTC_PRIORITY not defined in mcuconf.h"
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* IRQ priority checks. The alarm handler interacts with the kernel,
+   therefore a kernel-compatible priority is required.*/
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_RTC_PRIORITY)
+#error "Invalid IRQ priority assigned to RTC"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Implementation-specific @p hal_rtc_driver_c fields.
+ */
+#define rtc_lld_driver_fields                                               \
+  /* Pointer to the RTC registers block.*/                                  \
+  RTC_TypeDef               *rtc;                                           \
+  /* Alarm time in seconds since the Unix epoch, zero when disarmed.*/      \
+  uint32_t                  alrmr
+
+/**
+ * @brief   Implementation-specific @p hal_rtc_config_t fields.
+ * @note    Empty, the shared @p cr and @p prer fields are accepted and
+ *          ignored by this port.
+ */
+#define rtc_lld_config_fields
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rtc_lld_init(void);
+  msg_t rtc_lld_start(hal_rtc_driver_c *rtcp);
+  void rtc_lld_stop(hal_rtc_driver_c *rtcp);
+  const hal_rtc_config_t *rtc_lld_setcfg(hal_rtc_driver_c *rtcp,
+                                         const hal_rtc_config_t *config);
+  const hal_rtc_config_t *rtc_lld_selcfg(hal_rtc_driver_c *rtcp,
+                                         unsigned cfgnum);
+  void rtc_lld_set_callback(hal_rtc_driver_c *rtcp, drv_cb_t cb);
+  void rtc_lld_serve_interrupt(void);
+  msg_t rtc_lld_set_datetime(hal_rtc_driver_c *rtcp,
+                             const rtc_datetime_t *timespec);
+  msg_t rtc_lld_get_datetime(hal_rtc_driver_c *rtcp,
+                             rtc_datetime_t *timespec);
+  msg_t rtc_lld_set_alarm(hal_rtc_driver_c *rtcp,
+                          rtcalarm_t alarm,
+                          const rtc_alarm_t *alarmspec);
+  msg_t rtc_lld_get_alarm(hal_rtc_driver_c *rtcp,
+                          rtcalarm_t alarm,
+                          rtc_alarm_t *alarmspec);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_RTC == TRUE */
+
+#endif /* HAL_RTC_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/RTCv2/driver.mk
+++ b/os/xhal/ports/RP/LLD/RTCv2/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_RTC TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv2

--- a/os/xhal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
+++ b/os/xhal/ports/RP/LLD/RTCv2/hal_rtc_lld.c
@@ -1,0 +1,574 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RTCv2/hal_rtc_lld.c
+ * @brief   RP2350 RTC subsystem low level driver source.
+ * @details This driver is built on the POWMAN "Always-On" timer. The
+ *          timer time base is milliseconds since the Unix epoch, the
+ *          timescale of @p rtc_time64_t; the classic driver used
+ *          milliseconds since @p RTC_BASE_YEAR instead, see the
+ *          @p RP_RTC_TIME_BASE_LEGACY_1980 option in the driver header
+ *          for coexistence with counters retained from classic
+ *          firmware. The alarm representation used by this driver is
+ *          documented in the driver header.
+ *
+ * @addtogroup HAL_RTC
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/* Nominal LPOSC frequency, matching the RP2350 power-on-reset default
+   for these registers (32.768kHz target for the internal low power
+   oscillator).*/
+#define RP_LPOSC_NOMINAL_FREQ_KHZ_INT   32UL
+#define RP_LPOSC_NOMINAL_FREQ_KHZ_FRAC  0xC49CUL
+
+/* Offset, in milliseconds, between the classic driver time base
+   1980-01-01T00:00:00Z and the Unix epoch used by this driver, see
+   @p RP_RTC_TIME_BASE_LEGACY_1980 in the driver header.*/
+#define RP_RTC_EPOCH_1980_OFFSET_MS     315532800000ULL
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   RTC driver identifier.
+ */
+hal_rtc_driver_c RTCD1;
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver default configuration.
+ * @note    The shared configuration fields are STM32 register images
+ *          with no meaning on this port, the default configuration is
+ *          intentionally empty.
+ */
+static const hal_rtc_config_t rtc_default_config = {
+  .cr                       = 0U,
+  .prer                     = 0U
+};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Translates an on-silicon counter value into Unix time.
+ *
+ * @param[in] counter_ms  counter value in milliseconds
+ * @return                Milliseconds since the Unix epoch.
+ *
+ * @notapi
+ */
+static uint64_t rtc_counter_to_unix_ms(uint64_t counter_ms) {
+
+#if RP_RTC_TIME_BASE_LEGACY_1980 == TRUE
+  return counter_ms + RP_RTC_EPOCH_1980_OFFSET_MS;
+#else
+  return counter_ms;
+#endif
+}
+
+/**
+ * @brief   Translates a Unix time into an on-silicon counter value.
+ * @note    Unix times before 1980-01-01 never reach this function,
+ *          they are rejected by the shared representation floor.
+ *
+ * @param[in] unix_ms   milliseconds since the Unix epoch
+ * @return              The counter value in milliseconds.
+ *
+ * @notapi
+ */
+static uint64_t rtc_unix_to_counter_ms(uint64_t unix_ms) {
+
+#if RP_RTC_TIME_BASE_LEGACY_1980 == TRUE
+  return unix_ms - RP_RTC_EPOCH_1980_OFFSET_MS;
+#else
+  return unix_ms;
+#endif
+}
+
+/**
+ * @brief   Returns the current AON timer value.
+ * @details Value is expressed in milliseconds since the Unix epoch,
+ *          translated from the on-silicon time base.
+ *
+ * @return              The timer value.
+ *
+ * @notapi
+ */
+static uint64_t powman_now_ms(void) {
+  uint32_t upper_word, lower_word, upper_word_recheck;
+
+  /* The 64-bit counter is exposed as two 32-bit halves; re-reading the
+     upper word after the lower one detects a rollover race between the
+     two reads.*/
+  upper_word = POWMAN->READ_TIME_UPPER;
+  for (;;) {
+    lower_word = POWMAN->READ_TIME_LOWER;
+    upper_word_recheck = POWMAN->READ_TIME_UPPER;
+    if (upper_word_recheck == upper_word) {
+      break;
+    }
+    upper_word = upper_word_recheck;
+  }
+  return rtc_counter_to_unix_ms(((uint64_t)upper_word << 32) | lower_word);
+}
+
+/**
+ * @brief   Disables the alarm comparator and its interrupt.
+ *
+ * @notapi
+ */
+static void rtc_disable_alarm(void) {
+
+  POWMAN->CLR.INTE  = POWMAN_PASSWORD | POWMAN_INTE_TIMER;
+  POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM_ENAB;
+}
+
+/**
+ * @brief   Programs the alarm comparator and enables it.
+ * @note    The comparator must be disabled while its registers are
+ *          written.
+ *
+ * @param[in] alarm_ms  alarm time in counter milliseconds, in the
+ *                      on-silicon time base
+ *
+ * @notapi
+ */
+static void rtc_arm_alarm(uint64_t alarm_ms) {
+
+  POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM_ENAB;
+  POWMAN->ALARM_TIME_15TO0 = POWMAN_PASSWORD |
+                             (uint32_t)(alarm_ms & 0xFFFFUL);
+  POWMAN->ALARM_TIME_31TO16 = POWMAN_PASSWORD |
+                              (uint32_t)((alarm_ms >> 16) & 0xFFFFUL);
+  POWMAN->ALARM_TIME_47TO32 = POWMAN_PASSWORD |
+                              (uint32_t)((alarm_ms >> 32) & 0xFFFFUL);
+  POWMAN->ALARM_TIME_63TO48 = POWMAN_PASSWORD |
+                              (uint32_t)((alarm_ms >> 48) & 0xFFFFUL);
+  POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM;
+
+  /* An interrupt pended by a previous alarm must not be misattributed
+     to the new one, pending state is cleared before enabling so that
+     an intentionally-past alarm time still fires.*/
+  nvicClearPending(RP_POWMAN_IRQ_TIMER_NUMBER);
+
+  POWMAN->SET.INTE  = POWMAN_PASSWORD | POWMAN_INTE_TIMER;
+  POWMAN->SET.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM_ENAB;
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   POWMAN timer alarm interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_POWMAN_IRQ_TIMER_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  rtc_lld_serve_interrupt();
+
+  CH_IRQ_EPILOGUE();
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Shared interrupt service routine.
+ * @details The routine resolves the @p RTCD1 singleton, the POWMAN AON
+ *          timer is unique. The alarm event flag is published under
+ *          lock before the callback is invoked; the callback runs in
+ *          ISR context outside the system lock.
+ *
+ * @notapi
+ */
+void rtc_lld_serve_interrupt(void) {
+  syssts_t sts;
+  bool armed;
+
+  /* The alarm comparator is level-sensitive (alarm_time >= current
+     time), so it must be disabled before the latched flag is cleared.
+     The alarm is single-shot through the portable API so it is not
+     re-armed.*/
+  rtc_disable_alarm();
+  POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM;
+
+  /* A stale pending interrupt taken after the alarm has been disarmed
+     must not publish the event nor invoke the callback. The fired
+     one-shot alarm reads back as disarmed from here on.*/
+  sts = chSysGetStatusAndLockX();
+  armed = (RTCD1.alrmr != 0U);
+  RTCD1.alrmr = 0U;
+  if (armed) {
+    RTCD1.events |= RTC_FLAGS_ALARM_A;
+  }
+  chSysRestoreStatusX(sts);
+
+  if (armed && (RTCD1.cb != NULL)) {
+    RTCD1.cb(&RTCD1);
+  }
+}
+
+/**
+ * @brief   Low level RTC driver initialization.
+ *
+ * @notapi
+ */
+void rtc_lld_init(void) {
+
+  /* RTC object initialization.*/
+  rtcObjectInit(&RTCD1);
+
+  /* No alarm armed initially.*/
+  RTCD1.alrmr = 0U;
+}
+
+/**
+ * @brief   Configures and activates the POWMAN AON timer.
+ * @note    A timer already running keeps its time, the AON domain
+ *          survives ordinary chip resets by design.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @return                      The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_start(hal_rtc_driver_c *rtcp) {
+  const hal_rtc_config_t *cfg;
+  uint32_t timer;
+
+  cfg = (const hal_rtc_config_t *)rtcp->config;
+  if (cfg == NULL) {
+    cfg = rtc_lld_selcfg(rtcp, 0U);
+  }
+  if (cfg == NULL) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+  rtcp->config = cfg;
+
+  /* POWMAN is in the Always-On power domain: it is not part of the
+     RESETS block and survives ordinary chip resets by design. The
+     LPOSC calibration and the tick source may only be written while
+     the timer is stopped or ticking from another source; a timer
+     already running from LPOSC keeps the calibration in effect and
+     is left untouched.*/
+  timer = POWMAN->TIMER;
+  if ((timer & (POWMAN_TIMER_RUN | POWMAN_TIMER_USING_LPOSC)) !=
+      (POWMAN_TIMER_RUN | POWMAN_TIMER_USING_LPOSC)) {
+    /* Stopping the timer while the tick source is calibrated and
+       selected, clearing RUN preserves the counted time.*/
+    POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_RUN;
+    POWMAN->LPOSC_FREQ_KHZ_INT = POWMAN_PASSWORD |
+                                 RP_LPOSC_NOMINAL_FREQ_KHZ_INT;
+    POWMAN->LPOSC_FREQ_KHZ_FRAC = POWMAN_PASSWORD |
+                                  RP_LPOSC_NOMINAL_FREQ_KHZ_FRAC;
+    POWMAN->SET.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_USE_LPOSC;
+  }
+
+  if ((POWMAN->TIMER & POWMAN_TIMER_RUN) == 0U) {
+    /* Timer not running: first power-up of the AON domain, a previous
+       explicit stop, or the tick source switch above.*/
+    POWMAN->SET.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_RUN;
+  }
+
+  /* The USING_LPOSC status asserts only while the timer is running,
+     the wait covers both the source switch and the untouched
+     already-running case.*/
+  while ((POWMAN->TIMER & POWMAN_TIMER_USING_LPOSC) == 0U) {
+  }
+
+  /* Start from a disarmed alarm state and enable the alarm vector.*/
+  rtc_disable_alarm();
+  POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM;
+  rtcp->alrmr = 0U;
+  rtcp->events = 0U;
+  nvicEnableVector(RP_POWMAN_IRQ_TIMER_NUMBER, RP_IRQ_RTC_PRIORITY);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the RTC alarm machinery.
+ * @note    The AON timer keeps counting after a driver stop, time is
+ *          not lost; only the alarm and its interrupt are disabled.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ *
+ * @notapi
+ */
+void rtc_lld_stop(hal_rtc_driver_c *rtcp) {
+
+  rtc_disable_alarm();
+  POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM;
+  nvicDisableVector(RP_POWMAN_IRQ_TIMER_NUMBER);
+  rtcp->alrmr = 0U;
+  rtcp->cb = NULL;
+  rtcp->events = 0U;
+}
+
+/**
+ * @brief   Applies a configuration.
+ * @note    The @p cr and @p prer fields are accepted and ignored, see
+ *          the driver header notes.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @param[in]     config        Pointer to the configuration structure.
+ * @return                      The accepted configuration or @p NULL.
+ *
+ * @notapi
+ */
+const hal_rtc_config_t *rtc_lld_setcfg(hal_rtc_driver_c *rtcp,
+                                       const hal_rtc_config_t *config) {
+
+  /* A missing configuration is replaced with the default one.*/
+  if (config == NULL) {
+    return rtc_lld_selcfg(rtcp, 0U);
+  }
+
+  return config;
+}
+
+/**
+ * @brief   Selects one of the predefined configurations.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @param[in]     cfgnum        Configuration selector.
+ * @return                      The selected configuration or @p NULL.
+ *
+ * @notapi
+ */
+const hal_rtc_config_t *rtc_lld_selcfg(hal_rtc_driver_c *rtcp,
+                                       unsigned cfgnum) {
+
+  (void)rtcp;
+
+  if (cfgnum != 0U) {
+    return NULL;
+  }
+
+  return &rtc_default_config;
+}
+
+/**
+ * @brief   Driver callback setting hook.
+ * @note    The callback pointer is stored by the base class and the
+ *          alarm interrupt source is managed by @p rtc_lld_set_alarm(),
+ *          no low level action is required.
+ *
+ * @param[in,out] rtcp          Pointer to the @p hal_rtc_driver_c object.
+ * @param         cb            Callback function or @p NULL.
+ *
+ * @notapi
+ */
+void rtc_lld_set_callback(hal_rtc_driver_c *rtcp, drv_cb_t cb) {
+
+  (void)rtcp;
+  (void)cb;
+}
+
+/**
+ * @brief   Sets the current date/time.
+ * @note    The function can be called from any context.
+ *
+ * @param[in] rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[in] timespec  pointer to a @p rtc_datetime_t structure
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_set_datetime(hal_rtc_driver_c *rtcp,
+                           const rtc_datetime_t *timespec) {
+  rtc_time64_t tv;
+  uint64_t milliseconds;
+  syssts_t sts;
+
+  (void)rtcp;
+
+  /* Conversion through the shared helper, the caller has already
+     validated the broken-down time. The counter is written in the
+     on-silicon time base.*/
+  if (rtcConvertDateTimeToTime64(timespec, &tv) != HAL_RET_SUCCESS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+  milliseconds = rtc_unix_to_counter_ms(((uint64_t)tv.tv_sec * 1000U) +
+                                        ((uint64_t)tv.tv_nsec / 1000000U));
+
+  /* Entering a reentrant critical zone.*/
+  sts = chSysGetStatusAndLockX();
+
+  /* SET_TIME_* may only be written while the timer is stopped.*/
+  POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_RUN;
+  POWMAN->SET_TIME_15TO0 = POWMAN_PASSWORD |
+                           (uint32_t)(milliseconds & 0xFFFFUL);
+  POWMAN->SET_TIME_31TO16 = POWMAN_PASSWORD |
+                            (uint32_t)((milliseconds >> 16) & 0xFFFFUL);
+  POWMAN->SET_TIME_47TO32 = POWMAN_PASSWORD |
+                            (uint32_t)((milliseconds >> 32) & 0xFFFFUL);
+  POWMAN->SET_TIME_63TO48 = POWMAN_PASSWORD |
+                            (uint32_t)((milliseconds >> 48) & 0xFFFFUL);
+  POWMAN->SET.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_RUN;
+
+  /* Leaving a reentrant critical zone.*/
+  chSysRestoreStatusX(sts);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Gets the current date/time.
+ * @note    The function can be called from any context.
+ * @note    The operation fails while the timer holds a value before
+ *          1980-01-01, the floor of the shared representation, which
+ *          means the time has never been set.
+ *
+ * @param[in]  rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[out] timespec  pointer to a @p rtc_datetime_t structure
+ * @return               The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_get_datetime(hal_rtc_driver_c *rtcp,
+                           rtc_datetime_t *timespec) {
+  rtc_time64_t tv;
+  uint64_t milliseconds;
+
+  (void)rtcp;
+
+  milliseconds = powman_now_ms();
+  tv.tv_sec = (int64_t)(milliseconds / 1000U);
+  tv.tv_nsec = (uint32_t)(milliseconds % 1000U) * 1000000U;
+
+  return rtcConvertTime64ToDateTime(&tv, timespec);
+}
+
+/**
+ * @brief   Sets an alarm.
+ * @details The @p alrmr word of the alarm specification is an absolute
+ *          time in seconds since the Unix epoch, see the driver header
+ *          notes; the POWMAN comparator is programmed at
+ *          @p alrmr * 1000 milliseconds as a one-shot alarm. An alarm
+ *          time already in the past fires immediately.
+ * @note    A @p NULL alarm specification disables the alarm.
+ * @note    The function can be called from any context.
+ *
+ * @param[in] rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[in] alarm     alarm identifier
+ * @param[in] alarmspec pointer to a @p rtc_alarm_t structure or @p NULL
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_set_alarm(hal_rtc_driver_c *rtcp,
+                        rtcalarm_t alarm,
+                        const rtc_alarm_t *alarmspec) {
+  rtc_time64_t tv;
+  rtc_datetime_t dt;
+  syssts_t sts;
+
+  if (alarm >= (rtcalarm_t)RTC_ALARMS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  if (alarmspec == NULL) {
+    /* Entering a reentrant critical zone.*/
+    sts = chSysGetStatusAndLockX();
+
+    rtc_disable_alarm();
+    POWMAN->CLR.TIMER = POWMAN_PASSWORD | POWMAN_TIMER_ALARM;
+
+    /* The alarm reads back as disarmed.*/
+    rtcp->alrmr = 0U;
+
+    /* Leaving a reentrant critical zone.*/
+    chSysRestoreStatusX(sts);
+
+    return HAL_RET_SUCCESS;
+  }
+
+  /* Validation through the shared conversion helper keeps the accepted
+     alrmr domain identical on both RP variants, times before
+     1980-01-01 are rejected.*/
+  tv.tv_sec = (int64_t)alarmspec->alrmr;
+  tv.tv_nsec = 0U;
+  if (rtcConvertTime64ToDateTime(&tv, &dt) != HAL_RET_SUCCESS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  /* Entering a reentrant critical zone.*/
+  sts = chSysGetStatusAndLockX();
+
+  /* Programming the comparator at the alarm time in milliseconds,
+     translated into the on-silicon time base.*/
+  rtc_arm_alarm(rtc_unix_to_counter_ms((uint64_t)alarmspec->alrmr * 1000U));
+
+  /* Save the alarm settings.*/
+  rtcp->alrmr = alarmspec->alrmr;
+
+  /* Leaving a reentrant critical zone.*/
+  chSysRestoreStatusX(sts);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Gets an alarm.
+ * @note    The returned @p alrmr word is the stored alarm time in
+ *          seconds since the Unix epoch, zero when the alarm is
+ *          disarmed.
+ * @note    The function can be called from any context.
+ *
+ * @param[in]  rtcp      pointer to the @p hal_rtc_driver_c object
+ * @param[in]  alarm     alarm identifier
+ * @param[out] alarmspec pointer to a @p rtc_alarm_t structure
+ * @return               The operation status.
+ *
+ * @notapi
+ */
+msg_t rtc_lld_get_alarm(hal_rtc_driver_c *rtcp,
+                        rtcalarm_t alarm,
+                        rtc_alarm_t *alarmspec) {
+
+  if (alarm >= (rtcalarm_t)RTC_ALARMS) {
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  alarmspec->alrmr = rtcp->alrmr;
+
+  return HAL_RET_SUCCESS;
+}
+
+#endif /* HAL_USE_RTC */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/RTCv2/hal_rtc_lld.h
+++ b/os/xhal/ports/RP/LLD/RTCv2/hal_rtc_lld.h
@@ -1,0 +1,202 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    RTCv2/hal_rtc_lld.h
+ * @brief   RP2350 RTC subsystem low level driver header.
+ * @details The driver is built on the POWMAN "Always-On" timer, the
+ *          RP2350 has no dedicated RTC peripheral. The timer counts
+ *          milliseconds since the Unix epoch (1970-01-01 00:00:00
+ *          UTC), the timescale of @p rtc_time64_t.
+ *
+ * @section rtcv2_retained_time Retained time base
+ *
+ * The AON timer counter is retained across ordinary chip resets, it is
+ * part of a persistent ABI shared with whatever firmware ran before.
+ * The classic driver in os/hal/ports/RP/LLD/RTCv2 keeps the counter in
+ * milliseconds since 1980-01-01T00:00:00Z (@p RTC_BASE_YEAR) while
+ * this driver keeps it in milliseconds since the Unix epoch: the two
+ * time bases differ by 315532800 seconds, a counter retained from
+ * classic firmware through a warm reset would be read that far in the
+ * past. Such a counter needs one of:
+ * - @p RP_RTC_TIME_BASE_LEGACY_1980 set to @p TRUE, the on-silicon
+ *   time base then stays at 1980-01-01 for coexistence with classic
+ *   firmware and this driver translates on every counter access;
+ * - a date/time set after the first boot of this firmware, which
+ *   rebases the counter to the Unix epoch (the default base).
+ *
+ * @section rtcv2_alarm_representation Alarm representation
+ *
+ * The portable @p rtc_alarm_t type carries a single 32-bit @p alrmr
+ * word which, on STM32 parts, is an ALRMR register image. On this port
+ * @p alrmr is NOT a register image: it is an ABSOLUTE alarm time
+ * expressed in SECONDS since the Unix epoch (1970-01-01 00:00:00 UTC),
+ * the same timescale carried by @p rtc_time64_t::tv_sec and used by
+ * @p rtcSetTime64() and @p rtcGetTime64(), i.e. the timescale the
+ * application uses when it sets the date/time. The driver programs the
+ * 64-bit POWMAN alarm comparator at @p alrmr * 1000 milliseconds, the
+ * alarm fires once when the timer value in milliseconds divided by
+ * 1000 reaches @p alrmr.
+ *
+ * @note    Being a 32-bit seconds count the representation wraps on
+ *          2106-02-07T06:28:15Z; alarms beyond that instant cannot be
+ *          expressed through the portable API. Alarm times before
+ *          1980-01-01 (the floor of the shared date/time
+ *          representation) are rejected with @p HAL_RET_CONFIG_ERROR.
+ * @note    Repeating and field-masked alarms are not available through
+ *          the portable API even though the classic driver in
+ *          os/hal/ports/RP/LLD/RTCv2 implements mask-based repetition
+ *          in software on top of the single POWMAN comparator.
+ *          Dedicated rtcRP* extension functions are possible future
+ *          work.
+ * @note    The @p cr and @p prer fields of the shared
+ *          @p hal_rtc_config_t are STM32 register images with no
+ *          meaning on this port, they are accepted and ignored.
+ *
+ * @addtogroup HAL_RTC
+ * @{
+ */
+
+#ifndef HAL_RTC_LLD_H
+#define HAL_RTC_LLD_H
+
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Implementation capabilities
+ * @{
+ */
+/**
+ * @brief   Callback support in the driver.
+ * @note    Kept for parity with the classic RP2350 driver which also
+ *          supports alarm callbacks.
+ */
+#define RTC_SUPPORTS_CALLBACKS      TRUE
+
+/**
+ * @brief   Number of alarms available.
+ * @note    The RP2350 POWMAN AON timer has a single 64-bit alarm
+ *          comparator.
+ */
+#define RTC_ALARMS                  1
+
+/**
+ * @brief   Presence of a local persistent storage.
+ */
+#define RTC_HAS_STORAGE             FALSE
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   Keeps the on-silicon time base at 1980-01-01.
+ * @details When @p TRUE the retained AON counter holds milliseconds
+ *          since 1980-01-01T00:00:00Z, the time base used by the
+ *          classic RP2350 driver, and this driver translates to and
+ *          from the Unix timescale on every counter access. When
+ *          @p FALSE the counter holds milliseconds since the Unix
+ *          epoch. See the retained time base section above.
+ */
+#if !defined(RP_RTC_TIME_BASE_LEGACY_1980) || defined(__DOXYGEN__)
+#define RP_RTC_TIME_BASE_LEGACY_1980    FALSE
+#endif
+
+/* Priority settings checks.*/
+#if !defined(RP_IRQ_RTC_PRIORITY)
+#error "RP_IRQ_RTC_PRIORITY not defined in mcuconf.h"
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* IRQ priority checks. The alarm handler interacts with the kernel,
+   therefore a kernel-compatible priority is required.*/
+#if !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_RTC_PRIORITY)
+#error "Invalid IRQ priority assigned to RTC"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Implementation-specific @p hal_rtc_driver_c fields.
+ * @note    There is a single AON timer, reached through the CMSIS
+ *          @p POWMAN peripheral pointer, so no per-instance register
+ *          pointer field is required.
+ */
+#define rtc_lld_driver_fields                                               \
+  /* Alarm time in seconds since the Unix epoch, zero when disarmed.*/      \
+  uint32_t                  alrmr
+
+/**
+ * @brief   Implementation-specific @p hal_rtc_config_t fields.
+ * @note    Empty, the shared @p cr and @p prer fields are accepted and
+ *          ignored by this port.
+ */
+#define rtc_lld_config_fields
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void rtc_lld_init(void);
+  msg_t rtc_lld_start(hal_rtc_driver_c *rtcp);
+  void rtc_lld_stop(hal_rtc_driver_c *rtcp);
+  const hal_rtc_config_t *rtc_lld_setcfg(hal_rtc_driver_c *rtcp,
+                                         const hal_rtc_config_t *config);
+  const hal_rtc_config_t *rtc_lld_selcfg(hal_rtc_driver_c *rtcp,
+                                         unsigned cfgnum);
+  void rtc_lld_set_callback(hal_rtc_driver_c *rtcp, drv_cb_t cb);
+  void rtc_lld_serve_interrupt(void);
+  msg_t rtc_lld_set_datetime(hal_rtc_driver_c *rtcp,
+                             const rtc_datetime_t *timespec);
+  msg_t rtc_lld_get_datetime(hal_rtc_driver_c *rtcp,
+                             rtc_datetime_t *timespec);
+  msg_t rtc_lld_set_alarm(hal_rtc_driver_c *rtcp,
+                          rtcalarm_t alarm,
+                          const rtc_alarm_t *alarmspec);
+  msg_t rtc_lld_get_alarm(hal_rtc_driver_c *rtcp,
+                          rtcalarm_t alarm,
+                          rtc_alarm_t *alarmspec);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_RTC == TRUE */
+
+#endif /* HAL_RTC_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/platform.mk
+++ b/os/xhal/ports/RP/RP2040/platform.mk
@@ -32,6 +32,7 @@ endif
 # Drivers compatible with the platform.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk

--- a/os/xhal/ports/RP/RP2350/platform.mk
+++ b/os/xhal/ports/RP/RP2350/platform.mk
@@ -32,6 +32,7 @@ endif
 # Drivers compatible with the platform.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv2/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk


### PR DESCRIPTION
## Summary

Stage 3c of the RP2040/RP2350 XHAL port: both RTC variants under the XHAL contract, implementing the campaign's alarm-representation decision — the shared `rtc_alarm_t` carries a single 32-bit STM32-shaped register image, so RP alarms adopt **absolute seconds since the Unix epoch** on both variants (one-shot full-field date-time match on the RP2040 RTC block; millisecond comparator on the RP2350 AON timer). Repeating/masked alarms are unreachable through the portable API and documented as such; `rtcRP*` extensions remain future work, and making `rtc_alarm_t` LLD-overridable upstream stays an open option if this lossy mapping proves too limiting.

Design decisions for reviewer attention:
- **RTCv2 time base rebased to Unix-epoch milliseconds** (comparator = alarm×1000). Retained counters written by classic firmware (1980 base) would read 10 years off — the `RP_RTC_TIME_BASE_LEGACY_1980` knob (default FALSE) keeps the on-silicon 1980 base with translation at every access for coexistence, and the header documents the retained-time ABI difference prominently.
- **RTCv1 advertised range ends 2100-02-28**: the RP2040 hardware treats every fourth year as leap including 2100 (classic shares this), so datetime/alarm values beyond the bound are rejected rather than silently drifting a day.
- Reading the date before time is set reports a configuration error rather than fabricating an epoch date.
- Conversion reuses the shared civil-calendar helpers, deleting classic's private date math; classic register-access disciplines preserved (verified against the datasheet sequences).

## Review triage

- codex adversarial review: 1 BLOCKER fixed (LPOSC calibration was written while the retained timer could be running — now guarded on the running/USING_LPOSC state with a stop-write-restart path preserving the count); 3 MAJOR fixed (2100 leap handling → bounded range; stale pended-IRQ misattribution on re-arm → `nvicClearPending` in the arm sequence; classic-counter epoch corruption → legacy-base knob + documentation); 2 MINOR fixed (fired one-shot alarms now read back disarmed under the publication lock, hardening the stale-interrupt guard; live `CLKDIVM1` rewrite skipped when matching, controlled disable/update/re-enable otherwise). Verified sound by review: 64-bit comparator arithmetic, shared-conversion round-trips, DOTW handling, register sequences, callback lock discipline.
- coderabbit CLI: 4 findings, all overlapping the codex set — fixed as above.
- Follow-up: an RP-compatible XHAL RTC validation app (the existing testxhal/RTC main constructs STM32 register images and cannot exercise this contract).

## Verification

- Build matrix clean: both chips × {default, +`CH_DBG_ENABLE_CHECKS/ASSERTS`}, `USE_SMART_BUILD=no`, SPI regression leg; OSAL gate, stylecheck, `git diff --check` clean; zero shared XHAL changes.
- On-hardware legs (alarm fire, warm-reset retention in both time bases, WDG-reset retention) queued for the batched bench pass.

## Changelog

- XHAL: RP port gains the RTC drivers with absolute-time alarms.