### PR TITLE
ARMv6-M: give PORT_IRQ_HANDLER bodies external linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,12 @@ applied to a maintenance branch are marked *(backported to 21.11.6)*.
 
 ### Fixed
 
+- ARMv6-M could fail to link with `-flto` (an "undefined reference" to the
+  interrupt handler body) once an image grew large enough for the LTO
+  partitioner to split it; the `PORT_IRQ_HANDLER` body now has external
+  linkage and a reserved name so the trampoline's assembler reference
+  resolves across partitions
+  ([#216](https://github.com/chibios-upstream/chibios/pull/216)).
 - Serial over USB input remained inactive after a USB suspend/wakeup cycle on
   STM32 OTG devices. The generic USB driver terminates all pending
   transactions on suspend and the OTG LLD also disables the endpoints in

--- a/os/common/ports/ARMv6-M/chcore.h
+++ b/os/common/ports/ARMv6-M/chcore.h
@@ -444,12 +444,20 @@ struct port_context {
  *          body GCC is free to place the body and the trampoline in different
  *          @p ltrans partitions, or to privatise the local symbol under a new
  *          name; the literal then has nothing to bind to and the link fails
- *          with @p "undefined @p reference @p to @p Vector7C_isr" as soon as
- *          an image grows large enough for @p -flto to split it.
+ *          with @p "undefined @p reference" as soon as an image grows large
+ *          enough for @p -flto to split it.
  *          @p __attribute__((used)) only pins the body against dead-code
  *          elimination, it does not make the asm-only reference visible: do
  *          not re-add @p static here. @p PORT_IRQ_HANDLER_LINKAGE keeps the
  *          assembler name unmangled when a handler is compiled as C++.
+ *          @n@n
+ *          Because that linkage publishes one global symbol per handler, the
+ *          body is deliberately named @p __port_irq_body_<id> rather than
+ *          @p <id>_isr, keeping it in the implementation-reserved namespace
+ *          already used by @p __port_irq_epilogue() and the other port
+ *          internals so it cannot collide with an application symbol. The
+ *          name is part of the macro contract: the forward declaration, the
+ *          definition and the @p ".word" literal must be kept in step.
  */
 #if defined(__GNUC__) || defined(__DOXYGEN__)
   #ifdef __cplusplus
@@ -459,17 +467,17 @@ struct port_context {
   #endif
   #define PORT_IRQ_HANDLER(id)                                              \
     PORT_IRQ_HANDLER_LINKAGE __attribute__((used))                         \
-    void id##_isr(uint32_t _saved_lr);                                     \
+    void __port_irq_body_##id(uint32_t _saved_lr);                         \
     PORT_IRQ_HANDLER_LINKAGE __attribute__((naked, used))                  \
     void id(void) {                                                        \
       __asm volatile ("mov   r0, lr            \n\t"                       \
                       "ldr   r1, 1f            \n\t"                       \
                       "bx    r1                \n\t"                       \
                       ".balign 4               \n\t"                       \
-                      "1: .word " #id "_isr    \n\t");                     \
+                      "1: .word __port_irq_body_" #id "\n\t");             \
     }                                                                      \
     PORT_IRQ_HANDLER_LINKAGE __attribute__((used))                         \
-    void id##_isr(uint32_t _saved_lr)
+    void __port_irq_body_##id(uint32_t _saved_lr)
 #else /* IAR (__ICCARM__) / ARMCC5 (__CC_ARM): EXC_RETURN captured in the
          prologue via a compiler intrinsic; no trampoline.
          TODO: verify whether these toolchains' duplicate-function merging

--- a/os/common/ports/ARMv6-M/chcore.h
+++ b/os/common/ports/ARMv6-M/chcore.h
@@ -436,6 +436,20 @@ struct port_context {
  *          of the only unconditional Thumb branch available on ARMv6-M. The
  *          address literal is emitted immediately after the trampoline so the
  *          Thumb-1 literal load is independent of assembler pool placement.
+ *          @n@n
+ *          The body must have external linkage. The trampoline reaches it
+ *          only through the assembler name in the @p ".word" literal, and a
+ *          reference that lives inside inline assembly is invisible to the
+ *          compiler and, critically, to the LTO partitioner. With a @p static
+ *          body GCC is free to place the body and the trampoline in different
+ *          @p ltrans partitions, or to privatise the local symbol under a new
+ *          name; the literal then has nothing to bind to and the link fails
+ *          with @p "undefined @p reference @p to @p Vector7C_isr" as soon as
+ *          an image grows large enough for @p -flto to split it.
+ *          @p __attribute__((used)) only pins the body against dead-code
+ *          elimination, it does not make the asm-only reference visible: do
+ *          not re-add @p static here. @p PORT_IRQ_HANDLER_LINKAGE keeps the
+ *          assembler name unmangled when a handler is compiled as C++.
  */
 #if defined(__GNUC__) || defined(__DOXYGEN__)
   #ifdef __cplusplus
@@ -444,7 +458,8 @@ struct port_context {
     #define PORT_IRQ_HANDLER_LINKAGE
   #endif
   #define PORT_IRQ_HANDLER(id)                                              \
-    static __attribute__((used)) void id##_isr(uint32_t _saved_lr);        \
+    PORT_IRQ_HANDLER_LINKAGE __attribute__((used))                         \
+    void id##_isr(uint32_t _saved_lr);                                     \
     PORT_IRQ_HANDLER_LINKAGE __attribute__((naked, used))                  \
     void id(void) {                                                        \
       __asm volatile ("mov   r0, lr            \n\t"                       \
@@ -453,7 +468,8 @@ struct port_context {
                       ".balign 4               \n\t"                       \
                       "1: .word " #id "_isr    \n\t");                     \
     }                                                                      \
-    static __attribute__((used)) void id##_isr(uint32_t _saved_lr)
+    PORT_IRQ_HANDLER_LINKAGE __attribute__((used))                         \
+    void id##_isr(uint32_t _saved_lr)
 #else /* IAR (__ICCARM__) / ARMCC5 (__CC_ARM): EXC_RETURN captured in the
          prologue via a compiler intrinsic; no trampoline.
          TODO: verify whether these toolchains' duplicate-function merging


### PR DESCRIPTION
Fixes #215.

## Summary

`PORT_IRQ_HANDLER(id)` expands to a `static` body named `id##_isr` plus a `naked` trampoline that reaches it through an inline-asm literal (`.word id##_isr`). GCC's LTO partitioner cannot see references that exist only inside inline asm, so once an image is large enough to be split across ltrans partitions the body can be privatised or placed in a different partition than the trampoline, and the link fails:

```
os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c:311: undefined reference to `Vector7C_isr'
```

The body now has external linkage, routed through the existing `PORT_IRQ_HANDLER_LINKAGE` that the trampoline already uses, with `used` retained and a comment explaining why `static` must not come back.

## Why this mechanism

Two alternatives were tried and rejected:

- `__attribute__((externally_visible))` — GCC's `handle_externally_visible_attribute` warns *"attribute have effect only on public objects"* for a non-`TREE_PUBLIC` function, so on a `static` body it adds a `-Wattributes` warning **and** does not fix the linkage.
- an explicit `.global id##_isr` inside the trampoline's asm — that marks the symbol global in the *trampoline's* partition, where it is undefined; the definition in the other partition stays local and may be renamed.

External linkage is what a cross-partition reference actually requires: even if the partitioner knew about the reference, a local symbol cannot be bound across partitions.

Reusing `PORT_IRQ_HANDLER_LINKAGE` also closes a latent C++ problem — with the body `static`, a C++ translation unit would mangle its assembler name and the `.word` literal could never resolve.

## Scope

Exactly one port is affected. A repo-wide grep for `##_isr` matches only this file; every other port (ARMv6-M-ALT, ARMv7-M(-ALT), ARMv8-M-ML(-ALT/-TZ), ARMvx-M-SB, ARMv7-R, ARM, e200, AVR, RISCV-HAZARD3, the simulators and the templates) declares `PORT_IRQ_HANDLER(id)` as a plain function with no trampoline and no asm literal.

## Verification

- **Reproducer**: an RP2040 dual-core image with checks and assertions fails to link before the change and links after it, same tree, same command.
- **No code-generation change**: `nm -n` on `demos/RP/RT-RP2040-PICO` before/after differs only in the eight handler bodies moving from `t` to `T` **at identical addresses**; trampolines unchanged in address, type and binding; text size byte-identical at 99152. The only other diff is DWARF file-hash symbols in non-allocated sections.
- Builds clean, stock and with checks+assertions: `demos/RP/RT-RP2040-PICO`, `testhal/RP/RP2040/SIO-VALIDATION`; plus `testhal/RP/RP2350/SIO-VALIDATION` as an ARMv8-M sanity check that the shared header is undisturbed. No new warnings.

Left as a draft so the mechanism can be swapped if you prefer a different one — the reproducer and the `nm` control make it easy to re-verify any variant.

## Changelog

- ARMv6-M: interrupt handler bodies are given external linkage so LTO partitioning cannot separate them from their trampolines.
