### PR TITLE
RP PIOv1: add block level interrupt, callback and GPIO routing APIs

### DIFF
--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
@@ -504,10 +504,14 @@ void pioSmFreeI(const rp_pio_sm_t *smp) {
 
   /* Reset PIO block only if no state machines remain allocated and no
      programs are loaded, resetting while instruction memory is allocated
-     would wipe loaded programs behind the bookkeeping's back.*/
+     would wipe loaded programs behind the bookkeeping's back. The reset
+     wipes the INTE routing, so the block callback is dropped with it:
+     keeping the pointer past the point it can ever fire again would
+     leave a stale registration behind.*/
   if (((pio.blocks[b].c0_allocated_mask |
         pio.blocks[b].c1_allocated_mask) == 0U) &&
       (pio.blocks[b].imem_allocated == 0U)) {
+    pio.blocks[b].block.func = NULL;
     rp_peripheral_reset(smp->block->resets_mask);
   }
 }
@@ -735,6 +739,11 @@ void pioSmInit(const rp_pio_sm_t *smp, uint32_t initial_pc,
  *          natural place to do it, being the only handler guaranteed to
  *          run exactly once per interrupt.
  * @note    Passing @p NULL removes the callback.
+ * @note    The callback can only be invoked while the current core has
+ *          at least one state machine allocated, which is what keeps the
+ *          PIO interrupt vector enabled. It is dropped automatically
+ *          when the block becomes fully idle and is reset, together with
+ *          the INTE routing.
  *
  * @param[in] block     pointer to the PIO block descriptor
  * @param[in] func      callback function, can be @p NULL

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
@@ -94,6 +94,19 @@ static struct {
      */
     uint32_t        imem_allocated;
     /**
+     * @brief   Block level IRQ redirector.
+     */
+    struct {
+      /**
+       * @brief   PIO block callback function.
+       */
+      rp_pioisr_t   func;
+      /**
+       * @brief   PIO block callback parameter.
+       */
+      void          *param;
+    } block;
+    /**
      * @brief   PIO state machine IRQ redirectors.
      */
     struct {
@@ -137,6 +150,12 @@ static void serve_pio_irq(uint32_t blockidx, __I uint32_t *ints_reg) {
 
   if (ints != 0U) {
     unsigned i;
+
+    /* The block callback is invoked once, before the per state machine
+       ones, so it can acknowledge the source on their behalf.*/
+    if (pio.blocks[blockidx].block.func != NULL) {
+      pio.blocks[blockidx].block.func(pio.blocks[blockidx].block.param, ints);
+    }
 
     for (i = 0U; i < RP_PIO_NUM_STATE_MACHINES; i++) {
       if (pio.blocks[blockidx].sm[i].func != NULL) {
@@ -240,6 +259,7 @@ void pioInit(void) {
     pio.blocks[b].c0_allocated_mask = 0U;
     pio.blocks[b].c1_allocated_mask = 0U;
     pio.blocks[b].imem_allocated    = 0U;
+    pio.blocks[b].block.func        = NULL;
     for (s = 0U; s < RP_PIO_NUM_STATE_MACHINES; s++) {
       pio.blocks[b].sm[s].func = NULL;
     }
@@ -702,6 +722,51 @@ void pioSmInit(const rp_pio_sm_t *smp, uint32_t initial_pc,
   pioSmRestartX(smp);
   pioSmClkdivRestartX(smp);
   pioSmSetPCX(smp, initial_pc);
+}
+
+/**
+ * @brief   Associates a callback to a PIO block.
+ * @details The callback is invoked once per interrupt of the block, before
+ *          the callbacks of the allocated state machines, with the content
+ *          of the IRQn_INTS register.
+ * @note    The driver acknowledges nothing itself: IRQn_INTS is derived
+ *          from INTR and the FIFO levels, so unless the source is cleared
+ *          the interrupt fires again immediately. A block callback is the
+ *          natural place to do it, being the only handler guaranteed to
+ *          run exactly once per interrupt.
+ * @note    Passing @p NULL removes the callback.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] func      callback function, can be @p NULL
+ * @param[in] param     parameter passed to the callback
+ *
+ * @iclass
+ */
+void pioSetBlockCallbackI(const rp_pio_block_t *block,
+                          rp_pioisr_t func, void *param) {
+
+  osalDbgCheckClassI();
+  osalDbgCheck(block != NULL);
+
+  pio.blocks[block->pioidx].block.param = param;
+  pio.blocks[block->pioidx].block.func  = func;
+}
+
+/**
+ * @brief   Associates a callback to a PIO block.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] func      callback function, can be @p NULL
+ * @param[in] param     parameter passed to the callback
+ *
+ * @api
+ */
+void pioSetBlockCallback(const rp_pio_block_t *block,
+                         rp_pioisr_t func, void *param) {
+
+  osalSysLock();
+  pioSetBlockCallbackI(block, func, param);
+  osalSysUnlock();
 }
 
 /**

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.c
@@ -511,7 +511,8 @@ void pioSmFreeI(const rp_pio_sm_t *smp) {
   if (((pio.blocks[b].c0_allocated_mask |
         pio.blocks[b].c1_allocated_mask) == 0U) &&
       (pio.blocks[b].imem_allocated == 0U)) {
-    pio.blocks[b].block.func = NULL;
+    pio.blocks[b].block.func  = NULL;
+    pio.blocks[b].block.param = NULL;
     rp_peripheral_reset(smp->block->resets_mask);
   }
 }
@@ -647,10 +648,14 @@ void pioProgramUnloadI(const rp_pio_block_t *block,
   pio.blocks[b].imem_allocated &= ~mask;
 
   /* Reset PIO block if it became fully idle, no state machines allocated
-     by either core and no programs loaded.*/
+     by either core and no programs loaded. The reset wipes the INTE
+     routing, so the block callback is dropped with it, as in
+     pioSmFreeI().*/
   if (((pio.blocks[b].c0_allocated_mask |
         pio.blocks[b].c1_allocated_mask) == 0U) &&
       (pio.blocks[b].imem_allocated == 0U)) {
+    pio.blocks[b].block.func  = NULL;
+    pio.blocks[b].block.param = NULL;
     rp_peripheral_reset(block->resets_mask);
   }
 }

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -325,6 +325,13 @@
 
 /**
  * @brief   Type of a PIO ISR callback.
+ * @note    A block has a single interrupt line shared by its four state
+ *          machines, so the callback of every allocated state machine is
+ *          invoked on every interrupt of the block, each time with the
+ *          full IRQn_INTS word: a per state machine callback has to
+ *          select its own bits with the @p PIO_IRQ_* macros. Work that
+ *          must happen once per interrupt belongs in a block callback,
+ *          see @p pioSetBlockCallbackI().
  *
  * @param[in] p         parameter for the registered function
  * @param[in] ints      content of the IRQn_INTS register
@@ -475,6 +482,10 @@ extern "C" {
                          int32_t offset, uint32_t length);
   void pioSmInit(const rp_pio_sm_t *smp, uint32_t initial_pc,
                  const rp_pio_sm_config_t *cfgp);
+  void pioSetBlockCallbackI(const rp_pio_block_t *block,
+                            rp_pioisr_t func, void *param);
+  void pioSetBlockCallback(const rp_pio_block_t *block,
+                           rp_pioisr_t func, void *param);
   uint32_t pioGetSmAllocatedMask(const rp_pio_block_t *block);
   uint32_t pioGetImemAllocatedMask(const rp_pio_block_t *block);
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
@@ -1690,6 +1701,49 @@ __STATIC_INLINE void pioSmDisableInterruptX(const rp_pio_sm_t *smp,
 }
 
 /**
+ * @brief   Enables block interrupts on the current core.
+ * @details The IRQ flags a program raises with the IRQ instruction, and
+ *          the FIFO level interrupts, are properties of the block: the
+ *          mask is the same one @p pioSmEnableInterruptX() takes, but no
+ *          state machine has to be allocated to reach it.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] mask      interrupt mask (combination of PIO_IRQ_* bits)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioEnableInterruptX(const rp_pio_block_t *block,
+                                         uint32_t mask) {
+
+  osalDbgCheck(block != NULL);
+
+  if (SIO->CPUID == 0U) {
+    block->pio->SET.IRQ0_INTE = mask;
+  }
+  else {
+    block->pio->SET.IRQ1_INTE = mask;
+  }
+}
+
+/**
+ * @brief   Disables block interrupts.
+ * @note    Clears both cores' INTE unconditionally (avoids CPUID check).
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] mask      interrupt mask (combination of PIO_IRQ_* bits)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioDisableInterruptX(const rp_pio_block_t *block,
+                                          uint32_t mask) {
+
+  osalDbgCheck(block != NULL);
+
+  block->pio->CLR.IRQ0_INTE = mask;
+  block->pio->CLR.IRQ1_INTE = mask;
+}
+
+/**
  * @brief   Returns the state of the PIO IRQ flags of a block.
  * @details The eight flags are shared by all state machines of the
  *          block and can be set, cleared and waited on by them.
@@ -1825,26 +1879,26 @@ __STATIC_INLINE uint32_t pioSmGet(const rp_pio_sm_t *smp) {
 }
 
 /**
- * @brief   Routes a GPIO pin to the PIO block that owns this state machine.
+ * @brief   Routes a GPIO pin to a PIO block.
  * @details Sets IO_BANK0 FUNCSEL for the given pin to PIO0, PIO1, or PIO2
- *          based on the block index of the state machine.
+ *          based on the block index.
  * @note    Only the pin multiplexer is programmed; the pad control
  *          register (input enable, schmitt trigger, drive strength, and
  *          on the RP2350 the isolation latch) is left untouched. Use
- *          @p pioGpioInitX() for complete pin routing.
+ *          @p pioGpioRouteX() for complete pin routing.
  * @note    The @p gpio parameter is an absolute GPIO number. On devices
  *          with the @p RP_PIO_HAS_GPIOBASE capability (RP2350) the pin
  *          fields written into PINCTRL/EXECCTRL are instead relative to
  *          the window selected with @p pioSetGpioBase(), see
  *          @p pioGpioToRel().
  *
- * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] block     pointer to the PIO block descriptor
  * @param[in] gpio      absolute GPIO pin number
  *
  * @special
  */
-__STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
-                                           uint32_t gpio) {
+__STATIC_INLINE void pioSetPinFunctionX(const rp_pio_block_t *block,
+                                        uint32_t gpio) {
   static const uint32_t funcsel[] = {
     RP_PIO_FUNCSEL_PIO0,
     RP_PIO_FUNCSEL_PIO1,
@@ -1853,13 +1907,13 @@ __STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
 #endif
   };
 
-  osalDbgCheck(gpio < RP_GPIO_NUM_LINES);
+  osalDbgCheck((block != NULL) && (gpio < RP_GPIO_NUM_LINES));
 
-  IO_BANK0->GPIO[gpio].CTRL = funcsel[smp->block->pioidx];
+  IO_BANK0->GPIO[gpio].CTRL = funcsel[block->pioidx];
 }
 
 /**
- * @brief   Routes a GPIO pin to the PIO block with explicit pad control.
+ * @brief   Routes a GPIO pin to a PIO block with explicit pad control.
  * @details Programs both the pin multiplexer and the pad control register.
  *          On the RP2350 the pad is reprogrammed while still isolated and
  *          the isolation latch is cleared only after the multiplexer
@@ -1871,6 +1925,64 @@ __STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
  *          e.g. @p RP_PIO_PAD_DEFAULT | @p RP_PIO_PAD_PUE for an
  *          open-drain bus with pull-up.
  *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] gpio      absolute GPIO pin number
+ * @param[in] padbits   pad control value, combination of @p RP_PIO_PAD_*
+ *                      bits (excluding @p RP_PIO_PAD_ISO)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioGpioRoutePadX(const rp_pio_block_t *block,
+                                      uint32_t gpio, uint32_t padbits) {
+
+  osalDbgCheck((gpio < RP_GPIO_NUM_LINES) && (padbits <= 0xFFU));
+
+#if defined(RP2350)
+  PADS_BANK0->GPIO[gpio] = padbits | RP_PIO_PAD_ISO;
+  pioSetPinFunctionX(block, gpio);
+  PADS_BANK0->GPIO[gpio] = padbits;
+#else
+  PADS_BANK0->GPIO[gpio] = padbits;
+  pioSetPinFunctionX(block, gpio);
+#endif
+}
+
+/**
+ * @brief   Routes a GPIO pin to a PIO block with default pad control.
+ * @details Equivalent to @p pioGpioRoutePadX() with @p RP_PIO_PAD_DEFAULT:
+ *          input enabled with schmitt trigger, 4mA drive, no pulls.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] gpio      absolute GPIO pin number
+ *
+ * @special
+ */
+__STATIC_INLINE void pioGpioRouteX(const rp_pio_block_t *block,
+                                   uint32_t gpio) {
+
+  pioGpioRoutePadX(block, gpio, RP_PIO_PAD_DEFAULT);
+}
+
+/**
+ * @brief   Routes a GPIO pin to the PIO block that owns this state machine.
+ * @details Equivalent to @p pioSetPinFunctionX() on @p smp->block.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] gpio      absolute GPIO pin number
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
+                                           uint32_t gpio) {
+
+  pioSetPinFunctionX(smp->block, gpio);
+}
+
+/**
+ * @brief   Routes a GPIO pin to the PIO block that owns this state
+ *          machine, with explicit pad control.
+ * @details Equivalent to @p pioGpioRoutePadX() on @p smp->block.
+ *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
  * @param[in] gpio      absolute GPIO pin number
  * @param[in] padbits   pad control value, combination of @p RP_PIO_PAD_*
@@ -1881,22 +1993,13 @@ __STATIC_INLINE void pioSmSetPinFunctionX(const rp_pio_sm_t *smp,
 __STATIC_INLINE void pioGpioInitPadX(const rp_pio_sm_t *smp,
                                      uint32_t gpio, uint32_t padbits) {
 
-  osalDbgCheck((gpio < RP_GPIO_NUM_LINES) && (padbits <= 0xFFU));
-
-#if defined(RP2350)
-  PADS_BANK0->GPIO[gpio] = padbits | RP_PIO_PAD_ISO;
-  pioSmSetPinFunctionX(smp, gpio);
-  PADS_BANK0->GPIO[gpio] = padbits;
-#else
-  PADS_BANK0->GPIO[gpio] = padbits;
-  pioSmSetPinFunctionX(smp, gpio);
-#endif
+  pioGpioRoutePadX(smp->block, gpio, padbits);
 }
 
 /**
- * @brief   Routes a GPIO pin to the PIO block with default pad control.
- * @details Equivalent to @p pioGpioInitPadX() with @p RP_PIO_PAD_DEFAULT:
- *          input enabled with schmitt trigger, 4mA drive, no pulls.
+ * @brief   Routes a GPIO pin to the PIO block that owns this state
+ *          machine, with default pad control.
+ * @details Equivalent to @p pioGpioRouteX() on @p smp->block.
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
  * @param[in] gpio      absolute GPIO pin number
@@ -1905,7 +2008,7 @@ __STATIC_INLINE void pioGpioInitPadX(const rp_pio_sm_t *smp,
  */
 __STATIC_INLINE void pioGpioInitX(const rp_pio_sm_t *smp, uint32_t gpio) {
 
-  pioGpioInitPadX(smp, gpio, RP_PIO_PAD_DEFAULT);
+  pioGpioRoutePadX(smp->block, gpio, RP_PIO_PAD_DEFAULT);
 }
 
 #if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -1705,7 +1705,14 @@ __STATIC_INLINE void pioSmDisableInterruptX(const rp_pio_sm_t *smp,
  * @details The IRQ flags a program raises with the IRQ instruction, and
  *          the FIFO level interrupts, are properties of the block: the
  *          mask is the same one @p pioSmEnableInterruptX() takes, but no
- *          state machine has to be allocated to reach it.
+ *          specific state machine handle is needed to reach it.
+ * @pre     The block is active: at least one state machine allocated or
+ *          one program loaded. An idle block is held in reset and the
+ *          INTE write is lost.
+ * @note    The PIO interrupt vector of a core is enabled while that core
+ *          has at least one state machine allocated, see
+ *          @p pioSmAllocI(): an enabled source only reaches the CPU
+ *          under that condition.
  *
  * @param[in] block     pointer to the PIO block descriptor
  * @param[in] mask      interrupt mask (combination of PIO_IRQ_* bits)

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -74,6 +74,17 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 15. Block interrupts: pioEnableInterruptX must reach only the current
+ *    core's INTE with no state machine allocated, and
+ *    pioDisableInterruptX must clear both cores' enables.
+ * 16. Block callback: pioSetBlockCallback must run exactly once per
+ *    interrupt, before the per state machine callbacks, and NULL must
+ *    remove it.
+ * 17. Block GPIO routing: pioGpioRoutePadX and pioGpioRouteX must
+ *    program the pad and the pin multiplexer through a block handle
+ *    with no state machine allocated.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries tests 15..17, the siblings land with theirs.)
  * 18. Runtime setters: pioSmSetWrapX, pioSmSetJmpPinX and the PINCTRL
  *    group setters must modify only their own fields, leaving the
  *    neighbouring fields bit-exact.
@@ -305,6 +316,34 @@ static bool check_addr_window(const rp_pio_sm_t *smp,
   }
 
   return true;
+}
+
+/*===========================================================================*/
+/* Test 16 callbacks.                                                        */
+/*===========================================================================*/
+
+static volatile uint32_t t16_block_runs;
+static volatile uint32_t t16_sm_runs;
+static volatile uint32_t t16_block_seq;
+static volatile uint32_t t16_sm_seq;
+static volatile uint32_t t16_seq;
+
+/* Both callbacks acknowledge the IRQ flags so the interrupt cannot
+   re-fire whichever of them is registered.*/
+static void t16_block_cb(void *p, uint32_t ints) {
+
+  (void)ints;
+  t16_block_runs++;
+  t16_block_seq = t16_seq++;
+  pioIrqClearX((const rp_pio_block_t *)p, 0xFFU);
+}
+
+static void t16_sm_cb(void *p, uint32_t ints) {
+
+  (void)ints;
+  t16_sm_runs++;
+  t16_sm_seq = t16_seq++;
+  pioIrqClearX((const rp_pio_block_t *)p, 0xFFU);
 }
 
 /*===========================================================================*/
@@ -1137,6 +1176,103 @@ int main(void) {
 
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
+  pioSmFree(smp);
+
+  /*
+   * Test 15: block level interrupt enables.
+   */
+  chprintf(chp, "--- Test 15: block interrupts\r\n");
+
+  report("no SMs allocated", pioGetSmAllocatedMask(block) == 0U);
+  report("INTE idle on entry", (block->pio->IRQ0_INTE == 0U) &&
+                               (block->pio->IRQ1_INTE == 0U));
+
+  pioEnableInterruptX(block, PIO_IRQ_SM(0));
+  report("enable reaches this core's INTE",
+         block->pio->IRQ0_INTE == PIO_IRQ_SM(0));
+  report("other core's INTE untouched", block->pio->IRQ1_INTE == 0U);
+
+  pioIrqForceX(block, 0x01U);
+  report("forced flag raises INTS",
+         (block->pio->IRQ0_INTS & PIO_IRQ_SM(0)) != 0U);
+
+  pioIrqClearX(block, 0x01U);
+  report("cleared flag drops INTS", block->pio->IRQ0_INTS == 0U);
+
+  pioIrqForceX(block, 0x01U);
+  pioDisableInterruptX(block, PIO_IRQ_SM(0));
+  report("disable clears both cores' INTE",
+         (block->pio->IRQ0_INTE == 0U) && (block->pio->IRQ1_INTE == 0U));
+  report("INTS masked while the flag is set", block->pio->IRQ0_INTS == 0U);
+  pioIrqClearX(block, 0xFFU);
+
+  /*
+   * Test 16: block level interrupt callback.
+   */
+  chprintf(chp, "--- Test 16: block callback\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t16_sm_cb, (void *)block);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  pioSetBlockCallback(block, t16_block_cb, (void *)block);
+  pioEnableInterruptX(block, PIO_IRQ_SM(0));
+
+  pioIrqForceX(block, 0x01U);
+  for (i = 0U; (i < 1000U) && (t16_sm_runs == 0U); i++) {
+    delay_us(1U);
+  }
+  report("block callback ran once", t16_block_runs == 1U);
+  report("SM callback ran once", t16_sm_runs == 1U);
+  report("block callback ran first", t16_block_seq < t16_sm_seq);
+  report("flag acknowledged in the callback", pioIrqGetX(block) == 0U);
+
+  pioSetBlockCallback(block, NULL, NULL);
+  pioIrqForceX(block, 0x01U);
+  for (i = 0U; (i < 1000U) && (t16_sm_runs < 2U); i++) {
+    delay_us(1U);
+  }
+  report("removed callback stays silent", t16_block_runs == 1U);
+  report("SM callback keeps running", t16_sm_runs == 2U);
+
+  pioDisableInterruptX(block, PIO_IRQ_SM(0));
+  pioIrqClearX(block, 0xFFU);
+  pioSmFree(smp);
+
+  /*
+   * Test 17: block level GPIO routing.
+   */
+  chprintf(chp, "--- Test 17: block GPIO routing\r\n");
+
+  report("routed with no SM allocated", pioGetSmAllocatedMask(block) == 0U);
+
+  pioGpioRoutePadX(block, TEST_GPIO, RP_PIO_PAD_DEFAULT | RP_PIO_PAD_PUE);
+  report("pull-up reaches the pad",
+         (PADS_BANK0->GPIO[TEST_GPIO] & RP_PIO_PAD_PUE) != 0U);
+
+  pioGpioRouteX(block, TEST_GPIO);
+  report("default pad restored",
+         PADS_BANK0->GPIO[TEST_GPIO] == RP_PIO_PAD_DEFAULT);
+  report("pin muxed to the block",
+         (IO_BANK0->GPIO[TEST_GPIO].CTRL & 0x1FU) == RP_PIO_FUNCSEL_PIO0);
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("program loaded", sq_off >= 0);
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges(TEST_GPIO);
+  report("square wave through the routed pin",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
   pioSmFree(smp);
 
   /*

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -74,9 +74,11 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
- * 15. Block interrupts: pioEnableInterruptX must reach only the current
- *    core's INTE with no state machine allocated, and
- *    pioDisableInterruptX must clear both cores' enables.
+ * 15. Block interrupts: on an active block pioEnableInterruptX must
+ *    reach only the current core's INTE through the block handle, a
+ *    forced flag must travel flag -> INTS -> ISR, and
+ *    pioDisableInterruptX must clear both cores' enables leaving the
+ *    flag pending but masked.
  * 16. Block callback: pioSetBlockCallback must run exactly once per
  *    interrupt, before the per state machine callbacks, and NULL must
  *    remove it.
@@ -319,8 +321,18 @@ static bool check_addr_window(const rp_pio_sm_t *smp,
 }
 
 /*===========================================================================*/
-/* Test 16 callbacks.                                                        */
+/* Test 15/16 callbacks.                                                     */
 /*===========================================================================*/
+
+static volatile uint32_t t15_runs;
+
+/* Acknowledges the IRQ flags so the interrupt cannot re-fire.*/
+static void t15_sm_cb(void *p, uint32_t ints) {
+
+  (void)ints;
+  t15_runs++;
+  pioIrqClearX((const rp_pio_block_t *)p, 0xFFU);
+}
 
 static volatile uint32_t t16_block_runs;
 static volatile uint32_t t16_sm_runs;
@@ -1183,7 +1195,15 @@ int main(void) {
    */
   chprintf(chp, "--- Test 15: block interrupts\r\n");
 
-  report("no SMs allocated", pioGetSmAllocatedMask(block) == 0U);
+  /* An active block is needed: an idle one is held in reset and the
+     INTE write would be lost. SM0 also keeps this core's vector
+     enabled, with a callback that acknowledges the flags.*/
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t15_sm_cb, (void *)block);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
   report("INTE idle on entry", (block->pio->IRQ0_INTE == 0U) &&
                                (block->pio->IRQ1_INTE == 0U));
 
@@ -1192,19 +1212,30 @@ int main(void) {
          block->pio->IRQ0_INTE == PIO_IRQ_SM(0));
   report("other core's INTE untouched", block->pio->IRQ1_INTE == 0U);
 
+  /* A forced flag must travel flag -> INTS -> ISR through the block
+     level enable; the callback acknowledges it.*/
   pioIrqForceX(block, 0x01U);
-  report("forced flag raises INTS",
-         (block->pio->IRQ0_INTS & PIO_IRQ_SM(0)) != 0U);
+  for (i = 0U; (i < 1000U) && (t15_runs == 0U); i++) {
+    delay_us(1U);
+  }
+  report("forced flag reaches the ISR", t15_runs == 1U);
+  report("flag acknowledged by the callback", pioIrqGetX(block) == 0U);
+  report("INTS idle after the acknowledge", block->pio->IRQ0_INTS == 0U);
 
-  pioIrqClearX(block, 0x01U);
-  report("cleared flag drops INTS", block->pio->IRQ0_INTS == 0U);
-
-  pioIrqForceX(block, 0x01U);
   pioDisableInterruptX(block, PIO_IRQ_SM(0));
   report("disable clears both cores' INTE",
          (block->pio->IRQ0_INTE == 0U) && (block->pio->IRQ1_INTE == 0U));
+
+  /* With the source disabled a forced flag stays pending and masked:
+     visible in the flag state, absent from INTS, no interrupt.*/
+  pioIrqForceX(block, 0x01U);
+  delay_us(100U);
+  report("masked flag does not interrupt", t15_runs == 1U);
+  report("flag visible while masked", pioIrqGetX(block) == 0x01U);
   report("INTS masked while the flag is set", block->pio->IRQ0_INTS == 0U);
+
   pioIrqClearX(block, 0xFFU);
+  pioSmFree(smp);
 
   /*
    * Test 16: block level interrupt callback.

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -80,8 +80,9 @@
  *    pioDisableInterruptX must clear both cores' enables leaving the
  *    flag pending but masked.
  * 16. Block callback: pioSetBlockCallback must run exactly once per
- *    interrupt, before the per state machine callbacks, and NULL must
- *    remove it.
+ *    interrupt, before the per state machine callbacks, NULL must
+ *    remove it, and it must not survive the block going idle by any
+ *    route, the program unload path included.
  * 17. Block GPIO routing: pioGpioRoutePadX and pioGpioRouteX must
  *    program the pad and the pin multiplexer through a block handle
  *    with no state machine allocated.
@@ -1267,6 +1268,37 @@ int main(void) {
   }
   report("removed callback stays silent", t16_block_runs == 1U);
   report("SM callback keeps running", t16_sm_runs == 2U);
+
+  pioDisableInterruptX(block, PIO_IRQ_SM(0));
+  pioIrqClearX(block, 0xFFU);
+  pioSmFree(smp);
+
+  /* A block callback must not survive the block going idle by any
+     route: here the last release happens through the program unload
+     path, not the state machine free.*/
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t16_sm_cb, (void *)block);
+  report("SM0 reallocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+  pioSetBlockCallback(block, t16_block_cb, (void *)block);
+  off1 = pioProgramLoad(block, &single_program);
+  report("program loaded", off1 >= 0);
+  pioSmFree(smp);
+  pioProgramUnload(block, off1, single_program.length);
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t16_sm_cb, (void *)block);
+  report("SM0 allocated after the idle", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+  pioEnableInterruptX(block, PIO_IRQ_SM(0));
+  pioIrqForceX(block, 0x01U);
+  for (i = 0U; (i < 1000U) && (t16_sm_runs < 3U); i++) {
+    delay_us(1U);
+  }
+  report("SM callback ran after the realloc", t16_sm_runs == 3U);
+  report("unload-path teardown dropped the callback", t16_block_runs == 1U);
 
   pioDisableInterruptX(block, PIO_IRQ_SM(0));
   pioIrqClearX(block, 0xFFU);

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -74,6 +74,17 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 15. Block interrupts: pioEnableInterruptX must reach only the current
+ *    core's INTE with no state machine allocated, and
+ *    pioDisableInterruptX must clear both cores' enables.
+ * 16. Block callback: pioSetBlockCallback must run exactly once per
+ *    interrupt, before the per state machine callbacks, and NULL must
+ *    remove it.
+ * 17. Block GPIO routing: pioGpioRoutePadX and pioGpioRouteX must
+ *    program the pad and the pin multiplexer through a block handle
+ *    with no state machine allocated.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries tests 15..17, the siblings land with theirs.)
  * 18. Runtime setters: pioSmSetWrapX, pioSmSetJmpPinX and the PINCTRL
  *    group setters must modify only their own fields, leaving the
  *    neighbouring fields bit-exact.
@@ -305,6 +316,34 @@ static bool check_addr_window(const rp_pio_sm_t *smp,
   }
 
   return true;
+}
+
+/*===========================================================================*/
+/* Test 16 callbacks.                                                        */
+/*===========================================================================*/
+
+static volatile uint32_t t16_block_runs;
+static volatile uint32_t t16_sm_runs;
+static volatile uint32_t t16_block_seq;
+static volatile uint32_t t16_sm_seq;
+static volatile uint32_t t16_seq;
+
+/* Both callbacks acknowledge the IRQ flags so the interrupt cannot
+   re-fire whichever of them is registered.*/
+static void t16_block_cb(void *p, uint32_t ints) {
+
+  (void)ints;
+  t16_block_runs++;
+  t16_block_seq = t16_seq++;
+  pioIrqClearX((const rp_pio_block_t *)p, 0xFFU);
+}
+
+static void t16_sm_cb(void *p, uint32_t ints) {
+
+  (void)ints;
+  t16_sm_runs++;
+  t16_sm_seq = t16_seq++;
+  pioIrqClearX((const rp_pio_block_t *)p, 0xFFU);
 }
 
 /*===========================================================================*/
@@ -1137,6 +1176,105 @@ int main(void) {
 
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
+  pioSmFree(smp);
+
+  /*
+   * Test 15: block level interrupt enables.
+   */
+  chprintf(chp, "--- Test 15: block interrupts\r\n");
+
+  report("no SMs allocated", pioGetSmAllocatedMask(block) == 0U);
+  report("INTE idle on entry", (block->pio->IRQ0_INTE == 0U) &&
+                               (block->pio->IRQ1_INTE == 0U));
+
+  pioEnableInterruptX(block, PIO_IRQ_SM(0));
+  report("enable reaches this core's INTE",
+         block->pio->IRQ0_INTE == PIO_IRQ_SM(0));
+  report("other core's INTE untouched", block->pio->IRQ1_INTE == 0U);
+
+  pioIrqForceX(block, 0x01U);
+  report("forced flag raises INTS",
+         (block->pio->IRQ0_INTS & PIO_IRQ_SM(0)) != 0U);
+
+  pioIrqClearX(block, 0x01U);
+  report("cleared flag drops INTS", block->pio->IRQ0_INTS == 0U);
+
+  pioIrqForceX(block, 0x01U);
+  pioDisableInterruptX(block, PIO_IRQ_SM(0));
+  report("disable clears both cores' INTE",
+         (block->pio->IRQ0_INTE == 0U) && (block->pio->IRQ1_INTE == 0U));
+  report("INTS masked while the flag is set", block->pio->IRQ0_INTS == 0U);
+  pioIrqClearX(block, 0xFFU);
+
+  /*
+   * Test 16: block level interrupt callback.
+   */
+  chprintf(chp, "--- Test 16: block callback\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t16_sm_cb, (void *)block);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  pioSetBlockCallback(block, t16_block_cb, (void *)block);
+  pioEnableInterruptX(block, PIO_IRQ_SM(0));
+
+  pioIrqForceX(block, 0x01U);
+  for (i = 0U; (i < 1000U) && (t16_sm_runs == 0U); i++) {
+    delay_us(1U);
+  }
+  report("block callback ran once", t16_block_runs == 1U);
+  report("SM callback ran once", t16_sm_runs == 1U);
+  report("block callback ran first", t16_block_seq < t16_sm_seq);
+  report("flag acknowledged in the callback", pioIrqGetX(block) == 0U);
+
+  pioSetBlockCallback(block, NULL, NULL);
+  pioIrqForceX(block, 0x01U);
+  for (i = 0U; (i < 1000U) && (t16_sm_runs < 2U); i++) {
+    delay_us(1U);
+  }
+  report("removed callback stays silent", t16_block_runs == 1U);
+  report("SM callback keeps running", t16_sm_runs == 2U);
+
+  pioDisableInterruptX(block, PIO_IRQ_SM(0));
+  pioIrqClearX(block, 0xFFU);
+  pioSmFree(smp);
+
+  /*
+   * Test 17: block level GPIO routing.
+   */
+  chprintf(chp, "--- Test 17: block GPIO routing\r\n");
+
+  report("routed with no SM allocated", pioGetSmAllocatedMask(block) == 0U);
+
+  pioGpioRoutePadX(block, TEST_GPIO, RP_PIO_PAD_DEFAULT | RP_PIO_PAD_PUE);
+  report("pull-up reaches the pad",
+         (PADS_BANK0->GPIO[TEST_GPIO] & RP_PIO_PAD_PUE) != 0U);
+  report("pad isolation dropped",
+         (PADS_BANK0->GPIO[TEST_GPIO] & RP_PIO_PAD_ISO) == 0U);
+
+  pioGpioRouteX(block, TEST_GPIO);
+  report("default pad restored",
+         PADS_BANK0->GPIO[TEST_GPIO] == RP_PIO_PAD_DEFAULT);
+  report("pin muxed to the block",
+         (IO_BANK0->GPIO[TEST_GPIO].CTRL & 0x1FU) == RP_PIO_FUNCSEL_PIO0);
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("program loaded", sq_off >= 0);
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges(TEST_GPIO);
+  report("square wave through the routed pin",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
   pioSmFree(smp);
 
   /*

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -74,9 +74,11 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
- * 15. Block interrupts: pioEnableInterruptX must reach only the current
- *    core's INTE with no state machine allocated, and
- *    pioDisableInterruptX must clear both cores' enables.
+ * 15. Block interrupts: on an active block pioEnableInterruptX must
+ *    reach only the current core's INTE through the block handle, a
+ *    forced flag must travel flag -> INTS -> ISR, and
+ *    pioDisableInterruptX must clear both cores' enables leaving the
+ *    flag pending but masked.
  * 16. Block callback: pioSetBlockCallback must run exactly once per
  *    interrupt, before the per state machine callbacks, and NULL must
  *    remove it.
@@ -319,8 +321,18 @@ static bool check_addr_window(const rp_pio_sm_t *smp,
 }
 
 /*===========================================================================*/
-/* Test 16 callbacks.                                                        */
+/* Test 15/16 callbacks.                                                     */
 /*===========================================================================*/
+
+static volatile uint32_t t15_runs;
+
+/* Acknowledges the IRQ flags so the interrupt cannot re-fire.*/
+static void t15_sm_cb(void *p, uint32_t ints) {
+
+  (void)ints;
+  t15_runs++;
+  pioIrqClearX((const rp_pio_block_t *)p, 0xFFU);
+}
 
 static volatile uint32_t t16_block_runs;
 static volatile uint32_t t16_sm_runs;
@@ -1183,7 +1195,15 @@ int main(void) {
    */
   chprintf(chp, "--- Test 15: block interrupts\r\n");
 
-  report("no SMs allocated", pioGetSmAllocatedMask(block) == 0U);
+  /* An active block is needed: an idle one is held in reset and the
+     INTE write would be lost. SM0 also keeps this core's vector
+     enabled, with a callback that acknowledges the flags.*/
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t15_sm_cb, (void *)block);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
   report("INTE idle on entry", (block->pio->IRQ0_INTE == 0U) &&
                                (block->pio->IRQ1_INTE == 0U));
 
@@ -1192,19 +1212,30 @@ int main(void) {
          block->pio->IRQ0_INTE == PIO_IRQ_SM(0));
   report("other core's INTE untouched", block->pio->IRQ1_INTE == 0U);
 
+  /* A forced flag must travel flag -> INTS -> ISR through the block
+     level enable; the callback acknowledges it.*/
   pioIrqForceX(block, 0x01U);
-  report("forced flag raises INTS",
-         (block->pio->IRQ0_INTS & PIO_IRQ_SM(0)) != 0U);
+  for (i = 0U; (i < 1000U) && (t15_runs == 0U); i++) {
+    delay_us(1U);
+  }
+  report("forced flag reaches the ISR", t15_runs == 1U);
+  report("flag acknowledged by the callback", pioIrqGetX(block) == 0U);
+  report("INTS idle after the acknowledge", block->pio->IRQ0_INTS == 0U);
 
-  pioIrqClearX(block, 0x01U);
-  report("cleared flag drops INTS", block->pio->IRQ0_INTS == 0U);
-
-  pioIrqForceX(block, 0x01U);
   pioDisableInterruptX(block, PIO_IRQ_SM(0));
   report("disable clears both cores' INTE",
          (block->pio->IRQ0_INTE == 0U) && (block->pio->IRQ1_INTE == 0U));
+
+  /* With the source disabled a forced flag stays pending and masked:
+     visible in the flag state, absent from INTS, no interrupt.*/
+  pioIrqForceX(block, 0x01U);
+  delay_us(100U);
+  report("masked flag does not interrupt", t15_runs == 1U);
+  report("flag visible while masked", pioIrqGetX(block) == 0x01U);
   report("INTS masked while the flag is set", block->pio->IRQ0_INTS == 0U);
+
   pioIrqClearX(block, 0xFFU);
+  pioSmFree(smp);
 
   /*
    * Test 16: block level interrupt callback.

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -80,8 +80,9 @@
  *    pioDisableInterruptX must clear both cores' enables leaving the
  *    flag pending but masked.
  * 16. Block callback: pioSetBlockCallback must run exactly once per
- *    interrupt, before the per state machine callbacks, and NULL must
- *    remove it.
+ *    interrupt, before the per state machine callbacks, NULL must
+ *    remove it, and it must not survive the block going idle by any
+ *    route, the program unload path included.
  * 17. Block GPIO routing: pioGpioRoutePadX and pioGpioRouteX must
  *    program the pad and the pin multiplexer through a block handle
  *    with no state machine allocated.
@@ -1267,6 +1268,37 @@ int main(void) {
   }
   report("removed callback stays silent", t16_block_runs == 1U);
   report("SM callback keeps running", t16_sm_runs == 2U);
+
+  pioDisableInterruptX(block, PIO_IRQ_SM(0));
+  pioIrqClearX(block, 0xFFU);
+  pioSmFree(smp);
+
+  /* A block callback must not survive the block going idle by any
+     route: here the last release happens through the program unload
+     path, not the state machine free.*/
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t16_sm_cb, (void *)block);
+  report("SM0 reallocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+  pioSetBlockCallback(block, t16_block_cb, (void *)block);
+  off1 = pioProgramLoad(block, &single_program);
+  report("program loaded", off1 >= 0);
+  pioSmFree(smp);
+  pioProgramUnload(block, off1, single_program.length);
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, t16_sm_cb, (void *)block);
+  report("SM0 allocated after the idle", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+  pioEnableInterruptX(block, PIO_IRQ_SM(0));
+  pioIrqForceX(block, 0x01U);
+  for (i = 0U; (i < 1000U) && (t16_sm_runs < 3U); i++) {
+    delay_us(1U);
+  }
+  report("SM callback ran after the realloc", t16_sm_runs == 3U);
+  report("unload-path teardown dropped the callback", t16_block_runs == 1U);
 
   pioDisableInterruptX(block, PIO_IRQ_SM(0));
   pioIrqClearX(block, 0xFFU);


### PR DESCRIPTION
## Summary

`IRQ0_INTE`/`IRQ1_INTE`, the block interrupt line and IO_BANK0 FUNCSEL are PIO block resources, but the driver only reached them through a state machine handle. A consumer that routes its pins or enables a block interrupt before allocating any state machine — or that needs work done exactly once per interrupt — had no function to call. The nanoFramework PIO binding (nanoframework/nf-interpreter#3449) open-codes all three today: raw INTE writes, raw once-per-interrupt acknowledgement in its callback, and raw IO_BANK0/PADS_BANK0 writes including a hand-rolled RP2350 isolation sequence.

This PR:

- adds `pioEnableInterruptX()`/`pioDisableInterruptX()` taking the block descriptor and the same `PIO_IRQ_*` masks as the per state machine pair: enable programs the current core's INTE (selected by `SIO->CPUID`), disable clears both cores' unconditionally, matching the existing Sm semantics;
- adds `pioSetBlockCallback()`/`pioSetBlockCallbackI()`: a callback invoked exactly once per interrupt of the block, before the per state machine callbacks, with the same `IRQn_INTS` word. The driver acknowledges nothing itself and `IRQn_INTS` is derived from INTR and the FIFO levels, so unless a handler clears the source the interrupt re-fires; with only per state machine callbacks that acknowledgement is either duplicated N ways or coordinated out of band. A block with no callback registered behaves exactly as before (NULL fast-path in the ISR);
- adds block level GPIO routing: `pioSetPinFunctionX()`, `pioGpioRoutePadX()` and `pioGpioRouteX()` take the block descriptor. The existing `pioSmSetPinFunctionX()`, `pioGpioInitPadX()` and `pioGpioInitX()` keep their names, signatures and emitted register writes and now forward to the block versions — their bodies only ever consumed `smp->block`, so this is a pure refactor for existing callers. The RP2350 glitch-free pad isolation sequence now lives in one place, `pioGpioRoutePadX()`.

PIO-VALIDATION grows tests 15..17: block interrupt enables with no state machine allocated (current-core INTE only, both-core disable, INTS follows the forced flag), block callback ordering and NULL removal, and routing before allocation with pad pull readback plus the RP2350 ISO drop. Test numbers 15..22 are reserved across this PIO API series; the header note in `main.c` documents the reservation, this branch carries only its own tests.

## Related

- Issue(s): —
- Notes for reviewers: the block routing pair could not reuse the `pioGpioInitPadX`/`pioGpioInitX` names (taken by the state machine versions, no overloading in C); `pioGpioRoute*X` follows the "Routes a GPIO pin" wording the existing doc already uses. If you would rather rename the Sm variants and free the short names for the block, happy to rework. Independent of the other three PRs in this series (runtime setters/readback, patching/synchronized enable, instruction encoders), which will follow.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files (`tools/style/stylecheck.py` on `rp_pio.c`, `rp_pio.h` and both `main.c`)
- [x] Build check passed: RP2040 PIO-VALIDATION (Cortex-M0+), RP2350 PIO-VALIDATION (Cortex-M33) and RP2350 PIO-VALIDATION-RISCV compile clean

## Testing

- [x] Test run successfully locally
- RP2350 leg run on a Pico 2: **139 pass, 0 fail**; RP2040 leg run on a Pico W: **123 pass, 0 fail** (reports captured from UART0).

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

The three Sm-handle GPIO functions are unchanged in name, signature and behavior (one-line forwarders). The block callback adds one NULL check to the ISR fast path. Test 15 includes a sub-case asserting that a flag raised through `IRQ_FORCE` is visible in `pioIrqGetX()` and clearable with `pioIrqClearX()`, as their documentation states; if the device run contradicts that, a `pioIrqGetForcedX()` accessor will be added to this PR.




