### PR TITLE
XHAL: RP port USB device driver

### DIFF
--- a/os/xhal/OSAL_REMOVAL_BUILDS.txt
+++ b/os/xhal/OSAL_REMOVAL_BUILDS.txt
@@ -46,6 +46,8 @@ testxhal/SPI/make/stm32wl55jc_nucleo64.make
 testxhal/TRNG/make/stm32g474re_nucleo64.make
 testxhal/TRNG/make/stm32h563zi_nucleo144.make
 testxhal/TRNG/make/stm32wl55jc_nucleo64.make
+testxhal/USB_CDC/make/rp2040_pico.make
+testxhal/USB_CDC/make/rp2350_pico2.make
 testxhal/USB_CDC/make/stm32g474re_nucleo64.make
 testxhal/WDG/make/rp2040_pico.make
 testxhal/WDG/make/rp2350_pico2.make

--- a/os/xhal/ports/RP/LLD/USBv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/USBv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_USB TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/USBv1/hal_usb_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/USBv1/hal_usb_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/USBv1

--- a/os/xhal/ports/RP/LLD/USBv1/hal_usb_lld.c
+++ b/os/xhal/ports/RP/LLD/USBv1/hal_usb_lld.c
@@ -1,0 +1,1111 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    USBv1/hal_usb_lld.c
+ * @brief   RP USB subsystem low level driver source.
+ * @note    This driver is based on the RP2040 USB LLD originally created by
+ *          @hanya and @xyzz wth significant improvements by @KarlK90. It has
+ *          been updated for the RP2350 and to fix a few defects and errata.
+ *
+ * @addtogroup USB
+ * @{
+ */
+
+#include <string.h>
+
+#include "hal.h"
+
+#if (HAL_USE_USB == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Get endpoint control register.
+ */
+#define EP_CTRL(ep)       (USB_DPSRAM->EPCTRL[ep - 1])
+/**
+ * @brief   Get buffer control register for endpoint.
+ */
+#define BUF_CTRL(ep)      (USB_DPSRAM->BUFCTRL[ep])
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   USB1 driver identifier.
+ */
+#if (RP_USB_USE_USB1 == TRUE) || defined(__DOXYGEN__)
+hal_usb_driver_c USBD1;
+
+/**
+ * @brief   Driver default configuration.
+ */
+static const hal_usb_config_t default_usb_config = {
+};
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   EP0 state.
+ * @note    The IN and OUT states can share the same memory because control
+ *          transfer phases are strictly sequential; the per-direction data
+ *          PIDs and DPRAM buffer assignments, which must survive phases of
+ *          the opposite direction, live in the driver endpoint hardware
+ *          contexts instead.
+ */
+static union {
+  /**
+   * @brief   IN EP0 state.
+   */
+  USBInEndpointState in;
+  /**
+   * @brief   OUT EP0 state.
+   */
+  USBOutEndpointState out;
+} ep0_state;
+
+/**
+ * @brief   EP0 initialization structure.
+ * @note    The setup buffer is not used, setup packets are captured by the
+ *          hardware in the dedicated DPRAM area.
+ */
+static const USBEndpointConfig ep0config = {
+  .ep_mode          = USB_EP_MODE_TYPE_CTRL,
+  .setup_cb         = _usb_ep0setup,
+  .in_cb            = _usb_ep0in,
+  .out_cb           = _usb_ep0out,
+  .in_maxsize       = 0x40U,
+  .out_maxsize      = 0x40U,
+  .in_state         = &ep0_state.in,
+  .out_state        = &ep0_state.out,
+  .ep_buffers       = 1U,
+  .setup_buf        = NULL
+};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+#if defined(__ARM_ARCH_8M_MAIN__) || defined(__riscv)
+/**
+ * @brief   Copy memory using byte accesses.
+ * @note    On RP2350 USB DPRAM requires strict alignment.
+ */
+static inline void usb_dpram_memcpy(void *dst, const void *src, size_t n) {
+  volatile uint8_t *d = (volatile uint8_t *)dst;
+  const volatile uint8_t *s = (const volatile uint8_t *)src;
+
+  while (n-- > 0) {
+    *d++ = *s++;
+  }
+}
+#else
+/**
+ * @brief   Copy memory using memcpy
+ * @note    On RP2040 USB DPRAM is normal memory.
+ */
+#define usb_dpram_memcpy(dst, src, n) memcpy(dst, src, n)
+#endif
+
+/**
+ * @brief   Buffer mode for isochronous in buffer control register.
+ */
+static uint16_t usb_isochronous_buffer_mode(uint16_t size) {
+  switch (size) {
+    case 128:
+      return 0;
+    case 256:
+      return 1;
+    case 512:
+      return 2;
+    case 1024:
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * @brief   Calculate isochronous buffer size in valid step.
+ * @details Valid buffer size is one of 128, 256, 512 or 1024.
+ */
+static uint16_t usb_isochronous_buffer_size(uint16_t max_size) {
+  uint16_t size;
+
+  /* Double buffer offset must be one of 128, 256, 512 or 1024. */
+  size = ((max_size - 1) / 128 + 1) * 128;
+  if (size == 384) {
+    size = 512;
+  } else if (size == 640 || size == 768 || size > 1024) {
+    size = 1024;
+  }
+  return size;
+}
+
+/**
+ * @brief   Calculate next offset for buffer data, 64 bytes aligned.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] size      buffer size to allocate
+ * @param[in] is_double true if double-buffered (allocates size * 2)
+ * @return              offset into DATA region for the buffer
+ */
+static uint16_t usb_buffer_next_offset(hal_usb_driver_c *usbp, uint16_t size,
+                                       bool is_double) {
+  uint16_t offset;
+  uint16_t alloc;
+
+  offset = usbp->noffset;
+  alloc = is_double ? (uint16_t)(size * 2U) : size;
+
+  chDbgAssert((uint32_t)offset + alloc <= USB_DPRAM_DATA_SIZE,
+              "USB DPRAM buffer overflow");
+
+  usbp->noffset += alloc;
+
+  return offset;
+}
+
+/**
+ * @brief   Reset endpoint 0.
+ */
+static void reset_ep0(hal_usb_driver_c *usbp) {
+  usbp->epd[0].out.next_pid = 1U;
+  usbp->epd[0].in.next_pid = 1U;
+}
+
+#if (RP_USB_E15_WORKAROUND == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   TIMER0 timestamp of the most recent frame start.
+ */
+static volatile uint32_t usb_e15_last_sof_time;
+
+/**
+ * @brief   Defers a bulk IN publication falling into the frame end.
+ * @details RP2040-E15: making a bulk IN buffer available during roughly
+ *          the last 200 us of a frame can corrupt the transfer on
+ *          affected host topologies. Publication is delayed by busy-wait
+ *          until the next frame starts; if frame timing stops (suspend
+ *          or detach) the wait is abandoned after one frame time.
+ */
+static void usb_e15_defer_if_frame_end(const USBEndpointConfig *epcp) {
+
+  if ((epcp->ep_mode & USB_EP_MODE_TYPE) != USB_EP_MODE_TYPE_BULK) {
+    return;
+  }
+  /* The position inside the nominal 1 ms frame cadence is derived by
+     modulo from the last recorded SOF: this path often runs inside the
+     USB interrupt handler where the SOF handler cannot refresh the
+     timestamp, and a timestamp stale by whole frames still yields the
+     correct position. The wait is bounded to the ~200 us frame tail by
+     construction, also when SOFs have stopped entirely.*/
+  while (((TIMER0->TIMERAWL - usb_e15_last_sof_time) % 1000U) >= 800U) {
+  }
+}
+#endif /* RP_USB_E15_WORKAROUND == TRUE */
+
+/**
+ * @brief   Prepare buffer for receiving data.
+ */
+static uint32_t usb_prepare_out_ep_buffer(hal_usb_driver_c *usbp, usbep_t ep,
+                                          uint8_t buffer_index) {
+    uint32_t buf_ctrl = 0;
+    const USBEndpointConfig *epcp = usbp->epc[ep];
+    USBOutEndpointState *oesp = usbp->epc[ep]->out_state;
+    rp_usb_ep_side_t *oepd = &usbp->epd[ep].out;
+    uint16_t buf_len;
+
+    /* PID */
+    buf_ctrl |= oepd->next_pid ? USB_BUFFER_BUFFER0_DATA_PID : 0;
+    oepd->next_pid ^= 1U;
+
+    /* The uint16_t width is safe here, the clamp to out_maxsize (a
+       hardware packet size, at most 1023) is what bounds the value. */
+    buf_len = oesp->rxsize < epcp->out_maxsize ? oesp->rxsize : epcp->out_maxsize;
+    buf_ctrl |= USB_BUFFER_BUFFER0_AVAILABLE | buf_len;
+    buf_ctrl &= ~USB_BUFFER_BUFFER0_FULL;
+
+    /* The rxsize field holds the remaining transfer size, this buffer is
+       the last one of the transfer when it covers all of the remaining
+       data. */
+    if (buf_len >= oesp->rxsize) {
+        /* Last buffer */
+        buf_ctrl |= USB_BUFFER_BUFFER0_LAST;
+    }
+
+    if (buffer_index) {
+      buf_ctrl = buf_ctrl << 16;
+    }
+
+    return buf_ctrl;
+}
+
+/**
+ * @brief   Prepare for receiving data from host.
+ */
+static void usb_prepare_out_ep(hal_usb_driver_c *usbp, usbep_t ep) {
+  uint32_t buf_ctrl;
+  uint32_t ep_ctrl;
+
+  if (ep == 0) {
+    ep_ctrl = USB->SIECTRL;
+  } else {
+    ep_ctrl = EP_CTRL(ep).OUT;
+  }
+
+  /* Fill first buffer */
+  buf_ctrl = usb_prepare_out_ep_buffer(usbp, ep, 0);
+
+  /* To avoid short packet, we use single buffered here. */
+  /* Single buffered */
+  ep_ctrl &= ~(USB_EP_BUFFER_DOUBLE | USB_EP_BUFFER_IRQ_DOUBLE_EN);
+  ep_ctrl |= USB_EP_BUFFER_IRQ_EN;
+
+  if (ep == 0) {
+    USB->SIECTRL = ep_ctrl;
+  } else {
+    EP_CTRL(ep).OUT = ep_ctrl;
+  }
+
+  BUF_CTRL(ep).OUT = buf_ctrl;
+  __DSB();
+}
+
+/**
+ * @brief   Prepare buffer for sending data.
+ */
+static uint32_t usb_prepare_in_ep_buffer(hal_usb_driver_c *usbp, usbep_t ep,
+                                         uint8_t buffer_index) {
+    uint8_t *buff;
+    uint16_t buf_len;
+    uint32_t buf_ctrl = 0;
+    const USBEndpointConfig *epcp = usbp->epc[ep];
+    USBInEndpointState *iesp = usbp->epc[ep]->in_state;
+    rp_usb_ep_side_t *iepd = &usbp->epd[ep].in;
+
+    /* The txsize - txlast difference is the size of data to be sent but
+       not yet in the buffer. uint16_t is safe for buf_len, the clamp to
+       in_maxsize (a hardware packet size, at most 1023) is what bounds
+       the value. */
+    buf_len = epcp->in_maxsize < iesp->txsize - iesp->txlast ?
+              epcp->in_maxsize : iesp->txsize - iesp->txlast;
+
+    iesp->txlast += buf_len;
+
+    /* Host only? */
+    if (iesp->txsize <= iesp->txlast) {
+      /* Last buffer */
+      buf_ctrl |= USB_BUFFER_BUFFER0_LAST;
+    }
+
+    /* PID */
+    buf_ctrl |= iepd->next_pid ? USB_BUFFER_BUFFER0_DATA_PID : 0;
+    iepd->next_pid ^= 1U;
+
+    /* Copy data into hardware buffer */
+    buff = (uint8_t*)iepd->hw_buf + (buffer_index == 0 ? 0 : iepd->buf_size);
+    usb_dpram_memcpy((void *)buff, (void *)iesp->txbuf, buf_len);
+    iesp->txbuf += buf_len;
+
+    buf_ctrl |= USB_BUFFER_BUFFER0_FULL |
+                USB_BUFFER_BUFFER0_AVAILABLE |
+                buf_len;
+
+    if (buffer_index) {
+      buf_ctrl = buf_ctrl << 16;
+    }
+
+    return buf_ctrl;
+}
+
+/**
+ * @brief   Prepare endpoint for sending data.
+ */
+static void usb_prepare_in_ep(hal_usb_driver_c *usbp, usbep_t ep) {
+  uint32_t buf_ctrl;
+  uint32_t ep_ctrl;
+  USBInEndpointState *iesp = usbp->epc[ep]->in_state;
+
+  if (ep == 0) {
+    ep_ctrl = USB->SIECTRL;
+  } else {
+    ep_ctrl = EP_CTRL(ep).IN;
+  }
+
+  /* Fill first buffer */
+  buf_ctrl = usb_prepare_in_ep_buffer(usbp, ep, 0);
+
+  /* Second buffer if required */
+  /* The txsize - txlast difference is the size not yet in the buffer */
+  if (iesp->txsize - iesp->txlast > 0) {
+    buf_ctrl |= usb_prepare_in_ep_buffer(usbp, ep, 1);
+  }
+
+  if (buf_ctrl & USB_BUFFER_BUFFER1_AVAILABLE) {
+    /* Double buffered */
+    ep_ctrl &= ~USB_EP_BUFFER_IRQ_EN;
+    ep_ctrl |= USB_EP_BUFFER_DOUBLE | USB_EP_BUFFER_IRQ_DOUBLE_EN;
+  } else {
+    /* Single buffered */
+    ep_ctrl &= ~(USB_EP_BUFFER_DOUBLE | USB_EP_BUFFER_IRQ_DOUBLE_EN);
+    ep_ctrl |= USB_EP_BUFFER_IRQ_EN;
+  }
+
+  if (ep == 0) {
+    USB->SIECTRL = ep_ctrl;
+  } else {
+    EP_CTRL(ep).IN = ep_ctrl;
+  }
+
+#if RP_USB_E15_WORKAROUND == TRUE
+  usb_e15_defer_if_frame_end(usbp->epc[ep]);
+#endif
+
+  BUF_CTRL(ep).IN = buf_ctrl;
+  __DSB();
+}
+
+/**
+ * @brief   Work on an endpoint after transfer.
+ */
+static void usb_serve_endpoint(hal_usb_driver_c *usbp, usbep_t ep, bool is_in) {
+  const USBEndpointConfig *epcp = usbp->epc[ep];
+  USBOutEndpointState *oesp;
+  USBInEndpointState *iesp;
+  size_t n;
+
+  if (is_in) {
+    /* IN endpoint */
+    iesp = usbp->epc[ep]->in_state;
+
+    /* The txlast field is the size sent plus the size of the last buffer */
+    iesp->txcnt = iesp->txlast;
+    n = iesp->txsize - iesp->txcnt;
+    if (n > 0) {
+      /* Transfer not completed, there are more packets to send. */
+      usb_prepare_in_ep(usbp, ep);
+    } else {
+      /* Transfer complete */
+      _usb_isr_invoke_in_cb(usbp, ep);
+    }
+  } else {
+    /* OUT endpoint */
+    oesp = usbp->epc[ep]->out_state;
+
+    /* Length received */
+    n = BUF_CTRL(ep).OUT & USB_BUFFER_BUFFER0_TRANS_LENGTH_Msk;
+
+    /* Copy received data into user buffer */
+    usb_dpram_memcpy((void *)oesp->rxbuf, (void *)usbp->epd[ep].out.hw_buf, n);
+    oesp->rxbuf += n;
+    oesp->rxcnt += n;
+    oesp->rxsize -= n;
+
+    oesp->rxpkts -= 1;
+
+    /* Short packet or all packets have been received. */
+    if (oesp->rxpkts == 0 || n < epcp->out_maxsize) {
+      /* Transfer complete */
+      _usb_isr_invoke_out_cb(usbp, ep);
+    } else {
+      /* Receive remained data */
+      usb_prepare_out_ep(usbp, ep);
+    }
+  }
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers and threads.                                    */
+/*===========================================================================*/
+
+#if (RP_USB_USE_USB1 == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   USB interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_USBCTRL_IRQ_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  usb_lld_serve_interrupt(&USBD1);
+
+  CH_IRQ_EPILOGUE();
+}
+#endif /* RP_USB_USE_USB1 == TRUE */
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level USB driver initialization.
+ *
+ * @notapi
+ */
+void usb_lld_init(void) {
+#if RP_USB_USE_USB1 == TRUE
+  /* Driver initialization.*/
+  usbObjectInit(&USBD1);
+
+  /* Reset buffer offset. */
+  USBD1.noffset = 0;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the USB peripheral.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t usb_lld_start(hal_usb_driver_c *usbp) {
+
+  if (usbp->config == NULL) {
+    usbp->config = &default_usb_config;
+  }
+
+  if (false) {
+  }
+#if RP_USB_USE_USB1 == TRUE
+  else if (&USBD1 == usbp) {
+
+    chDbgAssert(RP_USB_CLK == 48000000U,
+                "invalid USB clock frequency");
+
+    /* Reset usb controller. */
+    rp_peripheral_reset(RESETS_ALLREG_USBCTRL);
+    rp_peripheral_unreset(RESETS_ALLREG_USBCTRL);
+
+    /* Clear any previous state in dpram and hw regs */
+    memset(USB, 0, sizeof(*USB));
+    memset(USB_DPSRAM, 0, sizeof(*USB_DPSRAM));
+
+    /* Mux the controller to the onboard usb phy */
+    USB->MUXING = USB_USB_MUXING_SOFTCON | USB_USB_MUXING_TO_PHY;
+
+#if RP_USB_FORCE_VBUS_DETECT == TRUE
+    /* Force VBUS detect so the device thinks it is plugged into a host */
+    USB->PWR = USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN | USB_USB_PWR_VBUS_DETECT;
+#else
+#if RP_USE_EXTERNAL_VBUS_DETECT == TRUE
+    /* If VBUS is detected by pin without USB VBUS DET pin,
+     * define usb_vbus_detect which returns true if VBUS is enabled.
+     */
+    if (usb_vbus_detect()) {
+      USB->PWR = USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN | USB_USB_PWR_VBUS_DETECT;
+    }
+#endif /* RP_USE_EXTERNAL_VBUS_DETECT */
+#endif /* RP_USB_FORCE_VBUS_DETECT */
+
+    /* Reset procedure enforced on driver start.*/
+    usb_lld_reset(usbp);
+
+    /* Enable the USB controller in device mode. */
+    USB->MAINCTRL = USB_MAIN_CTRL_CONTROLLER_EN;
+
+    /* Enable an interrupt per EP0 transaction */
+    USB->SIECTRL = USB_SIE_CTRL_EP0_INT_1BUF;
+
+    /* Enable interrupts */
+    USB->INTE = USB_INTE_SETUP_REQ |
+                USB_INTE_DEV_RESUME_FROM_HOST |
+                USB_INTE_DEV_SUSPEND |
+                USB_INTE_BUS_RESET |
+                USB_INTE_BUFF_STATUS;
+
+#if RP_USB_E15_WORKAROUND == TRUE
+    /* The frame-end publication guard needs continuous frame timing.*/
+    USB->SET.INTE = USB_INTE_DEV_SOF;
+#endif
+
+#if RP_USB_USE_ERROR_DATA_SEQ_INTR == TRUE
+    USB->SET.INTE = USB_INTE_ERROR_DATA_SEQ;
+#endif /* RP_USB_USE_ERROR_DATA_SEQ_INTR */
+
+    /* Enable USB interrupt. */
+    nvicEnableVector(RP_USBCTRL_IRQ_NUMBER, RP_IRQ_USB0_PRIORITY);
+  }
+#endif
+  else {
+    chDbgAssert(false, "invalid USB instance");
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the USB peripheral.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ *
+ * @notapi
+ */
+void usb_lld_stop(hal_usb_driver_c *usbp) {
+
+  if (usbp->state != HAL_DRV_STATE_STOP) {
+#if RP_USB_USE_USB1 == TRUE
+    if (&USBD1 == usbp) {
+      /* Disable USB interrupt */
+      USB->INTE = 0;
+      nvicDisableVector(RP_USBCTRL_IRQ_NUMBER);
+
+      /* Disable controller */
+      USB->CLR.MAINCTRL = USB_MAIN_CTRL_CONTROLLER_EN;
+    }
+#endif
+  }
+}
+
+/**
+ * @brief   USB configuration.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] config    pointer to the @p hal_usb_config_t structure
+ * @return              A pointer to the current configuration structure.
+ * @retval NULL         if the configuration failed.
+ *
+ * @notapi
+ */
+const hal_usb_config_t *usb_lld_setcfg(hal_usb_driver_c *usbp,
+                                       const hal_usb_config_t *config) {
+  (void)usbp;
+
+  if (config == NULL) {
+    config = &default_usb_config;
+  }
+
+  return config;
+}
+
+/**
+ * @brief   USB enumerated configuration selection.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] cfgnum    driver configuration number
+ * @return              A pointer to the current configuration structure.
+ * @retval NULL         if the configuration failed.
+ *
+ * @notapi
+ */
+const hal_usb_config_t *usb_lld_selcfg(hal_usb_driver_c *usbp,
+                                       unsigned cfgnum) {
+#if USB_USE_CONFIGURATIONS == TRUE
+  if (cfgnum < usb_configurations.cfgsnum) {
+    return usb_lld_setcfg(usbp, &usb_configurations.cfgs[cfgnum]);
+  }
+
+  return NULL;
+#else
+
+  if (cfgnum > 0U) {
+    return NULL;
+  }
+
+  return usb_lld_setcfg(usbp, NULL);
+#endif
+}
+
+/**
+ * @brief   USB low level reset routine.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ *
+ * @notapi
+ */
+void usb_lld_reset(hal_usb_driver_c *usbp) {
+    int ep;
+
+    /* EP0 initialization.*/
+    usbp->epc[0] = &ep0config;
+    usb_lld_init_endpoint(usbp, 0U);
+
+    /* Reset device address. */
+    USB->DEVADDRCTRL = 0U;
+
+    /* Reset USB memory */
+    usbp->noffset = 0U;
+
+    /* Clear all non control endpoint registers */
+    for (ep = 1; ep <= USB_MAX_ENDPOINTS; ep++) {
+        EP_CTRL(ep).IN   = 0U;
+        BUF_CTRL(ep).IN  = 0U;
+        EP_CTRL(ep).OUT  = 0U;
+        BUF_CTRL(ep).OUT = 0U;
+    }
+
+    /* Discard all pending buffer completions, they belong to transfers
+       that were aborted by the bus reset. */
+    USB->CLR.BUFSTATUS = 0xFFFFFFFFU;
+
+#if RP_USB_E15_WORKAROUND == FALSE
+    /* The binder SOF service needs frame interrupts. The decision is
+       taken here because a binder can be attached after the driver
+       start and this path runs on every bus reset. With the E15
+       workaround enabled the SOF interrupt is permanently enabled at
+       driver start instead. */
+    if (usbp->binder != NULL) {
+        USB->SET.INTE = USB_INTE_DEV_SOF;
+    }
+#endif
+}
+
+/**
+ * @brief   Sets the USB address.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ *
+ * @notapi
+ */
+void usb_lld_set_address(hal_usb_driver_c *usbp) {
+  /* Set address to hardware here. */
+  USB->DEVADDRCTRL = USB_ADDR_ENDP0_ADDRESS_Msk & (usbp->address << USB_ADDR_ENDP0_ADDRESS_Pos);
+}
+
+/**
+ * @brief   Enables an endpoint.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ *
+ * @notapi
+ */
+void usb_lld_init_endpoint(hal_usb_driver_c *usbp, usbep_t ep) {
+    uint16_t                 buf_size;
+    uint16_t                 buf_offset;
+    uint32_t                 buf_ctrl;
+    const USBEndpointConfig *epcp = usbp->epc[ep];
+    rp_usb_ep_context_t     *epdp = &usbp->epd[ep];
+
+    if (ep == 0) {
+        epdp->in.hw_buf    = (uint8_t *)&USB_DPSRAM->EP0BUF0;
+        epdp->in.buf_size  = 64;
+        epdp->in.next_pid  = 0U;
+        epdp->out.hw_buf   = (uint8_t *)&USB_DPSRAM->EP0BUF0;
+        epdp->out.buf_size = 64;
+        epdp->out.next_pid = 0U;
+        USB->SET.SIECTRL = USB_EP_BUFFER_IRQ_EN;
+        return;
+    }
+
+    /* Isochronous endpoints cannot be bidirectional per USB 2.0 specification. */
+    if (epcp->ep_mode == USB_EP_MODE_TYPE_ISOC) {
+        chDbgAssert((epcp->in_state == NULL) || (epcp->out_state == NULL),
+                    "isochronous EP cannot be IN and OUT");
+    }
+
+    if (epcp->in_state) {
+        buf_ctrl          = 0U;
+        BUF_CTRL(ep).IN   = buf_ctrl;
+        epdp->in.next_pid = 0U;
+
+        if (epcp->ep_mode == USB_EP_MODE_TYPE_ISOC) {
+            buf_size = usb_isochronous_buffer_size(epcp->in_maxsize);
+            buf_ctrl |= usb_isochronous_buffer_mode(buf_size) << USB_BUFFER_DOUBLE_BUFFER_OFFSET_Pos;
+        } else {
+            buf_size = 64;
+        }
+        buf_offset        = usb_buffer_next_offset(usbp, buf_size, true);
+        epdp->in.hw_buf   = (uint8_t *)&USB_DPSRAM->DATA[buf_offset];
+        epdp->in.buf_size = buf_size;
+
+        EP_CTRL(ep).IN  = USB_EP_EN | (epcp->ep_mode << USB_EP_TYPE_Pos) | ((uint8_t *)epdp->in.hw_buf - (uint8_t *)USB_DPSRAM);
+        BUF_CTRL(ep).IN = buf_ctrl;
+    }
+
+    if (epcp->out_state) {
+        buf_ctrl           = 0U;
+        BUF_CTRL(ep).OUT   = buf_ctrl;
+        epdp->out.next_pid = 0U;
+
+        if (epcp->ep_mode == USB_EP_MODE_TYPE_ISOC) {
+            buf_size = usb_isochronous_buffer_size(epcp->out_maxsize);
+            buf_ctrl |= usb_isochronous_buffer_mode(buf_size) << USB_BUFFER_DOUBLE_BUFFER_OFFSET_Pos;
+        } else {
+            buf_size = 64;
+        }
+        buf_offset         = usb_buffer_next_offset(usbp, buf_size, false);
+        epdp->out.hw_buf   = (uint8_t *)&USB_DPSRAM->DATA[buf_offset];
+        epdp->out.buf_size = buf_size;
+
+        EP_CTRL(ep).OUT  = USB_EP_EN | (epcp->ep_mode << USB_EP_TYPE_Pos) | ((uint8_t *)epdp->out.hw_buf - (uint8_t *)USB_DPSRAM);
+        BUF_CTRL(ep).OUT = buf_ctrl;
+    }
+}
+
+/**
+ * @brief   Disables all the active endpoints except the endpoint zero.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ *
+ * @notapi
+ */
+void usb_lld_disable_endpoints(hal_usb_driver_c *usbp) {
+  uint8_t ep;
+
+  /* Reset the packet memory allocator. */
+  usbp->noffset = 0U;
+
+#if defined(RP2350)
+  /* Buffer controls may still be owned by the controller (AVAILABLE
+     set, transaction admitted); the hardware defines EP_ABORT_DONE as
+     the point where they are safe to modify. Abort all non-EP0
+     endpoints and wait, bounded, for the acknowledge before touching
+     the buffer controls. RP2040 silicon lacks these registers, its
+     teardown below remains best-effort. */
+  USB->ABORT = 0xFFFFFFFCU;
+  {
+    uint32_t start = TIMER0->TIMERAWL;
+
+    while ((USB->ABORTDONE & 0xFFFFFFFCU) != 0xFFFFFFFCU) {
+      if ((uint32_t)(TIMER0->TIMERAWL - start) > 1000U) {
+        break;
+      }
+    }
+  }
+#endif
+
+  /* Fully tear down all non control endpoints, mirroring the reset path:
+     clearing only USB_EP_EN would leave stale buffer controls (AVAILABLE,
+     STALL, PIDs) behind for the next configuration. */
+  for (ep = 1; ep <= USB_MAX_ENDPOINTS; ep++) {
+    EP_CTRL(ep).IN   = 0U;
+    BUF_CTRL(ep).IN  = 0U;
+    EP_CTRL(ep).OUT  = 0U;
+    BUF_CTRL(ep).OUT = 0U;
+  }
+
+#if defined(RP2350)
+  /* Releasing the abort requests after the buffer controls are clean,
+     then acknowledging the done flags: they are sticky write-clear and
+     held asserted while the abort request stands (bootrom teardown uses
+     this order), so clearing them first could leave them set to falsely
+     satisfy the next teardown's wait. */
+  USB->ABORT = 0U;
+  USB->CLR.ABORTDONE = 0xFFFFFFFCU;
+#endif
+
+  /* Discard pending buffer completions of the torn down endpoints, EP0
+     (bits 0 and 1) is left untouched. */
+  USB->CLR.BUFSTATUS = 0xFFFFFFFCU;
+}
+
+/**
+ * @brief   Returns the status of an OUT endpoint.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ * @return              The endpoint status.
+ * @retval EP_STATUS_DISABLED The endpoint is not active.
+ * @retval EP_STATUS_STALLED  The endpoint is stalled.
+ * @retval EP_STATUS_ACTIVE   The endpoint is active.
+ *
+ * @notapi
+ */
+usbepstatus_t usb_lld_get_status_out(hal_usb_driver_c *usbp, usbep_t ep) {
+  (void)usbp;
+
+  if (BUF_CTRL(ep).OUT & USB_BUFFER_STALL) {
+    return EP_STATUS_STALLED;
+  }
+  /* EP0 is always active once USB is started - it has no EPCTRL entry. */
+  if (ep == 0U) {
+    return EP_STATUS_ACTIVE;
+  }
+  if (EP_CTRL(ep).OUT & USB_EP_EN) {
+    return EP_STATUS_ACTIVE;
+  }
+  return EP_STATUS_DISABLED;
+}
+
+/**
+ * @brief   Returns the status of an IN endpoint.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ * @return              The endpoint status.
+ * @retval EP_STATUS_DISABLED The endpoint is not active.
+ * @retval EP_STATUS_STALLED  The endpoint is stalled.
+ * @retval EP_STATUS_ACTIVE   The endpoint is active.
+ *
+ * @notapi
+ */
+usbepstatus_t usb_lld_get_status_in(hal_usb_driver_c *usbp, usbep_t ep) {
+  (void)usbp;
+
+  if (BUF_CTRL(ep).IN & USB_BUFFER_STALL) {
+    return EP_STATUS_STALLED;
+  }
+  /* EP0 is always active once USB is started - it has no EPCTRL entry. */
+  if (ep == 0U) {
+    return EP_STATUS_ACTIVE;
+  }
+  if (EP_CTRL(ep).IN & USB_EP_EN) {
+    return EP_STATUS_ACTIVE;
+  }
+  return EP_STATUS_DISABLED;
+}
+
+/**
+ * @brief   Reads a setup packet from the dedicated packet buffer.
+ * @details This function must be invoked in the context of the @p setup_cb
+ *          callback in order to read the received setup packet.
+ * @pre     In order to use this function the endpoint must have been
+ *          initialized as a control endpoint.
+ * @post    The endpoint is ready to accept another packet.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ * @param[out] buf      buffer where to copy the packet data
+ *
+ * @notapi
+ */
+void usb_lld_read_setup(hal_usb_driver_c *usbp, usbep_t ep, uint8_t *buf) {
+  (void)usbp;
+  (void)ep;
+  /* Copy data from hardware buffer to user buffer */
+  usb_dpram_memcpy(buf, (void *)USB_DPSRAM->SETUPPACKET, 8);
+}
+
+/**
+ * @brief   Starts a receive operation on an OUT endpoint.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ *
+ * @notapi
+ */
+void usb_lld_start_out(hal_usb_driver_c *usbp, usbep_t ep) {
+  USBOutEndpointState *oesp = usbp->epc[ep]->out_state;
+
+  /* Transfer initialization.*/
+  if (oesp->rxsize == 0U) {
+    /* Special case for zero sized packets.*/
+    oesp->rxpkts = 1U;
+  } else {
+    oesp->rxpkts = (oesp->rxsize + usbp->epc[ep]->out_maxsize - 1) /
+                   usbp->epc[ep]->out_maxsize;
+  }
+
+  usb_prepare_out_ep(usbp, ep);
+}
+
+/**
+ * @brief   Starts a transmit operation on an IN endpoint.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ *
+ * @notapi
+ */
+void usb_lld_start_in(hal_usb_driver_c *usbp, usbep_t ep) {
+  USBInEndpointState *iesp = usbp->epc[ep]->in_state;
+
+  iesp->txlast = 0;
+
+  /* Prepare IN endpoint. */
+  usb_prepare_in_ep(usbp, ep);
+}
+
+/**
+ * @brief   Brings an OUT endpoint in the stalled state.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ *
+ * @notapi
+ */
+void usb_lld_stall_out(hal_usb_driver_c *usbp, usbep_t ep) {
+    (void)usbp;
+
+    if (ep == 0) {
+        USB->SET.EPSTALLARM = USB_EP_STALL_ARM_EP0_OUT;
+    }
+    BUF_CTRL(ep).OUT |= USB_BUFFER_STALL;
+    __DSB();
+}
+
+/**
+ * @brief   Brings an IN endpoint in the stalled state.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ *
+ * @notapi
+ */
+void usb_lld_stall_in(hal_usb_driver_c *usbp, usbep_t ep) {
+    (void)usbp;
+
+    if (ep == 0) {
+        USB->SET.EPSTALLARM = USB_EP_STALL_ARM_EP0_IN;
+    }
+    BUF_CTRL(ep).IN |= USB_BUFFER_STALL;
+    __DSB();
+}
+
+/**
+ * @brief   Brings an OUT endpoint in the active state.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ *
+ * @notapi
+ */
+void usb_lld_clear_out(hal_usb_driver_c *usbp, usbep_t ep) {
+    if (ep > 0) {
+        BUF_CTRL(ep).OUT &= ~USB_BUFFER_STALL;
+    }
+    usbp->epd[ep].out.next_pid = 0U;
+}
+
+/**
+ * @brief   Brings an IN endpoint in the active state.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ *
+ * @notapi
+ */
+void usb_lld_clear_in(hal_usb_driver_c *usbp, usbep_t ep) {
+    if (ep > 0) {
+        BUF_CTRL(ep).IN &= ~USB_BUFFER_STALL;
+    }
+    usbp->epd[ep].in.next_pid = 0U;
+}
+
+/**
+ * @brief   USB interrupt service routine.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ *
+ * @notapi
+ */
+void usb_lld_serve_interrupt(hal_usb_driver_c *usbp) {
+  uint32_t ints;
+
+  ints = USB->INTS;
+
+  /* Bus reset must be handled before BUFF_STATUS and SETUP_REQ: the
+   * pre-reset completions belong to transfers that died with the bus and
+   * usb_lld_reset() discards them, and processing SETUP first would queue
+   * a response that _usb_reset() destroys. The remaining bits of this
+   * pre-reset snapshot are equally stale, so the handler stops here;
+   * anything still genuinely pending re-enters the interrupt. */
+  if (ints & USB_INTS_BUS_RESET) {
+    USB->CLR.SIESTATUS = USB_SIE_STATUS_BUS_RESET;
+
+    /* Suspend/resume causes captured in this snapshot predate the reset
+       and are discarded. SETUP_REC is deliberately preserved: when
+       interrupt service was delayed past the end of the reset condition
+       the same snapshot can already hold the first genuine SETUP of the
+       fresh bus, and discarding it would force a host retry. The sticky
+       flag makes the handler re-enter after the reset processing and
+       serve that SETUP against clean state; a stale pre-reset SETUP
+       handled the same way is harmless because a new SETUP always
+       supersedes EP0 state. */
+    USB->CLR.SIESTATUS = USB_SIE_STATUS_SUSPENDED |
+                         USB_SIE_STATUS_RESUME;
+
+    _usb_reset(usbp);
+    return;
+  }
+
+  /* Endpoint events handling. */
+  if (ints & USB_INTS_BUFF_STATUS) {
+    uint32_t buf_status = USB->BUFSTATUS;
+    uint32_t bit = 1U;
+    uint8_t i;
+
+    for (i = 0; buf_status && i < 32; i++) {
+      if (buf_status & bit) {
+        /* Clear flag. */
+        USB->CLR.BUFSTATUS = bit;
+        /* Finish on the endpoint or transfer remained data. */
+        usb_serve_endpoint(usbp, i >> 1U, (i & 1U) == 0);
+
+        buf_status &= ~bit;
+      }
+      bit <<= 1U;
+    }
+  }
+
+  /* USB setup packet handling. */
+  if (ints & USB_INTS_SETUP_REQ) {
+    USB->CLR.SIESTATUS = USB_SIE_STATUS_SETUP_REC;
+
+    reset_ep0(usbp);
+
+    _usb_isr_invoke_setup_cb(usbp, 0);
+  }
+
+  /* USB bus SUSPEND condition handling.*/
+  if (ints & USB_INTS_DEV_SUSPEND) {
+    USB->CLR.SIESTATUS = USB_SIE_STATUS_SUSPENDED;
+
+    _usb_suspend(usbp);
+  }
+
+  /* Resume condition handling */
+  if (ints & USB_INTS_DEV_RESUME_FROM_HOST) {
+    USB->CLR.SIESTATUS = USB_SIE_STATUS_RESUME;
+
+    _usb_wakeup(usbp);
+  }
+
+  /* SOF handling.*/
+  if (ints & USB_INTS_DEV_SOF) {
+#if RP_USB_E15_WORKAROUND == TRUE
+    /* Frame timing reference for the bulk IN publication guard.*/
+    usb_e15_last_sof_time = TIMER0->TIMERAWL;
+#else
+    /* SOF interrupt was used to detect resume of the USB bus after issuing a
+     * remote wake up of the host, therefore we disable it again. */
+    if (usbp->binder == NULL) {
+      USB->CLR.INTE = USB_INTE_DEV_SOF;
+    }
+#endif
+    if (usbp->state == USB_SUSPENDED) {
+      _usb_wakeup(usbp);
+    }
+
+    _usb_isr_invoke_sof_cb(usbp);
+
+    /* Reading SOF_RD clears the DEV_SOF interrupt flag. It does not by
+       itself address RP2040-E15; the actual workaround is the bulk IN
+       publication guard around the frame end. */
+    (void)USB->SOFRD;
+  }
+
+#if RP_USB_USE_ERROR_DATA_SEQ_INTR == TRUE
+  if (ints & USB_INTS_ERROR_DATA_SEQ) {
+    USB->CLR.SIESTATUS = USB_SIE_STATUS_DATA_SEQ_ERROR;
+  }
+#endif /* RP_USB_USE_ERROR_DATA_SEQ_INTR */
+}
+
+#endif /* HAL_USE_USB == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/USBv1/hal_usb_lld.h
+++ b/os/xhal/ports/RP/LLD/USBv1/hal_usb_lld.h
@@ -1,0 +1,324 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    USBv1/hal_usb_lld.h
+ * @brief   RP USB subsystem low level driver header.
+ * @note    This driver is based on the RP2040 USB LLD originally created by
+ *          @hanya and @xyzz with significant improvements by @KarlK90. It has
+ *          been updated for the RP2350 and to fix a few defects and errata.
+ *
+ * @addtogroup USB
+ * @{
+ */
+
+#ifndef HAL_USB_LLD_H
+#define HAL_USB_LLD_H
+
+#if (HAL_USE_USB == TRUE) || defined(__DOXYGEN__)
+
+#include "rp_usb.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Maximum endpoint address.
+ */
+#define USB_MAX_ENDPOINTS                   USB_ENDPOINTS_NUMBER
+
+/**
+ * @brief   Status stage handling method.
+ */
+#define USB_EP0_STATUS_STAGE                USB_EP0_STATUS_STAGE_SW
+
+/**
+ * @brief   The address can be changed immediately upon packet reception.
+ */
+#define USB_SET_ADDRESS_MODE                USB_LATE_SET_ADDRESS
+
+/**
+ * @brief   Method for set address acknowledge.
+ */
+#define USB_SET_ADDRESS_ACK_HANDLING        USB_SET_ADDRESS_ACK_SW
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    RP configuration options
+ * @{
+ */
+/**
+ * @brief   USB driver enable switch.
+ * @details If set to @p TRUE the support for USB1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_USB_USE_USB1) || defined(__DOXYGEN__)
+#define RP_USB_USE_USB1                     FALSE
+#endif
+
+/**
+ * @brief Force to set VBUS detect register.
+ * @details If you want to use non VBUS DETECT pin for this purpose,
+            set this flag to FALSE and define bool usb_vbus_detect(void) function
+            which returns true to force VBUS DETECT.
+            See RP_USE_EXTERNAL_VBUS_DETECT.
+ */
+#if !defined(RP_USB_FORCE_VBUS_DETECT) || defined(__DOXYGEN__)
+#define RP_USB_FORCE_VBUS_DETECT            TRUE
+#endif
+/** @} */
+
+/**
+ * @brief Use custom VBUS detection.
+   @details If RP_USB_FORCE_VBUS_DETECT is FALSE, this flag can be TRUE
+            to detect custom function to detect VBUS.
+ */
+#if !defined(RP_USE_EXTERNAL_VBUS_DETECT) || defined(__DOXYGEN__)
+#define RP_USE_EXTERNAL_VBUS_DETECT         FALSE
+#endif
+
+#if RP_USE_EXTERNAL_VBUS_DETECT == TRUE
+extern bool usb_vbus_detect(void);
+#endif
+
+/**
+ * @brief Enables the error data sequence interrupt.
+ * @details This flag is useful if you develop low level driver.
+ */
+#if !defined(RP_USB_USE_ERROR_DATA_SEQ_INTR) || defined(__DOXYGEN__)
+#define RP_USB_USE_ERROR_DATA_SEQ_INTR      FALSE
+#endif
+
+/**
+ * @brief   Enables the RP2040-E15 bulk IN workaround.
+ * @details Affected RP2040 devices can corrupt bulk IN transfers larger
+ *          than 50 bytes when a buffer is made available during the last
+ *          200 us of a frame on some host topologies (VL805-class hubs).
+ *          The workaround defers bulk IN buffer publication until the
+ *          next frame start, costing up to ~200 us of busy-wait per
+ *          deferred publication. Enabled by default on RP2040; the
+ *          erratum does not apply to RP2350.
+ */
+#if !defined(RP_USB_E15_WORKAROUND) || defined(__DOXYGEN__)
+#if defined(RP2040) || defined(__DOXYGEN__)
+#define RP_USB_E15_WORKAROUND               TRUE
+#else
+#define RP_USB_E15_WORKAROUND               FALSE
+#endif
+#endif
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness.*/
+#if !defined(RP_HAS_USB)
+#error "RP_HAS_USB not defined in registry"
+#endif
+
+/* Device selection checks.*/
+#if RP_USB_USE_USB1 && !RP_HAS_USB
+#error "USB not present in the selected device"
+#endif
+
+#if !RP_USB_USE_USB1
+#error "USB driver activated but no USB peripheral assigned"
+#endif
+
+/* IRQ priority checks. The USB vector handler interacts with the kernel,
+   therefore a kernel-compatible priority is required.*/
+#if !defined(RP_IRQ_USB0_PRIORITY)
+#error "RP_IRQ_USB0_PRIORITY not defined in xmcuconf.h"
+#endif
+
+#if RP_USB_USE_USB1 &&                                                      \
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_USB0_PRIORITY)
+#error "Invalid IRQ priority assigned to USB"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Type of the hardware context of one endpoint direction.
+ * @note    The DPRAM buffer assignment and the data PID sequence are
+ *          hardware state owned by this driver. They are kept out of the
+ *          architecture-defined endpoint state structures because the PID
+ *          of one endpoint-zero direction must survive transfers of the
+ *          opposite direction within the same control transaction.
+ */
+typedef struct {
+  /**
+   * @brief   Buffer in the hardware DPRAM.
+   */
+  uint8_t                       *hw_buf;
+  /**
+   * @brief   Buffer size.
+   */
+  uint16_t                      buf_size;
+  /**
+   * @brief   Data PID used by next transfer.
+   */
+  uint8_t                       next_pid;
+} rp_usb_ep_side_t;
+
+/**
+ * @brief   Type of the hardware context of an endpoint pair.
+ */
+typedef struct {
+  /**
+   * @brief   IN direction context.
+   */
+  rp_usb_ep_side_t              in;
+  /**
+   * @brief   OUT direction context.
+   */
+  rp_usb_ep_side_t              out;
+} rp_usb_ep_context_t;
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level fields of the USB configuration structure.
+ */
+#define usb_lld_config_fields
+
+/**
+ * @brief   Low level fields of the USB driver structure.
+ */
+#define usb_lld_driver_fields                                               \
+  /* Next allocation offset in the DPRAM data pool.*/                       \
+  uint16_t                      noffset;                                    \
+  /* Endpoints hardware contexts, index zero is endpoint zero.*/            \
+  rp_usb_ep_context_t           epd[USB_MAX_ENDPOINTS + 1U]
+
+/**
+ * @brief   Returns the current frame number.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @return              The current frame number.
+ *
+ * @notapi
+ */
+#define usb_lld_get_frame_number(usbp)                                      \
+  (USB->SOFRD & USB_SOF_RD_COUNT_Msk)
+
+/**
+ * @brief   Returns the exact size of a receive transaction.
+ * @details The received size can be different from the size specified in
+ *          @p usbStartReceiveI() because the last packet could have a size
+ *          different from the expected one.
+ * @pre     The OUT endpoint must have been configured in transaction mode
+ *          in order to use this function.
+ *
+ * @param[in] usbp      pointer to the @p hal_usb_driver_c object
+ * @param[in] ep        endpoint number
+ * @return              Received data size.
+ *
+ * @notapi
+ */
+#define usb_lld_get_transaction_size(usbp, ep)                              \
+  ((usbp)->epc[ep]->out_state->rxcnt)
+
+/**
+ * @brief   Connects the USB device.
+ *
+ * @api
+ */
+#if !defined(usb_lld_connect_bus)
+#define usb_lld_connect_bus(usbp)                                           \
+  do {                                                                      \
+    USB->SET.SIECTRL = USB_SIE_CTRL_PULLUP_EN;                              \
+  } while (false)
+#endif
+
+/**
+ * @brief   Disconnect the USB device.
+ *
+ * @api
+ */
+#if !defined(usb_lld_disconnect_bus)
+#define usb_lld_disconnect_bus(usbp)                                        \
+  do {                                                                      \
+    USB->CLR.SIECTRL = USB_SIE_CTRL_PULLUP_EN;                              \
+  } while (false)
+#endif
+
+/**
+ * @brief   Start of host wake-up procedure.
+ *
+ * @notapi
+ */
+#define usb_lld_wakeup_host(usbp)                                           \
+  do {                                                                      \
+    /* Remote wakeup doesn't trigger the wakeup interrupt, therefore        \
+     * we use the SOF interrupt to detect resume of the bus. */             \
+    USB->SET.INTE = USB_INTE_DEV_SOF;                                       \
+    USB->SET.SIECTRL = USB_SIE_CTRL_RESUME;                                 \
+  } while (false)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (RP_USB_USE_USB1 == TRUE) && !defined(__DOXYGEN__)
+extern hal_usb_driver_c USBD1;
+#endif
+
+#if (USB_USE_CONFIGURATIONS == TRUE) && !defined(__DOXYGEN__)
+extern usb_configurations_t usb_configurations;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void usb_lld_init(void);
+  const hal_usb_config_t *usb_lld_setcfg(hal_usb_driver_c *usbp,
+                                         const hal_usb_config_t *config);
+  const hal_usb_config_t *usb_lld_selcfg(hal_usb_driver_c *usbp,
+                                         unsigned cfgnum);
+  msg_t usb_lld_start(hal_usb_driver_c *usbp);
+  void usb_lld_stop(hal_usb_driver_c *usbp);
+  void usb_lld_reset(hal_usb_driver_c *usbp);
+  void usb_lld_set_address(hal_usb_driver_c *usbp);
+  void usb_lld_init_endpoint(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_disable_endpoints(hal_usb_driver_c *usbp);
+  usbepstatus_t usb_lld_get_status_in(hal_usb_driver_c *usbp, usbep_t ep);
+  usbepstatus_t usb_lld_get_status_out(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_read_setup(hal_usb_driver_c *usbp, usbep_t ep, uint8_t *buf);
+  void usb_lld_start_out(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_start_in(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_stall_out(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_stall_in(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_clear_out(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_clear_in(hal_usb_driver_c *usbp, usbep_t ep);
+  void usb_lld_serve_interrupt(hal_usb_driver_c *usbp);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_USB == TRUE */
+
+#endif /* HAL_USB_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/USBv1/rp_usb.h
+++ b/os/xhal/ports/RP/LLD/USBv1/rp_usb.h
@@ -1,0 +1,366 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    USBv1/rp_usb.h
+ * @brief   RP2040/RP2350 USB registers layout header.
+ * @note    This file provides unified USB register definitions for both
+ *          RP2040 and RP2350 platforms.
+ *
+ * @addtogroup USB
+ * @{
+ */
+
+#ifndef RP_USB_H
+#define RP_USB_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* DPRAM memory structure.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   USB DPRAM base address.
+ */
+#define USB_DPRAM_BASE                  0x50100000U
+
+/**
+ * @brief   USB DPRAM size in bytes.
+ */
+#define USB_DPRAM_SIZE                  4096U
+
+/**
+ * @brief   USB DPRAM data buffer region size.
+ * @details This is the size of the DATA region used for EP1-15 buffers.
+ *          EP0 has separate dedicated buffers (EP0BUF0/EP0BUF1) and does
+ *          not consume space from this region.
+ */
+#define USB_DPRAM_DATA_SIZE             3712U
+
+/**
+ * @brief   USB DPRAM structure for device mode.
+ */
+typedef struct {
+  __IO uint8_t      SETUPPACKET[8];     /**< @brief Setup packet buffer.   */
+  struct {
+    __IO uint32_t   IN;                 /**< @brief IN endpoint control.   */
+    __IO uint32_t   OUT;                /**< @brief OUT endpoint control.  */
+  } EPCTRL[15];                         /**< @brief EP1-15 control regs.   */
+  struct {
+    __IO uint32_t   IN;                 /**< @brief IN buffer control.     */
+    __IO uint32_t   OUT;                /**< @brief OUT buffer control.    */
+  } BUFCTRL[16];                        /**< @brief EP0-15 buffer control. */
+  __IO uint8_t      EP0BUF0[64];        /**< @brief EP0 buffer A.          */
+  __IO uint8_t      EP0BUF1[64];        /**< @brief EP0 buffer B.          */
+  __IO uint8_t      DATA[USB_DPRAM_DATA_SIZE]; /**< @brief EP1-15 data buffers. */
+} USB_DPRAM_TypeDef;
+
+/**
+ * @brief   USB DPRAM pointer.
+ */
+#define USB_DPSRAM          ((USB_DPRAM_TypeDef *)USB_DPRAM_BASE)
+
+/*===========================================================================*/
+/* Address and endpoint register bits.                                       */
+/*===========================================================================*/
+
+#define USB_ADDR_ENDP0_ENDPOINT_Pos         16U
+#define USB_ADDR_ENDP0_ENDPOINT_Msk         (0xFU << USB_ADDR_ENDP0_ENDPOINT_Pos)
+#define USB_ADDR_ENDP0_ADDRESS_Pos          0U
+#define USB_ADDR_ENDP0_ADDRESS_Msk          (0x7FU << USB_ADDR_ENDP0_ADDRESS_Pos)
+
+#define USB_ADDR_ENDP_INTEP_PREAMBLE        (1U << 26)
+#define USB_ADDR_ENDP_INTEP_DIR             (1U << 25)
+#define USB_ADDR_ENDP_ENDPOINT_Pos          16U
+#define USB_ADDR_ENDP_ENDPOINT_Msk          (0xFU << USB_ADDR_ENDP_ENDPOINT_Pos)
+#define USB_ADDR_ENDP_ADDRESS_Pos           0U
+#define USB_ADDR_ENDP_ADDRESS_Msk           (0x7FU << USB_ADDR_ENDP_ADDRESS_Pos)
+
+/*===========================================================================*/
+/* Main control register bits.                                               */
+/*===========================================================================*/
+
+#define USB_MAIN_CTRL_SIM_TIMING            (1U << 31)
+#define USB_MAIN_CTRL_HOST_NDEVICE          (1U << 1)
+#define USB_MAIN_CTRL_CONTROLLER_EN         (1U << 0)
+
+/*===========================================================================*/
+/* SOF register bits.                                                        */
+/*===========================================================================*/
+
+#define USB_SOF_WR_COUNT_Pos                0U
+#define USB_SOF_WR_COUNT_Msk                (0x3FFU << USB_SOF_WR_COUNT_Pos)
+
+#define USB_SOF_RD_COUNT_Pos                0U
+#define USB_SOF_RD_COUNT_Msk                (0x3FFU << USB_SOF_RD_COUNT_Pos)
+
+/*===========================================================================*/
+/* SIE control register bits.                                                */
+/*===========================================================================*/
+
+#define USB_SIE_CTRL_EP0_INT_STALL          (1U << 31)
+#define USB_SIE_CTRL_EP0_DOUBLE_BUF         (1U << 30)
+#define USB_SIE_CTRL_EP0_INT_1BUF           (1U << 29)
+#define USB_SIE_CTRL_EP0_INT_2BUF           (1U << 28)
+#define USB_SIE_CTRL_EP0_INT_NAK            (1U << 27)
+#define USB_SIE_CTRL_DIRECT_EN              (1U << 26)
+#define USB_SIE_CTRL_DIRECT_DP              (1U << 25)
+#define USB_SIE_CTRL_DIRECT_DM              (1U << 24)
+#define USB_SIE_CTRL_TRANSCEIVER_PD         (1U << 18)
+#define USB_SIE_CTRL_RPU_OPT                (1U << 17)
+#define USB_SIE_CTRL_PULLUP_EN              (1U << 16)
+#define USB_SIE_CTRL_PULLDOWN_EN            (1U << 15)
+#define USB_SIE_CTRL_RESET_BUS              (1U << 13)
+#define USB_SIE_CTRL_RESUME                 (1U << 12)
+#define USB_SIE_CTRL_VBUS_EN                (1U << 11)
+#define USB_SIE_CTRL_KEEP_ALIVE_EN          (1U << 10)
+#define USB_SIE_CTRL_SOF_EN                 (1U << 9)
+#define USB_SIE_CTRL_SOF_SYNC               (1U << 8)
+#define USB_SIE_CTRL_PREAMBLE_EN            (1U << 6)
+#define USB_SIE_CTRL_STOP_TRANS             (1U << 4)
+#define USB_SIE_CTRL_RECEIVE_DATA           (1U << 3)
+#define USB_SIE_CTRL_SEND_DATA              (1U << 2)
+#define USB_SIE_CTRL_SEND_SETUP             (1U << 1)
+#define USB_SIE_CTRL_START_TRANS            (1U << 0)
+
+/*===========================================================================*/
+/* SIE status register bits.                                                 */
+/*===========================================================================*/
+
+#define USB_SIE_STATUS_DATA_SEQ_ERROR       (1U << 31)
+#define USB_SIE_STATUS_ACK_REC              (1U << 30)
+#define USB_SIE_STATUS_STALL_REC            (1U << 29)
+#define USB_SIE_STATUS_NAK_REC              (1U << 28)
+#define USB_SIE_STATUS_RX_TIMEOUT           (1U << 27)
+#define USB_SIE_STATUS_RX_OVERFLOW          (1U << 26)
+#define USB_SIE_STATUS_BIT_STUFF_ERROR      (1U << 25)
+#define USB_SIE_STATUS_CRC_ERROR            (1U << 24)
+#define USB_SIE_STATUS_BUS_RESET            (1U << 19)
+#define USB_SIE_STATUS_TRANS_COMPLETE       (1U << 18)
+#define USB_SIE_STATUS_SETUP_REC            (1U << 17)
+#define USB_SIE_STATUS_CONNECTED            (1U << 16)
+#define USB_SIE_STATUS_RESUME               (1U << 11)
+#define USB_SIE_STATUS_VBUS_OVER_CURR       (1U << 10)
+#define USB_SIE_STATUS_SPEED_Pos            8U
+#define USB_SIE_STATUS_SPEED_Msk            (0x3U << USB_SIE_STATUS_SPEED_Pos)
+#define USB_SIE_STATUS_SUSPENDED            (1U << 4)
+#define USB_SIE_STATUS_LINE_STATE_Pos       2U
+#define USB_SIE_STATUS_LINE_STATE_Msk       (0x3U << USB_SIE_STATUS_LINE_STATE_Pos)
+#define USB_SIE_STATUS_VBUS_DETECTED        (1U << 0)
+
+/*===========================================================================*/
+/* Buffer status register bits.                                              */
+/*===========================================================================*/
+
+#define USB_BUFF_STATUS_EP15_OUT            (1U << 31)
+#define USB_BUFF_STATUS_EP15_IN             (1U << 30)
+#define USB_BUFF_STATUS_EP14_OUT            (1U << 29)
+#define USB_BUFF_STATUS_EP14_IN             (1U << 28)
+#define USB_BUFF_STATUS_EP13_OUT            (1U << 27)
+#define USB_BUFF_STATUS_EP13_IN             (1U << 26)
+#define USB_BUFF_STATUS_EP12_OUT            (1U << 25)
+#define USB_BUFF_STATUS_EP12_IN             (1U << 24)
+#define USB_BUFF_STATUS_EP11_OUT            (1U << 23)
+#define USB_BUFF_STATUS_EP11_IN             (1U << 22)
+#define USB_BUFF_STATUS_EP10_OUT            (1U << 21)
+#define USB_BUFF_STATUS_EP10_IN             (1U << 20)
+#define USB_BUFF_STATUS_EP9_OUT             (1U << 19)
+#define USB_BUFF_STATUS_EP9_IN              (1U << 18)
+#define USB_BUFF_STATUS_EP8_OUT             (1U << 17)
+#define USB_BUFF_STATUS_EP8_IN              (1U << 16)
+#define USB_BUFF_STATUS_EP7_OUT             (1U << 15)
+#define USB_BUFF_STATUS_EP7_IN              (1U << 14)
+#define USB_BUFF_STATUS_EP6_OUT             (1U << 13)
+#define USB_BUFF_STATUS_EP6_IN              (1U << 12)
+#define USB_BUFF_STATUS_EP5_OUT             (1U << 11)
+#define USB_BUFF_STATUS_EP5_IN              (1U << 10)
+#define USB_BUFF_STATUS_EP4_OUT             (1U << 9)
+#define USB_BUFF_STATUS_EP4_IN              (1U << 8)
+#define USB_BUFF_STATUS_EP3_OUT             (1U << 7)
+#define USB_BUFF_STATUS_EP3_IN              (1U << 6)
+#define USB_BUFF_STATUS_EP2_OUT             (1U << 5)
+#define USB_BUFF_STATUS_EP2_IN              (1U << 4)
+#define USB_BUFF_STATUS_EP1_OUT             (1U << 3)
+#define USB_BUFF_STATUS_EP1_IN              (1U << 2)
+#define USB_BUFF_STATUS_EP0_OUT             (1U << 1)
+#define USB_BUFF_STATUS_EP0_IN              (1U << 0)
+
+/*===========================================================================*/
+/* EP stall arm register bits.                                               */
+/*===========================================================================*/
+
+#define USB_EP_STALL_ARM_EP0_OUT            (1U << 1)
+#define USB_EP_STALL_ARM_EP0_IN             (1U << 0)
+
+/*===========================================================================*/
+/* NAK poll register bits.                                                   */
+/*===========================================================================*/
+
+#define USB_NAK_POLL_DELAY_FS_Pos           16U
+#define USB_NAK_POLL_DELAY_FS_Msk           (0x3FFU << USB_NAK_POLL_DELAY_FS_Pos)
+#define USB_NAK_POLL_DELAY_LS_Pos           0U
+#define USB_NAK_POLL_DELAY_LS_Msk           (0x3FFU << USB_NAK_POLL_DELAY_LS_Pos)
+
+/*===========================================================================*/
+/* USB muxing register bits.                                                 */
+/*===========================================================================*/
+
+#define USB_USB_MUXING_SOFTCON              (1U << 3)
+#define USB_USB_MUXING_TO_DIGITAL_PAD       (1U << 2)
+#define USB_USB_MUXING_TO_EXTPHY            (1U << 1)
+#define USB_USB_MUXING_TO_PHY               (1U << 0)
+
+/*===========================================================================*/
+/* USB power register bits.                                                  */
+/*===========================================================================*/
+
+#define USB_USB_PWR_OVERCURR_DETECT_EN      (1U << 5)
+#define USB_USB_PWR_OVERCURR_DETECT         (1U << 4)
+#define USB_USB_PWR_VBUS_DETECT_OVERRIDE_EN (1U << 3)
+#define USB_USB_PWR_VBUS_DETECT             (1U << 2)
+#define USB_USB_PWR_VBUS_EN_OVERRIDE_EN     (1U << 1)
+#define USB_USB_PWR_VBUS_EN                 (1U << 0)
+
+/*===========================================================================*/
+/* Interrupt register bits.                                                  */
+/*===========================================================================*/
+
+#define USB_INTR_EP_STALL_NAK               (1U << 19)
+#define USB_INTR_ABORT_DONE                 (1U << 18)
+#define USB_INTR_DEV_SOF                    (1U << 17)
+#define USB_INTR_SETUP_REQ                  (1U << 16)
+#define USB_INTR_DEV_RESUME_FROM_HOST       (1U << 15)
+#define USB_INTR_DEV_SUSPEND                (1U << 14)
+#define USB_INTR_DEV_CONN_DIS               (1U << 13)
+#define USB_INTR_BUS_RESET                  (1U << 12)
+#define USB_INTR_VBUS_DETECT                (1U << 11)
+#define USB_INTR_STALL                      (1U << 10)
+#define USB_INTR_ERROR_CRC                  (1U << 9)
+#define USB_INTR_ERROR_BIT_STUFF            (1U << 8)
+#define USB_INTR_ERROR_RX_OVERFLOW          (1U << 7)
+#define USB_INTR_ERROR_RX_TIMEOUT           (1U << 6)
+#define USB_INTR_ERROR_DATA_SEQ             (1U << 5)
+#define USB_INTR_BUFF_STATUS                (1U << 4)
+#define USB_INTR_TRANS_COMPLETE             (1U << 3)
+#define USB_INTR_HOST_SOF                   (1U << 2)
+#define USB_INTR_HOST_RESUME                (1U << 1)
+#define USB_INTR_HOST_CONN_DIS              (1U << 0)
+
+#define USB_INTE_EP_STALL_NAK               (1U << 19)
+#define USB_INTE_ABORT_DONE                 (1U << 18)
+#define USB_INTE_DEV_SOF                    (1U << 17)
+#define USB_INTE_SETUP_REQ                  (1U << 16)
+#define USB_INTE_DEV_RESUME_FROM_HOST       (1U << 15)
+#define USB_INTE_DEV_SUSPEND                (1U << 14)
+#define USB_INTE_DEV_CONN_DIS               (1U << 13)
+#define USB_INTE_BUS_RESET                  (1U << 12)
+#define USB_INTE_VBUS_DETECT                (1U << 11)
+#define USB_INTE_STALL                      (1U << 10)
+#define USB_INTE_ERROR_CRC                  (1U << 9)
+#define USB_INTE_ERROR_BIT_STUFF            (1U << 8)
+#define USB_INTE_ERROR_RX_OVERFLOW          (1U << 7)
+#define USB_INTE_ERROR_RX_TIMEOUT           (1U << 6)
+#define USB_INTE_ERROR_DATA_SEQ             (1U << 5)
+#define USB_INTE_BUFF_STATUS                (1U << 4)
+#define USB_INTE_TRANS_COMPLETE             (1U << 3)
+#define USB_INTE_HOST_SOF                   (1U << 2)
+#define USB_INTE_HOST_RESUME                (1U << 1)
+#define USB_INTE_HOST_CONN_DIS              (1U << 0)
+
+#define USB_INTF_EP_STALL_NAK               (1U << 19)
+#define USB_INTF_ABORT_DONE                 (1U << 18)
+#define USB_INTF_DEV_SOF                    (1U << 17)
+#define USB_INTF_SETUP_REQ                  (1U << 16)
+#define USB_INTF_DEV_RESUME_FROM_HOST       (1U << 15)
+#define USB_INTF_DEV_SUSPEND                (1U << 14)
+#define USB_INTF_DEV_CONN_DIS               (1U << 13)
+#define USB_INTF_BUS_RESET                  (1U << 12)
+#define USB_INTF_VBUS_DETECT                (1U << 11)
+#define USB_INTF_STALL                      (1U << 10)
+#define USB_INTF_ERROR_CRC                  (1U << 9)
+#define USB_INTF_ERROR_BIT_STUFF            (1U << 8)
+#define USB_INTF_ERROR_RX_OVERFLOW          (1U << 7)
+#define USB_INTF_ERROR_RX_TIMEOUT           (1U << 6)
+#define USB_INTF_ERROR_DATA_SEQ             (1U << 5)
+#define USB_INTF_BUFF_STATUS                (1U << 4)
+#define USB_INTF_TRANS_COMPLETE             (1U << 3)
+#define USB_INTF_HOST_SOF                   (1U << 2)
+#define USB_INTF_HOST_RESUME                (1U << 1)
+#define USB_INTF_HOST_CONN_DIS              (1U << 0)
+
+#define USB_INTS_EP_STALL_NAK               (1U << 19)
+#define USB_INTS_ABORT_DONE                 (1U << 18)
+#define USB_INTS_DEV_SOF                    (1U << 17)
+#define USB_INTS_SETUP_REQ                  (1U << 16)
+#define USB_INTS_DEV_RESUME_FROM_HOST       (1U << 15)
+#define USB_INTS_DEV_SUSPEND                (1U << 14)
+#define USB_INTS_DEV_CONN_DIS               (1U << 13)
+#define USB_INTS_BUS_RESET                  (1U << 12)
+#define USB_INTS_VBUS_DETECT                (1U << 11)
+#define USB_INTS_STALL                      (1U << 10)
+#define USB_INTS_ERROR_CRC                  (1U << 9)
+#define USB_INTS_ERROR_BIT_STUFF            (1U << 8)
+#define USB_INTS_ERROR_RX_OVERFLOW          (1U << 7)
+#define USB_INTS_ERROR_RX_TIMEOUT           (1U << 6)
+#define USB_INTS_ERROR_DATA_SEQ             (1U << 5)
+#define USB_INTS_BUFF_STATUS                (1U << 4)
+#define USB_INTS_TRANS_COMPLETE             (1U << 3)
+#define USB_INTS_HOST_SOF                   (1U << 2)
+#define USB_INTS_HOST_RESUME                (1U << 1)
+#define USB_INTS_HOST_CONN_DIS              (1U << 0)
+
+/*===========================================================================*/
+/* Endpoint control register bits (DPRAM).                                   */
+/*===========================================================================*/
+
+#define USB_EP_EN                           (1U << 31)
+#define USB_EP_BUFFER_DOUBLE                (1U << 30)
+#define USB_EP_BUFFER_IRQ_EN                (1U << 29)
+#define USB_EP_BUFFER_IRQ_DOUBLE_EN         (1U << 28)
+#define USB_EP_TYPE_Pos                     26U
+#define USB_EP_TYPE_Msk                     (0x3U << USB_EP_TYPE_Pos)
+#define USB_EP_IRQ_STALL                    (1U << 17)
+#define USB_EP_IRQ_NAK                      (1U << 16)
+#define USB_EP_ADDR_OFFSET_Pos              0U
+#define USB_EP_ADDR_OFFSET_Msk              (0xFFFFU << USB_EP_ADDR_OFFSET_Pos)
+
+/*===========================================================================*/
+/* Buffer control register bits (DPRAM).                                     */
+/*===========================================================================*/
+
+#define USB_BUFFER_BUFFER1_FULL             (1U << 31)
+#define USB_BUFFER_BUFFER1_LAST             (1U << 30)
+#define USB_BUFFER_BUFFER1_DATA_PID         (1U << 29)
+#define USB_BUFFER_DOUBLE_BUFFER_OFFSET_Pos 27U
+#define USB_BUFFER_DOUBLE_BUFFER_OFFSET_Msk (0x3U << USB_BUFFER_DOUBLE_BUFFER_OFFSET_Pos)
+#define USB_BUFFER_BUFFER1_AVAILABLE        (1U << 26)
+#define USB_BUFFER_BUFFER1_TRANS_LENGTH_Pos 16U
+#define USB_BUFFER_BUFFER1_TRANS_LENGTH_Msk (0x3FFU << USB_BUFFER_BUFFER1_TRANS_LENGTH_Pos)
+#define USB_BUFFER_BUFFER0_FULL             (1U << 15)
+#define USB_BUFFER_BUFFER0_LAST             (1U << 14)
+#define USB_BUFFER_BUFFER0_DATA_PID         (1U << 13)
+#define USB_BUFFER_RESET_BUFFER             (1U << 12)
+#define USB_BUFFER_STALL                    (1U << 11)
+#define USB_BUFFER_BUFFER0_AVAILABLE        (1U << 10)
+#define USB_BUFFER_BUFFER0_TRANS_LENGTH_Pos 0U
+#define USB_BUFFER_BUFFER0_TRANS_LENGTH_Msk (0x3FFU << USB_BUFFER_BUFFER0_TRANS_LENGTH_Pos)
+
+#endif /* RP_USB_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/platform.mk
+++ b/os/xhal/ports/RP/RP2040/platform.mk
@@ -35,6 +35,7 @@ include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/USBv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/WDGv1/driver.mk
 
 # Shared variables

--- a/os/xhal/ports/RP/RP2350/platform.mk
+++ b/os/xhal/ports/RP/RP2350/platform.mk
@@ -35,6 +35,7 @@ include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/USBv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/WDGv1/driver.mk
 
 # Shared variables

--- a/testxhal/USB_CDC/cfg/rp2040_pico/chconf.h
+++ b/testxhal/USB_CDC/cfg/rp2040_pico/chconf.h
@@ -1,0 +1,857 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Disabled because the non-SMP ARMv6-M port has no realtime
+ *          counter support.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testxhal/USB_CDC/cfg/rp2040_pico/portab.c
+++ b/testxhal/USB_CDC/cfg/rp2040_pico/portab.c
@@ -1,0 +1,31 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "hal.h"
+
+#include "portab.h"
+
+void portab_setup(void) {
+
+  /*
+   * The USB peripheral uses the dedicated DP/DM pads, no GPIO
+   * multiplexing is required. Only the LED line needs setup because
+   * the Pico board files leave GP25 unconfigured.
+   */
+  palClearLine(PORTAB_BLINK_LED1);
+  palSetLineMode(PORTAB_BLINK_LED1, PAL_MODE_OUTPUT_PUSHPULL |
+                                    PAL_RP_PAD_DRIVE12);
+}

--- a/testxhal/USB_CDC/cfg/rp2040_pico/portab.h
+++ b/testxhal/USB_CDC/cfg/rp2040_pico/portab.h
@@ -1,0 +1,34 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+#define PORTAB_USB1                 USBD1
+#define PORTAB_SDU1                 SDU1
+
+/* The Pico on-board LED on GP25, active high like the reference target.*/
+#define PORTAB_BLINK_LED1           25U
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTAB_H */

--- a/testxhal/USB_CDC/cfg/rp2040_pico/xhalconf.h
+++ b/testxhal/USB_CDC/cfg/rp2040_pico/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         FALSE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         FALSE
+#define HAL_USE_SPI                         FALSE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         TRUE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   FALSE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               TRUE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/testxhal/USB_CDC/cfg/rp2040_pico/xmcuconf.h
+++ b/testxhal/USB_CDC/cfg/rp2040_pico/xmcuconf.h
@@ -1,0 +1,62 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2040 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 3...0        Lowest...Highest.
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2040_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_USB0_PRIORITY                3
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * USB driver system settings.
+ */
+#define RP_USB_USE_USB1                     TRUE
+#define RP_USB_FORCE_VBUS_DETECT            TRUE
+
+#endif /* XMCUCONF_H */

--- a/testxhal/USB_CDC/cfg/rp2350_pico2/chconf.h
+++ b/testxhal/USB_CDC/cfg/rp2350_pico2/chconf.h
@@ -1,0 +1,855 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application-specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel-related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact with each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kernel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks except forward link pointer validation.
+ *          - 3: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 20
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       TRUE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                TRUE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               TRUE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks that occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/testxhal/USB_CDC/cfg/rp2350_pico2/portab.c
+++ b/testxhal/USB_CDC/cfg/rp2350_pico2/portab.c
@@ -1,0 +1,31 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include "hal.h"
+
+#include "portab.h"
+
+void portab_setup(void) {
+
+  /*
+   * The USB peripheral uses the dedicated DP/DM pads, no GPIO
+   * multiplexing is required. Only the LED line needs setup because
+   * the Pico 2 board files leave GP25 unconfigured.
+   */
+  palClearLine(PORTAB_BLINK_LED1);
+  palSetLineMode(PORTAB_BLINK_LED1, PAL_MODE_OUTPUT_PUSHPULL |
+                                    PAL_RP_PAD_DRIVE12);
+}

--- a/testxhal/USB_CDC/cfg/rp2350_pico2/portab.h
+++ b/testxhal/USB_CDC/cfg/rp2350_pico2/portab.h
@@ -1,0 +1,34 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#ifndef PORTAB_H
+#define PORTAB_H
+
+#define PORTAB_USB1                 USBD1
+#define PORTAB_SDU1                 SDU1
+
+/* The Pico 2 on-board LED on GP25, active high like the reference target.*/
+#define PORTAB_BLINK_LED1           25U
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void portab_setup(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PORTAB_H */

--- a/testxhal/USB_CDC/cfg/rp2350_pico2/xhalconf.h
+++ b/testxhal/USB_CDC/cfg/rp2350_pico2/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         TRUE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         FALSE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         FALSE
+#define HAL_USE_SPI                         FALSE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         TRUE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   TRUE
+#define PAL_USE_WAIT                        TRUE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 38400
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   FALSE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               TRUE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/testxhal/USB_CDC/cfg/rp2350_pico2/xmcuconf.h
+++ b/testxhal/USB_CDC/cfg/rp2350_pico2/xmcuconf.h
@@ -1,0 +1,63 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * RP2350 drivers configuration.
+ * The following settings override the default settings present in
+ * the various device driver implementation headers.
+ * Note that the settings for each driver only have effect if the whole
+ * driver is enabled in xhalconf.h.
+ *
+ * IRQ priorities:
+ * 15...0       Lowest...Highest (4 bits on Cortex-M33).
+ *
+ * DMA priorities:
+ * 0...1        Lowest...Highest.
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define __RP2350_XMCUCONF__
+
+/*
+ * HAL driver system settings.
+ */
+#define RP_NO_INIT                          FALSE
+#define RP_CLOCK_DYNAMIC                    FALSE
+#define RP_CORE1_START                      FALSE
+#define RP_CORE1_VECTORS_TABLE              _vectors
+#define RP_CORE1_ENTRY_POINT                _crt0_c1_entry
+#define RP_CORE1_STACK_END                  __c1_main_stack_end__
+
+/*
+ * IRQ system settings.
+ */
+#define RP_IRQ_SYSTICK_PRIORITY             2
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_USB0_PRIORITY                3
+#define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * USB driver system settings.
+ */
+#define RP_USB_USE_USB1                     TRUE
+#define RP_USB_FORCE_VBUS_DETECT            TRUE
+
+#endif /* XMCUCONF_H */

--- a/testxhal/USB_CDC/make/rp2040_pico.make
+++ b/testxhal/USB_CDC/make/rp2040_pico.make
@@ -1,0 +1,194 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = no
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m0plus
+
+# Imported source files and paths.
+CHIBIOS  := ../../
+CONFDIR  := ./cfg/rp2040_pico
+BUILDDIR := ./build/rp2040_pico
+DEPDIR   := ./.dep/rp2040_pico
+
+OOPSELECT := base chprintf
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2040.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2040/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO_RP2040/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv6-M/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/xhal/lib/complex/serial-usb/hal_serial_usb.mk
+include $(CHIBIOS)/os/various/xshell/xshell.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2040_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# Project mandatory defines, kept out of UDEFS so that externally passed
+# UDEFS values do not drop them.
+DDEFS += -DCRT0_VTOR_INIT=1 -DOOP_USE_LEGACY -DXSHELL_CMD_TEST_ENABLED=FALSE
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS =
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################

--- a/testxhal/USB_CDC/make/rp2350_pico2.make
+++ b/testxhal/USB_CDC/make/rp2350_pico2.make
@@ -1,0 +1,199 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT =
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = yes
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the Cortex-M process stack. This stack is
+# the stack used by the main() thread.
+ifeq ($(USE_PROCESS_STACKSIZE),)
+  USE_PROCESS_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the Cortex-M main/exceptions stack. This
+# stack is used for processing interrupts and exceptions.
+ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
+  USE_EXCEPTIONS_STACKSIZE = 0x800
+endif
+
+# Enables the use of FPU (no, softfp, hard).
+ifeq ($(USE_FPU),)
+  USE_FPU = softfp
+endif
+
+# FPU-related options.
+ifeq ($(USE_FPU_OPT),)
+  USE_FPU_OPT = -mfloat-abi=$(USE_FPU) -mfpu=fpv5-sp-d16
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here
+PROJECT = ch
+
+# Target settings.
+MCU  = cortex-m33
+
+# Imported source files and paths.
+CHIBIOS  := ../../
+CONFDIR  := ./cfg/rp2350_pico2
+BUILDDIR := ./build/rp2350_pico2
+DEPDIR   := ./.dep/rp2350_pico2
+
+OOPSELECT := base chprintf
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk/startup_rp2350.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/RP/RP2350/platform.mk
+include $(CHIBIOS)/os/hal/ports/RP/rp_uf2_image.mk
+include $(CHIBIOS)/os/hal/boards/RP_PICO2_RP2350/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/mk/port_rp2.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+include $(CHIBIOS)/os/xhal/lib/complex/serial-usb/hal_serial_usb.mk
+include $(CHIBIOS)/os/various/xshell/xshell.mk
+
+# Define linker script file here.
+LDSCRIPT= $(STARTUPLD)/RP2350_FLASH.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(CONFDIR)/portab.c \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC)
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# Project mandatory defines, kept out of UDEFS so that externally passed
+# UDEFS values do not drop them.
+DDEFS += -DCRT0_VTOR_INIT=1 -DOOP_USE_LEGACY -DXSHELL_CMD_TEST_ENABLED=FALSE
+
+# List all user C define here, like -D_DEBUG=1
+UDEFS =
+
+# Define ASM defines here
+UADEFS = -DCRT0_VTOR_INIT=1
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/mk
+include $(RULESPATH)/arm-none-eabi.mk
+include $(RULESPATH)/rules.mk
+
+#
+# Common rules
+##############################################################################
+
+##############################################################################
+# Custom rules
+#
+
+# Firmware uploading via the bootloader, requires the .uf2 image built via
+# rp_uf2_image.mk and therefore an installed picotool.
+upload: $(BUILDDIR)/$(PROJECT).uf2
+	$(PICOTOOL) load -v -x $(BUILDDIR)/$(PROJECT).uf2
+
+#
+# Custom rules
+##############################################################################


### PR DESCRIPTION
## Summary

Stage 4b of the RP2040/RP2350 XHAL port — the final ARM driver: the USB device controller under the XHAL contract, plus RP targets for `testxhal/USB_CDC`.

- The hardware layer is preserved byte-faithfully (`rp_usb.h` is an untouched copy; DPRAM allocator, double-buffering, RP2350 abort teardown, RP2040-E15 workaround verified identical). The conversion is confined to the contract layer.
- Per-endpoint hardware state (`next_pid`/buffer geometry) that the shared XHAL endpoint structures no longer carry moves into LLD-private endpoint contexts; the EP0 state union follows the STM32 template, with the safety argument (directional state fully initialized before use, SETUP reseeding both directions) verified in review.
- The classic requirement trio maps onto the new shared model: late address setting via the retained `USB_SET_ADDRESS_MODE` (consumed by the shared status-stage thread — early SETUP correctly aborts stale application), while the software status-stage/address-ACK selections are now documented no-ops under the unconditional shared implementation.
- SOF interest moves from the classic config-callback test to binder presence evaluated at bus reset (binders attach before connect in the documented lifecycle — review confirmed the post-enumeration attach hole is unreachable through the normal API); E15 builds keep the continuous enable for erratum timing.
- No port-side terminal arbitration was added: the controller has a single vector and the shared busy bitmaps + EP0 sequence checks serialize all completion paths — reliance documented in-source.
- `testxhal/USB_CDC` gains both RP targets with the classic USB knob values and the full debug trio enabled (state checker included — these are single-core targets, unaffected by #205).

## Review triage

- codex adversarial review: **accept, no blockers or majors**. One MINOR fixed (debug trio in the new test configs). INFO items: the SOF lifecycle note above, and the shared test descriptor's ST VID/PID (`0483:5740`) — pre-existing collateral affecting all USB_CDC targets, flagged for a separate decision on a project test identity.
- coderabbit CLI: pending (rate-limited after today's review volume) — will be run and triaged before this leaves draft.

## Verification

- Build matrix clean, zero warnings: testxhal/USB_CDC rp2040+rp2350 × {default, debug}, `USE_SMART_BUILD=no` demo leg (shared `hal_usb.c`/`hal_usb_cdc.c` against the new headers), untouched STM32 leg.
- OSAL gate, per-file stylecheck, `git diff --check`: clean. Zero shared XHAL changes.
- On-hardware CDC enumeration/echo/reset-stress (host_check.py pattern) queued for the batched bench pass.

## Changelog

- XHAL: RP port gains the USB device driver; testxhal/USB_CDC gains RP2040/RP2350 targets.