### PR TITLE
XHAL: RP port I2C driver with asynchronous abort

### DIFF
--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.c
@@ -82,6 +82,13 @@ const hal_adc_config_t portab_adc_config = {
   .dummy          = 0U
 };
 
+/**
+ * @brief   I2C0 configuration, standard mode at 100kHz.
+ */
+const hal_i2c_config_t portab_i2ccfg = {
+  .baudrate       = 100000U
+};
+
 /*===========================================================================*/
 /* Module local types.                                                       */
 /*===========================================================================*/
@@ -93,6 +100,20 @@ const hal_adc_config_t portab_adc_config = {
 /*===========================================================================*/
 /* Module local functions.                                                   */
 /*===========================================================================*/
+
+/*
+ * Assigns the I2C pads to the I2C function with the internal pull-ups
+ * enabled. The demo bus carries no external pull-ups, without them the
+ * lines would float and an unanswered address would be reported as a bus
+ * error instead of the expected acknowledge failure.
+ */
+static void portab_i2c_pads(void) {
+
+  palSetLineMode(PORTAB_LINE_I2C_SDA, PAL_MODE_ALTERNATE_I2C |
+                                      PAL_RP_PAD_PUE);
+  palSetLineMode(PORTAB_LINE_I2C_SCL, PAL_MODE_ALTERNATE_I2C |
+                                      PAL_RP_PAD_PUE);
+}
 
 /*===========================================================================*/
 /* Module exported functions.                                                */
@@ -112,6 +133,25 @@ void portab_setup(void) {
    */
   palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
   palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+
+  /*
+   * I2C0 pads, SDA on GP4 and SCL on GP5.
+   */
+  portab_i2c_pads();
+}
+
+/*
+ * Attempts to recover a stuck I2C bus. The bus clear procedure drives the
+ * lines through the SIO function, the pads are therefore returned to the
+ * I2C function before the caller restarts the driver.
+ */
+bool portab_i2c_bus_clear(void) {
+  bool success;
+
+  success = i2cRPBusClear(PORTAB_LINE_I2C_SCL, PORTAB_LINE_I2C_SDA);
+  portab_i2c_pads();
+
+  return success;
 }
 
 /** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
@@ -44,6 +44,12 @@
 #define PORTAB_ADC                  ADCD1
 #define PORTAB_ADC_TEMP_GRP         0U
 
+/* I2C instance and pads of the scanned bus, SDA on GP4 and SCL on
+   GP5.*/
+#define PORTAB_I2C                  I2CD0
+#define PORTAB_LINE_I2C_SDA         4U
+#define PORTAB_LINE_I2C_SCL         5U
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -66,11 +72,13 @@
 
 extern const hal_pwm_config_t portab_pwm_config;
 extern const hal_adc_config_t portab_adc_config;
+extern const hal_i2c_config_t portab_i2ccfg;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
   void portab_setup(void);
+  bool portab_i2c_bus_clear(void);
 #ifdef __cplusplus
 }
 #endif

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
@@ -51,7 +51,7 @@
 #define HAL_USE_EFL                         FALSE
 #define HAL_USE_ETH                         FALSE
 #define HAL_USE_GPT                         FALSE
-#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2C                         TRUE
 #define HAL_USE_I2S                         FALSE
 #define HAL_USE_ICU                         FALSE
 #define HAL_USE_MMC_SPI                     FALSE

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
@@ -50,9 +50,17 @@
 #define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
 #define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
 #define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_I2C0_PRIORITY                3
+#define RP_IRQ_I2C1_PRIORITY                3
 #define RP_IRQ_UART0_PRIORITY               3
 #define RP_IRQ_UART1_PRIORITY               3
 #define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * I2C driver system settings.
+ */
+#define RP_I2C_USE_I2C0                     TRUE
+#define RP_I2C_USE_I2C1                     FALSE
 
 /*
  * SIO driver system settings.

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.c
@@ -82,6 +82,13 @@ const hal_adc_config_t portab_adc_config = {
   .dummy          = 0U
 };
 
+/**
+ * @brief   I2C0 configuration, standard mode at 100kHz.
+ */
+const hal_i2c_config_t portab_i2ccfg = {
+  .baudrate       = 100000U
+};
+
 /*===========================================================================*/
 /* Module local types.                                                       */
 /*===========================================================================*/
@@ -93,6 +100,20 @@ const hal_adc_config_t portab_adc_config = {
 /*===========================================================================*/
 /* Module local functions.                                                   */
 /*===========================================================================*/
+
+/*
+ * Assigns the I2C pads to the I2C function with the internal pull-ups
+ * enabled. The demo bus carries no external pull-ups, without them the
+ * lines would float and an unanswered address would be reported as a bus
+ * error instead of the expected acknowledge failure.
+ */
+static void portab_i2c_pads(void) {
+
+  palSetLineMode(PORTAB_LINE_I2C_SDA, PAL_MODE_ALTERNATE_I2C |
+                                      PAL_RP_PAD_PUE);
+  palSetLineMode(PORTAB_LINE_I2C_SCL, PAL_MODE_ALTERNATE_I2C |
+                                      PAL_RP_PAD_PUE);
+}
 
 /*===========================================================================*/
 /* Module exported functions.                                                */
@@ -112,6 +133,25 @@ void portab_setup(void) {
    */
   palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
   palSetLineMode(1U, PAL_MODE_ALTERNATE_UART);
+
+  /*
+   * I2C0 pads, SDA on GP4 and SCL on GP5.
+   */
+  portab_i2c_pads();
+}
+
+/*
+ * Attempts to recover a stuck I2C bus. The bus clear procedure drives the
+ * lines through the SIO function, the pads are therefore returned to the
+ * I2C function before the caller restarts the driver.
+ */
+bool portab_i2c_bus_clear(void) {
+  bool success;
+
+  success = i2cRPBusClear(PORTAB_LINE_I2C_SCL, PORTAB_LINE_I2C_SDA);
+  portab_i2c_pads();
+
+  return success;
 }
 
 /** @} */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
@@ -44,6 +44,12 @@
 #define PORTAB_ADC                  ADCD1
 #define PORTAB_ADC_TEMP_GRP         0U
 
+/* I2C instance and pads of the scanned bus, SDA on GP4 and SCL on
+   GP5.*/
+#define PORTAB_I2C                  I2CD0
+#define PORTAB_LINE_I2C_SDA         4U
+#define PORTAB_LINE_I2C_SCL         5U
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -66,11 +72,13 @@
 
 extern const hal_pwm_config_t portab_pwm_config;
 extern const hal_adc_config_t portab_adc_config;
+extern const hal_i2c_config_t portab_i2ccfg;
 
 #ifdef __cplusplus
 extern "C" {
 #endif
   void portab_setup(void);
+  bool portab_i2c_bus_clear(void);
 #ifdef __cplusplus
 }
 #endif

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
@@ -51,7 +51,7 @@
 #define HAL_USE_EFL                         FALSE
 #define HAL_USE_ETH                         FALSE
 #define HAL_USE_GPT                         FALSE
-#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2C                         TRUE
 #define HAL_USE_I2S                         FALSE
 #define HAL_USE_ICU                         FALSE
 #define HAL_USE_MMC_SPI                     FALSE

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
@@ -51,9 +51,17 @@
 #define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
 #define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
 #define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_I2C0_PRIORITY                3
+#define RP_IRQ_I2C1_PRIORITY                3
 #define RP_IRQ_UART0_PRIORITY               3
 #define RP_IRQ_UART1_PRIORITY               3
 #define RP_IO_IRQ_BANK0_PRIORITY            2
+
+/*
+ * I2C driver system settings.
+ */
+#define RP_I2C_USE_I2C0                     TRUE
+#define RP_I2C_USE_I2C1                     FALSE
 
 /*
  * SIO driver system settings.

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -23,9 +23,42 @@
 
 #include "portab.h"
 
+/*
+ * Scanned 7-bit address range, the reserved addresses outside it are not
+ * probed.
+ */
+#define I2C_SCAN_FIRST_ADDRESS      0x08U
+#define I2C_SCAN_LAST_ADDRESS       0x77U
+
+/*
+ * Synchronization timeout of a single probe. One byte at the configured
+ * rate takes tens of microseconds, a probe reaching this bound means the
+ * transfer could not be terminated at all.
+ */
+#define I2C_SCAN_TIMEOUT            TIME_MS2I(10)
+
+/*
+ * Bound of the retries performed when a probe is rejected because the
+ * controller has not finished the previous operation yet.
+ */
+#define I2C_SCAN_BUSY_RETRIES       4U
+
+/*
+ * Number of acknowledging addresses reported in the summary line.
+ */
+#define I2C_SCAN_FOUND_MAX          8U
+
+/*
+ * Scan period expressed in main loop iterations. One iteration is one LED
+ * fade cycle, 200 duty steps of 10ms each, so it lasts two seconds and
+ * the bus is scanned every four seconds.
+ */
+#define I2C_SCAN_PERIOD             2U
+
 static hal_buffered_sio_c bsio1;
 static uint8_t rxbuf[32];
 static uint8_t txbuf[32];
+static uint8_t found[I2C_SCAN_FOUND_MAX];
 
 /*
  * PWM period (wrap) events counted by the PWM callback, read by the
@@ -88,6 +121,40 @@ static void print_dec(BaseSequentialStream *stream, int32_t value) {
 }
 
 /*
+ * Writes an unsigned decimal number on the stream. Counters and any
+ * value that can exceed the signed range are printed through this
+ * helper, passing them to the signed printer would misrepresent them.
+ */
+static void print_udec(BaseSequentialStream *stream, uint32_t value) {
+  char buf[10];
+  size_t i;
+
+  i = sizeof buf;
+  do {
+    i--;
+    buf[i] = (char)('0' + (char)(value % 10U));
+    value = value / 10U;
+  } while (value > 0U);
+  stmWrite(stream, (const uint8_t *)&buf[i], sizeof buf - i);
+}
+
+/*
+ * Writes the low byte of a value as a two digits hexadecimal number on
+ * the stream.
+ */
+static void print_hex2(BaseSequentialStream *stream, uint32_t value) {
+  static const char digits[] = "0123456789abcdef";
+  char buf[4];
+
+  buf[0] = '0';
+  buf[1] = 'x';
+  buf[2] = digits[(value >> 4) & 0x0FU];
+  buf[3] = digits[value & 0x0FU];
+
+  stmWrite(stream, (const uint8_t *)buf, sizeof buf);
+}
+
+/*
  * Converts a raw temperature sensor sample into tenths of Celsius
  * degree. The RP conversion formula is T = 27 - (V - 0.706) / 0.001721
  * with the sample scaled against the 3.3V ADC reference, it is
@@ -102,6 +169,125 @@ static int32_t temp_raw_to_dc(adcsample_t raw) {
 }
 
 /*
+ * Recovery path of a transfer that could not be terminated: the driver is
+ * stopped so that the peripheral releases the bus, the bus is cleared by
+ * pulsing SCL from the port side and the driver is started again. This is
+ * the sequence documented by the RP I2C driver for a locked bus, it is
+ * also what takes the driver out of the locked state because the state is
+ * only cleared by a stop.
+ */
+static bool i2c_recover(void) {
+
+  drvStop(&PORTAB_I2C);
+  (void)portab_i2c_bus_clear();
+
+  return drvStart(&PORTAB_I2C, &portab_i2ccfg) == HAL_RET_SUCCESS;
+}
+
+/*
+ * One bus scan pass.
+ *
+ * Every address is probed with a single byte master receive. It is the
+ * shortest transaction the shared API accepts, a zero length transfer is
+ * rejected by the API parameter checks, and unlike a write probe it can
+ * never alter the state of a device that answers. On an unpopulated bus
+ * every address is answered with a NACK, so a pass exercises the transfer
+ * abort path, the abort cause decoding and the terminal event claim of
+ * the driver once per address.
+ */
+static void i2c_scan(BaseSequentialStream *stream) {
+  unsigned address, retries, acked, nacked, errors, locked, i;
+  i2cflags_t flags;
+  uint8_t probe;
+  msg_t msg;
+  bool wedged;
+
+  acked  = 0U;
+  nacked = 0U;
+  errors = 0U;
+  locked = 0U;
+  wedged = false;
+
+  /* A pass left the port unusable, one recovery attempt is made before
+     giving up on this pass.*/
+  if (drvGetStateX(&PORTAB_I2C) != HAL_DRV_STATE_READY) {
+    if (!i2c_recover()) {
+      print_str(stream, "i2c scan: port unavailable\r\n");
+      return;
+    }
+  }
+
+  for (address = I2C_SCAN_FIRST_ADDRESS;
+       address <= I2C_SCAN_LAST_ADDRESS;
+       address++) {
+    /* The controller can still be settling from the previous probe, such
+       a start is rejected without waiting and is simply retried.*/
+    retries = 0U;
+    while (true) {
+      msg = i2cMasterReceiveTimeout(&PORTAB_I2C, (i2caddr_t)address,
+                                    &probe, 1U, I2C_SCAN_TIMEOUT);
+      if ((msg != HAL_RET_HW_BUSY) || (retries == I2C_SCAN_BUSY_RETRIES)) {
+        break;
+      }
+
+      retries++;
+      chThdSleepMilliseconds(1);
+    }
+
+    if (msg == MSG_OK) {
+      if (acked < I2C_SCAN_FOUND_MAX) {
+        found[acked] = (uint8_t)address;
+      }
+      acked++;
+    }
+    else if (msg == MSG_RESET) {
+      /* The transfer was aborted, the cached flags tell an unanswered
+         address from a real bus problem.*/
+      flags = i2cGetAndClearErrorsX(&PORTAB_I2C);
+      if ((flags & I2C_ACK_FAILURE) != 0U) {
+        nacked++;
+      }
+      else {
+        errors++;
+      }
+    }
+    else if (msg == MSG_TIMEOUT) {
+      /* The transfer could not be terminated, the driver is left locked
+         and the port must be recovered before probing again.*/
+      locked++;
+      if (!i2c_recover()) {
+        wedged = true;
+        break;
+      }
+    }
+    else {
+      /* The controller never became startable within the retry bound.*/
+      errors++;
+    }
+  }
+
+  print_str(stream, "i2c scan: acked=");
+  print_udec(stream, acked);
+  print_str(stream, " nacked=");
+  print_udec(stream, nacked);
+  print_str(stream, " errors=");
+  print_udec(stream, errors);
+  print_str(stream, " locked=");
+  print_udec(stream, locked);
+
+  for (i = 0U; (i < acked) && (i < I2C_SCAN_FOUND_MAX); i++) {
+    print_str(stream, " ack=");
+    print_hex2(stream, found[i]);
+  }
+
+  if (wedged) {
+    print_str(stream, " (recovery failed)");
+  }
+
+  print_str(stream, "\r\n");
+}
+
+/*
  * Application entry point.
  */
 int main(void) {
@@ -109,6 +295,7 @@ int main(void) {
   msg_t msg;
   pwmcnt_t width;
   unsigned i;
+  unsigned iteration;
   int32_t tdc;
   int32_t frac;
 
@@ -164,11 +351,20 @@ int main(void) {
   chDbgAssert(msg == HAL_RET_SUCCESS, "ADC start failed");
 
   /*
+   * Activates the I2C driver used by the bus scan, the peripheral stays
+   * idle until the first probe.
+   */
+  msg = drvStart(&PORTAB_I2C, &portab_i2ccfg);
+  chDbgAssert(msg == HAL_RET_SUCCESS, "I2C start failed");
+
+  /*
    * Normal main() thread activity, in this demo it fades the board LED
    * through the PWM channel and, once per fade cycle, performs a
    * synchronous conversion of the on-die temperature sensor printing
-   * the result together with the wrap events counter.
+   * the result together with the wrap events counter. The I2C bus is
+   * scanned every I2C_SCAN_PERIOD fade cycles.
    */
+  iteration = 0U;
   while (true) {
     /* One triangular fade cycle, one percent duty step every 10ms for
        a two seconds cycle at a visibly smooth 1kHz PWM frequency.*/
@@ -207,6 +403,14 @@ int main(void) {
     }
     else {
       print_str(stream, "temp conversion failed\r\n");
+    }
+
+    /* Periodic bus scan, the pass is run from thread context between two
+       fade cycles.*/
+    iteration++;
+    if (iteration == I2C_SCAN_PERIOD) {
+      iteration = 0U;
+      i2c_scan(stream);
     }
   }
 }

--- a/os/xhal/ports/RP/LLD/I2Cv1/driver.mk
+++ b/os/xhal/ports/RP/LLD/I2Cv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_I2C TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/RP/LLD/I2Cv1

--- a/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -1,0 +1,1014 @@
+/*
+    ChibiOS - Copyright (C) 2022 Stefan Kerkmann.
+    ChibiOS - Copyright (C) 2021 Hanya.
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    I2Cv1/hal_i2c_lld.c
+ * @brief   RP I2C subsystem low level driver source.
+ *
+ * @addtogroup I2C
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define I2C_OVERRUN_ERRORS                                                  \
+  (I2C_IC_INTR_STAT_R_RX_OVER | I2C_IC_INTR_STAT_R_RX_UNDER |               \
+   I2C_IC_INTR_STAT_R_TX_OVER)
+
+#define I2C_ERROR_INTERRUPTS                                                \
+  (I2C_IC_INTR_MASK_M_TX_ABRT | I2C_IC_INTR_MASK_M_TX_OVER |                \
+   I2C_IC_INTR_MASK_M_RX_OVER | I2C_IC_INTR_MASK_M_RX_UNDER)
+
+/**
+ * @brief   Half period used by the bus clear procedure, in microseconds.
+ * @note    Rounded up to at least one system tick, bus recovery has no
+ *          minimum speed requirement.
+ */
+#define I2C_BUS_CLEAR_HALF_PERIOD_US        10U
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   I2C0 driver identifier.
+ */
+#if (RP_I2C_USE_I2C0 == TRUE) || defined(__DOXYGEN__)
+hal_i2c_driver_c I2CD0;
+#endif
+
+/**
+ * @brief   I2C1 driver identifier.
+ */
+#if (RP_I2C_USE_I2C1 == TRUE) || defined(__DOXYGEN__)
+hal_i2c_driver_c I2CD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver default configuration.
+ */
+static const hal_i2c_config_t i2c_default_config = I2C_DEFAULT_CONFIGURATION;
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Opens a new transfer generation.
+ * @details The generation counter becomes odd, marking a transfer in
+ *          flight with an unclaimed terminal event.
+ * @note    Must be called with the system lock held, the transfer start
+ *          methods are invoked in I-class context by the shared driver.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_tgen_open(hal_i2c_driver_c *i2cp) {
+
+  chDbgAssert((i2cp->tgen & 1U) == 0U, "transfer already in flight");
+
+  i2cp->tgen++;
+}
+
+/**
+ * @brief   Returns the resets controller mask of an I2C instance.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @return              The reset mask.
+ */
+static uint32_t i2c_lld_reset_mask(hal_i2c_driver_c *i2cp) {
+  uint32_t mask = 0U;
+
+  if (false) {
+  }
+#if RP_I2C_USE_I2C0 == TRUE
+  else if (&I2CD0 == i2cp) {
+    mask = RESETS_ALLREG_I2C0;
+  }
+#endif
+#if RP_I2C_USE_I2C1 == TRUE
+  else if (&I2CD1 == i2cp) {
+    mask = RESETS_ALLREG_I2C1;
+  }
+#endif
+  else {
+    chDbgAssert(false, "invalid I2C instance");
+  }
+
+  return mask;
+}
+
+/**
+ * @brief   I2C deactivation.
+ * @details Disables the peripheral vector and puts the peripheral back
+ *          in reset. Shared by the stop path and by the start failure
+ *          rollback.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_deactivate(hal_i2c_driver_c *i2cp) {
+
+  if (false) {
+  }
+#if RP_I2C_USE_I2C0 == TRUE
+  else if (&I2CD0 == i2cp) {
+    nvicDisableVector(RP_I2C0_IRQ_NUMBER);
+    rp_peripheral_reset(RESETS_ALLREG_I2C0);
+  }
+#endif
+#if RP_I2C_USE_I2C1 == TRUE
+  else if (&I2CD1 == i2cp) {
+    nvicDisableVector(RP_I2C1_IRQ_NUMBER);
+    rp_peripheral_reset(RESETS_ALLREG_I2C1);
+  }
+#endif
+  else {
+    chDbgAssert(false, "invalid I2C instance");
+  }
+}
+
+/**
+ * @brief   Programs the target address and starts the transfer engine.
+ * @details The target address register is gated on the ENABLE register
+ *          bit, cycling the enable also flushes both FIFOs from any
+ *          residue of a previously aborted transfer. The RP DW_apb_i2c
+ *          applies the enable state within two clk_sys cycles, hidden
+ *          behind the following register accesses, therefore no
+ *          settling wait is required with the controller idle.
+ * @note    Called with the system lock held. The FIFO engine runs
+ *          entirely in the interrupt service: with TX_EMPTY_CTRL
+ *          selected the first TX_EMPTY interrupt fires as soon as the
+ *          mask is armed because the TX FIFO is empty and no command is
+ *          in flight, the service then queues data or read commands.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] addr      slave device address
+ */
+static void i2c_lld_setup_transfer(hal_i2c_driver_c *i2cp, i2caddr_t addr) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  dp->ENABLE = 0U;
+  dp->TAR = (uint32_t)addr & I2C_IC_TAR_IC_TAR;
+  dp->INTRMASK = 0U;
+  dp->ENABLE = I2C_IC_ENABLE_ENABLE;
+
+  /* Stale flags cleared, this also releases the TX FIFO from the
+     flushed state following an abort.*/
+  (void)dp->CLRINTR;
+
+  /* Interrupt sources armed, the transfer proceeds in the service
+     routines from here.*/
+  dp->INTRMASK = I2C_IC_INTR_MASK_M_STOP_DET |
+                 I2C_IC_INTR_MASK_M_TX_EMPTY |
+                 I2C_ERROR_INTERRUPTS;
+}
+
+/**
+ * @brief   Requests data to be received, actual reception is done in the
+ *          interrupt handler.
+ * @note    Called with the system lock held from ISR context.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_request_data(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t data = I2C_IC_DATA_CMD_CMD;
+
+  /* RP Designware I2C peripheral has FIFO depth of 16 elements. As we
+     specify that the TX_EMPTY interrupt only fires if the TX FIFO is
+     truly empty we don't need to check the current fill level.*/
+  uint32_t batch = i2cp->rxbytes < 16U ? (uint32_t)i2cp->rxbytes : 16U;
+
+  if (i2cp->send_restart) {
+    data |= I2C_IC_DATA_CMD_RESTART;
+    i2cp->send_restart = false;
+  }
+
+  /* Setup RX FIFO trigger level to only trigger when the batch has been
+     completely received. Therefore we don't need to check if there are
+     any bytes still pending to be received.*/
+  dp->RXTL = batch > 1U ? batch - 1U : 0U;
+
+  while (batch > 0U) {
+    /* Send STOP after last byte.*/
+    if (i2cp->rxbytes == 1U) {
+      data |= I2C_IC_DATA_CMD_STOP;
+    }
+    dp->DATACMD = data;
+
+    batch--;
+    i2cp->rxbytes--;
+    data = I2C_IC_DATA_CMD_CMD;
+  }
+
+  /* Clear TX FIFO empty interrupt, it will be re-activated when data
+     has been received. Enable RX FULL interrupt to process received
+     data.*/
+  dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY;
+  dp->SET.INTRMASK = I2C_IC_INTR_MASK_M_RX_FULL;
+}
+
+/**
+ * @brief   Fills TX FIFO with data to be sent.
+ * @note    Called with the system lock held from ISR context.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_transmit_data(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t data;
+
+  while ((i2cp->txbytes > 0U) &&
+         ((dp->STATUS & I2C_IC_STATUS_TFNF) != 0U)) {
+    data = (uint32_t)*i2cp->txptr;
+
+    /* Send STOP after the last byte of a pure write. If a read phase
+       follows, the transfer continues with a repeated START instead.*/
+    if ((i2cp->txbytes == 1U) && (i2cp->rxbytes == 0U)) {
+      data |= I2C_IC_DATA_CMD_STOP;
+    }
+    dp->DATACMD = data;
+
+    i2cp->txptr++;
+    i2cp->txbytes--;
+  }
+
+  if (i2cp->txbytes == 0U) {
+    if (i2cp->rxbytes > 0U) {
+      /* All write commands are queued and a read phase follows. Switch
+         to the RX state now, the first read command will carry the
+         RESTART flag producing a repeated START on the wire. The
+         TX_EMPTY interrupt is kept enabled, with TX_EMPTY_CTRL set it
+         fires again only when the last write byte has completed on the
+         wire and the service then queues the read commands via
+         i2c_lld_request_data().*/
+      i2cp->state = I2C_ACTIVE_RX;
+      i2cp->send_restart = true;
+    }
+    else {
+      /* Nothing more to send, disable TX FIFO empty interrupt.*/
+      dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY;
+    }
+  }
+}
+
+/**
+ * @brief   Transmission errors service.
+ * @details The terminal event is claimed against the transfer generation
+ *          counter and the raw interrupt state before any driver state
+ *          transition, see the notes in the driver header. An error made
+ *          stale by a concurrent stop or already consumed by a new
+ *          transfer start loses the claim and is silenced without side
+ *          effects. The abort completion following a transfer stop takes
+ *          this same path: the stop already claimed the terminal event,
+ *          the service only clears the flags.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_serve_errors(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t raw, abort_source;
+  bool claimed;
+
+  chSysLockFromISR();
+  raw = dp->RAWINTRSTAT;
+  claimed = ((i2cp->tgen & 1U) != 0U) &&
+            ((raw & (I2C_IC_INTR_STAT_R_TX_ABRT | I2C_OVERRUN_ERRORS)) != 0U);
+  if (claimed) {
+    i2cp->tgen++;
+
+    /* Abort cause decoding, the source register is cleared together
+       with the interrupt flags below.*/
+    abort_source = dp->TXABRTSOURCE;
+    if ((abort_source & I2C_IC_TX_ABRT_SOURCE_ARB_LOST) != 0U) {
+      i2cp->errors |= I2C_ARBITRATION_LOST;
+    }
+    if ((abort_source & (I2C_IC_TX_ABRT_SOURCE_ABRT_7B_ADDR_NOACK |
+                         I2C_IC_TX_ABRT_SOURCE_ABRT_10ADDR1_NOACK |
+                         I2C_IC_TX_ABRT_SOURCE_ABRT_10ADDR2_NOACK |
+                         I2C_IC_TX_ABRT_SOURCE_ABRT_GCALL_NOACK   |
+                         I2C_IC_TX_ABRT_SOURCE_ABRT_TXDATA_NOACK)) != 0U) {
+      i2cp->errors |= I2C_ACK_FAILURE;
+    }
+    if ((raw & I2C_OVERRUN_ERRORS) != 0U) {
+      i2cp->errors |= I2C_OVERRUN;
+    }
+
+    /* Quiescing the peripheral within the claim critical section, no
+       start can interleave because starts run under the same lock.*/
+    dp->INTRMASK = 0U;
+    (void)dp->CLRINTR;
+  }
+  else {
+    if ((i2cp->tgen & 1U) == 0U) {
+      /* No transfer in flight, the flags belong to a terminated or
+         stopped transfer, silenced without dispatching.*/
+      dp->INTRMASK = 0U;
+      (void)dp->CLRINTR;
+    }
+    /* With a transfer in flight and no raw error left the flags have
+       already been consumed by a transfer start, nothing to do.*/
+  }
+  chSysUnlockFromISR();
+
+  if (claimed) {
+    /* The wakeup machinery is invoked outside the critical section by
+       the single terminal-event winner, the callback runs outside any
+       lock.*/
+    __i2c_error_isr(i2cp);
+  }
+}
+
+/**
+ * @brief   TX FIFO empty service.
+ * @details Feeds the transmit FIFO or queues read commands. The whole
+ *          service runs in a critical section: the generation check and
+ *          the FIFO accesses must be atomic with respect to a transfer
+ *          stop on the other core, otherwise the engine could feed an
+ *          aborting transfer or unmask interrupts behind its back.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_serve_tx_empty(hal_i2c_driver_c *i2cp) {
+
+  chSysLockFromISR();
+  if ((i2cp->tgen & 1U) != 0U) {
+    if (i2cp->state == HAL_DRV_STATE_ACTIVE) {
+      i2c_lld_transmit_data(i2cp);
+    }
+    else {
+      i2c_lld_request_data(i2cp);
+    }
+  }
+  else {
+    /* No transfer in flight, a stale data interrupt is silenced. The
+       mask write cannot stomp a concurrent start because starts run
+       under the same lock.*/
+    i2cp->i2c->CLR.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY |
+                              I2C_IC_INTR_MASK_M_RX_FULL;
+  }
+  chSysUnlockFromISR();
+}
+
+/**
+ * @brief   RX FIFO batch service.
+ * @details Drains the receive FIFO into the transfer buffer. The whole
+ *          service runs in a critical section: after a transfer stop
+ *          wins the terminal event the caller owns the receive buffer
+ *          again, draining into it is only legal while the generation
+ *          is still open.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_serve_rx_full(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  chSysLockFromISR();
+  if ((i2cp->tgen & 1U) != 0U) {
+    while ((dp->STATUS & I2C_IC_STATUS_RFNE) != 0U) {
+      /* Read out received data.*/
+      *i2cp->rxptr = (uint8_t)dp->DATACMD;
+      i2cp->rxptr++;
+    }
+
+    if (i2cp->rxbytes == 0U) {
+      /* Everything is received, therefore disable all FIFO IRQs.*/
+      dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_RX_FULL |
+                         I2C_IC_INTR_MASK_M_TX_EMPTY;
+    }
+    else {
+      /* Enable TX FIFO empty IRQ to request more data.*/
+      dp->SET.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY;
+    }
+  }
+  else {
+    /* No transfer in flight, the buffer is not touched, residual data
+       is flushed by the enable cycle of the next transfer start.*/
+    dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_RX_FULL |
+                       I2C_IC_INTR_MASK_M_TX_EMPTY;
+  }
+  chSysUnlockFromISR();
+}
+
+/**
+ * @brief   STOP detection service.
+ * @details Completion arbitration: the terminal event is claimed against
+ *          the transfer generation counter and the current hardware
+ *          state, all evaluated in one critical section. The RP silicon
+ *          hardwires IC_CON.STOP_DET_IF_MASTER_ACTIVE off (the write is
+ *          inert, verified by register read-back), so this interrupt
+ *          also fires for STOP conditions issued by other masters on the
+ *          bus. It only means completion when this driver's own final
+ *          command has completed on the wire: the byte counters cover
+ *          bytes not yet queued, TXFLR covers commands (data and read
+ *          requests alike) still sitting in the TX FIFO waiting for the
+ *          bus, and the raw TX_EMPTY flag - completion-qualified by
+ *          TX_EMPTY_CTRL - stays low while a command popped from the
+ *          FIFO is still executing. An own STOP can only appear after
+ *          all of that has drained, so any residue marks the STOP as
+ *          foreign; the own transfer then continues under hardware
+ *          arbitration.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_serve_stop(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t raw;
+  bool claimed = false;
+
+  chSysLockFromISR();
+  raw = dp->RAWINTRSTAT;
+  if (((i2cp->tgen & 1U) != 0U) &&
+      ((raw & I2C_IC_INTR_STAT_R_STOP_DET) != 0U) &&
+      ((raw & (I2C_IC_INTR_STAT_R_TX_ABRT | I2C_OVERRUN_ERRORS)) == 0U) &&
+      (i2cp->txbytes == 0U) && (i2cp->rxbytes == 0U) &&
+      (dp->TXFLR == 0U) &&
+      ((raw & I2C_IC_INTR_STAT_R_TX_EMPTY) != 0U)) {
+    if (dp->RXFLR == 0U) {
+      /* Own STOP with everything drained, the completion is claimed
+         and the peripheral quiesced within the critical section.*/
+      claimed = true;
+      i2cp->tgen++;
+      dp->INTRMASK = 0U;
+      (void)dp->CLRINTR;
+    }
+    /* Otherwise this is an own STOP racing the final RX batch: the
+       flag is left pending, the pending RX FULL service drains the
+       FIFO first and the STOP is then reevaluated on the next
+       dispatch of this level interrupt.*/
+  }
+  else {
+    /* Foreign or stale STOP condition, or a STOP trailing an abort
+       which is terminal through the error service: dropped without
+       touching the rest of the peripheral state.*/
+    (void)dp->CLRSTOPDET;
+  }
+  chSysUnlockFromISR();
+
+  if (claimed) {
+    /* The wakeup machinery is invoked outside the critical section by
+       the single terminal-event winner, the callback runs outside any
+       lock.*/
+    __i2c_complete_isr(i2cp);
+  }
+}
+
+/**
+ * @brief   I2C shared ISR code.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_serve_interrupt(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t intr = dp->INTRSTAT;
+
+  /* Transmission error detected, includes the abort completion of a
+     stopped transfer.*/
+  if ((intr & I2C_ERROR_INTERRUPTS) != 0U) {
+    i2c_lld_serve_errors(i2cp);
+    return;
+  }
+
+  /* If the TX FIFO is empty we can request or send more data.*/
+  if ((intr & I2C_IC_INTR_STAT_R_TX_EMPTY) != 0U) {
+    i2c_lld_serve_tx_empty(i2cp);
+    return;
+  }
+
+  /* A batch of data has been received.*/
+  if ((intr & I2C_IC_INTR_STAT_R_RX_FULL) != 0U) {
+    i2c_lld_serve_rx_full(i2cp);
+    return;
+  }
+
+  /* STOP condition detected, own STOPs terminate the transfer.*/
+  if ((intr & I2C_IC_INTR_STAT_R_STOP_DET) != 0U) {
+    i2c_lld_serve_stop(i2cp);
+  }
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+#if (RP_I2C_USE_I2C0 == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C0 interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_I2C0_IRQ_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  i2c_lld_serve_interrupt(&I2CD0);
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+
+#if (RP_I2C_USE_I2C1 == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   I2C1 interrupt handler.
+ *
+ * @isr
+ */
+CH_IRQ_HANDLER(RP_I2C1_IRQ_HANDLER) {
+
+  CH_IRQ_PROLOGUE();
+
+  i2c_lld_serve_interrupt(&I2CD1);
+
+  CH_IRQ_EPILOGUE();
+}
+#endif
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level I2C driver initialization.
+ *
+ * @notapi
+ */
+void i2c_lld_init(void) {
+
+#if RP_I2C_USE_I2C0 == TRUE
+  i2cObjectInit(&I2CD0);
+  I2CD0.i2c  = I2C0;
+  I2CD0.tgen = 0U;
+
+  /* Reset I2C.*/
+  rp_peripheral_reset(RESETS_ALLREG_I2C0);
+#endif
+
+#if RP_I2C_USE_I2C1 == TRUE
+  i2cObjectInit(&I2CD1);
+  I2CD1.i2c  = I2C1;
+  I2CD1.tgen = 0U;
+
+  /* Reset I2C.*/
+  rp_peripheral_reset(RESETS_ALLREG_I2C1);
+#endif
+}
+
+/**
+ * @brief   Configures and activates the I2C peripheral.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t i2c_lld_start(hal_i2c_driver_c *i2cp) {
+
+  /* Resources claim and peripheral activation.*/
+  if (false) {
+  }
+#if RP_I2C_USE_I2C0 == TRUE
+  else if (&I2CD0 == i2cp) {
+    rp_peripheral_unreset(RESETS_ALLREG_I2C0);
+    nvicEnableVector(RP_I2C0_IRQ_NUMBER, RP_IRQ_I2C0_PRIORITY);
+  }
+#endif
+#if RP_I2C_USE_I2C1 == TRUE
+  else if (&I2CD1 == i2cp) {
+    rp_peripheral_unreset(RESETS_ALLREG_I2C1);
+    nvicEnableVector(RP_I2C1_IRQ_NUMBER, RP_IRQ_I2C1_PRIORITY);
+  }
+#endif
+  else {
+    chDbgAssert(false, "invalid I2C instance");
+    return HAL_RET_NO_RESOURCE;
+  }
+
+  /* Register programming is delegated to the configuration method, a
+     NULL configuration selects the driver default.*/
+  i2cp->config = i2c_lld_setcfg(i2cp, (const hal_i2c_config_t *)i2cp->config);
+  if (i2cp->config == NULL) {
+    /* A rejected configuration must not leave the peripheral active,
+       the activation performed above is undone so that the shared
+       driver returns to the stop state cleanly.*/
+    i2c_lld_deactivate(i2cp);
+
+    return HAL_RET_CONFIG_ERROR;
+  }
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Deactivates the I2C peripheral.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ *
+ * @notapi
+ */
+void i2c_lld_stop(hal_i2c_driver_c *i2cp) {
+
+  if (i2cp->state != HAL_DRV_STATE_STOP) {
+    /* Any late terminal event loses its claim before the peripheral
+       goes away, interrupt sources are silenced under the same lock.*/
+    chSysLock();
+    if ((i2cp->tgen & 1U) != 0U) {
+      i2cp->tgen++;
+    }
+    i2cp->i2c->INTRMASK = 0U;
+    chSysUnlock();
+
+    i2c_lld_deactivate(i2cp);
+  }
+}
+
+/**
+ * @brief   I2C configuration.
+ * @details The SCL counts are derived from the requested rate and the
+ *          current system clock using the classic timing ratios,
+ *          configurations the divider fields cannot honor are rejected.
+ *          The peripheral is reprogrammed only while no transfer is in
+ *          flight: the controller disable performed for reprogramming
+ *          settles within two clk_sys cycles on an idle controller, the
+ *          bounded status poll below is a formality.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] config    pointer to the @p hal_i2c_config_t structure
+ * @return              A pointer to the current configuration structure.
+ * @retval NULL         if the configuration failed.
+ *
+ * @notapi
+ */
+const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
+                                       const hal_i2c_config_t *config) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t freq_in, baudrate, period, lcnt, hcnt, sda_tx_hold;
+
+  if (config == NULL) {
+    config = &i2c_default_config;
+  }
+
+  /* A configuration change is only legal while no transfer is in
+     flight.*/
+  if ((i2cp->tgen & 1U) != 0U) {
+    return NULL;
+  }
+
+  /* Timing derivation, the classic math with rejection instead of
+     assertion.*/
+  freq_in = (uint32_t)halClockGetPointX(RP_CLK_SYS);
+  baudrate = config->baudrate;
+
+  /* The RP silicon supports up to Fast Mode Plus.*/
+  if ((baudrate == 0U) || (baudrate > 1000000U)) {
+    return NULL;
+  }
+
+  period = (freq_in + (baudrate / 2U)) / baudrate;
+
+  /* Periods too long for the 16-bit count fields are rejected early,
+     this also keeps the ratio scaling below within 32 bits.*/
+  if (period > 0x20000U) {
+    return NULL;
+  }
+
+  if (baudrate <= 100000U) {
+    /* Standard Mode: H: 4000ns, L: 4700ns ~ 0.54.*/
+    lcnt = period * 54U / 100U;
+  }
+  else if (baudrate <= 400000U) {
+    /* Fast Mode: H: 600ns, L: 1300ns ~ 0.68.*/
+    lcnt = period * 68U / 100U;
+  }
+  else {
+    /* Fast Mode Plus: H: 500ns, L: 760ns ~ 0.60.*/
+    lcnt = period * 60U / 100U;
+  }
+  hcnt = period - lcnt;
+
+  if ((lcnt < 8U) || (lcnt > I2C_IC_FS_SCL_LCNT) ||
+      (hcnt < 8U) || (hcnt > I2C_IC_FS_SCL_HCNT)) {
+    return NULL;
+  }
+
+  if (baudrate < 1000000U) {
+    /* Standard and Fast Mode:
+       sda_tx_hold = freq_in [cycles/s] * 300ns * (1s / 1e9ns)
+       Reduce 300/1e9 to 3/1e7 to avoid numbers that don't fit in u32.
+       Add 1 to avoid division truncation.*/
+    sda_tx_hold = ((freq_in * 3U) / 10000000U) + 1U;
+  }
+  else {
+    /* Fast Mode Plus:
+       sda_tx_hold = freq_in [cycles/s] * 120ns * (1s / 1e9ns)
+       Reduce 120/1e9 to 3/25e6 to avoid numbers that don't fit in u32.
+       Add 1 to avoid division truncation.*/
+    sda_tx_hold = ((freq_in * 3U) / 25000000U) + 1U;
+  }
+
+  if (sda_tx_hold > (lcnt - 2U)) {
+    return NULL;
+  }
+
+  /* With the peripheral still held in reset only the validation is
+     performed: the shared start sequence applies a new configuration
+     before activating the peripheral, the register programming below
+     is then performed by i2c_lld_start() which invokes this method
+     again after releasing the reset.*/
+  if ((RESETS->RESET_DONE & i2c_lld_reset_mask(i2cp)) == 0U) {
+    return config;
+  }
+
+  /* Controller disabled during reprogramming, with no transfer in
+     flight this settles within two clk_sys cycles.*/
+  dp->ENABLE = 0U;
+  while ((dp->ENABLESTATUS & I2C_IC_ENABLE_STATUS_IC_EN) != 0U) {
+  }
+
+  dp->CON = I2C_IC_CON_IC_SLAVE_DISABLE |
+            I2C_IC_CON_IC_RESTART_EN |
+#if RP_I2C_ADDRESS_MODE_10BIT == TRUE
+            I2C_IC_CON_IC_10BITADDR_MASTER |
+#endif
+            (2U << I2C_IC_CON_SPEED_Pos) | /* Always Fast Mode.*/
+            I2C_IC_CON_MASTER_MODE |
+            I2C_IC_CON_STOP_DET_IF_MASTER_ACTIVE |
+            I2C_IC_CON_TX_EMPTY_CTRL;
+
+  dp->RXTL = 0U;
+  dp->TXTL = 0U;
+
+  dp->FSSCLHCNT = hcnt & I2C_IC_FS_SCL_HCNT;
+  dp->FSSCLLCNT = lcnt & I2C_IC_FS_SCL_LCNT;
+  dp->FSSPKLEN = (lcnt < 16U ? 1U : lcnt / 16U) &
+                 I2C_IC_FS_SPKLEN_IC_FS_SPKLEN;
+  dp->SDAHOLD = sda_tx_hold & I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD;
+
+  /* Interrupt sources masked until a transfer starts.*/
+  dp->INTRMASK = 0U;
+
+  /* Peripheral enabled again, flags cleared.*/
+  dp->ENABLE = I2C_IC_ENABLE_ENABLE;
+  (void)dp->CLRINTR;
+
+  return config;
+}
+
+/**
+ * @brief   Selects one of the pre-defined I2C configurations.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] cfgnum    driver configuration number
+ * @return              The configuration pointer.
+ *
+ * @notapi
+ */
+const hal_i2c_config_t *i2c_lld_selcfg(hal_i2c_driver_c *i2cp,
+                                       unsigned cfgnum) {
+#if I2C_USE_CONFIGURATIONS == TRUE
+  extern const i2c_configurations_t i2c_configurations;
+
+  if (cfgnum >= i2c_configurations.cfgsnum) {
+    return NULL;
+  }
+
+  return i2c_lld_setcfg(i2cp, &i2c_configurations.cfgs[cfgnum]);
+#else
+
+  if (cfgnum > 0U) {
+    return NULL;
+  }
+
+  return i2c_lld_setcfg(i2cp, NULL);
+#endif
+}
+
+/**
+ * @brief   Low level callback configuration hook.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] cb        callback pointer
+ *
+ * @notapi
+ */
+void i2c_lld_set_callback(hal_i2c_driver_c *i2cp, drv_cb_t cb) {
+
+  (void)i2cp;
+  (void)cb;
+}
+
+/**
+ * @brief   Stops the ongoing I2C transfer.
+ * @details The terminal event is claimed synchronously, this function is
+ *          invoked with the system lock held so the claim is atomic with
+ *          respect to the completion and error services on either core.
+ *          The hardware abort is only initiated, its completion arrives
+ *          later as the TX_ABRT interrupt which finds the generation
+ *          already even and silently clears the flags. Until the abort
+ *          completes the ACTIVITY status keeps the busy gate in the
+ *          transfer start methods closed.
+ * @note    If a slave holds SCL low indefinitely the abort cannot
+ *          complete and the controller remains busy, recovery requires
+ *          @p i2cRPBusClear() followed by a driver restart.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t i2c_lld_stop_transfer(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  if ((i2cp->tgen & 1U) != 0U) {
+    i2cp->tgen++;
+
+    /* Data and completion interrupt sources silenced, only the abort
+       completion event is left enabled.*/
+    dp->INTRMASK = I2C_IC_INTR_MASK_M_TX_ABRT;
+
+    /* Abort initiation, the bit self-clears when the hardware has
+       flushed the TX FIFO and terminated the transfer on the wire.*/
+    dp->ENABLE |= I2C_IC_ENABLE_ABORT;
+  }
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Receives data via the I2C bus as master.
+ * @details This asynchronous function starts a receive operation, the
+ *          transfer is advanced entirely by the interrupt services and
+ *          terminates with the wakeup/callback machinery.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] addr      slave device address
+ * @param[out] rxbuf    pointer to the receive buffer
+ * @param[in] rxbytes   number of bytes to be received
+ * @return              The operation status.
+ * @retval HAL_RET_SUCCESS     if the function succeeded.
+ * @retval HAL_RET_HW_BUSY     if the controller or the bus is busy, no
+ *                             waiting is performed, the caller retries
+ *                             or fails the operation.
+ *
+ * @notapi
+ */
+msg_t i2c_lld_start_master_receive(hal_i2c_driver_c *i2cp, i2caddr_t addr,
+                                   uint8_t *rxbuf, size_t rxbytes) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  /* The controller is busy while a previous transfer, an abort or
+     another bus master is still active, this is an I-class context and
+     waiting is not allowed.*/
+  (void)dp->CLRACTIVITY;
+  if ((dp->STATUS & I2C_IC_STATUS_ACTIVITY) != 0U) {
+    return HAL_RET_HW_BUSY;
+  }
+
+  /* Transaction setup.*/
+  i2cp->txptr        = NULL;
+  i2cp->txbytes      = (size_t)0;
+  i2cp->rxptr        = rxbuf;
+  i2cp->rxbytes      = rxbytes;
+  i2cp->send_restart = false;
+
+  /* Transfer generation opened, from here the terminal event belongs
+     to a single winner among the completion, error and stop paths.*/
+  i2c_lld_tgen_open(i2cp);
+
+  /* Hardware programming and start.*/
+  i2c_lld_setup_transfer(i2cp, addr);
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Transmits data via the I2C bus as master.
+ * @details This asynchronous function starts a transmit operation, when
+ *          @p rxbytes is greater than zero a receive phase follows the
+ *          transmit phase using a repeated START. The transfer is
+ *          advanced entirely by the interrupt services and terminates
+ *          with the wakeup/callback machinery.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] addr      slave device address
+ * @param[in] txbuf     pointer to the transmit buffer
+ * @param[in] txbytes   number of bytes to be transmitted
+ * @param[out] rxbuf    pointer to the receive buffer
+ * @param[in] rxbytes   number of bytes to be received
+ * @return              The operation status.
+ * @retval HAL_RET_SUCCESS     if the function succeeded.
+ * @retval HAL_RET_HW_BUSY     if the controller or the bus is busy, no
+ *                             waiting is performed, the caller retries
+ *                             or fails the operation.
+ *
+ * @notapi
+ */
+msg_t i2c_lld_start_master_transmit(hal_i2c_driver_c *i2cp, i2caddr_t addr,
+                                    const uint8_t *txbuf, size_t txbytes,
+                                    uint8_t *rxbuf, size_t rxbytes) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  /* The controller is busy while a previous transfer, an abort or
+     another bus master is still active, this is an I-class context and
+     waiting is not allowed.*/
+  (void)dp->CLRACTIVITY;
+  if ((dp->STATUS & I2C_IC_STATUS_ACTIVITY) != 0U) {
+    return HAL_RET_HW_BUSY;
+  }
+
+  /* Transaction setup.*/
+  i2cp->txptr        = txbuf;
+  i2cp->txbytes      = txbytes;
+  i2cp->rxptr        = rxbuf;
+  i2cp->rxbytes      = rxbytes;
+  i2cp->send_restart = false;
+
+  /* Transfer generation opened, from here the terminal event belongs
+     to a single winner among the completion, error and stop paths.*/
+  i2c_lld_tgen_open(i2cp);
+
+  /* Hardware programming and start.*/
+  i2c_lld_setup_transfer(i2cp, addr);
+
+  return HAL_RET_SUCCESS;
+}
+
+#if (HAL_USE_PAL == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Attempts to clear a stuck I2C bus by clocking SCL.
+ * @details Standard bus clear procedure: up to nine SCL pulses are
+ *          issued until the slave holding SDA low releases it, then a
+ *          STOP condition is generated. The lines are driven through
+ *          the SIO function emulating open drain outputs, the caller
+ *          must reassign the pads to the I2C function afterwards and
+ *          restart the driver.
+ * @note    Thread context only, this function sleeps between line
+ *          transitions. It is not wired into any I-class path.
+ *
+ * @param[in] sclline   line identifier of the SCL signal
+ * @param[in] sdaline   line identifier of the SDA signal
+ * @return              The bus state.
+ * @retval true         if SDA reads high after the procedure.
+ * @retval false        if SDA is still stuck low.
+ *
+ * @api
+ */
+bool i2cRPBusClear(ioline_t sclline, ioline_t sdaline) {
+  unsigned i;
+
+  /* Both lines released and observed through the SIO function.*/
+  palSetLineMode(sdaline, PAL_MODE_INPUT_PULLUP);
+  palSetLineMode(sclline, PAL_MODE_INPUT_PULLUP);
+  chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
+
+  for (i = 0U; i < 9U; i++) {
+    if (palReadLine(sdaline) == PAL_HIGH) {
+      break;
+    }
+
+    /* One SCL pulse, low is actively driven, high is released to the
+       pull-up.*/
+    palClearLine(sclline);
+    palSetLineMode(sclline, PAL_MODE_OUTPUT_PUSHPULL);
+    chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
+    palSetLineMode(sclline, PAL_MODE_INPUT_PULLUP);
+    chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
+  }
+
+  /* STOP condition: SDA released while SCL is high.*/
+  palClearLine(sdaline);
+  palSetLineMode(sdaline, PAL_MODE_OUTPUT_PUSHPULL);
+  chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
+  palSetLineMode(sdaline, PAL_MODE_INPUT_PULLUP);
+  chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
+
+  return palReadLine(sdaline) == PAL_HIGH;
+}
+#endif /* HAL_USE_PAL == TRUE */
+
+#endif /* HAL_USE_I2C == TRUE */
+
+/** @} */

--- a/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -73,6 +73,15 @@
  */
 #define I2C_ENABLE_HANDSHAKE_ITERATIONS     32U
 
+/**
+ * @brief   Depth of the transmit and receive FIFOs, in entries.
+ * @details Both FIFOs of the RP controller are sixteen entries deep.
+ *          Every FIFO service loop is additionally bounded by this
+ *          depth so that the critical section it runs in has a fixed
+ *          maximum length regardless of the hardware behaviour.
+ */
+#define I2C_FIFO_DEPTH                      16U
+
 /*===========================================================================*/
 /* Driver exported variables.                                                */
 /*===========================================================================*/
@@ -94,6 +103,28 @@ hal_i2c_driver_c I2CD1;
 /*===========================================================================*/
 /* Driver local variables and types.                                         */
 /*===========================================================================*/
+
+/**
+ * @brief   Snapshot of the configuration registers.
+ * @details These registers are gated on the controller enable bit and
+ *          hold everything the driver derives from a configuration.
+ *          A snapshot is taken before a configuration is replaced and
+ *          reprogrammed if the replacement cannot be confirmed, the
+ *          hardware then keeps describing the configuration the shared
+ *          layer keeps.
+ */
+typedef struct {
+  /* Control register, mode and feature selection.*/
+  uint32_t                  con;
+  /* SCL high count.*/
+  uint32_t                  hcnt;
+  /* SCL low count.*/
+  uint32_t                  lcnt;
+  /* Spike suppression length.*/
+  uint32_t                  spklen;
+  /* SDA transmit hold time.*/
+  uint32_t                  sdahold;
+} i2c_regs_t;
 
 /**
  * @brief   Driver default configuration.
@@ -208,39 +239,255 @@ static bool i2c_lld_wait_enable_state(I2C_TypeDef *dp, uint32_t state) {
 }
 
 /**
- * @brief   Programs the target address and starts the transfer engine.
+ * @brief   Reads the configuration registers into a snapshot.
+ * @details Register reads are legal in any enable state, the snapshot
+ *          therefore always describes the configuration the controller
+ *          is currently holding.
+ *
+ * @param[in] dp        pointer to the registers block
+ * @param[out] regs     pointer to the snapshot structure
+ */
+static void i2c_lld_read_regs(I2C_TypeDef *dp, i2c_regs_t *regs) {
+
+  regs->con     = dp->CON;
+  regs->hcnt    = dp->FSSCLHCNT;
+  regs->lcnt    = dp->FSSCLLCNT;
+  regs->spklen  = dp->FSSPKLEN;
+  regs->sdahold = dp->SDAHOLD;
+}
+
+/**
+ * @brief   Writes a configuration register snapshot.
+ * @details The FIFO trigger levels belong to the idle configuration and
+ *          are restored here as well: the receive level is retargeted
+ *          by the transfer engine for every read batch.
+ * @note    The controller must be confirmed disabled, these registers
+ *          are gated on the enable bit.
+ *
+ * @param[in] dp        pointer to the registers block
+ * @param[in] regs      pointer to the snapshot structure
+ */
+static void i2c_lld_write_regs(I2C_TypeDef *dp, const i2c_regs_t *regs) {
+
+  dp->CON       = regs->con;
+  dp->FSSCLHCNT = regs->hcnt;
+  dp->FSSCLLCNT = regs->lcnt;
+  dp->FSSPKLEN  = regs->spklen;
+  dp->SDAHOLD   = regs->sdahold;
+  dp->RXTL      = 0U;
+  dp->TXTL      = 0U;
+}
+
+/**
+ * @brief   Applies a register snapshot leaving the controller idle.
+ * @details The configuration registers are gated on the ENABLE register
+ *          bit, the disable is therefore confirmed through the
+ *          ENABLE_STATUS handshake before they are written and the
+ *          re-enable is confirmed before the controller is reported
+ *          usable again. A controller which does not confirm the
+ *          disable is reset and fully reinitialised from the snapshot,
+ *          a reset controller comes back disabled by definition and the
+ *          register gate is then open for certain. This is the single
+ *          point where the driver brings the hardware into a known
+ *          enabled-idle state, every failure path of the transfer setup
+ *          and of the reconfiguration goes through it.
+ * @note    Callable from any context, all waits are bounded: the enable
+ *          handshakes by @p I2C_ENABLE_HANDSHAKE_ITERATIONS and the
+ *          reset release by the resets controller acknowledge.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] regs      pointer to the snapshot structure
+ * @return              The operation outcome.
+ * @retval true         if the controller is confirmed enabled and idle
+ *                      holding the snapshot.
+ * @retval false        if the enable could not be confirmed, the
+ *                      snapshot has been programmed in any case.
+ */
+static bool i2c_lld_apply_regs(hal_i2c_driver_c *i2cp,
+                               const i2c_regs_t *regs) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t mask;
+
+  /* Interrupt sources masked, no service may run against a controller
+     under reconfiguration.*/
+  dp->INTRMASK = 0U;
+
+  dp->ENABLE = 0U;
+  if (!i2c_lld_wait_enable_state(dp, 0U)) {
+    /* The disable request was not confirmed, the controller is reset
+       instead of being written through a closed register gate.*/
+    mask = i2c_lld_reset_mask(i2cp);
+    rp_peripheral_reset(mask);
+    rp_peripheral_unreset(mask);
+  }
+
+  i2c_lld_write_regs(dp, regs);
+
+  /* Repeated after the possible reset, the interrupt mask does not
+     come out of reset masked.*/
+  dp->INTRMASK = 0U;
+
+  dp->ENABLE = I2C_IC_ENABLE_ENABLE;
+  if (!i2c_lld_wait_enable_state(dp, I2C_IC_ENABLE_STATUS_IC_EN)) {
+    return false;
+  }
+  (void)dp->CLRINTR;
+
+  return true;
+}
+
+/**
+ * @brief   Derives the configuration registers from a configuration.
+ * @details The SCL counts and the spike suppression length are derived
+ *          from the requested rate and the current system clock using
+ *          the classic timing ratios, configurations violating the
+ *          field ranges or the databook relations between the counts
+ *          and the suppression length are rejected. No hardware is
+ *          touched, a rejected configuration therefore leaves the
+ *          peripheral untouched.
+ *
+ * @param[in] config    pointer to the @p hal_i2c_config_t structure
+ * @param[out] regs     pointer to the snapshot structure
+ * @return              The derivation outcome.
+ * @retval true         if the configuration is representable.
+ * @retval false        if the configuration has been rejected.
+ */
+static bool i2c_lld_derive_regs(const hal_i2c_config_t *config,
+                                i2c_regs_t *regs) {
+  uint32_t freq_in, baudrate, period, lcnt, hcnt, spklen, sda_tx_hold;
+
+  freq_in = (uint32_t)halClockGetPointX(RP_CLK_SYS);
+  baudrate = config->baudrate;
+
+  /* The RP silicon supports up to Fast Mode Plus.*/
+  if ((baudrate == 0U) || (baudrate > 1000000U)) {
+    return false;
+  }
+
+  period = (freq_in + (baudrate / 2U)) / baudrate;
+
+  /* Periods too long for the 16-bit count fields are rejected early,
+     this also keeps the ratio scaling below within 32 bits.*/
+  if (period > 0x20000U) {
+    return false;
+  }
+
+  if (baudrate <= 100000U) {
+    /* Standard Mode: H: 4000ns, L: 4700ns ~ 0.54.*/
+    lcnt = period * 54U / 100U;
+  }
+  else if (baudrate <= 400000U) {
+    /* Fast Mode: H: 600ns, L: 1300ns ~ 0.68.*/
+    lcnt = period * 68U / 100U;
+  }
+  else {
+    /* Fast Mode Plus: H: 500ns, L: 760ns ~ 0.60.*/
+    lcnt = period * 60U / 100U;
+  }
+  hcnt = period - lcnt;
+
+  if ((lcnt > I2C_IC_FS_SCL_LCNT) || (hcnt > I2C_IC_FS_SCL_HCNT)) {
+    return false;
+  }
+
+  /* Spike suppression length derived as one sixteenth of the low
+     count, mirroring the reference implementation. Values beyond the
+     8-bit field are clamped: a longer than nominal suppression window
+     is harmless at the correspondingly slow SCL rates while silent
+     truncation would program a meaningless length.*/
+  spklen = lcnt < 16U ? 1U : lcnt / 16U;
+  if (spklen > I2C_IC_FS_SPKLEN_IC_FS_SPKLEN) {
+    spklen = I2C_IC_FS_SPKLEN_IC_FS_SPKLEN;
+  }
+
+  /* Databook validity relations between the SCL counts and the spike
+     suppression length: LCNT must exceed SPKLEN + 7 and HCNT must
+     exceed SPKLEN + 5.*/
+  if ((lcnt <= (spklen + 7U)) || (hcnt <= (spklen + 5U))) {
+    return false;
+  }
+
+  if (baudrate < 1000000U) {
+    /* Standard and Fast Mode:
+       sda_tx_hold = freq_in [cycles/s] * 300ns * (1s / 1e9ns)
+       Reduce 300/1e9 to 3/1e7 to avoid numbers that don't fit in u32.
+       Add 1 to avoid division truncation.*/
+    sda_tx_hold = ((freq_in * 3U) / 10000000U) + 1U;
+  }
+  else {
+    /* Fast Mode Plus:
+       sda_tx_hold = freq_in [cycles/s] * 120ns * (1s / 1e9ns)
+       Reduce 120/1e9 to 3/25e6 to avoid numbers that don't fit in u32.
+       Add 1 to avoid division truncation.*/
+    sda_tx_hold = ((freq_in * 3U) / 25000000U) + 1U;
+  }
+
+  if (sda_tx_hold > (lcnt - 2U)) {
+    return false;
+  }
+
+  regs->con     = I2C_IC_CON_IC_SLAVE_DISABLE |
+                  I2C_IC_CON_IC_RESTART_EN |
+#if RP_I2C_ADDRESS_MODE_10BIT == TRUE
+                  I2C_IC_CON_IC_10BITADDR_MASTER |
+#endif
+                  (2U << I2C_IC_CON_SPEED_Pos) | /* Always Fast Mode.*/
+                  I2C_IC_CON_MASTER_MODE |
+                  I2C_IC_CON_STOP_DET_IF_MASTER_ACTIVE |
+                  I2C_IC_CON_TX_EMPTY_CTRL;
+  regs->hcnt    = hcnt;
+  regs->lcnt    = lcnt;
+  regs->spklen  = spklen;
+  regs->sdahold = sda_tx_hold;
+
+  return true;
+}
+
+/**
+ * @brief   Programs the target address for a new transfer.
  * @details The target address register is gated on the ENABLE register
  *          bit, cycling the enable also flushes both FIFOs from any
  *          residue of a previously aborted transfer. Both edges of the
  *          enable cycle are confirmed through the ENABLE_STATUS
  *          handshake mandated by the databook before the dependent
  *          accesses are performed: the target address is written only
- *          on a confirmed disable, the interrupt sources are armed only
- *          on a confirmed enable.
- * @note    Called with the system lock held. The FIFO engine runs
- *          entirely in the interrupt service: with TX_EMPTY_CTRL
- *          selected the first TX_EMPTY interrupt fires as soon as the
- *          mask is armed because the TX FIFO is empty and no command is
- *          in flight, the service then queues data or read commands.
+ *          on a confirmed disable and the transfer is only started on a
+ *          confirmed enable.
+ *
+ *          This method has no effect other than on the hardware and it
+ *          is the only step of a transfer start which can fail. It is
+ *          therefore performed before any transaction state is
+ *          published: on failure the controller is put back into a
+ *          confirmed enabled-idle state holding the active
+ *          configuration and no trace of the attempted transaction is
+ *          left behind, neither in the driver nor in the peripheral.
+ * @note    Called with the system lock held. The interrupt sources are
+ *          deliberately not armed here, arming them is the last step of
+ *          the start sequence, see @p i2c_lld_arm_transfer().
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  * @param[in] addr      slave device address
  * @return              The operation status.
- * @retval HAL_RET_SUCCESS     if the transfer engine has been started.
+ * @retval HAL_RET_SUCCESS     if the controller is ready to be armed.
  * @retval HAL_RET_HW_BUSY     if an enable handshake bound was
- *                             exhausted, the peripheral is left masked
- *                             and the caller propagates the busy
+ *                             exhausted, the caller propagates the busy
  *                             condition.
  */
 static msg_t i2c_lld_setup_transfer(hal_i2c_driver_c *i2cp, i2caddr_t addr) {
   I2C_TypeDef *dp = i2cp->i2c;
+  i2c_regs_t regs;
 
-  /* All interrupt sources masked during the setup, this is also the
-     state left behind on a failed handshake.*/
+  /* All interrupt sources masked during the setup.*/
   dp->INTRMASK = 0U;
 
   dp->ENABLE = 0U;
   if (!i2c_lld_wait_enable_state(dp, 0U)) {
+    /* The setup never writes the configuration registers, their current
+       contents are the active configuration and are reprogrammed as
+       they are by the recovery.*/
+    i2c_lld_read_regs(dp, &regs);
+    (void)i2c_lld_apply_regs(i2cp, &regs);
+
     return HAL_RET_HW_BUSY;
   }
 
@@ -248,6 +495,9 @@ static msg_t i2c_lld_setup_transfer(hal_i2c_driver_c *i2cp, i2caddr_t addr) {
 
   dp->ENABLE = I2C_IC_ENABLE_ENABLE;
   if (!i2c_lld_wait_enable_state(dp, I2C_IC_ENABLE_STATUS_IC_EN)) {
+    i2c_lld_read_regs(dp, &regs);
+    (void)i2c_lld_apply_regs(i2cp, &regs);
+
     return HAL_RET_HW_BUSY;
   }
 
@@ -255,13 +505,29 @@ static msg_t i2c_lld_setup_transfer(hal_i2c_driver_c *i2cp, i2caddr_t addr) {
      flushed state following an abort.*/
   (void)dp->CLRINTR;
 
-  /* Interrupt sources armed, the transfer proceeds in the service
-     routines from here.*/
-  dp->INTRMASK = I2C_IC_INTR_MASK_M_STOP_DET |
-                 I2C_IC_INTR_MASK_M_TX_EMPTY |
-                 I2C_ERROR_INTERRUPTS;
-
   return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Arms the transfer interrupt sources.
+ * @details This is the last step of a transfer start and the point of
+ *          no return: the transfer proceeds in the service routines
+ *          from here. With TX_EMPTY_CTRL selected the first TX_EMPTY
+ *          interrupt fires as soon as the mask is armed because the TX
+ *          FIFO is empty and no command is in flight, the service then
+ *          queues data or read commands.
+ * @note    Called with the system lock held, after the transaction
+ *          state has been published and the transfer generation has
+ *          been opened. The service routines run under the same lock
+ *          and therefore observe a fully published transaction.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_arm_transfer(hal_i2c_driver_c *i2cp) {
+
+  i2cp->i2c->INTRMASK = I2C_IC_INTR_MASK_M_STOP_DET |
+                        I2C_IC_INTR_MASK_M_TX_EMPTY |
+                        I2C_ERROR_INTERRUPTS;
 }
 
 /**
@@ -312,7 +578,9 @@ static msg_t i2c_lld_check_startable(hal_i2c_driver_c *i2cp) {
  * @details The read command queued last carries the STOP bit and marks
  *          the transfer as stop-expected, anchoring the own-completion
  *          evidence used by the STOP detection service.
- * @note    Called with the system lock held from ISR context.
+ * @note    Called with the system lock held from ISR context. The queue
+ *          loop is bounded by the batch size, itself capped at the FIFO
+ *          depth, and the loop cannot spin.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  */
@@ -320,10 +588,11 @@ static void i2c_lld_request_data(hal_i2c_driver_c *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
   uint32_t data = I2C_IC_DATA_CMD_CMD;
 
-  /* RP Designware I2C peripheral has FIFO depth of 16 elements. As we
-     specify that the TX_EMPTY interrupt only fires if the TX FIFO is
-     truly empty we don't need to check the current fill level.*/
-  uint32_t batch = i2cp->rxbytes < 16U ? (uint32_t)i2cp->rxbytes : 16U;
+  /* The read commands are queued in FIFO sized batches. As we specify
+     that the TX_EMPTY interrupt only fires if the TX FIFO is truly
+     empty we don't need to check the current fill level.*/
+  uint32_t batch = i2cp->rxbytes < I2C_FIFO_DEPTH ?
+                   (uint32_t)i2cp->rxbytes : I2C_FIFO_DEPTH;
 
   if (i2cp->send_restart) {
     data |= I2C_IC_DATA_CMD_RESTART;
@@ -360,16 +629,24 @@ static void i2c_lld_request_data(hal_i2c_driver_c *i2cp) {
  * @details The data byte queued last in a pure write carries the STOP
  *          bit and marks the transfer as stop-expected, anchoring the
  *          own-completion evidence used by the STOP detection service.
- * @note    Called with the system lock held from ISR context.
+ * @note    Called with the system lock held from ISR context. The fill
+ *          loop is bounded by the FIFO depth in addition to the FIFO
+ *          full status and to the remaining byte count, breaking out
+ *          early is harmless: the TX_EMPTY source stays armed and the
+ *          service is redispatched when the FIFO drains.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  */
 static void i2c_lld_transmit_data(hal_i2c_driver_c *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
   uint32_t data;
+  unsigned i;
 
-  while ((i2cp->txbytes > 0U) &&
-         ((dp->STATUS & I2C_IC_STATUS_TFNF) != 0U)) {
+  for (i = 0U; i < I2C_FIFO_DEPTH; i++) {
+    if ((i2cp->txbytes == 0U) ||
+        ((dp->STATUS & I2C_IC_STATUS_TFNF) == 0U)) {
+      break;
+    }
     data = (uint32_t)*i2cp->txptr;
 
     /* Send STOP after the last byte of a pure write. If a read phase
@@ -408,13 +685,21 @@ static void i2c_lld_transmit_data(hal_i2c_driver_c *i2cp) {
  * @note    Called with the system lock held while the transfer
  *          generation is open, the buffer belongs to the driver only
  *          until the terminal event is claimed.
+ * @note    The drain loop is bounded by the FIFO depth in addition to
+ *          the FIFO empty status, a full FIFO is drained in a single
+ *          pass and the loop cannot spin.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  */
 static void i2c_lld_drain_rx(hal_i2c_driver_c *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
+  unsigned i;
 
-  while ((dp->STATUS & I2C_IC_STATUS_RFNE) != 0U) {
+  for (i = 0U; i < I2C_FIFO_DEPTH; i++) {
+    if ((dp->STATUS & I2C_IC_STATUS_RFNE) == 0U) {
+      break;
+    }
+
     /* Read out received data.*/
     *i2cp->rxptr = (uint8_t)dp->DATACMD;
     i2cp->rxptr++;
@@ -503,23 +788,28 @@ static void i2c_lld_claim_terminal(hal_i2c_driver_c *i2cp, msg_t msg) {
  * @brief   Transmission errors service.
  * @details The terminal event is claimed against the transfer generation
  *          counter and the raw interrupt state, the error decoding and
- *          the whole transfer termination are performed in one critical
- *          section, see @p i2c_lld_claim_terminal(). An error made stale
- *          by a concurrent stop or already consumed by a new transfer
- *          start loses the claim and is silenced without side effects.
- *          The abort completion following a transfer stop takes the
- *          losing path: the stop already claimed the terminal event,
- *          the service only clears the flags and releases the abort
- *          tracking.
+ *          the whole transfer termination are performed in the dispatch
+ *          critical section, see @p i2c_lld_claim_terminal(). An error
+ *          made stale by a concurrent stop or already consumed by a new
+ *          transfer start loses the claim and is silenced without side
+ *          effects. The abort completion following a transfer stop
+ *          takes the losing path: the stop already claimed the terminal
+ *          event, the service only clears the flags and releases the
+ *          abort tracking.
+ * @note    Called with the system lock held from ISR context, this is
+ *          the only service also dispatched with the generation closed.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @return              The terminal event claim outcome.
+ * @retval true         if this service terminated the transfer and owes
+ *                      the user callback.
+ * @retval false        if the event was stale or lost the claim.
  */
-static void i2c_lld_serve_errors(hal_i2c_driver_c *i2cp) {
+static bool i2c_lld_serve_errors(hal_i2c_driver_c *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
   uint32_t raw, abort_source;
   bool claimed;
 
-  chSysLockFromISR();
   raw = dp->RAWINTRSTAT;
 
   /* A raw abort event doubles as the completion notification of the
@@ -563,80 +853,61 @@ static void i2c_lld_serve_errors(hal_i2c_driver_c *i2cp) {
     /* With a transfer in flight and no raw error left the flags have
        already been consumed by a transfer start, nothing to do.*/
   }
-  chSysUnlockFromISR();
 
-  if (claimed) {
-    /* The user callback is the only piece running outside the critical
-       section, invoked by the single terminal-event winner.*/
-    __cbdrv_invoke_cb(i2cp);
-  }
+  return claimed;
 }
 
 /**
  * @brief   TX FIFO empty service.
- * @details Feeds the transmit FIFO or queues read commands. The whole
- *          service runs in a critical section: the generation check and
- *          the FIFO accesses must be atomic with respect to a transfer
- *          stop on the other core, otherwise the engine could feed an
- *          aborting transfer or unmask interrupts behind its back.
+ * @details Feeds the transmit FIFO or queues read commands.
+ * @note    Called with the system lock held from ISR context and with
+ *          the transfer generation validated as open by the dispatcher:
+ *          the interrupt status sample, the validation and these FIFO
+ *          accesses belong to the same critical section, the transfer
+ *          being served cannot change underneath.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  */
 static void i2c_lld_serve_tx_empty(hal_i2c_driver_c *i2cp) {
 
-  chSysLockFromISR();
-  if ((i2cp->tgen & 1U) != 0U) {
-    if (i2cp->state == HAL_DRV_STATE_ACTIVE) {
-      i2c_lld_transmit_data(i2cp);
-    }
-    else {
-      i2c_lld_request_data(i2cp);
-    }
+  chDbgAssert((i2cp->tgen & 1U) != 0U, "no transfer in flight");
+
+  if (i2cp->state == HAL_DRV_STATE_ACTIVE) {
+    i2c_lld_transmit_data(i2cp);
   }
   else {
-    /* No transfer in flight, a stale data interrupt is silenced. The
-       mask write cannot stomp a concurrent start because starts run
-       under the same lock.*/
-    i2cp->i2c->CLR.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY |
-                              I2C_IC_INTR_MASK_M_RX_FULL;
+    i2c_lld_request_data(i2cp);
   }
-  chSysUnlockFromISR();
 }
 
 /**
  * @brief   RX FIFO batch service.
- * @details Drains the receive FIFO into the transfer buffer. The whole
- *          service runs in a critical section: after a transfer stop
- *          wins the terminal event the caller owns the receive buffer
- *          again, draining into it is only legal while the generation
- *          is still open.
+ * @details Drains the receive FIFO into the transfer buffer.
+ * @note    Called with the system lock held from ISR context and with
+ *          the transfer generation validated as open by the dispatcher:
+ *          after a transfer stop wins the terminal event the caller
+ *          owns the receive buffer again, draining into it is only
+ *          legal while the generation is still open and the generation
+ *          cannot close inside the dispatch critical section.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  */
 static void i2c_lld_serve_rx_full(hal_i2c_driver_c *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
 
-  chSysLockFromISR();
-  if ((i2cp->tgen & 1U) != 0U) {
-    i2c_lld_drain_rx(i2cp);
+  chDbgAssert((i2cp->tgen & 1U) != 0U, "no transfer in flight");
 
-    if (i2cp->rxbytes == 0U) {
-      /* Everything is received, therefore disable all FIFO IRQs.*/
-      dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_RX_FULL |
-                         I2C_IC_INTR_MASK_M_TX_EMPTY;
-    }
-    else {
-      /* Enable TX FIFO empty IRQ to request more data.*/
-      dp->SET.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY;
-    }
-  }
-  else {
-    /* No transfer in flight, the buffer is not touched, residual data
-       is flushed by the enable cycle of the next transfer start.*/
+  i2c_lld_drain_rx(i2cp);
+
+  if (i2cp->rxbytes == 0U) {
+    /* Everything is received, therefore disable all FIFO IRQs.*/
     dp->CLR.INTRMASK = I2C_IC_INTR_MASK_M_RX_FULL |
                        I2C_IC_INTR_MASK_M_TX_EMPTY;
   }
-  chSysUnlockFromISR();
+  else {
+    /* Enable TX FIFO empty IRQ to request more data.*/
+    dp->SET.INTRMASK = I2C_IC_INTR_MASK_M_TX_EMPTY;
+  }
 }
 
 /**
@@ -661,17 +932,29 @@ static void i2c_lld_serve_rx_full(hal_i2c_driver_c *i2cp) {
  *          nothing is lost. With the evidence positive the final read
  *          data, if any, is already complete in the RX FIFO, it is
  *          drained here while the generation is still open.
+ * @note    Called with the system lock held from ISR context and with
+ *          the transfer generation validated as open by the dispatcher.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @return              The terminal event claim outcome.
+ * @retval true         if this service terminated the transfer and owes
+ *                      the user callback.
+ * @retval false        if the STOP was not the own completion.
  */
-static void i2c_lld_serve_stop(hal_i2c_driver_c *i2cp) {
+static bool i2c_lld_serve_stop(hal_i2c_driver_c *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
   bool claimed = false;
 
-  chSysLockFromISR();
-  if (((i2cp->tgen & 1U) != 0U) &&
-      ((dp->RAWINTRSTAT & (I2C_IC_INTR_STAT_R_TX_ABRT |
-                           I2C_OVERRUN_ERRORS)) == 0U)) {
+  chDbgAssert((i2cp->tgen & 1U) != 0U, "no transfer in flight");
+
+  if ((dp->RAWINTRSTAT & (I2C_IC_INTR_STAT_R_TX_ABRT |
+                          I2C_OVERRUN_ERRORS)) != 0U) {
+    /* A STOP trailing an abort or an overrun, which is terminal through
+       the error service: dropped without touching the rest of the
+       peripheral state.*/
+    (void)dp->CLRSTOPDET;
+  }
+  else {
     if (!i2c_lld_transfer_ended(i2cp)) {
       /* Foreign STOP so far, consumed and immediately reevaluated, see
          the details above.*/
@@ -689,11 +972,72 @@ static void i2c_lld_serve_stop(hal_i2c_driver_c *i2cp) {
       claimed = true;
     }
   }
+
+  return claimed;
+}
+
+/**
+ * @brief   I2C shared ISR code.
+ * @details The system lock is acquired before the interrupt status is
+ *          sampled and released only after the service has run: the
+ *          sample, the transfer generation validation and the actions
+ *          taken on FIFOs, buffers and interrupt masks all belong to
+ *          one critical section. Sampling the status outside the lock
+ *          would dispatch on a generation which the other core can
+ *          close, complete and reopen while this core is still waiting
+ *          for the lock, the service would then act on a transfer it
+ *          never observed. All work performed inside the section is
+ *          bounded by the FIFO depth or by the transfer byte counters,
+ *          no loop can spin, see @p i2c_lld_transmit_data(),
+ *          @p i2c_lld_request_data() and @p i2c_lld_drain_rx().
+ *          The user callback is the only piece which must run outside
+ *          the critical section, it is invoked after unlocking and only
+ *          by the service which won the terminal event.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_serve_interrupt(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+  uint32_t intr;
+  bool claimed = false;
+
+  chSysLockFromISR();
+
+  /* Interrupt status sampled inside the critical section, it describes
+     the transfer generation which is live right now.*/
+  intr = dp->INTRSTAT;
+
+  /* Transmission error detected, includes the abort completion of a
+     stopped transfer. This is the only service which is meaningful with
+     the generation already closed, it arbitrates the claim itself.*/
+  if ((intr & I2C_ERROR_INTERRUPTS) != 0U) {
+    claimed = i2c_lld_serve_errors(i2cp);
+  }
+  else if ((i2cp->tgen & 1U) == 0U) {
+    /* No transfer in flight, the remaining sources can only belong to a
+       terminated, stopped or reconfigured generation, they are silenced
+       without touching buffers or driver state. The mask write cannot
+       stomp a concurrent start because starts run under this lock.*/
+    if (intr != 0U) {
+      dp->INTRMASK = 0U;
+      (void)dp->CLRINTR;
+    }
+  }
+  /* If the TX FIFO is empty we can request or send more data.*/
+  else if ((intr & I2C_IC_INTR_STAT_R_TX_EMPTY) != 0U) {
+    i2c_lld_serve_tx_empty(i2cp);
+  }
+  /* A batch of data has been received.*/
+  else if ((intr & I2C_IC_INTR_STAT_R_RX_FULL) != 0U) {
+    i2c_lld_serve_rx_full(i2cp);
+  }
+  /* STOP condition detected, own STOPs terminate the transfer.*/
+  else if ((intr & I2C_IC_INTR_STAT_R_STOP_DET) != 0U) {
+    claimed = i2c_lld_serve_stop(i2cp);
+  }
   else {
-    /* Stale STOP with no transfer in flight, or a STOP trailing an
-       abort or overrun which is terminal through the error service:
-       dropped without touching the rest of the peripheral state.*/
-    (void)dp->CLRSTOPDET;
+    /* Nothing pending, a dispatch made spurious by a source which has
+       been consumed elsewhere.*/
   }
   chSysUnlockFromISR();
 
@@ -701,40 +1045,6 @@ static void i2c_lld_serve_stop(hal_i2c_driver_c *i2cp) {
     /* The user callback is the only piece running outside the critical
        section, invoked by the single terminal-event winner.*/
     __cbdrv_invoke_cb(i2cp);
-  }
-}
-
-/**
- * @brief   I2C shared ISR code.
- *
- * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
- */
-static void i2c_lld_serve_interrupt(hal_i2c_driver_c *i2cp) {
-  I2C_TypeDef *dp = i2cp->i2c;
-  uint32_t intr = dp->INTRSTAT;
-
-  /* Transmission error detected, includes the abort completion of a
-     stopped transfer.*/
-  if ((intr & I2C_ERROR_INTERRUPTS) != 0U) {
-    i2c_lld_serve_errors(i2cp);
-    return;
-  }
-
-  /* If the TX FIFO is empty we can request or send more data.*/
-  if ((intr & I2C_IC_INTR_STAT_R_TX_EMPTY) != 0U) {
-    i2c_lld_serve_tx_empty(i2cp);
-    return;
-  }
-
-  /* A batch of data has been received.*/
-  if ((intr & I2C_IC_INTR_STAT_R_RX_FULL) != 0U) {
-    i2c_lld_serve_rx_full(i2cp);
-    return;
-  }
-
-  /* STOP condition detected, own STOPs terminate the transfer.*/
-  if ((intr & I2C_IC_INTR_STAT_R_STOP_DET) != 0U) {
-    i2c_lld_serve_stop(i2cp);
   }
 }
 
@@ -908,27 +1218,34 @@ void i2c_lld_stop(hal_i2c_driver_c *i2cp) {
 
 /**
  * @brief   I2C configuration.
- * @details The SCL counts and the spike suppression length are derived
- *          from the requested rate and the current system clock using
- *          the classic timing ratios, configurations violating the
- *          field ranges or the databook relations between the counts
- *          and the suppression length are rejected. The peripheral is
- *          reprogrammed only while no transfer is in flight and no
- *          abort is still flushing: the controller disable performed
- *          for reprogramming then settles within the documented two
- *          clock cycles, the bounded handshake is a formality.
+ * @details The register values are derived and validated first, no
+ *          hardware is touched before the configuration is known to be
+ *          representable. The peripheral is reprogrammed only while no
+ *          transfer is in flight and no abort is still flushing: the
+ *          controller disable performed for reprogramming then settles
+ *          within the documented two clock cycles, the bounded
+ *          handshake is a formality.
+ *
+ *          The reprogramming is transactional. The register contents
+ *          describing the configuration currently in effect are saved
+ *          before they are replaced and, if the new configuration does
+ *          not reach a confirmed enabled state, they are programmed
+ *          back: this method returning @p NULL leaves the shared layer
+ *          holding the previous configuration pointer, the hardware
+ *          must be left describing exactly that configuration and never
+ *          a half applied one.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  * @param[in] config    pointer to the @p hal_i2c_config_t structure
  * @return              A pointer to the current configuration structure.
- * @retval NULL         if the configuration failed.
+ * @retval NULL         if the configuration failed, the peripheral
+ *                      keeps the previous configuration.
  *
  * @notapi
  */
 const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
                                        const hal_i2c_config_t *config) {
-  I2C_TypeDef *dp = i2cp->i2c;
-  uint32_t freq_in, baudrate, period, lcnt, hcnt, spklen, sda_tx_hold;
+  i2c_regs_t newregs, oldregs;
 
   if (config == NULL) {
     config = &i2c_default_config;
@@ -941,74 +1258,8 @@ const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
   }
 
   /* Timing derivation, the classic math with rejection instead of
-     assertion.*/
-  freq_in = (uint32_t)halClockGetPointX(RP_CLK_SYS);
-  baudrate = config->baudrate;
-
-  /* The RP silicon supports up to Fast Mode Plus.*/
-  if ((baudrate == 0U) || (baudrate > 1000000U)) {
-    return NULL;
-  }
-
-  period = (freq_in + (baudrate / 2U)) / baudrate;
-
-  /* Periods too long for the 16-bit count fields are rejected early,
-     this also keeps the ratio scaling below within 32 bits.*/
-  if (period > 0x20000U) {
-    return NULL;
-  }
-
-  if (baudrate <= 100000U) {
-    /* Standard Mode: H: 4000ns, L: 4700ns ~ 0.54.*/
-    lcnt = period * 54U / 100U;
-  }
-  else if (baudrate <= 400000U) {
-    /* Fast Mode: H: 600ns, L: 1300ns ~ 0.68.*/
-    lcnt = period * 68U / 100U;
-  }
-  else {
-    /* Fast Mode Plus: H: 500ns, L: 760ns ~ 0.60.*/
-    lcnt = period * 60U / 100U;
-  }
-  hcnt = period - lcnt;
-
-  if ((lcnt > I2C_IC_FS_SCL_LCNT) || (hcnt > I2C_IC_FS_SCL_HCNT)) {
-    return NULL;
-  }
-
-  /* Spike suppression length derived as one sixteenth of the low
-     count, mirroring the reference implementation. Values beyond the
-     8-bit field are clamped: a longer than nominal suppression window
-     is harmless at the correspondingly slow SCL rates while silent
-     truncation would program a meaningless length.*/
-  spklen = lcnt < 16U ? 1U : lcnt / 16U;
-  if (spklen > I2C_IC_FS_SPKLEN_IC_FS_SPKLEN) {
-    spklen = I2C_IC_FS_SPKLEN_IC_FS_SPKLEN;
-  }
-
-  /* Databook validity relations between the SCL counts and the spike
-     suppression length: LCNT must exceed SPKLEN + 7 and HCNT must
-     exceed SPKLEN + 5.*/
-  if ((lcnt <= (spklen + 7U)) || (hcnt <= (spklen + 5U))) {
-    return NULL;
-  }
-
-  if (baudrate < 1000000U) {
-    /* Standard and Fast Mode:
-       sda_tx_hold = freq_in [cycles/s] * 300ns * (1s / 1e9ns)
-       Reduce 300/1e9 to 3/1e7 to avoid numbers that don't fit in u32.
-       Add 1 to avoid division truncation.*/
-    sda_tx_hold = ((freq_in * 3U) / 10000000U) + 1U;
-  }
-  else {
-    /* Fast Mode Plus:
-       sda_tx_hold = freq_in [cycles/s] * 120ns * (1s / 1e9ns)
-       Reduce 120/1e9 to 3/25e6 to avoid numbers that don't fit in u32.
-       Add 1 to avoid division truncation.*/
-    sda_tx_hold = ((freq_in * 3U) / 25000000U) + 1U;
-  }
-
-  if (sda_tx_hold > (lcnt - 2U)) {
+     assertion, performed before the peripheral is touched.*/
+  if (!i2c_lld_derive_regs(config, &newregs)) {
     return NULL;
   }
 
@@ -1021,43 +1272,17 @@ const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
     return config;
   }
 
-  /* Controller disabled during reprogramming, the disable is confirmed
-     through the ENABLE_STATUS handshake before touching the enable
-     gated registers.*/
-  dp->ENABLE = 0U;
-  if (!i2c_lld_wait_enable_state(dp, 0U)) {
+  /* Configuration in effect saved for the rollback below.*/
+  i2c_lld_read_regs(i2cp->i2c, &oldregs);
+
+  if (!i2c_lld_apply_regs(i2cp, &newregs)) {
+    /* The new configuration did not reach a confirmed enabled state,
+       the previous one is programmed back so that the hardware keeps
+       matching the configuration the shared layer keeps.*/
+    (void)i2c_lld_apply_regs(i2cp, &oldregs);
+
     return NULL;
   }
-
-  dp->CON = I2C_IC_CON_IC_SLAVE_DISABLE |
-            I2C_IC_CON_IC_RESTART_EN |
-#if RP_I2C_ADDRESS_MODE_10BIT == TRUE
-            I2C_IC_CON_IC_10BITADDR_MASTER |
-#endif
-            (2U << I2C_IC_CON_SPEED_Pos) | /* Always Fast Mode.*/
-            I2C_IC_CON_MASTER_MODE |
-            I2C_IC_CON_STOP_DET_IF_MASTER_ACTIVE |
-            I2C_IC_CON_TX_EMPTY_CTRL;
-
-  dp->RXTL = 0U;
-  dp->TXTL = 0U;
-
-  /* All timing values validated above, written as derived.*/
-  dp->FSSCLHCNT = hcnt;
-  dp->FSSCLLCNT = lcnt;
-  dp->FSSPKLEN = spklen;
-  dp->SDAHOLD = sda_tx_hold;
-
-  /* Interrupt sources masked until a transfer starts.*/
-  dp->INTRMASK = 0U;
-
-  /* Peripheral enabled again with the enable confirmed, flags
-     cleared.*/
-  dp->ENABLE = I2C_IC_ENABLE_ENABLE;
-  if (!i2c_lld_wait_enable_state(dp, I2C_IC_ENABLE_STATUS_IC_EN)) {
-    return NULL;
-  }
-  (void)dp->CLRINTR;
 
   return config;
 }
@@ -1182,7 +1407,17 @@ msg_t i2c_lld_start_master_receive(hal_i2c_driver_c *i2cp, i2caddr_t addr,
     return msg;
   }
 
-  /* Transaction setup.*/
+  /* Hardware programming, the only step of a start which can fail. It
+     is performed before any transaction state is published, a failure
+     therefore leaves both the driver fields and the confirmed idle
+     peripheral exactly as they were.*/
+  msg = i2c_lld_setup_transfer(i2cp, addr);
+  if (msg != HAL_RET_SUCCESS) {
+    return msg;
+  }
+
+  /* Transaction setup, published only once the transfer is certain to
+     start.*/
   i2cp->txptr         = NULL;
   i2cp->txbytes       = (size_t)0;
   i2cp->rxptr         = rxbuf;
@@ -1190,16 +1425,12 @@ msg_t i2c_lld_start_master_receive(hal_i2c_driver_c *i2cp, i2caddr_t addr,
   i2cp->send_restart  = false;
   i2cp->stop_expected = false;
 
-  /* Hardware programming and start, a failed enable handshake rejects
-     the start before the transfer generation is opened.*/
-  msg = i2c_lld_setup_transfer(i2cp, addr);
-  if (msg != HAL_RET_SUCCESS) {
-    return msg;
-  }
-
   /* Transfer generation opened, from here the terminal event belongs
      to a single winner among the completion, error and stop paths.*/
   i2c_lld_tgen_open(i2cp);
+
+  /* Interrupt sources armed last, on a fully published transaction.*/
+  i2c_lld_arm_transfer(i2cp);
 
   return HAL_RET_SUCCESS;
 }
@@ -1240,7 +1471,17 @@ msg_t i2c_lld_start_master_transmit(hal_i2c_driver_c *i2cp, i2caddr_t addr,
     return msg;
   }
 
-  /* Transaction setup.*/
+  /* Hardware programming, the only step of a start which can fail. It
+     is performed before any transaction state is published, a failure
+     therefore leaves both the driver fields and the confirmed idle
+     peripheral exactly as they were.*/
+  msg = i2c_lld_setup_transfer(i2cp, addr);
+  if (msg != HAL_RET_SUCCESS) {
+    return msg;
+  }
+
+  /* Transaction setup, published only once the transfer is certain to
+     start.*/
   i2cp->txptr         = txbuf;
   i2cp->txbytes       = txbytes;
   i2cp->rxptr         = rxbuf;
@@ -1248,16 +1489,12 @@ msg_t i2c_lld_start_master_transmit(hal_i2c_driver_c *i2cp, i2caddr_t addr,
   i2cp->send_restart  = false;
   i2cp->stop_expected = false;
 
-  /* Hardware programming and start, a failed enable handshake rejects
-     the start before the transfer generation is opened.*/
-  msg = i2c_lld_setup_transfer(i2cp, addr);
-  if (msg != HAL_RET_SUCCESS) {
-    return msg;
-  }
-
   /* Transfer generation opened, from here the terminal event belongs
      to a single winner among the completion, error and stop paths.*/
   i2c_lld_tgen_open(i2cp);
+
+  /* Interrupt sources armed last, on a fully published transaction.*/
+  i2c_lld_arm_transfer(i2cp);
 
   return HAL_RET_SUCCESS;
 }

--- a/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
+++ b/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.c
@@ -47,6 +47,32 @@
  */
 #define I2C_BUS_CLEAR_HALF_PERIOD_US        10U
 
+/**
+ * @brief   Bound of a single SCL rise wait of the bus clear procedure,
+ *          in half period sleeps.
+ * @details A device may legally stretch the SCL low phase, the wait
+ *          therefore paces bounded sleeps instead of sampling once. A
+ *          clock line that does not rise within the bound is considered
+ *          held by a failed device, such a bus cannot be recovered by
+ *          pulsing SCL from this side.
+ */
+#define I2C_BUS_CLEAR_SCL_RISE_CYCLES       100U
+
+/**
+ * @brief   Bound of the controller enable handshake, in status polling
+ *          iterations.
+ * @details The databook bounds the propagation of an enable or disable
+ *          request to the ENABLE_STATUS register to two ic_clk cycles
+ *          for an idle controller, ic_clk being clk_sys on the RP
+ *          ports. The handshake is only ever performed with the
+ *          controller idle, enforced by the transfer start gate. Each
+ *          polling iteration costs at least one APB status read of
+ *          several clk_sys cycles, the bound is therefore orders of
+ *          magnitude above the documented latency and only exhausted by
+ *          misbehaving hardware.
+ */
+#define I2C_ENABLE_HANDSHAKE_ITERATIONS     32U
+
 /*===========================================================================*/
 /* Driver exported variables.                                                */
 /*===========================================================================*/
@@ -152,13 +178,45 @@ static void i2c_lld_deactivate(hal_i2c_driver_c *i2cp) {
 }
 
 /**
+ * @brief   Waits for the controller enable state to settle.
+ * @details The ENABLE register only carries the request, the effective
+ *          state is reported by the ENABLE_STATUS register after the
+ *          documented propagation latency. Register accesses gated on
+ *          the enable state, first of all the target address register,
+ *          are only legal after the status has confirmed the requested
+ *          state.
+ * @note    Called with the system lock held, the poll is bounded, see
+ *          @p I2C_ENABLE_HANDSHAKE_ITERATIONS.
+ *
+ * @param[in] dp        pointer to the registers block
+ * @param[in] state     expected IC_EN state of the ENABLE_STATUS
+ *                      register
+ * @return              The handshake outcome.
+ * @retval true         if the controller reached the expected state.
+ * @retval false        if the poll bound was exhausted.
+ */
+static bool i2c_lld_wait_enable_state(I2C_TypeDef *dp, uint32_t state) {
+  unsigned i;
+
+  for (i = 0U; i < I2C_ENABLE_HANDSHAKE_ITERATIONS; i++) {
+    if ((dp->ENABLESTATUS & I2C_IC_ENABLE_STATUS_IC_EN) == state) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * @brief   Programs the target address and starts the transfer engine.
  * @details The target address register is gated on the ENABLE register
  *          bit, cycling the enable also flushes both FIFOs from any
- *          residue of a previously aborted transfer. The RP DW_apb_i2c
- *          applies the enable state within two clk_sys cycles, hidden
- *          behind the following register accesses, therefore no
- *          settling wait is required with the controller idle.
+ *          residue of a previously aborted transfer. Both edges of the
+ *          enable cycle are confirmed through the ENABLE_STATUS
+ *          handshake mandated by the databook before the dependent
+ *          accesses are performed: the target address is written only
+ *          on a confirmed disable, the interrupt sources are armed only
+ *          on a confirmed enable.
  * @note    Called with the system lock held. The FIFO engine runs
  *          entirely in the interrupt service: with TX_EMPTY_CTRL
  *          selected the first TX_EMPTY interrupt fires as soon as the
@@ -167,14 +225,31 @@ static void i2c_lld_deactivate(hal_i2c_driver_c *i2cp) {
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  * @param[in] addr      slave device address
+ * @return              The operation status.
+ * @retval HAL_RET_SUCCESS     if the transfer engine has been started.
+ * @retval HAL_RET_HW_BUSY     if an enable handshake bound was
+ *                             exhausted, the peripheral is left masked
+ *                             and the caller propagates the busy
+ *                             condition.
  */
-static void i2c_lld_setup_transfer(hal_i2c_driver_c *i2cp, i2caddr_t addr) {
+static msg_t i2c_lld_setup_transfer(hal_i2c_driver_c *i2cp, i2caddr_t addr) {
   I2C_TypeDef *dp = i2cp->i2c;
 
-  dp->ENABLE = 0U;
-  dp->TAR = (uint32_t)addr & I2C_IC_TAR_IC_TAR;
+  /* All interrupt sources masked during the setup, this is also the
+     state left behind on a failed handshake.*/
   dp->INTRMASK = 0U;
+
+  dp->ENABLE = 0U;
+  if (!i2c_lld_wait_enable_state(dp, 0U)) {
+    return HAL_RET_HW_BUSY;
+  }
+
+  dp->TAR = (uint32_t)addr & I2C_IC_TAR_IC_TAR;
+
   dp->ENABLE = I2C_IC_ENABLE_ENABLE;
+  if (!i2c_lld_wait_enable_state(dp, I2C_IC_ENABLE_STATUS_IC_EN)) {
+    return HAL_RET_HW_BUSY;
+  }
 
   /* Stale flags cleared, this also releases the TX FIFO from the
      flushed state following an abort.*/
@@ -185,11 +260,58 @@ static void i2c_lld_setup_transfer(hal_i2c_driver_c *i2cp, i2caddr_t addr) {
   dp->INTRMASK = I2C_IC_INTR_MASK_M_STOP_DET |
                  I2C_IC_INTR_MASK_M_TX_EMPTY |
                  I2C_ERROR_INTERRUPTS;
+
+  return HAL_RET_SUCCESS;
+}
+
+/**
+ * @brief   Transfer start gate.
+ * @details A transfer start is rejected while the controller can still
+ *          be processing a previous operation. The asynchronous abort
+ *          initiated by a transfer stop is tracked in software because
+ *          the ACTIVITY status only reflects the current state of the
+ *          transfer state machine: it can read idle after the aborted
+ *          transfer left the wire while the ABORT request is still
+ *          flushing the FIFO engine. The tracking is released when the
+ *          abort completion interrupt has been observed or, here, when
+ *          the ABORT request is read back as self-cleared, whichever
+ *          comes first.
+ * @note    Called with the system lock held from I-class context,
+ *          waiting is not allowed, a busy condition is reported to the
+ *          caller.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @return              The gate status.
+ * @retval HAL_RET_SUCCESS     if a transfer can be started.
+ * @retval HAL_RET_HW_BUSY     if the controller is busy.
+ */
+static msg_t i2c_lld_check_startable(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  if (i2cp->abort_pending) {
+    if ((dp->ENABLE & I2C_IC_ENABLE_ABORT) != 0U) {
+      return HAL_RET_HW_BUSY;
+    }
+
+    /* The abort request self-cleared, the latched abort flags are
+       consumed by the enable cycle of the transfer setup or silenced
+       by the error service which finds the generation closed.*/
+    i2cp->abort_pending = false;
+  }
+
+  if ((dp->STATUS & I2C_IC_STATUS_ACTIVITY) != 0U) {
+    return HAL_RET_HW_BUSY;
+  }
+
+  return HAL_RET_SUCCESS;
 }
 
 /**
  * @brief   Requests data to be received, actual reception is done in the
  *          interrupt handler.
+ * @details The read command queued last carries the STOP bit and marks
+ *          the transfer as stop-expected, anchoring the own-completion
+ *          evidence used by the STOP detection service.
  * @note    Called with the system lock held from ISR context.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
@@ -217,6 +339,7 @@ static void i2c_lld_request_data(hal_i2c_driver_c *i2cp) {
     /* Send STOP after last byte.*/
     if (i2cp->rxbytes == 1U) {
       data |= I2C_IC_DATA_CMD_STOP;
+      i2cp->stop_expected = true;
     }
     dp->DATACMD = data;
 
@@ -234,6 +357,9 @@ static void i2c_lld_request_data(hal_i2c_driver_c *i2cp) {
 
 /**
  * @brief   Fills TX FIFO with data to be sent.
+ * @details The data byte queued last in a pure write carries the STOP
+ *          bit and marks the transfer as stop-expected, anchoring the
+ *          own-completion evidence used by the STOP detection service.
  * @note    Called with the system lock held from ISR context.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
@@ -250,6 +376,7 @@ static void i2c_lld_transmit_data(hal_i2c_driver_c *i2cp) {
        follows, the transfer continues with a repeated START instead.*/
     if ((i2cp->txbytes == 1U) && (i2cp->rxbytes == 0U)) {
       data |= I2C_IC_DATA_CMD_STOP;
+      i2cp->stop_expected = true;
     }
     dp->DATACMD = data;
 
@@ -277,15 +404,113 @@ static void i2c_lld_transmit_data(hal_i2c_driver_c *i2cp) {
 }
 
 /**
+ * @brief   Drains the receive FIFO into the transfer buffer.
+ * @note    Called with the system lock held while the transfer
+ *          generation is open, the buffer belongs to the driver only
+ *          until the terminal event is claimed.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ */
+static void i2c_lld_drain_rx(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  while ((dp->STATUS & I2C_IC_STATUS_RFNE) != 0U) {
+    /* Read out received data.*/
+    *i2cp->rxptr = (uint8_t)dp->DATACMD;
+    i2cp->rxptr++;
+  }
+}
+
+/**
+ * @brief   Evaluates the own transfer completion evidence.
+ * @details The own transfer has completed on the wire when all of the
+ *          following holds, evaluated on live hardware state:
+ *          - The command carrying the STOP bit has been queued. Foreign
+ *            STOP conditions can only be observed before this point or
+ *            while own commands are still queued or executing, once the
+ *            controller owns the bus every STOP is its own.
+ *          - The TX FIFO has fully drained, no own command is waiting
+ *            for the bus.
+ *          - The raw TX_EMPTY flag is set. With TX_EMPTY_CTRL selected
+ *            this flag is completion qualified: it only rises after the
+ *            command popped last, here the STOP carrying one, has
+ *            completed on the wire.
+ *          For an open generation the evidence is stable once true, it
+ *          is only invalidated by the next transfer start.
+ * @note    Called with the system lock held.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @return              The completion evidence state.
+ */
+static bool i2c_lld_transfer_ended(hal_i2c_driver_c *i2cp) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  return i2cp->stop_expected &&
+         (dp->TXFLR == 0U) &&
+         ((dp->RAWINTRSTAT & I2C_IC_INTR_STAT_R_TX_EMPTY) != 0U);
+}
+
+/**
+ * @brief   Claims the terminal event and terminates the transfer.
+ * @details This is the single point where an interrupt service wins the
+ *          terminal event of an open transfer generation. The claim,
+ *          the peripheral quiescing, the driver state transition and
+ *          the waiter resumption form one atomic unit inside the
+ *          caller's critical section. This replicates the I-class core
+ *          of the shared @p __i2c_complete_isr() and @p __i2c_error_isr()
+ *          helpers which cannot be used here: they open a critical
+ *          section of their own after the claim section has closed,
+ *          leaving a window in which @p i2cStopTransferI() on the other
+ *          core observes a still active driver state on an already
+ *          claimed generation and wakes the waiter for a transfer that
+ *          has terminated, unconditionally, its wakeup is not gated on
+ *          the low level stop result. The user callback, the only piece
+ *          which must run outside the critical section, remains with
+ *          the caller.
+ * @note    Must be kept semantically aligned with the shared helpers in
+ *          hal_i2c.h: same terminal driver state, same wakeup messages,
+ *          waiter resumption only with the synchronization API enabled.
+ * @note    Called with the system lock held.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ * @param[in] msg       the wakeup message
+ */
+static void i2c_lld_claim_terminal(hal_i2c_driver_c *i2cp, msg_t msg) {
+  I2C_TypeDef *dp = i2cp->i2c;
+
+  chDbgAssert((i2cp->tgen & 1U) != 0U, "generation already claimed");
+
+  /* Terminal event claimed, the generation counter becomes even, every
+     other terminal path loses from here.*/
+  i2cp->tgen++;
+
+  /* Peripheral quiesced within the claim critical section, no start
+     can interleave because starts run under the same lock.*/
+  dp->INTRMASK = 0U;
+  (void)dp->CLRINTR;
+
+  /* Driver state transition and waiter resumption, atomic with the
+     claim above.*/
+  i2cp->state = HAL_DRV_STATE_READY;
+#if I2C_USE_SYNCHRONIZATION == TRUE
+  chThdResumeI(&i2cp->sync_transfer, msg);
+#else
+  (void)msg;
+#endif
+}
+
+/**
  * @brief   Transmission errors service.
  * @details The terminal event is claimed against the transfer generation
- *          counter and the raw interrupt state before any driver state
- *          transition, see the notes in the driver header. An error made
- *          stale by a concurrent stop or already consumed by a new
- *          transfer start loses the claim and is silenced without side
- *          effects. The abort completion following a transfer stop takes
- *          this same path: the stop already claimed the terminal event,
- *          the service only clears the flags.
+ *          counter and the raw interrupt state, the error decoding and
+ *          the whole transfer termination are performed in one critical
+ *          section, see @p i2c_lld_claim_terminal(). An error made stale
+ *          by a concurrent stop or already consumed by a new transfer
+ *          start loses the claim and is silenced without side effects.
+ *          The abort completion following a transfer stop takes the
+ *          losing path: the stop already claimed the terminal event,
+ *          the service only clears the flags and releases the abort
+ *          tracking.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  */
@@ -296,13 +521,19 @@ static void i2c_lld_serve_errors(hal_i2c_driver_c *i2cp) {
 
   chSysLockFromISR();
   raw = dp->RAWINTRSTAT;
+
+  /* A raw abort event doubles as the completion notification of the
+     asynchronous abort initiated by a transfer stop, the hardware
+     raises it only after the ABORT request has finished flushing.*/
+  if ((raw & I2C_IC_INTR_STAT_R_TX_ABRT) != 0U) {
+    i2cp->abort_pending = false;
+  }
+
   claimed = ((i2cp->tgen & 1U) != 0U) &&
             ((raw & (I2C_IC_INTR_STAT_R_TX_ABRT | I2C_OVERRUN_ERRORS)) != 0U);
   if (claimed) {
-    i2cp->tgen++;
-
     /* Abort cause decoding, the source register is cleared together
-       with the interrupt flags below.*/
+       with the interrupt flags by the claim below.*/
     abort_source = dp->TXABRTSOURCE;
     if ((abort_source & I2C_IC_TX_ABRT_SOURCE_ARB_LOST) != 0U) {
       i2cp->errors |= I2C_ARBITRATION_LOST;
@@ -318,10 +549,9 @@ static void i2c_lld_serve_errors(hal_i2c_driver_c *i2cp) {
       i2cp->errors |= I2C_OVERRUN;
     }
 
-    /* Quiescing the peripheral within the claim critical section, no
-       start can interleave because starts run under the same lock.*/
-    dp->INTRMASK = 0U;
-    (void)dp->CLRINTR;
+    /* Claim, quiescing, driver state transition and waiter resumption,
+       one atomic unit.*/
+    i2c_lld_claim_terminal(i2cp, MSG_RESET);
   }
   else {
     if ((i2cp->tgen & 1U) == 0U) {
@@ -336,10 +566,9 @@ static void i2c_lld_serve_errors(hal_i2c_driver_c *i2cp) {
   chSysUnlockFromISR();
 
   if (claimed) {
-    /* The wakeup machinery is invoked outside the critical section by
-       the single terminal-event winner, the callback runs outside any
-       lock.*/
-    __i2c_error_isr(i2cp);
+    /* The user callback is the only piece running outside the critical
+       section, invoked by the single terminal-event winner.*/
+    __cbdrv_invoke_cb(i2cp);
   }
 }
 
@@ -389,11 +618,7 @@ static void i2c_lld_serve_rx_full(hal_i2c_driver_c *i2cp) {
 
   chSysLockFromISR();
   if ((i2cp->tgen & 1U) != 0U) {
-    while ((dp->STATUS & I2C_IC_STATUS_RFNE) != 0U) {
-      /* Read out received data.*/
-      *i2cp->rxptr = (uint8_t)dp->DATACMD;
-      i2cp->rxptr++;
-    }
+    i2c_lld_drain_rx(i2cp);
 
     if (i2cp->rxbytes == 0U) {
       /* Everything is received, therefore disable all FIFO IRQs.*/
@@ -416,64 +641,66 @@ static void i2c_lld_serve_rx_full(hal_i2c_driver_c *i2cp) {
 
 /**
  * @brief   STOP detection service.
- * @details Completion arbitration: the terminal event is claimed against
- *          the transfer generation counter and the current hardware
- *          state, all evaluated in one critical section. The RP silicon
- *          hardwires IC_CON.STOP_DET_IF_MASTER_ACTIVE off (the write is
- *          inert, verified by register read-back), so this interrupt
- *          also fires for STOP conditions issued by other masters on the
- *          bus. It only means completion when this driver's own final
- *          command has completed on the wire: the byte counters cover
- *          bytes not yet queued, TXFLR covers commands (data and read
- *          requests alike) still sitting in the TX FIFO waiting for the
- *          bus, and the raw TX_EMPTY flag - completion-qualified by
- *          TX_EMPTY_CTRL - stays low while a command popped from the
- *          FIFO is still executing. An own STOP can only appear after
- *          all of that has drained, so any residue marks the STOP as
- *          foreign; the own transfer then continues under hardware
- *          arbitration.
+ * @details Completion arbitration. The RP silicon hardwires the
+ *          IC_CON.STOP_DET_IF_MASTER_ACTIVE feature off (the write is
+ *          inert, verified by register read-back), the STOP_DET flag
+ *          therefore also latches STOP conditions issued by other
+ *          masters and, being a single flag, coalesces multiple STOP
+ *          events. Completion is consequently decided only on the
+ *          own-completion evidence evaluated by
+ *          @p i2c_lld_transfer_ended() on live hardware state, never on
+ *          the flag itself. A foreign STOP must still be consumed or
+ *          the level-triggered interrupt storms, but the engine can
+ *          complete the own transfer between any evaluation and the
+ *          clear, the coalescing flag would then swallow the own STOP
+ *          event. The evidence is therefore reevaluated after every
+ *          clear within the same critical section: evidence appearing
+ *          after the clear is the swallowed own STOP and is claimed as
+ *          the completion, an own STOP arriving after the reevaluation
+ *          latches the flag again and redispatches this service,
+ *          nothing is lost. With the evidence positive the final read
+ *          data, if any, is already complete in the RX FIFO, it is
+ *          drained here while the generation is still open.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  */
 static void i2c_lld_serve_stop(hal_i2c_driver_c *i2cp) {
   I2C_TypeDef *dp = i2cp->i2c;
-  uint32_t raw;
   bool claimed = false;
 
   chSysLockFromISR();
-  raw = dp->RAWINTRSTAT;
   if (((i2cp->tgen & 1U) != 0U) &&
-      ((raw & I2C_IC_INTR_STAT_R_STOP_DET) != 0U) &&
-      ((raw & (I2C_IC_INTR_STAT_R_TX_ABRT | I2C_OVERRUN_ERRORS)) == 0U) &&
-      (i2cp->txbytes == 0U) && (i2cp->rxbytes == 0U) &&
-      (dp->TXFLR == 0U) &&
-      ((raw & I2C_IC_INTR_STAT_R_TX_EMPTY) != 0U)) {
-    if (dp->RXFLR == 0U) {
-      /* Own STOP with everything drained, the completion is claimed
-         and the peripheral quiesced within the critical section.*/
-      claimed = true;
-      i2cp->tgen++;
-      dp->INTRMASK = 0U;
-      (void)dp->CLRINTR;
+      ((dp->RAWINTRSTAT & (I2C_IC_INTR_STAT_R_TX_ABRT |
+                           I2C_OVERRUN_ERRORS)) == 0U)) {
+    if (!i2c_lld_transfer_ended(i2cp)) {
+      /* Foreign STOP so far, consumed and immediately reevaluated, see
+         the details above.*/
+      (void)dp->CLRSTOPDET;
     }
-    /* Otherwise this is an own STOP racing the final RX batch: the
-       flag is left pending, the pending RX FULL service drains the
-       FIFO first and the STOP is then reevaluated on the next
-       dispatch of this level interrupt.*/
+
+    if (i2c_lld_transfer_ended(i2cp)) {
+      /* Own STOP, the receive buffer is completed while the generation
+         is still open, then the transfer is terminated.*/
+      chDbgAssert((i2cp->txbytes == 0U) && (i2cp->rxbytes == 0U),
+                  "counters not drained");
+
+      i2c_lld_drain_rx(i2cp);
+      i2c_lld_claim_terminal(i2cp, MSG_OK);
+      claimed = true;
+    }
   }
   else {
-    /* Foreign or stale STOP condition, or a STOP trailing an abort
-       which is terminal through the error service: dropped without
-       touching the rest of the peripheral state.*/
+    /* Stale STOP with no transfer in flight, or a STOP trailing an
+       abort or overrun which is terminal through the error service:
+       dropped without touching the rest of the peripheral state.*/
     (void)dp->CLRSTOPDET;
   }
   chSysUnlockFromISR();
 
   if (claimed) {
-    /* The wakeup machinery is invoked outside the critical section by
-       the single terminal-event winner, the callback runs outside any
-       lock.*/
-    __i2c_complete_isr(i2cp);
+    /* The user callback is the only piece running outside the critical
+       section, invoked by the single terminal-event winner.*/
+    __cbdrv_invoke_cb(i2cp);
   }
 }
 
@@ -510,6 +737,33 @@ static void i2c_lld_serve_interrupt(hal_i2c_driver_c *i2cp) {
     i2c_lld_serve_stop(i2cp);
   }
 }
+
+#if (HAL_USE_PAL == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Waits for a line to read high.
+ * @details The line is sampled at the bus clear half period pace, the
+ *          wait is bounded, see @p I2C_BUS_CLEAR_SCL_RISE_CYCLES.
+ * @note    Thread context only, this function sleeps between samples.
+ *
+ * @param[in] line      line identifier
+ * @return              The line state.
+ * @retval true         if the line reads high within the bound.
+ * @retval false        if the line never rose.
+ */
+static bool i2c_lld_wait_line_high(ioline_t line) {
+  unsigned i;
+
+  for (i = 0U; i < I2C_BUS_CLEAR_SCL_RISE_CYCLES; i++) {
+    if (palReadLine(line) == PAL_HIGH) {
+      return true;
+    }
+
+    chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
+  }
+
+  return false;
+}
+#endif /* HAL_USE_PAL == TRUE */
 
 /*===========================================================================*/
 /* Driver interrupt handlers.                                                */
@@ -560,8 +814,10 @@ void i2c_lld_init(void) {
 
 #if RP_I2C_USE_I2C0 == TRUE
   i2cObjectInit(&I2CD0);
-  I2CD0.i2c  = I2C0;
-  I2CD0.tgen = 0U;
+  I2CD0.i2c           = I2C0;
+  I2CD0.tgen          = 0U;
+  I2CD0.stop_expected = false;
+  I2CD0.abort_pending = false;
 
   /* Reset I2C.*/
   rp_peripheral_reset(RESETS_ALLREG_I2C0);
@@ -569,8 +825,10 @@ void i2c_lld_init(void) {
 
 #if RP_I2C_USE_I2C1 == TRUE
   i2cObjectInit(&I2CD1);
-  I2CD1.i2c  = I2C1;
-  I2CD1.tgen = 0U;
+  I2CD1.i2c           = I2C1;
+  I2CD1.tgen          = 0U;
+  I2CD1.stop_expected = false;
+  I2CD1.abort_pending = false;
 
   /* Reset I2C.*/
   rp_peripheral_reset(RESETS_ALLREG_I2C1);
@@ -633,11 +891,14 @@ void i2c_lld_stop(hal_i2c_driver_c *i2cp) {
 
   if (i2cp->state != HAL_DRV_STATE_STOP) {
     /* Any late terminal event loses its claim before the peripheral
-       goes away, interrupt sources are silenced under the same lock.*/
+       goes away, interrupt sources are silenced under the same lock.
+       The peripheral reset below also cancels a still flushing
+       asynchronous abort, the software tracking is released with it.*/
     chSysLock();
     if ((i2cp->tgen & 1U) != 0U) {
       i2cp->tgen++;
     }
+    i2cp->abort_pending = false;
     i2cp->i2c->INTRMASK = 0U;
     chSysUnlock();
 
@@ -647,13 +908,15 @@ void i2c_lld_stop(hal_i2c_driver_c *i2cp) {
 
 /**
  * @brief   I2C configuration.
- * @details The SCL counts are derived from the requested rate and the
- *          current system clock using the classic timing ratios,
- *          configurations the divider fields cannot honor are rejected.
- *          The peripheral is reprogrammed only while no transfer is in
- *          flight: the controller disable performed for reprogramming
- *          settles within two clk_sys cycles on an idle controller, the
- *          bounded status poll below is a formality.
+ * @details The SCL counts and the spike suppression length are derived
+ *          from the requested rate and the current system clock using
+ *          the classic timing ratios, configurations violating the
+ *          field ranges or the databook relations between the counts
+ *          and the suppression length are rejected. The peripheral is
+ *          reprogrammed only while no transfer is in flight and no
+ *          abort is still flushing: the controller disable performed
+ *          for reprogramming then settles within the documented two
+ *          clock cycles, the bounded handshake is a formality.
  *
  * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
  * @param[in] config    pointer to the @p hal_i2c_config_t structure
@@ -665,15 +928,15 @@ void i2c_lld_stop(hal_i2c_driver_c *i2cp) {
 const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
                                        const hal_i2c_config_t *config) {
   I2C_TypeDef *dp = i2cp->i2c;
-  uint32_t freq_in, baudrate, period, lcnt, hcnt, sda_tx_hold;
+  uint32_t freq_in, baudrate, period, lcnt, hcnt, spklen, sda_tx_hold;
 
   if (config == NULL) {
     config = &i2c_default_config;
   }
 
   /* A configuration change is only legal while no transfer is in
-     flight.*/
-  if ((i2cp->tgen & 1U) != 0U) {
+     flight and no asynchronous abort is still flushing.*/
+  if (((i2cp->tgen & 1U) != 0U) || i2cp->abort_pending) {
     return NULL;
   }
 
@@ -709,8 +972,24 @@ const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
   }
   hcnt = period - lcnt;
 
-  if ((lcnt < 8U) || (lcnt > I2C_IC_FS_SCL_LCNT) ||
-      (hcnt < 8U) || (hcnt > I2C_IC_FS_SCL_HCNT)) {
+  if ((lcnt > I2C_IC_FS_SCL_LCNT) || (hcnt > I2C_IC_FS_SCL_HCNT)) {
+    return NULL;
+  }
+
+  /* Spike suppression length derived as one sixteenth of the low
+     count, mirroring the reference implementation. Values beyond the
+     8-bit field are clamped: a longer than nominal suppression window
+     is harmless at the correspondingly slow SCL rates while silent
+     truncation would program a meaningless length.*/
+  spklen = lcnt < 16U ? 1U : lcnt / 16U;
+  if (spklen > I2C_IC_FS_SPKLEN_IC_FS_SPKLEN) {
+    spklen = I2C_IC_FS_SPKLEN_IC_FS_SPKLEN;
+  }
+
+  /* Databook validity relations between the SCL counts and the spike
+     suppression length: LCNT must exceed SPKLEN + 7 and HCNT must
+     exceed SPKLEN + 5.*/
+  if ((lcnt <= (spklen + 7U)) || (hcnt <= (spklen + 5U))) {
     return NULL;
   }
 
@@ -742,10 +1021,12 @@ const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
     return config;
   }
 
-  /* Controller disabled during reprogramming, with no transfer in
-     flight this settles within two clk_sys cycles.*/
+  /* Controller disabled during reprogramming, the disable is confirmed
+     through the ENABLE_STATUS handshake before touching the enable
+     gated registers.*/
   dp->ENABLE = 0U;
-  while ((dp->ENABLESTATUS & I2C_IC_ENABLE_STATUS_IC_EN) != 0U) {
+  if (!i2c_lld_wait_enable_state(dp, 0U)) {
+    return NULL;
   }
 
   dp->CON = I2C_IC_CON_IC_SLAVE_DISABLE |
@@ -761,17 +1042,21 @@ const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
   dp->RXTL = 0U;
   dp->TXTL = 0U;
 
-  dp->FSSCLHCNT = hcnt & I2C_IC_FS_SCL_HCNT;
-  dp->FSSCLLCNT = lcnt & I2C_IC_FS_SCL_LCNT;
-  dp->FSSPKLEN = (lcnt < 16U ? 1U : lcnt / 16U) &
-                 I2C_IC_FS_SPKLEN_IC_FS_SPKLEN;
-  dp->SDAHOLD = sda_tx_hold & I2C_IC_SDA_HOLD_IC_SDA_TX_HOLD;
+  /* All timing values validated above, written as derived.*/
+  dp->FSSCLHCNT = hcnt;
+  dp->FSSCLLCNT = lcnt;
+  dp->FSSPKLEN = spklen;
+  dp->SDAHOLD = sda_tx_hold;
 
   /* Interrupt sources masked until a transfer starts.*/
   dp->INTRMASK = 0U;
 
-  /* Peripheral enabled again, flags cleared.*/
+  /* Peripheral enabled again with the enable confirmed, flags
+     cleared.*/
   dp->ENABLE = I2C_IC_ENABLE_ENABLE;
+  if (!i2c_lld_wait_enable_state(dp, I2C_IC_ENABLE_STATUS_IC_EN)) {
+    return NULL;
+  }
   (void)dp->CLRINTR;
 
   return config;
@@ -825,11 +1110,17 @@ void i2c_lld_set_callback(hal_i2c_driver_c *i2cp, drv_cb_t cb) {
  * @details The terminal event is claimed synchronously, this function is
  *          invoked with the system lock held so the claim is atomic with
  *          respect to the completion and error services on either core.
- *          The hardware abort is only initiated, its completion arrives
- *          later as the TX_ABRT interrupt which finds the generation
- *          already even and silently clears the flags. Until the abort
- *          completes the ACTIVITY status keeps the busy gate in the
- *          transfer start methods closed.
+ *          Those services terminate the driver state inside their own
+ *          claim critical section, a driver state still reported as
+ *          active to the caller therefore implies an unclaimed
+ *          generation: this claim then always wins and the shared layer
+ *          performs the state transition and the waiter wakeup under
+ *          the same lock it already holds. The hardware abort is only
+ *          initiated here and tracked by the abort-pending flag, its
+ *          completion arrives later as the TX_ABRT interrupt which
+ *          finds the generation already even, clears the flags and
+ *          releases the tracking. Transfer starts are rejected while
+ *          the abort is pending, see @p i2c_lld_check_startable().
  * @note    If a slave holds SCL low indefinitely the abort cannot
  *          complete and the controller remains busy, recovery requires
  *          @p i2cRPBusClear() followed by a driver restart.
@@ -849,8 +1140,11 @@ msg_t i2c_lld_stop_transfer(hal_i2c_driver_c *i2cp) {
        completion event is left enabled.*/
     dp->INTRMASK = I2C_IC_INTR_MASK_M_TX_ABRT;
 
-    /* Abort initiation, the bit self-clears when the hardware has
-       flushed the TX FIFO and terminated the transfer on the wire.*/
+    /* Abort initiation, the request self-clears when the hardware has
+       flushed the TX FIFO and terminated the transfer on the wire.
+       Tracked in software because the ACTIVITY status alone does not
+       cover the whole flush.*/
+    i2cp->abort_pending = true;
     dp->ENABLE |= I2C_IC_ENABLE_ABORT;
   }
 
@@ -869,37 +1163,43 @@ msg_t i2c_lld_stop_transfer(hal_i2c_driver_c *i2cp) {
  * @param[in] rxbytes   number of bytes to be received
  * @return              The operation status.
  * @retval HAL_RET_SUCCESS     if the function succeeded.
- * @retval HAL_RET_HW_BUSY     if the controller or the bus is busy, no
- *                             waiting is performed, the caller retries
- *                             or fails the operation.
+ * @retval HAL_RET_HW_BUSY     if the controller is busy or an abort is
+ *                             still flushing, no waiting is performed,
+ *                             the caller retries or fails the
+ *                             operation.
  *
  * @notapi
  */
 msg_t i2c_lld_start_master_receive(hal_i2c_driver_c *i2cp, i2caddr_t addr,
                                    uint8_t *rxbuf, size_t rxbytes) {
-  I2C_TypeDef *dp = i2cp->i2c;
+  msg_t msg;
 
-  /* The controller is busy while a previous transfer, an abort or
-     another bus master is still active, this is an I-class context and
-     waiting is not allowed.*/
-  (void)dp->CLRACTIVITY;
-  if ((dp->STATUS & I2C_IC_STATUS_ACTIVITY) != 0U) {
-    return HAL_RET_HW_BUSY;
+  /* Start gate, a busy controller or a still flushing abort rejects
+     the start, this is an I-class context and waiting is not
+     allowed.*/
+  msg = i2c_lld_check_startable(i2cp);
+  if (msg != HAL_RET_SUCCESS) {
+    return msg;
   }
 
   /* Transaction setup.*/
-  i2cp->txptr        = NULL;
-  i2cp->txbytes      = (size_t)0;
-  i2cp->rxptr        = rxbuf;
-  i2cp->rxbytes      = rxbytes;
-  i2cp->send_restart = false;
+  i2cp->txptr         = NULL;
+  i2cp->txbytes       = (size_t)0;
+  i2cp->rxptr         = rxbuf;
+  i2cp->rxbytes       = rxbytes;
+  i2cp->send_restart  = false;
+  i2cp->stop_expected = false;
+
+  /* Hardware programming and start, a failed enable handshake rejects
+     the start before the transfer generation is opened.*/
+  msg = i2c_lld_setup_transfer(i2cp, addr);
+  if (msg != HAL_RET_SUCCESS) {
+    return msg;
+  }
 
   /* Transfer generation opened, from here the terminal event belongs
      to a single winner among the completion, error and stop paths.*/
   i2c_lld_tgen_open(i2cp);
-
-  /* Hardware programming and start.*/
-  i2c_lld_setup_transfer(i2cp, addr);
 
   return HAL_RET_SUCCESS;
 }
@@ -920,38 +1220,44 @@ msg_t i2c_lld_start_master_receive(hal_i2c_driver_c *i2cp, i2caddr_t addr,
  * @param[in] rxbytes   number of bytes to be received
  * @return              The operation status.
  * @retval HAL_RET_SUCCESS     if the function succeeded.
- * @retval HAL_RET_HW_BUSY     if the controller or the bus is busy, no
- *                             waiting is performed, the caller retries
- *                             or fails the operation.
+ * @retval HAL_RET_HW_BUSY     if the controller is busy or an abort is
+ *                             still flushing, no waiting is performed,
+ *                             the caller retries or fails the
+ *                             operation.
  *
  * @notapi
  */
 msg_t i2c_lld_start_master_transmit(hal_i2c_driver_c *i2cp, i2caddr_t addr,
                                     const uint8_t *txbuf, size_t txbytes,
                                     uint8_t *rxbuf, size_t rxbytes) {
-  I2C_TypeDef *dp = i2cp->i2c;
+  msg_t msg;
 
-  /* The controller is busy while a previous transfer, an abort or
-     another bus master is still active, this is an I-class context and
-     waiting is not allowed.*/
-  (void)dp->CLRACTIVITY;
-  if ((dp->STATUS & I2C_IC_STATUS_ACTIVITY) != 0U) {
-    return HAL_RET_HW_BUSY;
+  /* Start gate, a busy controller or a still flushing abort rejects
+     the start, this is an I-class context and waiting is not
+     allowed.*/
+  msg = i2c_lld_check_startable(i2cp);
+  if (msg != HAL_RET_SUCCESS) {
+    return msg;
   }
 
   /* Transaction setup.*/
-  i2cp->txptr        = txbuf;
-  i2cp->txbytes      = txbytes;
-  i2cp->rxptr        = rxbuf;
-  i2cp->rxbytes      = rxbytes;
-  i2cp->send_restart = false;
+  i2cp->txptr         = txbuf;
+  i2cp->txbytes       = txbytes;
+  i2cp->rxptr         = rxbuf;
+  i2cp->rxbytes       = rxbytes;
+  i2cp->send_restart  = false;
+  i2cp->stop_expected = false;
+
+  /* Hardware programming and start, a failed enable handshake rejects
+     the start before the transfer generation is opened.*/
+  msg = i2c_lld_setup_transfer(i2cp, addr);
+  if (msg != HAL_RET_SUCCESS) {
+    return msg;
+  }
 
   /* Transfer generation opened, from here the terminal event belongs
      to a single winner among the completion, error and stop paths.*/
   i2c_lld_tgen_open(i2cp);
-
-  /* Hardware programming and start.*/
-  i2c_lld_setup_transfer(i2cp, addr);
 
   return HAL_RET_SUCCESS;
 }
@@ -964,15 +1270,21 @@ msg_t i2c_lld_start_master_transmit(hal_i2c_driver_c *i2cp, i2caddr_t addr,
  *          STOP condition is generated. The lines are driven through
  *          the SIO function emulating open drain outputs, the caller
  *          must reassign the pads to the I2C function afterwards and
- *          restart the driver.
+ *          restart the driver. Every SCL release is verified with a
+ *          bounded wait: a clock line that never reads high is held by
+ *          another device and such a bus cannot be recovered from this
+ *          side, the procedure then fails instead of reporting a false
+ *          success derived from the SDA observation alone. The STOP
+ *          condition is generated only from a state with both lines
+ *          observed releasable.
  * @note    Thread context only, this function sleeps between line
  *          transitions. It is not wired into any I-class path.
  *
  * @param[in] sclline   line identifier of the SCL signal
  * @param[in] sdaline   line identifier of the SDA signal
  * @return              The bus state.
- * @retval true         if SDA reads high after the procedure.
- * @retval false        if SDA is still stuck low.
+ * @retval true         if both lines read high after the procedure.
+ * @retval false        if a line is still stuck low.
  *
  * @api
  */
@@ -984,28 +1296,51 @@ bool i2cRPBusClear(ioline_t sclline, ioline_t sdaline) {
   palSetLineMode(sclline, PAL_MODE_INPUT_PULLUP);
   chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
 
+  /* SCL must be releasable before pulsing, a clock line held low
+     cannot be recovered from this side of the bus.*/
+  if (!i2c_lld_wait_line_high(sclline)) {
+    return false;
+  }
+
   for (i = 0U; i < 9U; i++) {
     if (palReadLine(sdaline) == PAL_HIGH) {
       break;
     }
 
     /* One SCL pulse, low is actively driven, high is released to the
-       pull-up.*/
+       pull-up and verified: a device may legally stretch the low phase
+       within the wait bound, a line that never rises fails the
+       procedure.*/
     palClearLine(sclline);
     palSetLineMode(sclline, PAL_MODE_OUTPUT_PUSHPULL);
     chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
     palSetLineMode(sclline, PAL_MODE_INPUT_PULLUP);
+    if (!i2c_lld_wait_line_high(sclline)) {
+      return false;
+    }
+
+    /* High phase settling time before the next pulse or the SDA
+       sampling.*/
     chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
   }
 
-  /* STOP condition: SDA released while SCL is high.*/
+  /* The STOP condition is only meaningful on a bus with both lines
+     releasable, a still held SDA is a failure.*/
+  if (palReadLine(sdaline) != PAL_HIGH) {
+    return false;
+  }
+
+  /* STOP condition: SDA driven low and then released while SCL stays
+     high.*/
   palClearLine(sdaline);
   palSetLineMode(sdaline, PAL_MODE_OUTPUT_PUSHPULL);
   chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
   palSetLineMode(sdaline, PAL_MODE_INPUT_PULLUP);
   chThdSleep(TIME_US2I(I2C_BUS_CLEAR_HALF_PERIOD_US));
 
-  return palReadLine(sdaline) == PAL_HIGH;
+  /* Success only with both lines observed high at the end.*/
+  return (palReadLine(sclline) == PAL_HIGH) &&
+         (palReadLine(sdaline) == PAL_HIGH);
 }
 #endif /* HAL_USE_PAL == TRUE */
 

--- a/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
@@ -159,17 +159,50 @@
  *          completion, transmission error, transfer stop, driver stop)
  *          claims the event in a critical section against the live
  *          counter, only the single winner terminates the transfer.
- *          The interrupt service winners perform the driver state
- *          transition and the waiter resumption inside the claim
- *          critical section itself, atomically with the claim: the
- *          shared I-class stop path decides on the driver state and
- *          wakes the waiter unconditionally under the lock it holds,
- *          state and generation must therefore never disagree, a
- *          driver state observed as active always carries an unclaimed
- *          generation. Losing paths never touch the driver state, the
- *          buffers or the waiter, they only silence hardware flags.
- *          This serializes completions, errors and stops across both
- *          cores.
+ *          Losing paths never touch the driver state, the buffers or
+ *          the waiter, they only silence hardware flags and, in the
+ *          case of an error service losing to a transfer stop, release
+ *          the abort tracking. This serializes completions, errors and
+ *          stops across both cores.
+ * @note    The claim, the peripheral quiescing, the driver state
+ *          transition and the waiter resumption form one atomic unit
+ *          for the three terminal paths of a live transfer: the
+ *          interrupt completion service, the interrupt error service
+ *          and @p i2cStopTransferI(). For these paths the driver state
+ *          and the generation cannot be observed disagreeing, an active
+ *          driver state always carries an unclaimed generation, which is
+ *          what the shared I-class stop path relies on when it decides
+ *          on the driver state and wakes the waiter under the lock it
+ *          holds. Three exceptions are deliberate and do not weaken the
+ *          rule for those paths:
+ *          - The driver lifecycle stop, @p drvStop(), transitions the
+ *            driver through @p HAL_DRV_STATE_STOPPING before the low
+ *            level stop closes the generation, and the shared stop
+ *            implementation resumes the waiter in a critical section of
+ *            its own. Generation closing, state transition and waiter
+ *            resumption are therefore separate sections there, the
+ *            driver is being torn down and no start can interleave.
+ *          - An error service which loses the claim may still clear the
+ *            @p abort_pending flag, this is the abort completion
+ *            notification and it touches no transfer state.
+ *          - The generic @p i2cStopTransfer() wrapper resumes the
+ *            waiter through @p i2cStopTransferI() irrespective of which
+ *            side won the claim, its wakeup is not gated on the low
+ *            level stop result.
+ * @note    The interrupt dispatcher samples the interrupt status inside
+ *          the same critical section in which it validates the
+ *          generation and runs the service, a service therefore always
+ *          acts on the transfer generation the sampled status belongs
+ *          to. The user callback of a terminal service is the only part
+ *          which runs outside that section.
+ * @note    The buffer fields and @p stop_expected are published by a
+ *          transfer start only after the hardware setup has succeeded
+ *          and before the generation is opened, the interrupt sources
+ *          are armed as the last step, all under the same system lock.
+ *          A start which fails publishes nothing and leaves the
+ *          peripheral in a confirmed enabled-idle state, the previous
+ *          transaction remains described by the fields and no service
+ *          can observe either.
  * @note    The @p stop_expected flag is set under the system lock when
  *          the command carrying the STOP bit is queued, it anchors the
  *          own-completion evidence used by the STOP detection service:

--- a/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
@@ -156,12 +156,33 @@
  *          again when the transfer terminal event is claimed, its value
  *          is therefore odd exactly while a transfer is in flight with
  *          an unclaimed terminal event. Every terminal path (STOP
- *          completion, transmission abort, transfer stop) claims the
- *          event in a critical section against the live counter and the
- *          raw interrupt state, only the single winner performs the
- *          driver state transition and invokes the wakeup machinery.
- *          This serializes completions, errors and aborts across both
- *          cores, mirroring the SPI driver of this port.
+ *          completion, transmission error, transfer stop, driver stop)
+ *          claims the event in a critical section against the live
+ *          counter, only the single winner terminates the transfer.
+ *          The interrupt service winners perform the driver state
+ *          transition and the waiter resumption inside the claim
+ *          critical section itself, atomically with the claim: the
+ *          shared I-class stop path decides on the driver state and
+ *          wakes the waiter unconditionally under the lock it holds,
+ *          state and generation must therefore never disagree, a
+ *          driver state observed as active always carries an unclaimed
+ *          generation. Losing paths never touch the driver state, the
+ *          buffers or the waiter, they only silence hardware flags.
+ *          This serializes completions, errors and stops across both
+ *          cores.
+ * @note    The @p stop_expected flag is set under the system lock when
+ *          the command carrying the STOP bit is queued, it anchors the
+ *          own-completion evidence used by the STOP detection service:
+ *          the RP silicon latches foreign STOP conditions into the same
+ *          coalescing STOP_DET flag, completion is therefore decided on
+ *          hardware progress evidence and never on the flag itself.
+ * @note    The @p abort_pending flag tracks the asynchronous abort of a
+ *          stopped transfer from its initiation until the abort
+ *          completion interrupt is observed or the ABORT request is
+ *          read back as self-cleared, transfer starts are rejected in
+ *          between: the ACTIVITY status only reflects the current
+ *          transfer state machine state and can read idle while the
+ *          abort is still flushing the FIFO engine.
  */
 #define i2c_lld_driver_fields                                               \
   /* Pointer to the I2Cx registers block.*/                                 \
@@ -176,6 +197,10 @@
   size_t                    rxbytes;                                        \
   /* A repeated START is carried by the next queued read command.*/         \
   bool                      send_restart;                                   \
+  /* The command carrying the STOP bit has been queued.*/                   \
+  bool                      stop_expected;                                  \
+  /* An asynchronous abort is still flushing, starts are gated.*/           \
+  bool                      abort_pending;                                  \
   /* Transfer generation counter, see the structure notes.*/                \
   uint32_t                  tgen
 

--- a/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
+++ b/os/xhal/ports/RP/LLD/I2Cv1/hal_i2c_lld.h
@@ -1,0 +1,231 @@
+/*
+    ChibiOS - Copyright (C) 2022 Stefan Kerkmann.
+    ChibiOS - Copyright (C) 2021 Hanya.
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    I2Cv1/hal_i2c_lld.h
+ * @brief   RP I2C subsystem low level driver header.
+ *
+ * @addtogroup I2C
+ * @{
+ */
+
+#ifndef HAL_I2C_LLD_H
+#define HAL_I2C_LLD_H
+
+#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Slave mode support flag.
+ */
+#define I2C_SUPPORTS_SLAVE_MODE             FALSE
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    RP configuration options
+ * @{
+ */
+/**
+ * @brief   I2C 10-bit address mode switch.
+ * @details If set to @p TRUE 10-bit address mode is enabled.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(RP_I2C_ADDRESS_MODE_10BIT) || defined(__DOXYGEN__)
+#define RP_I2C_ADDRESS_MODE_10BIT           FALSE
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+/* Registry checks for robustness.*/
+#if !defined(RP_HAS_I2C0)
+#error "RP_HAS_I2C0 not defined in registry"
+#endif
+
+#if !defined(RP_HAS_I2C1)
+#error "RP_HAS_I2C1 not defined in registry"
+#endif
+
+/* Mcuconf.h checks.*/
+#if !defined(RP_I2C_USE_I2C0)
+#error "RP_I2C_USE_I2C0 not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_I2C_USE_I2C1)
+#error "RP_I2C_USE_I2C1 not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_IRQ_I2C0_PRIORITY)
+#error "RP_IRQ_I2C0_PRIORITY not defined in mcuconf.h"
+#endif
+
+#if !defined(RP_IRQ_I2C1_PRIORITY)
+#error "RP_IRQ_I2C1_PRIORITY not defined in mcuconf.h"
+#endif
+
+/* Option checks.*/
+#if (RP_I2C_ADDRESS_MODE_10BIT != FALSE) && (RP_I2C_ADDRESS_MODE_10BIT != TRUE)
+#error "invalid RP_I2C_ADDRESS_MODE_10BIT value"
+#endif
+
+/* The classic driver RP_I2C_BUSY_TIMEOUT setting is intentionally not
+   supported: it parameterized thread-context polling loops waiting out a
+   busy bus inside the transfer functions. In this driver the transfer
+   start methods are I-class and never wait, a busy controller or bus is
+   reported as HAL_RET_HW_BUSY to the caller and all transfer timeouts
+   are handled by the shared driver synchronization layer.*/
+
+/* Device selection checks.*/
+#if RP_I2C_USE_I2C0 && !RP_HAS_I2C0
+#error "I2C0 not present in the selected device"
+#endif
+
+#if RP_I2C_USE_I2C1 && !RP_HAS_I2C1
+#error "I2C1 not present in the selected device"
+#endif
+
+#if !RP_I2C_USE_I2C0 && !RP_I2C_USE_I2C1
+#error "I2C driver activated but no I2C peripheral assigned"
+#endif
+
+/* IRQ priority checks. The service routines interact with the kernel,
+   therefore kernel-compatible priorities are required.*/
+#if RP_I2C_USE_I2C0 &&                                                      \
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_I2C0_PRIORITY)
+#error "Invalid IRQ priority assigned to I2C0"
+#endif
+
+#if RP_I2C_USE_I2C1 &&                                                      \
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(RP_IRQ_I2C1_PRIORITY)
+#error "Invalid IRQ priority assigned to I2C1"
+#endif
+
+/**
+ * @brief   Default I2C configuration.
+ * @details Standard mode, 100kHz bus clock. The SCL counts are derived
+ *          at runtime from the current system clock, the standard mode
+ *          rate is representable for every supported clock tree setup.
+ */
+#define I2C_DEFAULT_CONFIGURATION                                           \
+{                                                                           \
+  .baudrate         = 100000U                                               \
+}
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level fields of the I2C configuration structure.
+ */
+#define i2c_lld_config_fields                                               \
+  /* Requested bus clock in Hz.*/                                           \
+  uint32_t                  baudrate
+
+/**
+ * @brief   Low level fields of the I2C driver structure.
+ * @note    The @p tgen field is the transfer generation counter: it is
+ *          incremented under the system lock when a transfer starts and
+ *          again when the transfer terminal event is claimed, its value
+ *          is therefore odd exactly while a transfer is in flight with
+ *          an unclaimed terminal event. Every terminal path (STOP
+ *          completion, transmission abort, transfer stop) claims the
+ *          event in a critical section against the live counter and the
+ *          raw interrupt state, only the single winner performs the
+ *          driver state transition and invokes the wakeup machinery.
+ *          This serializes completions, errors and aborts across both
+ *          cores, mirroring the SPI driver of this port.
+ */
+#define i2c_lld_driver_fields                                               \
+  /* Pointer to the I2Cx registers block.*/                                 \
+  I2C_TypeDef               *i2c;                                           \
+  /* Pointer to the next TX buffer location.*/                              \
+  const uint8_t             *txptr;                                         \
+  /* Number of bytes in TX phase not yet queued.*/                          \
+  size_t                    txbytes;                                        \
+  /* Pointer to the next RX buffer location.*/                              \
+  uint8_t                   *rxptr;                                         \
+  /* Number of RX read commands not yet queued.*/                           \
+  size_t                    rxbytes;                                        \
+  /* A repeated START is carried by the next queued read command.*/         \
+  bool                      send_restart;                                   \
+  /* Transfer generation counter, see the structure notes.*/                \
+  uint32_t                  tgen
+
+/**
+ * @brief   Returns the active configuration.
+ *
+ * @param[in] i2cp      pointer to the @p hal_i2c_driver_c object
+ *
+ * @notapi
+ */
+#define i2c_lld_getcfg(i2cp) ((const hal_i2c_config_t *)((i2cp)->config))
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (RP_I2C_USE_I2C0 == TRUE) && !defined(__DOXYGEN__)
+extern hal_i2c_driver_c I2CD0;
+#endif
+
+#if (RP_I2C_USE_I2C1 == TRUE) && !defined(__DOXYGEN__)
+extern hal_i2c_driver_c I2CD1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void i2c_lld_init(void);
+  msg_t i2c_lld_start(hal_i2c_driver_c *i2cp);
+  void i2c_lld_stop(hal_i2c_driver_c *i2cp);
+  const hal_i2c_config_t *i2c_lld_setcfg(hal_i2c_driver_c *i2cp,
+                                         const hal_i2c_config_t *config);
+  const hal_i2c_config_t *i2c_lld_selcfg(hal_i2c_driver_c *i2cp,
+                                         unsigned cfgnum);
+  void i2c_lld_set_callback(hal_i2c_driver_c *i2cp, drv_cb_t cb);
+  msg_t i2c_lld_start_master_transmit(hal_i2c_driver_c *i2cp, i2caddr_t addr,
+                                      const uint8_t *txbuf, size_t txbytes,
+                                      uint8_t *rxbuf, size_t rxbytes);
+  msg_t i2c_lld_start_master_receive(hal_i2c_driver_c *i2cp, i2caddr_t addr,
+                                     uint8_t *rxbuf, size_t rxbytes);
+  msg_t i2c_lld_stop_transfer(hal_i2c_driver_c *i2cp);
+#if (HAL_USE_PAL == TRUE) || defined(__DOXYGEN__)
+  bool i2cRPBusClear(ioline_t sclline, ioline_t sdaline);
+#endif
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_I2C == TRUE */
+
+#endif /* HAL_I2C_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/RP/RP2040/platform.mk
+++ b/os/xhal/ports/RP/RP2040/platform.mk
@@ -40,8 +40,9 @@ include $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/EFLv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
-include $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/I2Cv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk

--- a/os/xhal/ports/RP/RP2350/platform.mk
+++ b/os/xhal/ports/RP/RP2350/platform.mk
@@ -40,8 +40,9 @@ include $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/EFLv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
-include $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv2/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/I2Cv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/RTCv2/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/TIMERv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk


### PR DESCRIPTION
## Summary

Stage 3b of the RP2040/RP2350 XHAL port and the campaign's largest single-driver rework: the DW_apb_i2c driver inverted from the classic blocking model to the XHAL asynchronous contract.

- **Control inversion**: the I-class starters program the peripheral and return; thread suspension and timeout ownership move to the shared synchronization layer. Every classic thread-context polling loop is gone — the busy wait becomes a single-shot gate, the abort becomes asynchronous, and the internal thread suspensions disappear.
- **Asynchronous abort**: initiated system-locked, completing on the transfer-abort interrupt, with the user-abort source silenced by construction through the terminal claim. A software abort-pending latch gates new transfers until the hardware confirms the flush, since the activity status reflects bus state rather than abort progress.
- **Terminal-event serialization** (reworked after review — see below): the claim, the driver-state transition and the waiter resume are one atomic unit, so the driver state *is* the arbitration point; only the user callback runs outside the lock.
- **Completion evidence**: decided from live FIFO state anchored on a stop-expected marker rather than the coalescing stop-detected flag, which could otherwise swallow the driver's own stop when cleared from a stale foreign-stop observation. Every flag clear is followed by re-evaluation in the same critical section.
- Classic interrupt engine, abort-cause decoding and timing derivation preserved; validation now rejects rates and counts the divider math cannot honor and enforces the documented spike-suppression relationships. A thread-context bus-clear helper is added for stuck-bus recovery (verifying both lines rise).

### Protocol invariants

1. **Claim atomicity** — generation parity, driver state and the waiter reference are only ever mutated together under one system-lock section.
2. **Single winner** — exactly one terminal path closes each generation (stop-completion, error, `stop_transfer`, `stop`); losers touch no state, buffers or waiter, only hardware flags.
3. **State/generation coherence** — an active driver state observed under the lock always carries an unclaimed generation, so `i2cStopTransferI` either legitimately wins or does nothing; it can never wake a waiter for an already-terminated transfer.
4. **Stop discipline** — completion never decided on the coalescing flag; evidence is monotonic for an open generation and re-evaluated after every clear.
5. **Buffer ownership** — the receive buffer is written only while a generation is open; residue is drained before the claim flips it, so after any claim the buffer belongs wholly to the caller.
6. **Start gating** — a start is accepted only with no abort pending, an idle bus and both enable handshakes confirmed; otherwise a busy return with no side effects.

## Review triage

- codex adversarial review round 1: **rejected as written** — 2 BLOCKER (claim/state non-atomicity opening a stop-vs-completion window; stop-detected clear-on-read race able to hang a transfer) and 3 MAJOR (activity status not an abort interlock; missing peripheral-disable handshake before the target-address write; bus clear false-succeeding with the clock line stuck low) plus 1 MINOR (spike-suppression derivation). All fixed by the rework above; the invariants were re-derived rather than patched.
- coderabbit CLI: rate-limited after today's volume — will be run and triaged before this leaves draft.

## Verification

- Build matrix clean: both chips × {default, checks+asserts+state-checker}, `USE_SMART_BUILD=no`; per-file stylecheck, OSAL gate, `git diff --check` clean; zero shared XHAL changes.
- On-hardware legs queued for the batched bench pass: NACK handling, mid-transfer abort, timeout-induced stop, and a bus scan against a bench device.

## Changelog

- XHAL: RP port gains the I2C driver with asynchronous aborts.