### PR TITLE
RT-ARMCR8-GENERIC: drop the stale ARMv7-R note, add a headless Renode script

### DIFF
--- a/demos/various/RT-ARMCR8-GENERIC/readme.txt
+++ b/demos/various/RT-ARMCR8-GENERIC/readme.txt
@@ -18,7 +18,5 @@ Run make from this directory.
 
 ** Notes **
 
-The RTOS-related Makefile includes and main.c code are intentionally commented
-out until the ARMv7-R port is available. The generic linker script can be
-overridden by defining FLASH_ORIGIN, FLASH_LEN, RAM_ORIGIN and RAM_LEN from
-the Makefile or command line.
+The generic linker script can be overridden by defining FLASH_ORIGIN,
+FLASH_LEN, RAM_ORIGIN and RAM_LEN from the Makefile or command line.

--- a/demos/various/RT-ARMCR8-GENERIC/renode-headless-test.resc
+++ b/demos/various/RT-ARMCR8-GENERIC/renode-headless-test.resc
@@ -1,0 +1,20 @@
+:name: ChibiOS ARMCR8 headless smoke test
+:description: Runs the demo for 5 virtual seconds and dumps the counters.
+
+include @renode.resc
+
+emulation RunFor "5"
+
+echo "=== counters after 5 virtual seconds ==="
+echo "fpu_error_counter:"
+sysbus ReadDoubleWord 0x00102690
+echo "fpu_main_counter:"
+sysbus ReadDoubleWord 0x00102694
+echo "fpu_thread_counter:"
+sysbus ReadDoubleWord 0x00102698
+echo "main_counter:"
+sysbus ReadDoubleWord 0x0010269c
+echo "thread_counter:"
+sysbus ReadDoubleWord 0x001026a0
+
+quit


### PR DESCRIPTION
## Summary

Two small fixes to the generic Cortex-R8 demo, found while bringing up a Cortex-R5 board on top of the ARMv7-R port.

`readme.txt` still said the RTOS-related Makefile includes and `main.c` code were "intentionally commented out until the ARMv7-R port is available". The demo already includes `os/rt/rt.mk` and calls `chSysInit()`, so that note has been stale since the port landed.

Also adds a headless Renode script so the demo can be run without hardware.

## Related

- Issue(s): none
- Notes for reviewers: documentation and tooling only, no code paths are touched.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files — no `.c`/`.h` files are changed
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile) —
      `RT-Posix-Simulator` links, `RT-ARMCR8-GENERIC` builds at text 4892 B with
      `arm-none-eabi-gcc 13.2.1`, unchanged from the unpatched tree

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? Not applicable, there is no code change.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided — not applicable
- [x] Risks/limitations are documented below

No risk: a corrected comment and a new standalone script. The Renode script is additive and is not referenced by the build.