### PR TITLE
XHAL: do not start the EFL-MFS console from inside an assertion

### DIFF
--- a/testxhal/EFL-MFS/main.c
+++ b/testxhal/EFL-MFS/main.c
@@ -55,6 +55,7 @@ static uint8_t bsio1_ob[512];
 
 int main(void) {
   bool button_pressed;
+  msg_t msg;
 
   halInit();
   chSysInit();
@@ -71,8 +72,8 @@ int main(void) {
   drvStop(&bsio1);
   chDbgAssert(drvGetStateX(&bsio1) == HAL_DRV_STATE_STOP,
               "SIO not stopped");
-  chDbgAssert(drvStart(&bsio1, NULL) == HAL_RET_SUCCESS,
-              "SIO restart failed");
+  msg = drvStart(&bsio1, NULL);
+  chDbgAssert(msg == HAL_RET_SUCCESS, "SIO restart failed");
 
   chThdCreateStatic(waThread1, sizeof(waThread1), NORMALPRIO, Thread1, NULL);
 


### PR DESCRIPTION
Found on silicon during the batched bench pass on merged master.

`chDbgAssert(c, r)` expands to `if (CH_DBG_ENABLE_ASSERTS != FALSE) { if (unlikely(!(c))) chSysHalt(...); }`. With assertions disabled — the default for this project — the condition is never evaluated, so **any side effect inside it is compiled out**. The buffered SIO restart that this test performs after exercising the stop path lived inside such an assertion:

```c
drvStop(&bsio1);
chDbgAssert(drvGetStateX(&bsio1) == HAL_DRV_STATE_STOP, "SIO not stopped");
chDbgAssert(drvStart(&bsio1, NULL) == HAL_RET_SUCCESS, "SIO restart failed");   /* never called */
```

## Effect on hardware

The preceding `drvStop()` had stopped the console and nothing restarted it, so the suite produced **no output at all** while the kernel ran normally — which is what made it hard to place. Confirmed on an RP2350 with the target halted under gdb:

| Observation | Value |
|---|---|
| `RESETS_RESET` bit 26 (UART0) | set — peripheral held in reset |
| `UARTCR` / `UARTIBRD` / `UARTFBRD` / `UARTLCR_H` | all `0` (reads of a block in reset) |
| `bsio1` driver state | `1` = `HAL_DRV_STATE_STOP`, `config = NULL` |
| `SIOD0` driver state | `1` = `HAL_DRV_STATE_STOP`, `enabled = 0` |
| `ch0.mainthread.state` | `8` = `CH_STATE_SLEEPING` — the button loop was running fine |

Pads stayed correctly muxed to UART (`GP0`/`GP1` `CTRL` = `0x02`), which is why the failure looked like a driver problem rather than a missing call. The EFL and SIO drivers were never at fault.

## Fix

Hoist the call out of the assertion so the restart happens in every configuration and the assertion only inspects its result.

## Verification

Rebuilt with assertions **disabled** (as shipped) and re-run on both chips:

- **RP2350**: 12/12 MFS cases, `Final result: SUCCESS`. UART0 comes up correctly — out of reset, `UARTCR=0x301` (UARTEN\|TXE\|RXE), `IBRD=244` = 38400 from a 150 MHz `clk_peri`.
- **RP2040**: 12/12 MFS cases, `Final result: SUCCESS`.

A repo-wide sweep of the RP/XHAL work found no other side-effect-in-assertion site. Per-file `stylecheck.py` and `git diff --check` clean.
