### PR TITLE
XHAL: restore the RISC-V leg of the RP multi-target demo

### DIFF
--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/portab.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/portab.c
@@ -34,6 +34,54 @@
 /* Module exported variables.                                                */
 /*===========================================================================*/
 
+/**
+ * @brief   PWM configuration for the LED slice.
+ * @details The slice counts at 1MHz over a 1000 ticks period giving a
+ *          1kHz PWM frequency, the LED on GP25 is driven by the B
+ *          channel. Events are enabled at runtime by the application.
+ */
+const hal_pwm_config_t portab_pwm_config = {
+  .frequency      = 1000000U,
+  .period         = 1000U,
+  .enabled_events = 0U,
+  .channels       = {
+    {
+      .mode       = PWM_OUTPUT_DISABLED
+    },
+    {
+      .mode       = PWM_OUTPUT_ACTIVE_HIGH
+    }
+  },
+  .dummy          = 0U
+};
+
+/**
+ * @brief   Conversion groups of the portability ADC configuration.
+ * @details A single conversion group sampling the on-die temperature
+ *          sensor at the free-running rate, the sensor bias is enabled
+ *          by the driver for the duration of the conversion.
+ */
+static const adc_conversion_groups_t portab_adc_groups = {
+  .grpsnum        = 1U,
+  .grps           = {
+    {
+      .num_channels = 1U,
+      .channel      = ADC_CHANNEL_TEMPSENSOR,
+      .rrobin       = 0U,
+      .div          = 0U,
+      .ts_enabled   = true
+    }
+  }
+};
+
+/**
+ * @brief   ADC configuration carrying the temperature sensor group.
+ */
+const hal_adc_config_t portab_adc_config = {
+  .grps           = &portab_adc_groups,
+  .dummy          = 0U
+};
+
 /*===========================================================================*/
 /* Module local types.                                                       */
 /*===========================================================================*/
@@ -53,11 +101,11 @@
 void portab_setup(void) {
 
   /*
-   * LED line as output.
+   * LED line on the PWM function, the pad is driven by slice 4
+   * channel B.
    */
-  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_OUTPUT_PUSHPULL |
+  palSetLineMode(PORTAB_LINE_LED, PAL_MODE_ALTERNATE_PWM |
                                   PAL_RP_PAD_DRIVE12);
-  palWriteLine(PORTAB_LINE_LED, PORTAB_LED_OFF);
 
   /*
    * UART0 console pads, TX on GP0 and RX on GP1.

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/portab.h
@@ -35,6 +35,15 @@
 
 #define PORTAB_SIO_CONSOLE          SIOD0
 
+/* The board LED on GP25 is served by PWM slice 4 channel B.*/
+#define PORTAB_PWM                  PWMD4
+#define PORTAB_PWM_CHANNEL          1U
+
+/* ADC instance and index of the temperature sensor conversion group
+   within the portability ADC configuration.*/
+#define PORTAB_ADC                  ADCD1
+#define PORTAB_ADC_TEMP_GRP         0U
+
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -54,6 +63,9 @@
 /*===========================================================================*/
 /* External declarations.                                                    */
 /*===========================================================================*/
+
+extern const hal_pwm_config_t portab_pwm_config;
+extern const hal_adc_config_t portab_adc_config;
 
 #ifdef __cplusplus
 extern "C" {

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/xhalconf.h
@@ -45,7 +45,7 @@
 /*===========================================================================*/
 
 #define HAL_USE_PAL                         TRUE
-#define HAL_USE_ADC                         FALSE
+#define HAL_USE_ADC                         TRUE
 #define HAL_USE_DAC                         FALSE
 #define HAL_USE_CAN                         FALSE
 #define HAL_USE_EFL                         FALSE
@@ -55,7 +55,7 @@
 #define HAL_USE_I2S                         FALSE
 #define HAL_USE_ICU                         FALSE
 #define HAL_USE_MMC_SPI                     FALSE
-#define HAL_USE_PWM                         FALSE
+#define HAL_USE_PWM                         TRUE
 #define HAL_USE_RTC                         FALSE
 #define HAL_USE_SDC                         FALSE
 #define HAL_USE_SIO                         TRUE

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/xmcuconf.h
@@ -62,7 +62,12 @@
 #define RP_ADC_USE_ADC1                     TRUE
 #define RP_ADC_ADC1_DMA_CHANNEL             RP_DMA_CHANNEL_ID_ANY
 #define RP_ADC_ADC1_DMA_PRIORITY            0
-#define RP_ADC_ADC1_DMA_IRQ_PRIORITY        3
+/* The Hazard3 controller offers four priority levels against the sixteen
+   of the ARM core, so the value used by the ARM configuration would place
+   this interrupt at the bottom here rather than near the top. The
+   conversions are free running into an eight entry FIFO and stop only
+   when this interrupt is served, so it is kept urgent.*/
+#define RP_ADC_ADC1_DMA_IRQ_PRIORITY        1
 
 /*
  * PWM driver system settings.

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2_riscv/xmcuconf.h
@@ -56,4 +56,29 @@
 #define RP_SIO_USE_UART0                    TRUE
 #define RP_SIO_USE_UART1                    FALSE
 
+/*
+ * ADC driver system settings.
+ */
+#define RP_ADC_USE_ADC1                     TRUE
+#define RP_ADC_ADC1_DMA_CHANNEL             RP_DMA_CHANNEL_ID_ANY
+#define RP_ADC_ADC1_DMA_PRIORITY            0
+#define RP_ADC_ADC1_DMA_IRQ_PRIORITY        3
+
+/*
+ * PWM driver system settings.
+ */
+#define RP_PWM_USE_PWM0                     FALSE
+#define RP_PWM_USE_PWM1                     FALSE
+#define RP_PWM_USE_PWM2                     FALSE
+#define RP_PWM_USE_PWM3                     FALSE
+#define RP_PWM_USE_PWM4                     TRUE
+#define RP_PWM_USE_PWM5                     FALSE
+#define RP_PWM_USE_PWM6                     FALSE
+#define RP_PWM_USE_PWM7                     FALSE
+#define RP_PWM_USE_PWM8                     FALSE
+#define RP_PWM_USE_PWM9                     FALSE
+#define RP_PWM_USE_PWM10                    FALSE
+#define RP_PWM_USE_PWM11                    FALSE
+#define RP_PWM_IRQ_WRAP_NUMBER_PRIORITY     3
+
 #endif /* XMCUCONF_H */

--- a/os/xhal/ports/RP/RP2350/platform_riscv.mk
+++ b/os/xhal/ports/RP/RP2350/platform_riscv.mk
@@ -35,8 +35,12 @@ else
 endif
 
 # Drivers compatible with the platform.
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/ADCv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/DMAv1/driver.mk
+# EFLv1 is absent, the RP2350 XIP safety hooks park the other core using
+# the SMP port lockout services which the Hazard3 port does not provide.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/GPIOv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/RP/LLD/PWMv1/driver.mk
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/SPIv1/driver.mk
 # The Hazard3 port owns its core-local MTIME/MTIMECMP system timer.
 include $(CHIBIOS)/os/xhal/ports/RP/LLD/UARTv1/driver.mk


### PR DESCRIPTION
## Summary

`demos/RP/RT-XHAL-RP-MULTI/make/rp2350_pico2_riscv.make` has not compiled since #210 merged — 17 errors (`adcsample_t`, `pwmcnt_t`, `PWM_EVENT_PERIOD`, `PORTAB_PWM`, `PORTAB_ADC`, `pwmEnableEvents`, ...). Because the demo's top-level Makefile globs `make/*.make`, a bare `make` in that directory fails.

This is merge-order debt rather than a code defect: #208 extended the **shared** `main.c` with the PWM and ADC exercises, while #210 — authored against pre-#208 master and merged after it — brought a RISC-V config tree with `HAL_USE_PWM`/`HAL_USE_ADC` false, no `PORTAB_PWM`/`PORTAB_ADC` symbols, and a `platform_riscv.mk` without those drivers. #210's own PR body flagged the reconciliation as owed at rebase time; the merge landed before it happened.

Confirmed against pristine master with master's own `main.c`, so it is not an artefact of any pending branch.

## Change

- `os/xhal/ports/RP/RP2350/platform_riscv.mk`: add the ADCv1 and PWMv1 driver recipes.
- `cfg/rp2350_pico2_riscv/`: enable ADC and PWM, add the matching knobs, the `PORTAB_PWM`/`PORTAB_ADC` symbols and configurations, and move GP25 to the PWM alternate function (dropping the now-wrong LED write).

The RISC-V recipe deliberately keeps the classic port's exclusions rather than copying the ARM list wholesale:

| Driver | In RISC-V recipe? | Reason |
|---|---|---|
| ADCv1, PWMv1 | yes | needed by the shared demo; register-level LLDs whose only architecture contact is the Hazard3 NVIC shim, and whose default IRQ priority 3 is legal on Xh3irq (levels 0..3) |
| TIMERv1 | no | its recipe adds a second `hal_st_lld.c` on top of the Hazard3 one; the Hazard3 port owns its core-local timer |
| EFLv1 + flash safety | no | `rp_flash_safety.c` needs `__port_flash_lockout()`, which exists only in the ARM SMP ports; the Hazard3 port has no lockout services |
| RTCv2, USBv1 | no | nothing in-tree exercises them on RISC-V, and enabling RTCv2 needs an IRQ-priority knob this config tree does not define — deliberate future steps, not part of unbreaking the build |

After the change the ARM and RISC-V Pico 2 config trees differ only in `xmcuconf.h`, by the five ARM-only SysTick/TIMER0 knobs.

## Verification

- The failure was reproduced first, then fixed.
- **A bare `make` in `demos/RP/RT-XHAL-RP-MULTI` now exits 0 across all three recipes** — that is the point of the change.
- All three legs also build with checks and assertions enabled; `testxhal/SPI` RISC-V builds as a `platform_riscv.mk` regression.
- Remaining warnings are pre-existing and were confirmed on stock master (the two ARM RWX-segment linker notes, and one `-Wmaybe-uninitialized` in the RT test suite on the RISC-V leg).
- Style, `git diff --check` and the OSAL lexical gate all clean.

## Follow-up this implies

The same config tree will need the same treatment when I2C (#213) and the pending RTC demo exercise start being exercised from the shared `main.c`. RTCv2 on RISC-V in particular wants a deliberate decision — the classic RISC-V recipe omits it — so I have left that to the branch that needs it rather than inheriting my omission silently.

## Changelog

- XHAL: restored the RISC-V leg of the RP multi-target demo after the PWM and ADC exercises landed.
