### PR TITLE
RP PIOv1: add instruction patching and synchronized enable

### DIFF
--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -922,10 +922,11 @@ __STATIC_INLINE void pioSmDisableX(const rp_pio_sm_t *smp) {
 
 /**
  * @brief   Enables several state machines of a block simultaneously.
- * @details A single CTRL read-modify-write raises the SM_ENABLE and
- *          CLKDIV_RESTART bits of every state machine in the mask, so
- *          their clock dividers restart together and the machines run
- *          cycle-aligned. Machines outside the mask are not affected.
+ * @details A single write to the atomic SET alias raises the SM_ENABLE
+ *          and CLKDIV_RESTART bits of every state machine in the mask,
+ *          so their clock dividers restart together and the machines run
+ *          cycle-aligned. Machines outside the mask are not affected by
+ *          construction, and the write is atomic against the other core.
  * @pre     Each state machine in the mask is configured and its program
  *          counter is positioned, as before an individual
  *          @p pioSmEnableX().
@@ -937,12 +938,10 @@ __STATIC_INLINE void pioSmDisableX(const rp_pio_sm_t *smp) {
  */
 __STATIC_INLINE void pioEnableSmMaskInSyncX(const rp_pio_block_t *block,
                                             uint32_t mask) {
-  uint32_t ctrl;
 
   osalDbgCheck((block != NULL) && ((mask & ~0xFU) == 0U));
 
-  ctrl = block->pio->CTRL;
-  block->pio->CTRL = ctrl | mask | (mask << 8U);
+  block->pio->SET.CTRL = mask | (mask << 8U);
 }
 
 /**

--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -921,6 +921,31 @@ __STATIC_INLINE void pioSmDisableX(const rp_pio_sm_t *smp) {
 }
 
 /**
+ * @brief   Enables several state machines of a block simultaneously.
+ * @details A single CTRL read-modify-write raises the SM_ENABLE and
+ *          CLKDIV_RESTART bits of every state machine in the mask, so
+ *          their clock dividers restart together and the machines run
+ *          cycle-aligned. Machines outside the mask are not affected.
+ * @pre     Each state machine in the mask is configured and its program
+ *          counter is positioned, as before an individual
+ *          @p pioSmEnableX().
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] mask      mask of state machines, bits 0..3
+ *
+ * @special
+ */
+__STATIC_INLINE void pioEnableSmMaskInSyncX(const rp_pio_block_t *block,
+                                            uint32_t mask) {
+  uint32_t ctrl;
+
+  osalDbgCheck((block != NULL) && ((mask & ~0xFU) == 0U));
+
+  ctrl = block->pio->CTRL;
+  block->pio->CTRL = ctrl | mask | (mask << 8U);
+}
+
+/**
  * @brief   Restarts a state machine.
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
@@ -1229,6 +1254,31 @@ __STATIC_INLINE void pioSmExecX(const rp_pio_sm_t *smp,
                                  uint16_t instr) {
 
   smp->block->pio->SM[smp->smidx].INSTR = instr;
+}
+
+/**
+ * @brief   Rewrites one instruction memory slot of a block.
+ * @details Intended to patch instructions of an already loaded program at
+ *          runtime, typically JMP targets. The caller must own the slot
+ *          through a previous @p pioProgramLoad(); for a program loaded
+ *          at a non-zero offset both @p addr and any JMP target encoded
+ *          in @p instr must be rebased by the load offset, as the loader
+ *          itself does.
+ * @note    The instruction memory is write-only, a patch cannot be read
+ *          back.
+ *
+ * @param[in] block     pointer to the PIO block descriptor
+ * @param[in] addr      instruction memory address (0..31)
+ * @param[in] instr     16-bit PIO instruction
+ *
+ * @special
+ */
+__STATIC_INLINE void pioProgramPatchX(const rp_pio_block_t *block,
+                                      uint32_t addr, uint16_t instr) {
+
+  osalDbgCheck((block != NULL) && (addr < RP_PIO_NUM_INSTR_MEM));
+
+  block->pio->INSTR_MEM[addr] = (uint32_t)instr;
 }
 
 /**

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -74,6 +74,14 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 20. Instruction patching: pioProgramPatchX must rewrite a slot of a
+ *    running program (the pin freezes and recovers with the patch), at
+ *    rebased addresses when the program is loaded at an offset.
+ * 21. Synchronized enable: pioEnableSmMaskInSyncX must start two state
+ *    machines with one CTRL write and their divided clocks in phase,
+ *    without touching the other machines' enables.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries tests 20..21, the siblings land with theirs.)
  * 22. Instruction encoders: every pioEncode* must match the
  *    hand-assembled words this suite already uses, and a program built
  *    only with encoders must produce the reference square wave.
@@ -1123,6 +1131,104 @@ int main(void) {
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
   pioSmFree(smp);
+
+  /*
+   * Test 20: in-place instruction patching.
+   */
+  chprintf(chp, "--- Test 20: instruction patching\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  /* The parking program keeps address 0 busy so the square wave loads
+     at a non-zero offset and the patch address needs rebasing.*/
+  park_off = pioProgramLoad(block, &park_program);
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("programs loaded", (park_off == 0) && (sq_off > 0));
+
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges(TEST_GPIO);
+  report("square wave before the patch",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  /* "set pins, 1" patched to "set pins, 0" while running: the pin
+     freezes low without stopping the machine.*/
+  pioProgramPatchX(block, (uint32_t)sq_off, 0xE000U);
+  edges = count_edges(TEST_GPIO);
+  report("pin frozen after the patch", edges <= 2U);
+
+  pioProgramPatchX(block, (uint32_t)sq_off, 0xE001U);
+  edges = count_edges(TEST_GPIO);
+  report("square wave after the patch-back",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, park_off, park_program.length);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+  pioSmFree(smp);
+
+  /*
+   * Test 21: synchronized multi state machine enable.
+   */
+  chprintf(chp, "--- Test 21: synchronized enable\r\n");
+
+  sms[0] = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  sms[1] = pioSmAlloc(block, 1U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 and SM1 allocated", (sms[0] != NULL) && (sms[1] != NULL));
+  if ((sms[0] == NULL) || (sms[1] == NULL)) {
+    goto summary;
+  }
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("program loaded", sq_off >= 0);
+
+  /* Both machines set up for the same square wave on adjacent pins,
+     configured and positioned but not enabled.*/
+  for (i = 0U; i < 2U; i++) {
+    pioSmDisableX(sms[i]);
+    pioSmSetFrequencyX(sms[i], SM_TEST_FREQ);
+    pioSmSetExecctrlX(sms[i], PIO_SM_EXECCTRL_WRAP(0U, 31U));
+    pioSmSetShiftctrlX(sms[i], PIO_SM_SHIFTCTRL_IN_SHIFTDIR |
+                               PIO_SM_SHIFTCTRL_OUT_SHIFTDIR);
+    pioSmSetPinctrlX(sms[i], (1U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                             ((TEST_GPIO + i) << PIO_SM_PINCTRL_SET_BASE_Pos));
+    pioGpioInitX(sms[i], TEST_GPIO + i);
+    pioSmClearFifosX(sms[i]);
+    pioClearDebugX(sms[i]);
+    pioSmRestartX(sms[i]);
+    pioSmExecX(sms[i], 0xE081U);
+    pioSmSetPCX(sms[i], (uint32_t)sq_off);
+  }
+
+  pioEnableSmMaskInSyncX(block, 0x3U);
+  report("both enables set by one write",
+         (block->pio->CTRL & 0xFU) == 0x3U);
+
+  /* With the dividers restarted together the two machines execute the
+     same program cycle-aligned: a single GPIO_IN read must always see
+     the two pins equal.*/
+  lvl = TIMER0->TIMERAWL;
+  mask = 0U;
+  while ((uint32_t)(TIMER0->TIMERAWL - lvl) < MEASURE_US) {
+    uint32_t in = SIO->GPIO_IN;
+
+    if ((((in >> TEST_GPIO) ^ (in >> (TEST_GPIO + 1U))) & 1U) != 0U) {
+      mask++;
+    }
+  }
+  report("pins locked in phase", mask == 0U);
+
+  edges = count_edges(TEST_GPIO);
+  report("square wave running", (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(sms[0]);
+  pioSmDisableX(sms[1]);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+  pioSmFree(sms[0]);
+  pioSmFree(sms[1]);
 
   /*
    * Test 22: instruction encoders.

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -74,6 +74,14 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 20. Instruction patching: pioProgramPatchX must rewrite a slot of a
+ *    running program (the pin freezes and recovers with the patch), at
+ *    rebased addresses when the program is loaded at an offset.
+ * 21. Synchronized enable: pioEnableSmMaskInSyncX must start two state
+ *    machines with one CTRL write and their divided clocks in phase,
+ *    without touching the other machines' enables.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries tests 20..21, the siblings land with theirs.)
  * 22. Instruction encoders: every pioEncode* must match the
  *    hand-assembled words this suite already uses, and a program built
  *    only with encoders must produce the reference square wave.
@@ -1123,6 +1131,104 @@ int main(void) {
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
   pioSmFree(smp);
+
+  /*
+   * Test 20: in-place instruction patching.
+   */
+  chprintf(chp, "--- Test 20: instruction patching\r\n");
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  /* The parking program keeps address 0 busy so the square wave loads
+     at a non-zero offset and the patch address needs rebasing.*/
+  park_off = pioProgramLoad(block, &park_program);
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("programs loaded", (park_off == 0) && (sq_off > 0));
+
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges(TEST_GPIO);
+  report("square wave before the patch",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  /* "set pins, 1" patched to "set pins, 0" while running: the pin
+     freezes low without stopping the machine.*/
+  pioProgramPatchX(block, (uint32_t)sq_off, 0xE000U);
+  edges = count_edges(TEST_GPIO);
+  report("pin frozen after the patch", edges <= 2U);
+
+  pioProgramPatchX(block, (uint32_t)sq_off, 0xE001U);
+  edges = count_edges(TEST_GPIO);
+  report("square wave after the patch-back",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, park_off, park_program.length);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+  pioSmFree(smp);
+
+  /*
+   * Test 21: synchronized multi state machine enable.
+   */
+  chprintf(chp, "--- Test 21: synchronized enable\r\n");
+
+  sms[0] = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  sms[1] = pioSmAlloc(block, 1U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 and SM1 allocated", (sms[0] != NULL) && (sms[1] != NULL));
+  if ((sms[0] == NULL) || (sms[1] == NULL)) {
+    goto summary;
+  }
+
+  sq_off = pioProgramLoad(block, &sqwave_program);
+  report("program loaded", sq_off >= 0);
+
+  /* Both machines set up for the same square wave on adjacent pins,
+     configured and positioned but not enabled.*/
+  for (i = 0U; i < 2U; i++) {
+    pioSmDisableX(sms[i]);
+    pioSmSetFrequencyX(sms[i], SM_TEST_FREQ);
+    pioSmSetExecctrlX(sms[i], PIO_SM_EXECCTRL_WRAP(0U, 31U));
+    pioSmSetShiftctrlX(sms[i], PIO_SM_SHIFTCTRL_IN_SHIFTDIR |
+                               PIO_SM_SHIFTCTRL_OUT_SHIFTDIR);
+    pioSmSetPinctrlX(sms[i], (1U << PIO_SM_PINCTRL_SET_COUNT_Pos) |
+                             ((TEST_GPIO + i) << PIO_SM_PINCTRL_SET_BASE_Pos));
+    pioGpioInitX(sms[i], TEST_GPIO + i);
+    pioSmClearFifosX(sms[i]);
+    pioClearDebugX(sms[i]);
+    pioSmRestartX(sms[i]);
+    pioSmExecX(sms[i], 0xE081U);
+    pioSmSetPCX(sms[i], (uint32_t)sq_off);
+  }
+
+  pioEnableSmMaskInSyncX(block, 0x3U);
+  report("both enables set by one write",
+         (block->pio->CTRL & 0xFU) == 0x3U);
+
+  /* With the dividers restarted together the two machines execute the
+     same program cycle-aligned: a single GPIO_IN read must always see
+     the two pins equal.*/
+  lvl = TIMER0->TIMERAWL;
+  mask = 0U;
+  while ((uint32_t)(TIMER0->TIMERAWL - lvl) < MEASURE_US) {
+    uint32_t in = SIO->GPIO_IN;
+
+    if ((((in >> TEST_GPIO) ^ (in >> (TEST_GPIO + 1U))) & 1U) != 0U) {
+      mask++;
+    }
+  }
+  report("pins locked in phase", mask == 0U);
+
+  edges = count_edges(TEST_GPIO);
+  report("square wave running", (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(sms[0]);
+  pioSmDisableX(sms[1]);
+  pioProgramUnload(block, sq_off, sqwave_program.length);
+  pioSmFree(sms[0]);
+  pioSmFree(sms[1]);
 
   /*
    * Test 22: instruction encoders.


### PR DESCRIPTION
## Summary

Two program-lifecycle operations had no API and forced consumers onto the raw registers:

- **`pioProgramPatchX(block, addr, instr)`** rewrites one instruction memory slot of a loaded program. The loader already relocates JMP targets *at load time*; this covers relocation *after* the load — repointing a JMP at runtime, which the nanoFramework CYW43 PIO-SPI driver does today by writing `pio->INSTR_MEM[offset + i]` directly. Addresses follow the same rebasing rule as the loader (both `addr` and any JMP target encoded in `instr` are absolute, offset included), and the doc says so.
- **`pioEnableSmMaskInSyncX(block, mask)`** raises `SM_ENABLE` and `CLKDIV_RESTART` for a mask of state machines in a single CTRL read-modify-write, so their divided clocks restart together and the machines run cycle-aligned. There is no way to do this with the existing per-machine calls: `pioSmEnableX()` + `pioSmClkdivRestartX()` are separate CTRL writes and with dividers > 1 the machines come up with arbitrary relative phase. The RMW (rather than a full register write) preserves the enables of machines outside the mask; the CLKDIV_RESTART bits are self-clearing and read back as zero, so they cannot pollute the OR. This is `pio_enable_sm_mask_in_sync()` in the pico-sdk.

PIO-VALIDATION grows tests 20..21. The instruction memory is write-only on both chips, so test 20 is behavioral rather than a readback: the parking program pins address 0 so the square wave loads at a non-zero offset (exercising the rebasing), then a live patch of `set pins, 1` to `set pins, 0` freezes the pin without stopping the machine, and the patch-back restores the wave. Test 21 checks both enables appear with one CTRL write and then samples `SIO->GPIO_IN` for 100 ms requiring the two pins driven by the same program on SM0/SM1 to be equal in every single read — a phase misalignment would make ~2/3 of the samples differ, so the pass/fail separation is wide and the test demands zero mismatches. Test numbers 15..22 are reserved across this PIO API series; this branch carries only its own tests.

## Related

- Issue(s): —
- Notes for reviewers — two deliberate design choices here are the weak points and I would value your call on both:
  1. **`pioProgramPatchX()` does not assert slot ownership.** Validating `addr` against the instruction memory allocation bitmap would require either calling `pioGetImemAllocatedMask()` (an `@api` function that takes the system lock — not callable from an X-class inline) or moving the function into `rp_pio.c` behind the lock, which taxes every caller for a setup-path operation. Ownership is a documented precondition instead ("the caller must own the slot through a previous `pioProgramLoad()`"). If you prefer the locked `.c` variant, or an I-class flavor with a debug assert, happy to rework.
  2. **No `pio_set_sm_mask_enabled()` counterpart.** Only the in-sync enable is added; a mask enable/disable *without* the divider restart was left out to keep the PR minimal. It is a two-line addition if you want the pair completed here.

  Independent of the other PRs in the series (#222 block level APIs, #223 runtime setters/readback, instruction encoders to follow).

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files (`tools/style/stylecheck.py` on `rp_pio.h` and both `main.c`)
- [x] Build check passed: RP2040 PIO-VALIDATION (Cortex-M0+), RP2350 PIO-VALIDATION (Cortex-M33) and RP2350 PIO-VALIDATION-RISCV compile clean

## Testing

- [x] Test run successfully locally
- RP2350 leg run on a Pico 2: **123 pass, 0 fail**; RP2040 leg run on a Pico W: **108 pass, 0 fail** (reports captured from UART0).

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

Additive only. `pioProgramPatchX()` trusts the caller on slot ownership (see reviewer note 1); a patch to a slot owned by another program is a documented misuse the debug build cannot currently catch. `pioEnableSmMaskInSyncX()` is a read-modify-write on CTRL and therefore not atomic against a concurrent CTRL write from the other core — the same caveat every RMW on a shared block register carries.




