### PR TITLE
RP PIOv1: add runtime state machine setters and readback

### DIFF
--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -1099,22 +1099,22 @@ __STATIC_INLINE void pioSmSetPinctrlX(const rp_pio_sm_t *smp,
  *          @p RP_PIO_HAS_GPIOBASE capability, see @p pioGpioToRel().
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
- * @param[in] base      first pin of the OUT group (0..31)
+ * @param[in] pin_base  first pin of the OUT group (0..31)
  * @param[in] count     number of pins in the OUT group (0..32)
  *
  * @special
  */
 __STATIC_INLINE void pioSmSetOutPinsX(const rp_pio_sm_t *smp,
-                                      uint32_t base, uint32_t count) {
+                                      uint32_t pin_base, uint32_t count) {
   uint32_t pinctrl;
 
-  osalDbgCheck((base < 32U) && (count <= 32U));
+  osalDbgCheck((pin_base < 32U) && (count <= 32U));
 
   pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
   smp->block->pio->SM[smp->smidx].PINCTRL =
     (pinctrl & ~(PIO_SM_PINCTRL_OUT_BASE_Msk |
                  PIO_SM_PINCTRL_OUT_COUNT_Msk)) |
-    (base << PIO_SM_PINCTRL_OUT_BASE_Pos) |
+    (pin_base << PIO_SM_PINCTRL_OUT_BASE_Pos) |
     (count << PIO_SM_PINCTRL_OUT_COUNT_Pos);
 }
 
@@ -1126,71 +1126,71 @@ __STATIC_INLINE void pioSmSetOutPinsX(const rp_pio_sm_t *smp,
  *          @p RP_PIO_HAS_GPIOBASE capability, see @p pioGpioToRel().
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
- * @param[in] base      first pin of the SET group (0..31)
+ * @param[in] pin_base  first pin of the SET group (0..31)
  * @param[in] count     number of pins in the SET group (0..5)
  *
  * @special
  */
 __STATIC_INLINE void pioSmSetSetPinsX(const rp_pio_sm_t *smp,
-                                      uint32_t base, uint32_t count) {
+                                      uint32_t pin_base, uint32_t count) {
   uint32_t pinctrl;
 
-  osalDbgCheck((base < 32U) && (count <= 5U));
+  osalDbgCheck((pin_base < 32U) && (count <= 5U));
 
   pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
   smp->block->pio->SM[smp->smidx].PINCTRL =
     (pinctrl & ~(PIO_SM_PINCTRL_SET_BASE_Msk |
                  PIO_SM_PINCTRL_SET_COUNT_Msk)) |
-    (base << PIO_SM_PINCTRL_SET_BASE_Pos) |
+    (pin_base << PIO_SM_PINCTRL_SET_BASE_Pos) |
     (count << PIO_SM_PINCTRL_SET_COUNT_Pos);
 }
 
 /**
- * @brief   Sets the IN pin base of a running state machine.
+ * @brief   Sets the IN pins of a running state machine.
  * @details Only the IN_BASE field of PINCTRL is modified, the runtime
  *          counterpart of @p pioSmConfigSetInPinsX(). Pin numbers are
  *          block-relative on devices with the @p RP_PIO_HAS_GPIOBASE
  *          capability, see @p pioGpioToRel().
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
- * @param[in] base      first pin of the IN group (0..31)
+ * @param[in] pin_base  first pin of the IN group (0..31)
  *
  * @special
  */
-__STATIC_INLINE void pioSmSetInPinBaseX(const rp_pio_sm_t *smp,
-                                        uint32_t base) {
+__STATIC_INLINE void pioSmSetInPinsX(const rp_pio_sm_t *smp,
+                                     uint32_t pin_base) {
   uint32_t pinctrl;
 
-  osalDbgCheck(base < 32U);
+  osalDbgCheck(pin_base < 32U);
 
   pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
   smp->block->pio->SM[smp->smidx].PINCTRL =
     (pinctrl & ~PIO_SM_PINCTRL_IN_BASE_Msk) |
-    (base << PIO_SM_PINCTRL_IN_BASE_Pos);
+    (pin_base << PIO_SM_PINCTRL_IN_BASE_Pos);
 }
 
 /**
- * @brief   Sets the side-set pin base of a running state machine.
+ * @brief   Sets the side-set pin pin_base of a running state machine.
  * @details Only the SIDESET_BASE field of PINCTRL is modified, the runtime
  *          counterpart of @p pioSmConfigSetSidesetPinsX(). Pin numbers are
  *          block-relative on devices with the @p RP_PIO_HAS_GPIOBASE
  *          capability, see @p pioGpioToRel().
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
- * @param[in] base      first pin of the side-set group (0..31)
+ * @param[in] pin_base  first pin of the side-set group (0..31)
  *
  * @special
  */
 __STATIC_INLINE void pioSmSetSidesetPinsX(const rp_pio_sm_t *smp,
-                                          uint32_t base) {
+                                          uint32_t pin_base) {
   uint32_t pinctrl;
 
-  osalDbgCheck(base < 32U);
+  osalDbgCheck(pin_base < 32U);
 
   pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
   smp->block->pio->SM[smp->smidx].PINCTRL =
     (pinctrl & ~PIO_SM_PINCTRL_SIDESET_BASE_Msk) |
-    (base << PIO_SM_PINCTRL_SIDESET_BASE_Pos);
+    (pin_base << PIO_SM_PINCTRL_SIDESET_BASE_Pos);
 }
 
 /**
@@ -1913,6 +1913,9 @@ __STATIC_INLINE void pioGpioInitX(const rp_pio_sm_t *smp, uint32_t gpio) {
  * @brief   Returns the GPIO window base of a block.
  * @details The dual of @p pioSetGpioBase(): the base of the 32-pin GPIO
  *          window the pin fields of PINCTRL/EXECCTRL are relative to.
+ * @note    The value is only meaningful on a block that has been
+ *          configured or is active: an idle block is held in reset and
+ *          reads back 0, which coincides with the default window.
  *
  * @param[in] block     pointer to the PIO block descriptor
  * @return              The GPIOBASE register value, 0 or 16.

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -1170,7 +1170,7 @@ __STATIC_INLINE void pioSmSetInPinsX(const rp_pio_sm_t *smp,
 }
 
 /**
- * @brief   Sets the side-set pin pin_base of a running state machine.
+ * @brief   Sets the side-set pin base of a running state machine.
  * @details Only the SIDESET_BASE field of PINCTRL is modified, the runtime
  *          counterpart of @p pioSmConfigSetSidesetPinsX(). Pin numbers are
  *          block-relative on devices with the @p RP_PIO_HAS_GPIOBASE

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -983,6 +983,22 @@ __STATIC_INLINE void pioSmSetClkdivX(const rp_pio_sm_t *smp,
 }
 
 /**
+ * @brief   Returns the clock divider of a state machine.
+ * @details The raw CLKDIV register value, decomposable with the
+ *          @p PIO_SM_CLKDIV_INT_Msk/Pos and @p PIO_SM_CLKDIV_FRAC_Msk/Pos
+ *          macros.
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @return              The CLKDIV register value.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioSmGetClkdivX(const rp_pio_sm_t *smp) {
+
+  return smp->block->pio->SM[smp->smidx].CLKDIV;
+}
+
+/**
  * @brief   Sets the execution control of a state machine.
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
@@ -994,6 +1010,57 @@ __STATIC_INLINE void pioSmSetExecctrlX(const rp_pio_sm_t *smp,
                                         uint32_t execctrl) {
 
   smp->block->pio->SM[smp->smidx].EXECCTRL = execctrl;
+}
+
+/**
+ * @brief   Sets the program wrap range of a running state machine.
+ * @details Only the wrap fields of EXECCTRL are modified, everything else
+ *          in the register keeps its value. Repointing the wrap at another
+ *          program without disturbing the pin and side-set configuration is
+ *          how a single state machine is reused for several programs.
+ * @note    Both values are absolute instruction memory addresses, as in
+ *          @p pioSmConfigSetWrapX().
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] bottom    address to wrap from, i.e. wrap_target (0..31)
+ * @param[in] top       address to wrap after, i.e. wrap (0..31)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetWrapX(const rp_pio_sm_t *smp,
+                                   uint32_t bottom, uint32_t top) {
+  uint32_t execctrl;
+
+  osalDbgCheck((bottom < RP_PIO_NUM_INSTR_MEM) &&
+               (top < RP_PIO_NUM_INSTR_MEM));
+
+  execctrl = smp->block->pio->SM[smp->smidx].EXECCTRL;
+  smp->block->pio->SM[smp->smidx].EXECCTRL =
+    (execctrl & ~(PIO_SM_EXECCTRL_WRAP_BOTTOM_Msk |
+                  PIO_SM_EXECCTRL_WRAP_TOP_Msk)) |
+    PIO_SM_EXECCTRL_WRAP(bottom, top);
+}
+
+/**
+ * @brief   Sets the JMP PIN input of a running state machine.
+ * @details Only the JMP_PIN field of EXECCTRL is modified. The pin number
+ *          is block-relative on devices with the @p RP_PIO_HAS_GPIOBASE
+ *          capability, see @p pioGpioToRel().
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] pin       pin for the JMP PIN condition (0..31)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetJmpPinX(const rp_pio_sm_t *smp, uint32_t pin) {
+  uint32_t execctrl;
+
+  osalDbgCheck(pin < 32U);
+
+  execctrl = smp->block->pio->SM[smp->smidx].EXECCTRL;
+  smp->block->pio->SM[smp->smidx].EXECCTRL =
+    (execctrl & ~PIO_SM_EXECCTRL_JMP_PIN_Msk) |
+    (pin << PIO_SM_EXECCTRL_JMP_PIN_Pos);
 }
 
 /**
@@ -1022,6 +1089,108 @@ __STATIC_INLINE void pioSmSetPinctrlX(const rp_pio_sm_t *smp,
                                        uint32_t pinctrl) {
 
   smp->block->pio->SM[smp->smidx].PINCTRL = pinctrl;
+}
+
+/**
+ * @brief   Sets the OUT pin group of a running state machine.
+ * @details Only the OUT_BASE and OUT_COUNT fields of PINCTRL are modified,
+ *          the runtime counterpart of @p pioSmConfigSetOutPinsX(). Pin
+ *          numbers are block-relative on devices with the
+ *          @p RP_PIO_HAS_GPIOBASE capability, see @p pioGpioToRel().
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] base      first pin of the OUT group (0..31)
+ * @param[in] count     number of pins in the OUT group (0..32)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetOutPinsX(const rp_pio_sm_t *smp,
+                                      uint32_t base, uint32_t count) {
+  uint32_t pinctrl;
+
+  osalDbgCheck((base < 32U) && (count <= 32U));
+
+  pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
+  smp->block->pio->SM[smp->smidx].PINCTRL =
+    (pinctrl & ~(PIO_SM_PINCTRL_OUT_BASE_Msk |
+                 PIO_SM_PINCTRL_OUT_COUNT_Msk)) |
+    (base << PIO_SM_PINCTRL_OUT_BASE_Pos) |
+    (count << PIO_SM_PINCTRL_OUT_COUNT_Pos);
+}
+
+/**
+ * @brief   Sets the SET pin group of a running state machine.
+ * @details Only the SET_BASE and SET_COUNT fields of PINCTRL are modified,
+ *          the runtime counterpart of @p pioSmConfigSetSetPinsX(). Pin
+ *          numbers are block-relative on devices with the
+ *          @p RP_PIO_HAS_GPIOBASE capability, see @p pioGpioToRel().
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] base      first pin of the SET group (0..31)
+ * @param[in] count     number of pins in the SET group (0..5)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetSetPinsX(const rp_pio_sm_t *smp,
+                                      uint32_t base, uint32_t count) {
+  uint32_t pinctrl;
+
+  osalDbgCheck((base < 32U) && (count <= 5U));
+
+  pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
+  smp->block->pio->SM[smp->smidx].PINCTRL =
+    (pinctrl & ~(PIO_SM_PINCTRL_SET_BASE_Msk |
+                 PIO_SM_PINCTRL_SET_COUNT_Msk)) |
+    (base << PIO_SM_PINCTRL_SET_BASE_Pos) |
+    (count << PIO_SM_PINCTRL_SET_COUNT_Pos);
+}
+
+/**
+ * @brief   Sets the IN pin base of a running state machine.
+ * @details Only the IN_BASE field of PINCTRL is modified, the runtime
+ *          counterpart of @p pioSmConfigSetInPinsX(). Pin numbers are
+ *          block-relative on devices with the @p RP_PIO_HAS_GPIOBASE
+ *          capability, see @p pioGpioToRel().
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] base      first pin of the IN group (0..31)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetInPinBaseX(const rp_pio_sm_t *smp,
+                                        uint32_t base) {
+  uint32_t pinctrl;
+
+  osalDbgCheck(base < 32U);
+
+  pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
+  smp->block->pio->SM[smp->smidx].PINCTRL =
+    (pinctrl & ~PIO_SM_PINCTRL_IN_BASE_Msk) |
+    (base << PIO_SM_PINCTRL_IN_BASE_Pos);
+}
+
+/**
+ * @brief   Sets the side-set pin base of a running state machine.
+ * @details Only the SIDESET_BASE field of PINCTRL is modified, the runtime
+ *          counterpart of @p pioSmConfigSetSidesetPinsX(). Pin numbers are
+ *          block-relative on devices with the @p RP_PIO_HAS_GPIOBASE
+ *          capability, see @p pioGpioToRel().
+ *
+ * @param[in] smp       pointer to a rp_pio_sm_t structure
+ * @param[in] base      first pin of the side-set group (0..31)
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSmSetSidesetPinsX(const rp_pio_sm_t *smp,
+                                          uint32_t base) {
+  uint32_t pinctrl;
+
+  osalDbgCheck(base < 32U);
+
+  pinctrl = smp->block->pio->SM[smp->smidx].PINCTRL;
+  smp->block->pio->SM[smp->smidx].PINCTRL =
+    (pinctrl & ~PIO_SM_PINCTRL_SIDESET_BASE_Msk) |
+    (base << PIO_SM_PINCTRL_SIDESET_BASE_Pos);
 }
 
 /**
@@ -1583,6 +1752,49 @@ __STATIC_INLINE void pioIrqForceX(const rp_pio_block_t *block,
 }
 
 /**
+ * @brief   Controls the input synchronizer bypass of a block.
+ * @details A bypassed pin skips the 2-flip-flop input synchronizer, saving
+ *          two clock cycles of input latency for signals known to be
+ *          synchronous to the system clock. Bit @p n of the mask refers to
+ *          GPIO @p n; on devices with the @p RP_PIO_HAS_GPIOBASE
+ *          capability it refers to GPIO <tt>base + n</tt> of the window
+ *          selected with @p pioSetGpioBase().
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] mask      mask of pins to be changed
+ * @param[in] bypass    true to bypass the synchronizer, false to restore it
+ *
+ * @special
+ */
+__STATIC_INLINE void pioSetInputSyncBypassX(const rp_pio_block_t *block,
+                                            uint32_t mask, bool bypass) {
+
+  osalDbgCheck(block != NULL);
+
+  if (bypass) {
+    block->pio->SET.INPUT_SYNC_BYPASS = mask;
+  }
+  else {
+    block->pio->CLR.INPUT_SYNC_BYPASS = mask;
+  }
+}
+
+/**
+ * @brief   Returns the input synchronizer bypass mask of a block.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @return              The INPUT_SYNC_BYPASS register value.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioGetInputSyncBypassX(const rp_pio_block_t *block) {
+
+  osalDbgCheck(block != NULL);
+
+  return block->pio->INPUT_SYNC_BYPASS;
+}
+
+/**
  * @brief   Writes a word to the TX FIFO, blocking while full.
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
@@ -1695,6 +1907,25 @@ __STATIC_INLINE void pioGpioInitX(const rp_pio_sm_t *smp, uint32_t gpio) {
 
   pioGpioInitPadX(smp, gpio, RP_PIO_PAD_DEFAULT);
 }
+
+#if (RP_PIO_HAS_GPIOBASE == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   Returns the GPIO window base of a block.
+ * @details The dual of @p pioSetGpioBase(): the base of the 32-pin GPIO
+ *          window the pin fields of PINCTRL/EXECCTRL are relative to.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @return              The GPIOBASE register value, 0 or 16.
+ *
+ * @special
+ */
+__STATIC_INLINE uint32_t pioGetGpioBaseX(const rp_pio_block_t *block) {
+
+  osalDbgCheck(block != NULL);
+
+  return block->pio->GPIOBASE;
+}
+#endif /* RP_PIO_HAS_GPIOBASE == TRUE */
 
 /**
  * @brief   Converts an absolute GPIO number to a block-relative pin number.

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -74,6 +74,13 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 18. Runtime setters: pioSmSetWrapX, pioSmSetJmpPinX and the PINCTRL
+ *    group setters must modify only their own fields, leaving the
+ *    neighbouring fields bit-exact.
+ * 19. Readback: pioSmGetClkdivX and pioGetInputSyncBypassX (and, on the
+ *    RP2350, pioGetGpioBaseX) must return what the setters wrote.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries tests 18..19, the siblings land with theirs.)
  * 20. Instruction patching: pioProgramPatchX must rewrite a slot of a
  *    running program (the pin freezes and recovers with the patch), at
  *    rebased addresses when the program is loaded at an offset.
@@ -1130,6 +1137,89 @@ int main(void) {
 
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
+  pioSmFree(smp);
+
+  /*
+   * Test 18: field-scoped runtime setters.
+   */
+  chprintf(chp, "--- Test 18: runtime setters\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  /* EXECCTRL planted with distinctive values in the non-wrap fields.*/
+  pioSmSetExecctrlX(smp, PIO_SM_EXECCTRL_WRAP(3U, 12U) |
+                         PIO_SM_EXECCTRL_OUT_STICKY |
+                         PIO_SM_EXECCTRL_SIDE_PINDIR |
+                         (9U << PIO_SM_EXECCTRL_JMP_PIN_Pos));
+
+  pioSmSetWrapX(smp, 5U, 30U);
+  report("wrap repointed, neighbours preserved",
+         block->pio->SM[smp->smidx].EXECCTRL ==
+         (PIO_SM_EXECCTRL_WRAP(5U, 30U) | PIO_SM_EXECCTRL_OUT_STICKY |
+          PIO_SM_EXECCTRL_SIDE_PINDIR |
+          (9U << PIO_SM_EXECCTRL_JMP_PIN_Pos)));
+
+  pioSmSetJmpPinX(smp, 17U);
+  report("JMP_PIN repointed, neighbours preserved",
+         block->pio->SM[smp->smidx].EXECCTRL ==
+         (PIO_SM_EXECCTRL_WRAP(5U, 30U) | PIO_SM_EXECCTRL_OUT_STICKY |
+          PIO_SM_EXECCTRL_SIDE_PINDIR |
+          (17U << PIO_SM_EXECCTRL_JMP_PIN_Pos)));
+
+  /* PINCTRL planted whole, then rebuilt field by field; the side-set
+     count is the only field without a setter here and must survive.*/
+  pioSmSetPinctrlX(smp, (3U << PIO_SM_PINCTRL_OUT_BASE_Pos) |
+                        (7U << PIO_SM_PINCTRL_SET_BASE_Pos) |
+                        (11U << PIO_SM_PINCTRL_SIDESET_BASE_Pos) |
+                        (13U << PIO_SM_PINCTRL_IN_BASE_Pos) |
+                        (8U << PIO_SM_PINCTRL_OUT_COUNT_Pos) |
+                        (2U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                        (1U << PIO_SM_PINCTRL_SIDESET_COUNT_Pos));
+  pioSmSetOutPinsX(smp, 20U, 4U);
+  pioSmSetSetPinsX(smp, 6U, 3U);
+  pioSmSetInPinBaseX(smp, 14U);
+  pioSmSetSidesetPinsX(smp, 10U);
+  report("PINCTRL rebuilt field by field",
+         block->pio->SM[smp->smidx].PINCTRL ==
+         ((20U << PIO_SM_PINCTRL_OUT_BASE_Pos) |
+          (4U << PIO_SM_PINCTRL_OUT_COUNT_Pos) |
+          (6U << PIO_SM_PINCTRL_SET_BASE_Pos) |
+          (3U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+          (14U << PIO_SM_PINCTRL_IN_BASE_Pos) |
+          (10U << PIO_SM_PINCTRL_SIDESET_BASE_Pos) |
+          (1U << PIO_SM_PINCTRL_SIDESET_COUNT_Pos)));
+
+  pioSmSetExecctrlX(smp, PIO_SM_EXECCTRL_WRAP(0U, 31U));
+  pioSmSetPinctrlX(smp, 0U);
+  pioSmFree(smp);
+
+  /*
+   * Test 19: setter/getter roundtrips.
+   */
+  chprintf(chp, "--- Test 19: readback\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  pioSmSetClkdivX(smp, PIO_SM_CLKDIV(625U, 128U));
+  report("CLKDIV roundtrip",
+         pioSmGetClkdivX(smp) == PIO_SM_CLKDIV(625U, 128U));
+  pioSmSetClkdivX(smp, PIO_SM_CLKDIV(1U, 0U));
+
+  report("sync bypass idle on entry", pioGetInputSyncBypassX(block) == 0U);
+  pioSetInputSyncBypassX(block, 1U << TEST_GPIO, true);
+  report("sync bypass set",
+         pioGetInputSyncBypassX(block) == (1U << TEST_GPIO));
+  pioSetInputSyncBypassX(block, 1U << TEST_GPIO, false);
+  report("sync bypass cleared", pioGetInputSyncBypassX(block) == 0U);
+
   pioSmFree(smp);
 
   /*

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -1181,7 +1181,7 @@ int main(void) {
                         (1U << PIO_SM_PINCTRL_SIDESET_COUNT_Pos));
   pioSmSetOutPinsX(smp, 20U, 4U);
   pioSmSetSetPinsX(smp, 6U, 3U);
-  pioSmSetInPinBaseX(smp, 14U);
+  pioSmSetInPinsX(smp, 14U);
   pioSmSetSidesetPinsX(smp, 10U);
   report("PINCTRL rebuilt field by field",
          block->pio->SM[smp->smidx].PINCTRL ==

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -1181,7 +1181,7 @@ int main(void) {
                         (1U << PIO_SM_PINCTRL_SIDESET_COUNT_Pos));
   pioSmSetOutPinsX(smp, 20U, 4U);
   pioSmSetSetPinsX(smp, 6U, 3U);
-  pioSmSetInPinBaseX(smp, 14U);
+  pioSmSetInPinsX(smp, 14U);
   pioSmSetSidesetPinsX(smp, 10U);
   report("PINCTRL rebuilt field by field",
          block->pio->SM[smp->smidx].PINCTRL ==

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -74,6 +74,13 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 18. Runtime setters: pioSmSetWrapX, pioSmSetJmpPinX and the PINCTRL
+ *    group setters must modify only their own fields, leaving the
+ *    neighbouring fields bit-exact.
+ * 19. Readback: pioSmGetClkdivX and pioGetInputSyncBypassX (and, on the
+ *    RP2350, pioGetGpioBaseX) must return what the setters wrote.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries tests 18..19, the siblings land with theirs.)
  * 20. Instruction patching: pioProgramPatchX must rewrite a slot of a
  *    running program (the pin freezes and recovers with the patch), at
  *    rebased addresses when the program is loaded at an offset.
@@ -1131,6 +1138,96 @@ int main(void) {
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
   pioSmFree(smp);
+
+  /*
+   * Test 18: field-scoped runtime setters.
+   */
+  chprintf(chp, "--- Test 18: runtime setters\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  /* EXECCTRL planted with distinctive values in the non-wrap fields.*/
+  pioSmSetExecctrlX(smp, PIO_SM_EXECCTRL_WRAP(3U, 12U) |
+                         PIO_SM_EXECCTRL_OUT_STICKY |
+                         PIO_SM_EXECCTRL_SIDE_PINDIR |
+                         (9U << PIO_SM_EXECCTRL_JMP_PIN_Pos));
+
+  pioSmSetWrapX(smp, 5U, 30U);
+  report("wrap repointed, neighbours preserved",
+         block->pio->SM[smp->smidx].EXECCTRL ==
+         (PIO_SM_EXECCTRL_WRAP(5U, 30U) | PIO_SM_EXECCTRL_OUT_STICKY |
+          PIO_SM_EXECCTRL_SIDE_PINDIR |
+          (9U << PIO_SM_EXECCTRL_JMP_PIN_Pos)));
+
+  pioSmSetJmpPinX(smp, 17U);
+  report("JMP_PIN repointed, neighbours preserved",
+         block->pio->SM[smp->smidx].EXECCTRL ==
+         (PIO_SM_EXECCTRL_WRAP(5U, 30U) | PIO_SM_EXECCTRL_OUT_STICKY |
+          PIO_SM_EXECCTRL_SIDE_PINDIR |
+          (17U << PIO_SM_EXECCTRL_JMP_PIN_Pos)));
+
+  /* PINCTRL planted whole, then rebuilt field by field; the side-set
+     count is the only field without a setter here and must survive.*/
+  pioSmSetPinctrlX(smp, (3U << PIO_SM_PINCTRL_OUT_BASE_Pos) |
+                        (7U << PIO_SM_PINCTRL_SET_BASE_Pos) |
+                        (11U << PIO_SM_PINCTRL_SIDESET_BASE_Pos) |
+                        (13U << PIO_SM_PINCTRL_IN_BASE_Pos) |
+                        (8U << PIO_SM_PINCTRL_OUT_COUNT_Pos) |
+                        (2U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                        (1U << PIO_SM_PINCTRL_SIDESET_COUNT_Pos));
+  pioSmSetOutPinsX(smp, 20U, 4U);
+  pioSmSetSetPinsX(smp, 6U, 3U);
+  pioSmSetInPinBaseX(smp, 14U);
+  pioSmSetSidesetPinsX(smp, 10U);
+  report("PINCTRL rebuilt field by field",
+         block->pio->SM[smp->smidx].PINCTRL ==
+         ((20U << PIO_SM_PINCTRL_OUT_BASE_Pos) |
+          (4U << PIO_SM_PINCTRL_OUT_COUNT_Pos) |
+          (6U << PIO_SM_PINCTRL_SET_BASE_Pos) |
+          (3U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+          (14U << PIO_SM_PINCTRL_IN_BASE_Pos) |
+          (10U << PIO_SM_PINCTRL_SIDESET_BASE_Pos) |
+          (1U << PIO_SM_PINCTRL_SIDESET_COUNT_Pos)));
+
+  pioSmSetExecctrlX(smp, PIO_SM_EXECCTRL_WRAP(0U, 31U));
+  pioSmSetPinctrlX(smp, 0U);
+  pioSmFree(smp);
+
+  /*
+   * Test 19: setter/getter roundtrips.
+   */
+  chprintf(chp, "--- Test 19: readback\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  pioSmSetClkdivX(smp, PIO_SM_CLKDIV(625U, 128U));
+  report("CLKDIV roundtrip",
+         pioSmGetClkdivX(smp) == PIO_SM_CLKDIV(625U, 128U));
+  pioSmSetClkdivX(smp, PIO_SM_CLKDIV(1U, 0U));
+
+  report("sync bypass idle on entry", pioGetInputSyncBypassX(block) == 0U);
+  pioSetInputSyncBypassX(block, 1U << TEST_GPIO, true);
+  report("sync bypass set",
+         pioGetInputSyncBypassX(block) == (1U << TEST_GPIO));
+  pioSetInputSyncBypassX(block, 1U << TEST_GPIO, false);
+  report("sync bypass cleared", pioGetInputSyncBypassX(block) == 0U);
+
+  pioSmFree(smp);
+
+  /* The pin window can only move on an idle block, hence after the
+     free.*/
+  pioSetGpioBase(block, 16U);
+  report("GPIOBASE roundtrip", pioGetGpioBaseX(block) == 16U);
+  pioSetGpioBase(block, 0U);
+  report("GPIOBASE restored", pioGetGpioBaseX(block) == 0U);
 
   /*
    * Test 20: in-place instruction patching.


### PR DESCRIPTION
## Summary

`pioSmSetExecctrlX()` and `pioSmSetPinctrlX()` write their whole register, so changing one field of a configured state machine at runtime clears every other one. Repointing the wrap range at a second program — the way a single state machine is reused for several programs — through the full write destroys JMP_PIN, SIDE_EN, SIDE_PINDIR, OUT_STICKY, INLINE_OUT_EN and OUT_EN_SEL, so consumers open-code the read-modify-write (the nanoFramework CYW43 SPI driver carries exactly that, with a comment noting the full-write hazard). In the other direction, CLKDIV, GPIOBASE and INPUT_SYNC_BYPASS had setters or nothing but no readback, and the nanoFramework PIO binding (nanoframework/nf-interpreter#3449) reads the raw registers today.

This PR:

- adds `pioSmSetWrapX()` and `pioSmSetJmpPinX()`, modifying only their EXECCTRL fields (`pio_sm_set_wrap()` in the pico-sdk);
- adds `pioSmSetOutPinsX()`, `pioSmSetSetPinsX()`, `pioSmSetInPinBaseX()` and `pioSmSetSidesetPinsX()`, the runtime mirrors of the `pioSmConfigSet*` builders on PINCTRL, with the same field validation. SIDESET_COUNT deliberately has no runtime setter: changing the side-set width under a loaded program is incoherent, moving the base is not;
- adds `pioSmGetClkdivX()` (raw CLKDIV, decomposable with the existing `PIO_SM_CLKDIV_*` macros) and, on the RP2350, `pioGetGpioBaseX()`, the dual of `pioSetGpioBase()` under the same `RP_PIO_HAS_GPIOBASE` gate;
- adds `pioSetInputSyncBypassX()`/`pioGetInputSyncBypassX()` over the atomic SET/CLR aliases (`pio_set_input_sync_bypass()` in the pico-sdk), saving the two clock cycles of input synchronizer latency for signals synchronous to the system clock; the doc notes the RP2350 window semantics (bit n is GPIO base+n).

PIO-VALIDATION grows tests 18..19: test 18 plants distinctive values in every neighbouring EXECCTRL/PINCTRL field, touches each setter and checks the whole register bit-exact (the field without a setter must survive); test 19 does setter/getter roundtrips for CLKDIV, the sync bypass and (RP2350) GPIOBASE — the latter after the state machine free, since the pin window only moves on an idle block. Test numbers 15..22 are reserved across this PIO API series; this branch carries only its own tests.

## Related

- Issue(s): —
- Notes for reviewers: pin numbers in the new setters are window-relative on the RP2350, documented via `pioGpioToRel()` like the rest of the driver. Independent of the other PRs in the series (#222 block level APIs, plus patching/synchronized enable and instruction encoders to follow).

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files (`tools/style/stylecheck.py` on `rp_pio.h` and both `main.c`)
- [x] Build check passed: RP2040 PIO-VALIDATION (Cortex-M0+), RP2350 PIO-VALIDATION (Cortex-M33) and RP2350 PIO-VALIDATION-RISCV compile clean

## Testing

- [x] Test run successfully locally
- RP2350 leg run on a Pico 2: **124 pass, 0 fail**; RP2040 leg run on a Pico W: **107 pass, 0 fail** (reports captured from UART0).

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

Additive only: no existing function changes name, signature or behavior. The new setters are read-modify-write and therefore not atomic against a concurrent full-register write from the other core; that is the same caveat every RMW field access on these registers carries and is not introduced by this PR.




