### PR TITLE
XHAL: keep the RP demo RISC-V leg building without the I2C driver

### DIFF
--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -124,11 +124,13 @@ static void print_dec(BaseSequentialStream *stream, int32_t value) {
   stmWrite(stream, (const uint8_t *)&buf[i], sizeof buf - i);
 }
 
-#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
+#if (HAL_USE_I2C == TRUE) || (HAL_USE_RTC == TRUE) || defined(__DOXYGEN__)
 /*
  * Writes an unsigned decimal number on the stream. Counters and any
  * value that can exceed the signed range are printed through this
  * helper, passing them to the signed printer would misrepresent them.
+ * Both the bus scan and the RTC check need it, so it is available to
+ * either of them.
  */
 static void print_udec(BaseSequentialStream *stream, uint32_t value) {
   char buf[10];
@@ -142,7 +144,9 @@ static void print_udec(BaseSequentialStream *stream, uint32_t value) {
   } while (value > 0U);
   stmWrite(stream, (const uint8_t *)&buf[i], sizeof buf - i);
 }
+#endif /* HAL_USE_I2C == TRUE || HAL_USE_RTC == TRUE */
 
+#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
 /*
  * Writes the low byte of a value as a two digits hexadecimal number on
  * the stream.

--- a/demos/RP/RT-XHAL-RP-MULTI/main.c
+++ b/demos/RP/RT-XHAL-RP-MULTI/main.c
@@ -23,6 +23,7 @@
 
 #include "portab.h"
 
+#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
 /*
  * Scanned 7-bit address range, the reserved addresses outside it are not
  * probed.
@@ -54,11 +55,14 @@
  * the bus is scanned every four seconds.
  */
 #define I2C_SCAN_PERIOD             2U
+#endif /* HAL_USE_I2C == TRUE */
 
 static hal_buffered_sio_c bsio1;
 static uint8_t rxbuf[32];
 static uint8_t txbuf[32];
+#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
 static uint8_t found[I2C_SCAN_FOUND_MAX];
+#endif /* HAL_USE_I2C == TRUE */
 
 /*
  * PWM period (wrap) events counted by the PWM callback, read by the
@@ -120,6 +124,7 @@ static void print_dec(BaseSequentialStream *stream, int32_t value) {
   stmWrite(stream, (const uint8_t *)&buf[i], sizeof buf - i);
 }
 
+#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
 /*
  * Writes an unsigned decimal number on the stream. Counters and any
  * value that can exceed the signed range are printed through this
@@ -153,6 +158,7 @@ static void print_hex2(BaseSequentialStream *stream, uint32_t value) {
 
   stmWrite(stream, (const uint8_t *)buf, sizeof buf);
 }
+#endif /* HAL_USE_I2C == TRUE */
 
 /*
  * Converts a raw temperature sensor sample into tenths of Celsius
@@ -168,6 +174,7 @@ static int32_t temp_raw_to_dc(adcsample_t raw) {
   return 270 - (((uv - 706000) * 10) / 1721);
 }
 
+#if (HAL_USE_I2C == TRUE) || defined(__DOXYGEN__)
 /*
  * Recovery path of a transfer that could not be terminated: the driver is
  * stopped so that the peripheral releases the bus, the bus is cleared by
@@ -286,6 +293,7 @@ static void i2c_scan(BaseSequentialStream *stream) {
 
   print_str(stream, "\r\n");
 }
+#endif /* HAL_USE_I2C == TRUE */
 
 /*
  * Application entry point.
@@ -295,7 +303,9 @@ int main(void) {
   msg_t msg;
   pwmcnt_t width;
   unsigned i;
+#if HAL_USE_I2C == TRUE
   unsigned iteration;
+#endif
   int32_t tdc;
   int32_t frac;
 
@@ -350,12 +360,14 @@ int main(void) {
   msg = drvStart(&PORTAB_ADC, &portab_adc_config);
   chDbgAssert(msg == HAL_RET_SUCCESS, "ADC start failed");
 
+#if HAL_USE_I2C == TRUE
   /*
    * Activates the I2C driver used by the bus scan, the peripheral stays
    * idle until the first probe.
    */
   msg = drvStart(&PORTAB_I2C, &portab_i2ccfg);
   chDbgAssert(msg == HAL_RET_SUCCESS, "I2C start failed");
+#endif
 
   /*
    * Normal main() thread activity, in this demo it fades the board LED
@@ -364,7 +376,9 @@ int main(void) {
    * the result together with the wrap events counter. The I2C bus is
    * scanned every I2C_SCAN_PERIOD fade cycles.
    */
+#if HAL_USE_I2C == TRUE
   iteration = 0U;
+#endif
   while (true) {
     /* One triangular fade cycle, one percent duty step every 10ms for
        a two seconds cycle at a visibly smooth 1kHz PWM frequency.*/
@@ -405,6 +419,7 @@ int main(void) {
       print_str(stream, "temp conversion failed\r\n");
     }
 
+#if HAL_USE_I2C == TRUE
     /* Periodic bus scan, the pass is run from thread context between two
        fade cycles.*/
     iteration++;
@@ -412,5 +427,6 @@ int main(void) {
       iteration = 0U;
       i2c_scan(stream);
     }
+#endif
   }
 }


### PR DESCRIPTION
**Master is currently broken for `demos/RP/RT-XHAL-RP-MULTI` on RISC-V.** At `b63efdf6d4` (#213 merge):

```
main.c:181:12: error: 'PORTAB_I2C' undeclared (first use in this function)
main.c:182:9:  error: implicit declaration of function 'portab_i2c_bus_clear'
main.c:184:33: error: 'portab_i2ccfg' undeclared (first use in this function)
main.c:200:3:  error: unknown type name 'i2cflags_t'
```

The bus scan went into the shared `main.c` unconditionally, but `RP2350/platform_riscv.mk` does not build `I2Cv1` and the RISC-V configuration sets `HAL_USE_I2C` `FALSE`.

## Fix

Guards behind `HAL_USE_I2C`: the scan constants, the `found[]` array, `print_udec()`/`print_hex2()` (used only by the scan), `i2c_recover()`/`i2c_scan()`, and in `main()` the `iteration` counter, the driver activation and the periodic call.

Guarding rather than enabling the driver on RISC-V is the conservative choice here — it restores the previous state exactly. Enabling I2C for the RISC-V platform is defensible on the hardware (DW_apb_i2c is not core-specific) but it is a port change that deserves its own build and bench evidence, so it is noted below rather than bundled in.

## Verification

| Target | Result |
|---|---|
| `rp2040_pico` | builds, 108640 text, no `main.c` warnings |
| `rp2350_pico2` | builds, 111376 text, no `main.c` warnings |
| `rp2350_pico2_riscv` | **builds again**, 91822 text, no `main.c` warnings |

The guards are provably inert where I2C is enabled: the `rp2350_pico2` binary is **byte-identical** with and without them apart from the two bytes of compile timestamp in the banner string. The RISC-V image at 91822 text matches the size of the last RISC-V build taken before the I2C work landed.

Per-file `stylecheck.py` and `git diff --check` clean.

## Worth a decision

This is the third time an addition to this demo has broken the RISC-V leg — after #208/#210 (fixed by #217, PWM and ADC) and the RTC work in #218. One `main.c` serves three targets and the RISC-V platform deliberately carries a smaller driver set (no `TIMERv1`, `RTCv2`, `EFLv1`, `USBv1`, `I2Cv1`), so every driver-touching addition needs a guard and CI does not cover these targets. Two options worth considering: add the RP demo targets to the CI sweep so this fails in the PR rather than on master, and/or close the gap by adding `I2Cv1` to `platform_riscv.mk` where the hardware allows it.
