### PR TITLE
XHAL: exercise the RP RTC drivers from the multi-target demo

### DIFF
--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/portab.h
@@ -49,6 +49,24 @@
 #define PORTAB_I2C                  I2CD0
 #define PORTAB_LINE_I2C_SDA         4U
 #define PORTAB_LINE_I2C_SCL         5U
+#define PORTAB_RTC                  RTCD1
+
+/*
+ * The RP2040 RTC block sits behind the RESETS block and is held in reset
+ * at every chip reset, its counters always come up cleared. A date/time
+ * read taken before a date/time has been set therefore always reports the
+ * not-set condition.
+ */
+#define PORTAB_RTC_TIME_RETAINED    FALSE
+
+/*
+ * Alarm lead time, in RTC seconds, and the wall clock budget allowed for
+ * it to elapse. The RTC 1Hz reference is divided down from clk_rtc, which
+ * is crystal derived through the USB PLL, so RTC seconds and wall clock
+ * seconds match and a small margin is enough.
+ */
+#define PORTAB_RTC_ALARM_LEAD_S     3U
+#define PORTAB_RTC_ALARM_TIMEOUT_MS 6000U
 
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xhalconf.h
@@ -56,7 +56,7 @@
 #define HAL_USE_ICU                         FALSE
 #define HAL_USE_MMC_SPI                     FALSE
 #define HAL_USE_PWM                         TRUE
-#define HAL_USE_RTC                         FALSE
+#define HAL_USE_RTC                         TRUE
 #define HAL_USE_SDC                         FALSE
 #define HAL_USE_SIO                         TRUE
 #define HAL_USE_SPI                         FALSE

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2040_pico/xmcuconf.h
@@ -52,6 +52,7 @@
 #define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
 #define RP_IRQ_I2C0_PRIORITY                3
 #define RP_IRQ_I2C1_PRIORITY                3
+#define RP_IRQ_RTC_PRIORITY                 3
 #define RP_IRQ_UART0_PRIORITY               3
 #define RP_IRQ_UART1_PRIORITY               3
 #define RP_IO_IRQ_BANK0_PRIORITY            2

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/portab.h
@@ -49,6 +49,25 @@
 #define PORTAB_I2C                  I2CD0
 #define PORTAB_LINE_I2C_SDA         4U
 #define PORTAB_LINE_I2C_SCL         5U
+#define PORTAB_RTC                  RTCD1
+
+/*
+ * The RP2350 RTC is built on the POWMAN "Always-On" timer, its counter
+ * lives in the always-on domain and survives ordinary chip resets. A
+ * date/time read taken before this firmware has set a date/time reports
+ * the not-set condition only until the first date/time is ever set,
+ * afterwards it legitimately returns the retained time.
+ */
+#define PORTAB_RTC_TIME_RETAINED    TRUE
+
+/*
+ * Alarm lead time, in RTC seconds, and the wall clock budget allowed for
+ * it to elapse. The always-on timer ticks from the LPOSC at its nominal
+ * calibration, RTC seconds can be appreciably longer or shorter than wall
+ * clock seconds, hence the wide margin.
+ */
+#define PORTAB_RTC_ALARM_LEAD_S     3U
+#define PORTAB_RTC_ALARM_TIMEOUT_MS 12000U
 
 /*===========================================================================*/
 /* Module pre-compile time settings.                                         */

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xhalconf.h
@@ -56,7 +56,7 @@
 #define HAL_USE_ICU                         FALSE
 #define HAL_USE_MMC_SPI                     FALSE
 #define HAL_USE_PWM                         TRUE
-#define HAL_USE_RTC                         FALSE
+#define HAL_USE_RTC                         TRUE
 #define HAL_USE_SDC                         FALSE
 #define HAL_USE_SIO                         TRUE
 #define HAL_USE_SPI                         FALSE

--- a/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
+++ b/demos/RP/RT-XHAL-RP-MULTI/cfg/rp2350_pico2/xmcuconf.h
@@ -53,6 +53,7 @@
 #define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
 #define RP_IRQ_I2C0_PRIORITY                3
 #define RP_IRQ_I2C1_PRIORITY                3
+#define RP_IRQ_RTC_PRIORITY                 3
 #define RP_IRQ_UART0_PRIORITY               3
 #define RP_IRQ_UART1_PRIORITY               3
 #define RP_IO_IRQ_BANK0_PRIORITY            2

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -455,6 +455,9 @@ static bool rtc_selfcheck(BaseSequentialStream *stream) {
     waited += RTC_CHECK_POLL_MS;
   }
   if (rtc_alarm_count == 0U) {
+    /* Disarming before dropping the callback, in this order the alarm
+       source is silenced first and cannot fire in between.*/
+    (void) rtcSetAlarm(&PORTAB_RTC, 0U, NULL);
     drvSetCallbackX(&PORTAB_RTC, NULL);
     return rtc_fail(stream, "alarm timeout");
   }

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -55,6 +55,14 @@
  */
 #define I2C_SCAN_PERIOD             2U
 
+/* Known date/time used by the RTC self-check, 2026-01-01T00:00:00Z
+   expressed in seconds since the Unix epoch, the timescale of the shared
+   64-bit RTC representation.*/
+#define RTC_CHECK_EPOCH             1767225600U
+
+/* Polling period used while waiting for the alarm callback.*/
+#define RTC_CHECK_POLL_MS           50U
+
 static hal_buffered_sio_c bsio1;
 static uint8_t rxbuf[32];
 static uint8_t txbuf[32];
@@ -70,6 +78,13 @@ static volatile uint32_t pwm_wraps;
  * Buffer receiving the temperature sensor samples via DMA.
  */
 static adcsample_t temp_sample[1];
+
+/*
+ * RTC alarm callback state. The callback runs in ISR context, it only
+ * touches these two words which the self-check loop observes.
+ */
+static volatile uint32_t rtc_alarm_count;
+static volatile rtceventflags_t rtc_alarm_flags;
 
 static const char banner[] = "\r\n" BOARD_NAME " -- ChibiOS/RT "
                              CH_KERNEL_VERSION "\r\n";
@@ -124,6 +139,7 @@ static void print_dec(BaseSequentialStream *stream, int32_t value) {
  * Writes an unsigned decimal number on the stream. Counters and any
  * value that can exceed the signed range are printed through this
  * helper, passing them to the signed printer would misrepresent them.
+ * The Unix epoch seconds handled by the RTC check are one such value.
  */
 static void print_udec(BaseSequentialStream *stream, uint32_t value) {
   char buf[10];
@@ -152,6 +168,49 @@ static void print_hex2(BaseSequentialStream *stream, uint32_t value) {
   buf[3] = digits[value & 0x0FU];
 
   stmWrite(stream, (const uint8_t *)buf, sizeof buf);
+}
+
+/*
+ * Writes a two digits, zero padded, unsigned decimal number.
+ */
+static void print_dec2(BaseSequentialStream *stream, uint32_t value) {
+
+  if (value < 10U) {
+    print_str(stream, "0");
+  }
+  print_udec(stream, value);
+}
+
+/*
+ * Writes a 64-bit RTC time as seconds since the Unix epoch followed by
+ * the equivalent broken-down date/time.
+ */
+static void print_time(BaseSequentialStream *stream,
+                       const rtc_time64_t *timespec) {
+  rtc_datetime_t dt;
+  uint32_t sec;
+
+  print_udec(stream, (uint32_t)timespec->tv_sec);
+
+  if (rtcConvertTime64ToDateTime(timespec, &dt) != HAL_RET_SUCCESS) {
+    print_str(stream, " (not representable)");
+    return;
+  }
+
+  sec = dt.millisecond / 1000U;
+  print_str(stream, " ");
+  print_udec(stream, (uint32_t)dt.year + RTC_BASE_YEAR);
+  print_str(stream, "-");
+  print_dec2(stream, dt.month);
+  print_str(stream, "-");
+  print_dec2(stream, dt.day);
+  print_str(stream, "T");
+  print_dec2(stream, sec / 3600U);
+  print_str(stream, ":");
+  print_dec2(stream, (sec / 60U) % 60U);
+  print_str(stream, ":");
+  print_dec2(stream, sec % 60U);
+  print_str(stream, "Z");
 }
 
 /*
@@ -288,6 +347,164 @@ static void i2c_scan(BaseSequentialStream *stream) {
 }
 
 /*
+ * RTC alarm callback, it runs in ISR context.
+ */
+static void rtc_alarm_cb(void *ip) {
+
+  rtc_alarm_flags |= rtcGetAndClearEventsX(ip, RTC_FLAGS_ALARM_A);
+  rtc_alarm_count++;
+}
+
+/*
+ * Prints the self-check failure summary line, always returns false so
+ * that it can be used as the value of a failing return statement.
+ */
+static bool rtc_fail(BaseSequentialStream *stream, const char *what) {
+
+  print_str(stream, "rtc: FAIL ");
+  print_str(stream, what);
+  print_str(stream, "\r\n");
+
+  return false;
+}
+
+/*
+ * RTC self-check, it is executed once and prints one line per step. All
+ * the board and device specific knowledge is in portab.h, the check only
+ * uses shared XHAL APIs.
+ */
+static bool rtc_selfcheck(BaseSequentialStream *stream) {
+  rtc_time64_t tv;
+  rtc_alarm_t alarm;
+  uint32_t base, waited, delay;
+  msg_t msg;
+
+  /* Driver activation using the default configuration.*/
+  msg = drvStart(&PORTAB_RTC, NULL);
+  if (msg != HAL_RET_SUCCESS) {
+    return rtc_fail(stream, "start");
+  }
+  print_str(stream, "rtc: started\r\n");
+
+  /* Reading the date/time before setting it, the documented behavior is
+     a configuration error while no date/time has ever been set. Devices
+     retaining the time across resets can legitimately report a time
+     here instead.*/
+  msg = rtcGetTime64(&PORTAB_RTC, &tv);
+  if (msg == HAL_RET_CONFIG_ERROR) {
+    print_str(stream, "rtc: pre-set read reports not-set, ok\r\n");
+  }
+  else if ((msg == HAL_RET_SUCCESS) && PORTAB_RTC_TIME_RETAINED) {
+    print_str(stream, "rtc: pre-set read reports retained time ");
+    print_time(stream, &tv);
+    print_str(stream, ", ok\r\n");
+  }
+  else {
+    return rtc_fail(stream, "pre-set read");
+  }
+
+  /* Setting the known date/time.*/
+  tv.tv_sec  = (int64_t)RTC_CHECK_EPOCH;
+  tv.tv_nsec = 0U;
+  msg = rtcSetTime64(&PORTAB_RTC, &tv);
+  if (msg != HAL_RET_SUCCESS) {
+    return rtc_fail(stream, "set time");
+  }
+  print_str(stream, "rtc: set time ");
+  print_time(stream, &tv);
+  print_str(stream, "\r\n");
+
+  /* Reading the date/time back, one second of counting is tolerated
+     between the two operations.*/
+  msg = rtcGetTime64(&PORTAB_RTC, &tv);
+  if (msg != HAL_RET_SUCCESS) {
+    return rtc_fail(stream, "read back");
+  }
+  print_str(stream, "rtc: read back ");
+  print_time(stream, &tv);
+  print_str(stream, "\r\n");
+
+  base = (uint32_t)tv.tv_sec;
+  if ((base < RTC_CHECK_EPOCH) || ((base - RTC_CHECK_EPOCH) > 1U)) {
+    return rtc_fail(stream, "read back mismatch");
+  }
+  print_str(stream, "rtc: time round-trips, ok\r\n");
+
+  /* Arming a one-shot alarm a few seconds ahead, the alarm time is an
+     absolute time on the same timescale as the date/time just set.*/
+  rtc_alarm_count = 0U;
+  rtc_alarm_flags = 0U;
+  drvSetCallbackX(&PORTAB_RTC, rtc_alarm_cb);
+
+  alarm.alrmr = base + PORTAB_RTC_ALARM_LEAD_S;
+  msg = rtcSetAlarm(&PORTAB_RTC, 0U, &alarm);
+  if (msg != HAL_RET_SUCCESS) {
+    return rtc_fail(stream, "alarm set");
+  }
+  print_str(stream, "rtc: alarm armed at ");
+  print_udec(stream, alarm.alrmr);
+  print_str(stream, ", lead ");
+  print_udec(stream, PORTAB_RTC_ALARM_LEAD_S);
+  print_str(stream, " s\r\n");
+
+  /* Waiting for the callback to publish the alarm event.*/
+  waited = 0U;
+  while ((rtc_alarm_count == 0U) &&
+         (waited < PORTAB_RTC_ALARM_TIMEOUT_MS)) {
+    chThdSleepMilliseconds(RTC_CHECK_POLL_MS);
+    waited += RTC_CHECK_POLL_MS;
+  }
+  if (rtc_alarm_count == 0U) {
+    drvSetCallbackX(&PORTAB_RTC, NULL);
+    return rtc_fail(stream, "alarm timeout");
+  }
+
+  /* Measuring the elapsed delay against the RTC own clock.*/
+  msg = rtcGetTime64(&PORTAB_RTC, &tv);
+  if (msg != HAL_RET_SUCCESS) {
+    drvSetCallbackX(&PORTAB_RTC, NULL);
+    return rtc_fail(stream, "post-alarm read");
+  }
+  delay = (uint32_t)tv.tv_sec - base;
+
+  print_str(stream, "rtc: alarm fired after ");
+  print_udec(stream, delay);
+  print_str(stream, " s, callbacks ");
+  print_udec(stream, rtc_alarm_count);
+  print_str(stream, ", flags ");
+  print_udec(stream, rtc_alarm_flags);
+  print_str(stream, "\r\n");
+
+  drvSetCallbackX(&PORTAB_RTC, NULL);
+
+  if (rtc_alarm_count != 1U) {
+    return rtc_fail(stream, "alarm repeated");
+  }
+  if ((rtc_alarm_flags & RTC_FLAGS_ALARM_A) == 0U) {
+    return rtc_fail(stream, "alarm event flag");
+  }
+  if ((delay < (PORTAB_RTC_ALARM_LEAD_S - 1U)) ||
+      (delay > (PORTAB_RTC_ALARM_LEAD_S + 1U))) {
+    return rtc_fail(stream, "alarm delay");
+  }
+
+  /* A fired one-shot alarm must read back as disarmed.*/
+  msg = rtcGetAlarm(&PORTAB_RTC, 0U, &alarm);
+  if (msg != HAL_RET_SUCCESS) {
+    return rtc_fail(stream, "alarm read back");
+  }
+  if (alarm.alrmr != 0U) {
+    print_str(stream, "rtc: alarm still reads ");
+    print_udec(stream, alarm.alrmr);
+    print_str(stream, "\r\n");
+    return rtc_fail(stream, "alarm not disarmed");
+  }
+  print_str(stream, "rtc: alarm reads back disarmed, ok\r\n");
+
+  return true;
+}
+
+/*
  * Application entry point.
  */
 int main(void) {
@@ -332,6 +549,16 @@ int main(void) {
   stmWrite(stream, (const uint8_t *)banner, sizeof banner - 1U);
   test_execute(stream, &rt_test_suite);
   test_execute(stream, &oslib_test_suite);
+
+  /*
+   * Exercises the RTC driver once, the check prints its own failure
+   * summary line. It runs before the PWM and ADC drivers are started
+   * because it measures the alarm latency against a one second budget
+   * and the 1kHz PWM wrap interrupt would perturb that measurement.
+   */
+  if (rtc_selfcheck(stream)) {
+    print_str(stream, "rtc: PASS\r\n");
+  }
 
   /*
    * Activates the PWM driver on the LED slice using the portability

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -171,7 +171,7 @@ static void print_hex2(BaseSequentialStream *stream, uint32_t value) {
 }
 
 /*
- * Writes a two digits, zero padded, unsigned decimal number.
+ * Writes a two-digit, zero-padded, unsigned decimal number.
  */
 static void print_dec2(BaseSequentialStream *stream, uint32_t value) {
 

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -79,12 +79,14 @@ static volatile uint32_t pwm_wraps;
  */
 static adcsample_t temp_sample[1];
 
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
 /*
  * RTC alarm callback state. The callback runs in ISR context, it only
  * touches these two words which the self-check loop observes.
  */
 static volatile uint32_t rtc_alarm_count;
 static volatile rtceventflags_t rtc_alarm_flags;
+#endif /* HAL_USE_RTC == TRUE */
 
 static const char banner[] = "\r\n" BOARD_NAME " -- ChibiOS/RT "
                              CH_KERNEL_VERSION "\r\n";
@@ -170,6 +172,7 @@ static void print_hex2(BaseSequentialStream *stream, uint32_t value) {
   stmWrite(stream, (const uint8_t *)buf, sizeof buf);
 }
 
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
 /*
  * Writes a two-digit, zero-padded, unsigned decimal number.
  */
@@ -212,6 +215,7 @@ static void print_time(BaseSequentialStream *stream,
   print_dec2(stream, sec % 60U);
   print_str(stream, "Z");
 }
+#endif /* HAL_USE_RTC == TRUE */
 
 /*
  * Converts a raw temperature sensor sample into tenths of Celsius
@@ -346,6 +350,7 @@ static void i2c_scan(BaseSequentialStream *stream) {
   print_str(stream, "\r\n");
 }
 
+#if (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
 /*
  * RTC alarm callback, it runs in ISR context.
  */
@@ -506,6 +511,7 @@ static bool rtc_selfcheck(BaseSequentialStream *stream) {
 
   return true;
 }
+#endif /* HAL_USE_RTC == TRUE */
 
 /*
  * Application entry point.
@@ -559,9 +565,11 @@ int main(void) {
    * because it measures the alarm latency against a one second budget
    * and the 1kHz PWM wrap interrupt would perturb that measurement.
    */
+#if HAL_USE_RTC == TRUE
   if (rtc_selfcheck(stream)) {
     print_str(stream, "rtc: PASS\r\n");
   }
+#endif
 
   /*
    * Activates the PWM driver on the LED slice using the portability


### PR DESCRIPTION
## Summary

The RTC drivers landed in #211 without any on-target exercise: the demo self-check written alongside them was still an uncommitted working-tree change when the PR merged, so master has `HAL_USE_RTC FALSE` and the merged drivers have **no runtime coverage at all**. This restores it.

Adversarial review of #211 had also flagged the gap explicitly — the existing `testxhal/RTC` builds STM32 register images for its alarms and cannot exercise the RP contract, so the demo is the only vehicle available today.

The self-check runs once after the test suites and prints one line per step, so a bench capture can be read directly:

1. read the time *before* setting it, and confirm it reports the not-set condition (documented behaviour on this port, verified rather than treated as a failure);
2. set a known timestamp and read it back, confirming the round trip;
3. arm a one-shot alarm a few seconds out, wait for the callback, and report the measured delay against the RTC's own clock;
4. read the alarm back afterwards and confirm it reads as disarmed;
5. print a `rtc: PASS` / `rtc: FAIL <what>` summary.

## Notes for review

- **Ordering is a real constraint, not a style choice.** The check measures alarm latency and asserts it lands close to the expected lead, so it runs *before* the PWM and ADC exercises start — the 1 kHz PWM wrap interrupt would otherwise perturb the very timing it measures.
- **Per-chip divergence is deliberate.** The two config trees differ in the retained-time flag and the alarm timeout; everywhere else in this demo they are byte-identical, so this is the one place the usual "copy one over the other" shortcut is wrong.
- Master's console helpers are reused as-is; epoch and alarm values sit close to `INT32_MAX`, so they print through an unsigned helper rather than the existing signed one.

## Verification

Both targets build clean with default flags and with checks and assertions enabled, plus `USE_SMART_BUILD=no`; style, `git diff --check` and the OSAL gate are clean.

On-hardware results will be posted here from the bench batch that is working through the recently merged stages — this branch is the piece that makes the RTC part of that batch possible.

## Changelog

- XHAL: the RP multi-target demo exercises the RTC drivers.
