### PR TITLE
RP USB: publish buffer control before handing it to the controller

### DIFF
--- a/os/hal/ports/RP/LLD/USBv1/hal_usb_lld.c
+++ b/os/hal/ports/RP/LLD/USBv1/hal_usb_lld.c
@@ -118,6 +118,56 @@ static inline void usb_dpram_memcpy(void *dst, const void *src, size_t n) {
 #endif
 
 /**
+ * @brief   Publishes a buffer control word, arming AVAILABLE separately.
+ * @details The USB controller can sample a buffer control register while a
+ *          processor write to it is still in flight and then act on a
+ *          partially updated word. Both the RP2040 and the RP2350
+ *          datasheets therefore require the AVAILABLE bits to be written
+ *          in a separate, later write than the rest of the word. The word
+ *          is published with the AVAILABLE bits masked off, that write is
+ *          completed by a barrier, a short fixed delay is executed and
+ *          only then the complete word is written. Words carrying no
+ *          AVAILABLE bit hand nothing over to the controller and are
+ *          published in a single write.
+ * @note    Masking both AVAILABLE bits covers all the arming shapes used
+ *          by this driver: buffer 0 alone, buffer 1 alone (the word
+ *          shifted left by 16) and both buffers armed by one word.
+ * @note    The delay is a fixed sequence of twelve no operation
+ *          instructions, the budget used by the vendor reference
+ *          implementation. Twelve processor cycles exceed one 48 MHz USB
+ *          clock period for any system clock below 576 MHz (48 MHz * 12),
+ *          far above the fastest system clock supported by either device.
+ *          A fixed instruction sequence is used rather than a cycle
+ *          counter because ARMv6-M (RP2040) has none, and it is equally
+ *          valid on ARMv8-M and on the RISC-V core of the RP2350.
+ *
+ * @param[out] bcp      pointer to the buffer control register
+ * @param[in] buf_ctrl  buffer control word to be published
+ */
+static void usb_buffer_control_publish(volatile uint32_t *bcp,
+                                       uint32_t buf_ctrl) {
+  uint32_t avail;
+
+  avail = buf_ctrl & (USB_BUFFER_BUFFER0_AVAILABLE |
+                      USB_BUFFER_BUFFER1_AVAILABLE);
+
+  if (avail != 0U) {
+    /* Everything but the hand over to the controller. */
+    *bcp = buf_ctrl & ~avail;
+    __DSB();
+
+    /* Separation of the two writes, see the note above. */
+    __asm__ volatile ("nop\n\tnop\n\tnop\n\tnop\n\t"
+                      "nop\n\tnop\n\tnop\n\tnop\n\t"
+                      "nop\n\tnop\n\tnop\n\tnop"
+                      : : : "memory");
+  }
+
+  *bcp = buf_ctrl;
+  __DSB();
+}
+
+/**
  * @brief   Buffer mode for isochronous in buffer control register.
  */
 static uint16_t usb_isochronous_buffer_mode(uint16_t size) {
@@ -144,10 +194,13 @@ static uint16_t usb_isochronous_buffer_size(uint16_t max_size) {
 
   /* Double buffer offset must be one of 128, 256, 512 or 1024. */
   size = ((max_size - 1) / 128 + 1) * 128;
-  if (size == 384) {
-    size = 512;
-  } else if (size == 640 || size == 768 || size > 1024) {
+  if (size > 512) {
+    /* 640, 768, 896, 1024 and above, 1024 is the only legal offset from
+       here on. */
     size = 1024;
+  } else if (size > 256) {
+    /* 384 rounds up to the next legal offset, 512 is already legal. */
+    size = 512;
   }
   return size;
 }
@@ -273,8 +326,7 @@ static void usb_prepare_out_ep(USBDriver *usbp, usbep_t ep) {
     EP_CTRL(ep).OUT = ep_ctrl;
   }
 
-  BUF_CTRL(ep).OUT = buf_ctrl;
-  __DSB();
+  usb_buffer_control_publish(&BUF_CTRL(ep).OUT, buf_ctrl);
 }
 
 /**
@@ -364,8 +416,7 @@ static void usb_prepare_in_ep(USBDriver *usbp, usbep_t ep) {
   usb_e15_defer_if_frame_end(usbp->epc[ep]);
 #endif
 
-  BUF_CTRL(ep).IN = buf_ctrl;
-  __DSB();
+  usb_buffer_control_publish(&BUF_CTRL(ep).IN, buf_ctrl);
 }
 
 /**
@@ -397,6 +448,14 @@ static void usb_serve_endpoint(USBDriver *usbp, usbep_t ep, bool is_in) {
 
     /* Length received */
     n = BUF_CTRL(ep).OUT & USB_BUFFER_BUFFER0_TRANS_LENGTH_Msk;
+
+    /* The programmed buffer length is already the smaller of the remaining
+       transfer size and the endpoint packet size, so a longer reported
+       length would be a hardware anomaly. Clamping it keeps the copy
+       inside the user buffer and the remaining size from underflowing. */
+    if (n > oesp->rxsize) {
+      n = oesp->rxsize;
+    }
 
     /* Copy received data into user buffer */
     usb_dpram_memcpy((void *)oesp->rxbuf, (void *)oesp->hw_buf, n);


### PR DESCRIPTION
## Summary

Three defects in the classic RP USB device driver, found while reviewing its XHAL twin (#212) and confirmed present here. The first is a hardware-sequencing violation that affects shipped firmware.

**1. Buffer control is armed in a single store.** The driver builds a word carrying the length, the PID/FULL/LAST flags *and* the AVAILABLE bit, then writes it once. The RP2040 (4.1.2.7.1) and RP2350 (12.7.3.7.1) datasheets require AVAILABLE to be set in a **later, separate write**, because the controller may sample the buffer control register before the processor's store has landed, acting on a length and flag set that are not yet in place. The reference SDK/tinyusb implementations do the same two-step arm.

Arming now goes through one helper that writes the word with **both** AVAILABLE bits masked off, drains that store, waits a fixed 12-cycle delay, then writes the complete word. Masking both bits keeps a single code path correct for buffer index 0, for buffer index 1 (the `<<16` form, where `BUFFER0_AVAILABLE << 16 == BUFFER1_AVAILABLE`), and for the double-buffered word that carries both. No written value, PID toggle or double-buffer decision changes — only the ordering.

Delay rationale: the requirement is a separation exceeding one 48 MHz USB clock (20.8 ns). Twelve processor cycles exceed that for any system clock below 576 MHz; at the fastest supported clocks (133 MHz RP2040, 150 MHz RP2350) it is a ~4× margin, and the real separation is larger still because the barrier and the DPRAM store latency add on top. A fixed instruction sequence is used rather than a cycle counter because ARMv6-M has no DWT; `nop` and the barrier are available on Cortex-M0+, Cortex-M33 and Hazard3 alike, so no architecture conditionals were needed. Verified in the RP2350 disassembly: `str / dsb sy / 12×nop / str / dsb sy`.

**2. Isochronous buffer size rounding.** The rounding special-cased 384, 640, 768 and >1024 but left 896 (maximum sizes 769..896) to program an illegal double-buffer offset. Every rounded size above 512 now normalises to 1024; 128/256/512 are unchanged.

**3. Received length was unbounded.** The OUT completion path used the controller-reported length without clamping it to the remaining transfer size. In practice the programmed buffer length is already `min(rxsize, out_maxsize)`, so this is defensive — but the subtraction would underflow the remaining size if the hardware ever reported more.

## Verification

Built clean, no new warnings: `testhal/RP/RP2040/USB-VALIDATION` and `testhal/RP/RP2350/USB-VALIDATION`, each with stock flags and with checks+assertions.

**On hardware (Pico 2, driven by a second Pico as SWD probe, target USB to the host):**
- `host_check.py` echo leg: **PASS, 0 failures** — 50 rounds × 10 payload sizes spanning the packet boundary (1, 63, 64, 65, 128, 129, 192, 512, 4096, 8192), ~674 KB, device-side byte counter agreeing with the host.
- Re-enumeration stress: **15/15 PASS** — full target resets through the probe, each forcing a USB disconnect, re-enumeration and a complete endpoint re-arm, with the echo battery repeated after every cycle. This is the path the fix touches.
- The script's own `USBDEVFS_RESET` leg degraded to close/open on this host for lack of usbfs write permission, hence the probe-driven reset cycles above as the substitute; it reported PASS in degraded mode.

The XHAL twin in #212 carries the identical change, so that port keeps its byte-faithfulness to this hardware layer.

## Changelog

- RP USB: buffer control is published before the available bit is set, as the datasheets require; isochronous buffer sizes above 512 normalise correctly; the received length is bounded by the remaining transfer size.