### PR TITLE
RP PIOv1: add instruction encoders

### DIFF
--- a/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
+++ b/os/hal/ports/RP/LLD/PIOv1/rp_pio.h
@@ -257,6 +257,60 @@
 #define PIO_INSTR_NOP                   0xA042U
 /** @} */
 
+/**
+ * @name    PIO instruction operands
+ * @note    The encoding is shared by several instructions but not every
+ *          value is legal in every one of them, see the datasheet
+ *          instruction set tables.
+ * @{
+ */
+#define PIO_DEST_PINS                   0U
+#define PIO_DEST_X                      1U
+#define PIO_DEST_Y                      2U
+#define PIO_DEST_NULL                   3U
+#define PIO_DEST_PINDIRS                4U
+#define PIO_DEST_PC                     5U
+#define PIO_DEST_ISR                    6U
+#define PIO_DEST_OSR                    7U
+
+/* EXEC is encoded differently by OUT and MOV.*/
+#define PIO_OUT_DEST_EXEC               7U
+#define PIO_MOV_DEST_EXEC               4U
+
+#define PIO_SRC_PINS                    0U
+#define PIO_SRC_X                       1U
+#define PIO_SRC_Y                       2U
+#define PIO_SRC_NULL                    3U
+#define PIO_SRC_STATUS                  5U
+#define PIO_SRC_ISR                     6U
+#define PIO_SRC_OSR                     7U
+
+#define PIO_MOV_NONE                    0U
+#define PIO_MOV_INVERT                  1U
+#define PIO_MOV_BITREV                  2U
+
+#define PIO_JMP_ALWAYS                  0U
+#define PIO_JMP_NOT_X                   1U
+#define PIO_JMP_X_DEC                   2U
+#define PIO_JMP_NOT_Y                   3U
+#define PIO_JMP_Y_DEC                   4U
+#define PIO_JMP_X_NE_Y                  5U
+#define PIO_JMP_PIN                     6U
+#define PIO_JMP_NOT_OSRE                7U
+
+#define PIO_WAIT_GPIO                   0U
+#define PIO_WAIT_PIN                    1U
+#define PIO_WAIT_IRQ                    2U
+#if defined(RP2350) || defined(__DOXYGEN__)
+#define PIO_WAIT_JMPPIN                 3U
+#endif
+
+/* ORed into the index of pioEncodeIrq()/pioEncodeWait() with
+   PIO_WAIT_IRQ: the flag index is taken relative to the state machine
+   number.*/
+#define PIO_IRQ_INDEX_REL               0x10U
+/** @} */
+
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/
@@ -947,7 +1001,224 @@ __STATIC_INLINE void pioSmSetPinctrlX(const rp_pio_sm_t *smp,
 }
 
 /**
+ * @name    Instruction encoders
+ * @details Build the instruction word taken by @p pioSmExecX() and by
+ *          @p rp_pio_program_t instruction arrays. The delay/side-set
+ *          field is left zero; where needed, OR in the value built with
+ *          @p pioEncodeDelay() and @p pioEncodeSideSet(). An out of band
+ *          exec normally wants it zero: the delay of an exec'd
+ *          instruction is not applied and the side-set field would drive
+ *          pins the running program owns.
+ * @{
+ */
+
+/**
+ * @brief   Encodes a JMP.
+ *
+ * @param[in] cond      condition, one of the @p PIO_JMP_* macros
+ * @param[in] addr      absolute target instruction address (0..31)
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeJmp(uint32_t cond, uint32_t addr) {
+
+  osalDbgCheck((cond < 8U) && (addr < RP_PIO_NUM_INSTR_MEM));
+
+  return (uint16_t)(0x0000U | (cond << 5) | addr);
+}
+
+/**
+ * @brief   Encodes a WAIT.
+ * @note    With @p PIO_WAIT_GPIO the index is an absolute pin (on the
+ *          RP2350, relative to the GPIOBASE window), with @p PIO_WAIT_PIN
+ *          it is relative to the IN pin base, with @p PIO_WAIT_IRQ it is
+ *          a flag index (0..7, @p PIO_IRQ_INDEX_REL selects
+ *          machine-relative addressing). @p PIO_WAIT_JMPPIN exists on the
+ *          RP2350 only.
+ *
+ * @param[in] polarity  wait for a 1 when true, for a 0 when false
+ * @param[in] src       source, one of the @p PIO_WAIT_* macros
+ * @param[in] index     source index (0..31)
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeWait(bool polarity, uint32_t src,
+                                       uint32_t index) {
+
+  osalDbgCheck((src < 4U) && (index < 32U));
+
+  return (uint16_t)(0x2000U | (polarity ? 0x80U : 0U) | (src << 5) | index);
+}
+
+/**
+ * @brief   Encodes an IN.
+ *
+ * @param[in] src       source, one of @p PIO_SRC_PINS, @p PIO_SRC_X,
+ *                      @p PIO_SRC_Y, @p PIO_SRC_NULL, @p PIO_SRC_ISR,
+ *                      @p PIO_SRC_OSR
+ * @param[in] count     bit count (1..32, 32 encoded as 0)
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeIn(uint32_t src, uint32_t count) {
+
+  osalDbgCheck((src < 8U) && (count >= 1U) && (count <= 32U));
+
+  return (uint16_t)(0x4000U | (src << 5) | (count & 0x1FU));
+}
+
+/**
+ * @brief   Encodes an OUT.
+ *
+ * @param[in] dest      destination, one of @p PIO_DEST_PINS,
+ *                      @p PIO_DEST_X, @p PIO_DEST_Y, @p PIO_DEST_NULL,
+ *                      @p PIO_DEST_PINDIRS, @p PIO_DEST_PC,
+ *                      @p PIO_DEST_ISR, @p PIO_OUT_DEST_EXEC
+ * @param[in] count     bit count (1..32, 32 encoded as 0)
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeOut(uint32_t dest, uint32_t count) {
+
+  osalDbgCheck((dest < 8U) && (count >= 1U) && (count <= 32U));
+
+  return (uint16_t)(0x6000U | (dest << 5) | (count & 0x1FU));
+}
+
+/**
+ * @brief   Encodes a PUSH.
+ *
+ * @param[in] iffull    only push if the input threshold is reached
+ * @param[in] block     stall while the RX FIFO is full
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodePush(bool iffull, bool block) {
+
+  return (uint16_t)(0x8000U | (iffull ? 0x40U : 0U) | (block ? 0x20U : 0U));
+}
+
+/**
+ * @brief   Encodes a PULL.
+ *
+ * @param[in] ifempty   only pull if the output threshold is reached
+ * @param[in] block     stall while the TX FIFO is empty
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodePull(bool ifempty, bool block) {
+
+  return (uint16_t)(0x8080U | (ifempty ? 0x40U : 0U) | (block ? 0x20U : 0U));
+}
+
+/**
+ * @brief   Encodes a MOV.
+ *
+ * @param[in] dest      destination, one of the @p PIO_DEST_* macros or
+ *                      @p PIO_MOV_DEST_EXEC
+ * @param[in] op        operation, one of @p PIO_MOV_NONE,
+ *                      @p PIO_MOV_INVERT, @p PIO_MOV_BITREV
+ * @param[in] src       source, one of the @p PIO_SRC_* macros
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeMov(uint32_t dest, uint32_t op,
+                                      uint32_t src) {
+
+  osalDbgCheck((dest < 8U) && (op < 3U) && (src < 8U));
+
+  return (uint16_t)(0xA000U | (dest << 5) | (op << 3) | src);
+}
+
+/**
+ * @brief   Encodes an IRQ.
+ *
+ * @param[in] clear     clear the flag instead of raising it
+ * @param[in] wait      stall until the raised flag is cleared again,
+ *                      ignored when @p clear is true
+ * @param[in] index     flag index (0..7), optionally ORed with
+ *                      @p PIO_IRQ_INDEX_REL
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeIrq(bool clear, bool wait,
+                                      uint32_t index) {
+
+  osalDbgCheck(index < 32U);
+
+  return (uint16_t)(0xC000U | (clear ? 0x40U : 0U) | (wait ? 0x20U : 0U) |
+                    index);
+}
+
+/**
+ * @brief   Encodes a SET.
+ *
+ * @param[in] dest      destination, one of @p PIO_DEST_PINS,
+ *                      @p PIO_DEST_X, @p PIO_DEST_Y, @p PIO_DEST_PINDIRS
+ * @param[in] value     immediate value (0..31)
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeSet(uint32_t dest, uint32_t value) {
+
+  osalDbgCheck((dest < 8U) && (value < 32U));
+
+  return (uint16_t)(0xE000U | (dest << 5) | value);
+}
+
+/**
+ * @brief   Encodes a NOP, which is @p MOV Y, Y.
+ *
+ * @return              The instruction word.
+ */
+__STATIC_INLINE uint16_t pioEncodeNop(void) {
+
+  return pioEncodeMov(PIO_DEST_Y, PIO_MOV_NONE, PIO_SRC_Y);
+}
+
+/**
+ * @brief   Encodes the delay field, to be ORed into any instruction.
+ * @details The field shrinks as side-set bits are configured, so the
+ *          available delay range depends on the SIDESET_COUNT value the
+ *          state machine runs with.
+ *
+ * @param[in] cycles        delay cycles
+ * @param[in] sideset_bits  side-set bit count the state machine is
+ *                          configured with, enable bit included (0..5)
+ * @return              The delay field value.
+ */
+__STATIC_INLINE uint16_t pioEncodeDelay(uint32_t cycles,
+                                        uint32_t sideset_bits) {
+
+  osalDbgCheck((sideset_bits <= 5U) &&
+               (cycles < (1U << (5U - sideset_bits))));
+
+  return (uint16_t)(cycles << 8);
+}
+
+/**
+ * @brief   Encodes the side-set field, to be ORed into any instruction.
+ *
+ * @param[in] value         side-set value to drive
+ * @param[in] sideset_bits  side-set data bit count the state machine is
+ *                          configured with, enable bit excluded (1..5,
+ *                          1..4 with @p side_en)
+ * @param[in] side_en       side-set is optional (SIDE_EN configured):
+ *                          sets the enable bit so this instruction does
+ *                          drive the pins
+ * @return              The side-set field value.
+ */
+__STATIC_INLINE uint16_t pioEncodeSideSet(uint32_t value,
+                                          uint32_t sideset_bits,
+                                          bool side_en) {
+
+  osalDbgCheck((sideset_bits >= 1U) &&
+               (sideset_bits <= (side_en ? 4U : 5U)) &&
+               (value < (1U << sideset_bits)));
+
+  if (side_en) {
+    return (uint16_t)(0x1000U | (value << (12U - sideset_bits)));
+  }
+
+  return (uint16_t)(value << (13U - sideset_bits));
+}
+/** @} */
+
+/**
  * @brief   Executes an instruction immediately on a state machine.
+ * @note    The instruction is executed out of band, the program counter
+ *          is not affected unless the instruction itself changes it.
  *
  * @param[in] smp       pointer to a rp_pio_sm_t structure
  * @param[in] instr     16-bit PIO instruction
@@ -1477,7 +1748,7 @@ __STATIC_INLINE void pioSmSetConsecutivePindirsX(const rp_pio_sm_t *smp,
                                   (rel << PIO_SM_PINCTRL_SET_BASE_Pos);
     /* SET PINDIRS, all ones for outputs or all zeros for inputs; only the
        low "chunk" bits take effect.*/
-    pioSmExecX(smp, (uint16_t)(0xE080U | (out ? 0x1FU : 0x00U)));
+    pioSmExecX(smp, pioEncodeSet(PIO_DEST_PINDIRS, out ? 0x1FU : 0x00U));
     rel += chunk;
     count -= chunk;
   } while (count > 0U);
@@ -1501,7 +1772,7 @@ __STATIC_INLINE void pioSmSetConsecutivePindirsX(const rp_pio_sm_t *smp,
  * @special
  */
 __STATIC_INLINE void pioSmSetPCX(const rp_pio_sm_t *smp, uint32_t addr) {
-  pioSmExecX(smp, (uint16_t)(addr & 0x1FU));
+  pioSmExecX(smp, pioEncodeJmp(PIO_JMP_ALWAYS, addr & 0x1FU));
 }
 
 /**

--- a/testhal/RP/RP2040/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2040/PIO-VALIDATION/main.c
@@ -74,6 +74,11 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 22. Instruction encoders: every pioEncode* must match the
+ *    hand-assembled words this suite already uses, and a program built
+ *    only with encoders must produce the reference square wave.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries test 22, the siblings land with theirs.)
  *
  * The square wave is emitted on GPIO2 and read back through SIO GPIO_IN.
  * The report is emitted on UART0 (GPIO0/GPIO1) at the SIO default
@@ -207,6 +212,15 @@ static const rp_pio_program_t outpin_program = {
 
 /* DMA source pattern, filled at run time with alternating bits.*/
 static uint32_t dma_pattern[DMA_WORDS];
+
+/* Square-wave program rebuilt with the instruction encoders in test 22.*/
+static uint16_t encoded_instructions[3];
+
+static const rp_pio_program_t encoded_program = {
+  .instructions = encoded_instructions,
+  .length       = 3U,
+  .origin       = -1
+};
 
 /*===========================================================================*/
 /* Report helpers.                                                           */
@@ -1108,6 +1122,63 @@ int main(void) {
 
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
+  pioSmFree(smp);
+
+  /*
+   * Test 22: instruction encoders.
+   */
+  chprintf(chp, "--- Test 22: instruction encoders\r\n");
+
+  /* Every encoder against the hand-assembled words used elsewhere in
+     this suite and in the driver.*/
+  report("jmp", pioEncodeJmp(PIO_JMP_ALWAYS, 0U) == 0x0000U);
+  report("jmp x--", pioEncodeJmp(PIO_JMP_X_DEC, 5U) == 0x0045U);
+  report("wait 1 irq 3",
+         pioEncodeWait(true, PIO_WAIT_IRQ, 3U) == 0x20C3U);
+  report("in pins, 32", pioEncodeIn(PIO_SRC_PINS, 32U) == 0x4000U);
+  report("out null, 32",
+         pioEncodeOut(PIO_DEST_NULL, 32U) == PIO_INSTR_OUT_NULL_32);
+  report("out pins, 1", pioEncodeOut(PIO_DEST_PINS, 1U) == 0x6001U);
+  report("push block", pioEncodePush(false, true) == 0x8020U);
+  report("pull noblock",
+         pioEncodePull(false, false) == PIO_INSTR_PULL_NOBLOCK);
+  report("mov x, !pins",
+         pioEncodeMov(PIO_DEST_X, PIO_MOV_INVERT, PIO_SRC_PINS) == 0xA028U);
+  report("nop", pioEncodeNop() == PIO_INSTR_NOP);
+  report("irq set 3", pioEncodeIrq(false, false, 3U) == 0xC003U);
+  report("irq clear 3 rel",
+         pioEncodeIrq(true, false, 3U | PIO_IRQ_INDEX_REL) == 0xC053U);
+  report("set pins, 1", pioEncodeSet(PIO_DEST_PINS, 1U) == 0xE001U);
+  report("set pindirs, 1",
+         pioEncodeSet(PIO_DEST_PINDIRS, 1U) == 0xE081U);
+  report("delay [7]", pioEncodeDelay(7U, 0U) == 0x0700U);
+  report("side 1 of 1", pioEncodeSideSet(1U, 1U, false) == 0x1000U);
+  report("side 1 of 1 opt", pioEncodeSideSet(1U, 1U, true) == 0x1800U);
+
+  /* The reference square wave rebuilt with encoders alone.*/
+  encoded_instructions[0] = pioEncodeSet(PIO_DEST_PINS, 1U);
+  encoded_instructions[1] = pioEncodeSet(PIO_DEST_PINS, 0U);
+  encoded_instructions[2] = pioEncodeJmp(PIO_JMP_ALWAYS, 0U);
+  report("program matches the literal one",
+         (encoded_instructions[0] == sqwave_instructions[0]) &&
+         (encoded_instructions[1] == sqwave_instructions[1]) &&
+         (encoded_instructions[2] == sqwave_instructions[2]));
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  sq_off = pioProgramLoad(block, &encoded_program);
+  report("program loaded", sq_off >= 0);
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges(TEST_GPIO);
+  report("square wave from the encoded program",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, sq_off, encoded_program.length);
   pioSmFree(smp);
 
   /*

--- a/testhal/RP/RP2350/PIO-VALIDATION/main.c
+++ b/testhal/RP/RP2350/PIO-VALIDATION/main.c
@@ -74,6 +74,11 @@
  *    autopull states without touching SHIFTCTRL, leave no stalled exec
  *    behind, keep its hands off a stall it did not cause, and
  *    PIO_INSTR_NOP must displace a stalled exec'd instruction.
+ * 22. Instruction encoders: every pioEncode* must match the
+ *    hand-assembled words this suite already uses, and a program built
+ *    only with encoders must produce the reference square wave.
+ *    (Test numbers 15..22 are allocated across the PIO API series;
+ *    this branch carries test 22, the siblings land with theirs.)
  *
  * The square wave is emitted on GPIO2 and read back through SIO GPIO_IN.
  * The report is emitted on UART0 (GPIO0/GPIO1) at the SIO default
@@ -207,6 +212,15 @@ static const rp_pio_program_t outpin_program = {
 
 /* DMA source pattern, filled at run time with alternating bits.*/
 static uint32_t dma_pattern[DMA_WORDS];
+
+/* Square-wave program rebuilt with the instruction encoders in test 22.*/
+static uint16_t encoded_instructions[3];
+
+static const rp_pio_program_t encoded_program = {
+  .instructions = encoded_instructions,
+  .length       = 3U,
+  .origin       = -1
+};
 
 /*===========================================================================*/
 /* Report helpers.                                                           */
@@ -1108,6 +1122,65 @@ int main(void) {
 
   pioSmRestartX(smp);
   pioSmClearFifosX(smp);
+  pioSmFree(smp);
+
+  /*
+   * Test 22: instruction encoders.
+   */
+  chprintf(chp, "--- Test 22: instruction encoders\r\n");
+
+  /* Every encoder against the hand-assembled words used elsewhere in
+     this suite and in the driver.*/
+  report("jmp", pioEncodeJmp(PIO_JMP_ALWAYS, 0U) == 0x0000U);
+  report("jmp x--", pioEncodeJmp(PIO_JMP_X_DEC, 5U) == 0x0045U);
+  report("wait 1 irq 3",
+         pioEncodeWait(true, PIO_WAIT_IRQ, 3U) == 0x20C3U);
+  report("wait 0 jmppin",
+         pioEncodeWait(false, PIO_WAIT_JMPPIN, 0U) == 0x2060U);
+  report("in pins, 32", pioEncodeIn(PIO_SRC_PINS, 32U) == 0x4000U);
+  report("out null, 32",
+         pioEncodeOut(PIO_DEST_NULL, 32U) == PIO_INSTR_OUT_NULL_32);
+  report("out pins, 1", pioEncodeOut(PIO_DEST_PINS, 1U) == 0x6001U);
+  report("push block", pioEncodePush(false, true) == 0x8020U);
+  report("pull noblock",
+         pioEncodePull(false, false) == PIO_INSTR_PULL_NOBLOCK);
+  report("mov x, !pins",
+         pioEncodeMov(PIO_DEST_X, PIO_MOV_INVERT, PIO_SRC_PINS) == 0xA028U);
+  report("nop", pioEncodeNop() == PIO_INSTR_NOP);
+  report("irq set 3", pioEncodeIrq(false, false, 3U) == 0xC003U);
+  report("irq clear 3 rel",
+         pioEncodeIrq(true, false, 3U | PIO_IRQ_INDEX_REL) == 0xC053U);
+  report("set pins, 1", pioEncodeSet(PIO_DEST_PINS, 1U) == 0xE001U);
+  report("set pindirs, 1",
+         pioEncodeSet(PIO_DEST_PINDIRS, 1U) == 0xE081U);
+  report("delay [7]", pioEncodeDelay(7U, 0U) == 0x0700U);
+  report("side 1 of 1", pioEncodeSideSet(1U, 1U, false) == 0x1000U);
+  report("side 1 of 1 opt", pioEncodeSideSet(1U, 1U, true) == 0x1800U);
+
+  /* The reference square wave rebuilt with encoders alone.*/
+  encoded_instructions[0] = pioEncodeSet(PIO_DEST_PINS, 1U);
+  encoded_instructions[1] = pioEncodeSet(PIO_DEST_PINS, 0U);
+  encoded_instructions[2] = pioEncodeJmp(PIO_JMP_ALWAYS, 0U);
+  report("program matches the literal one",
+         (encoded_instructions[0] == sqwave_instructions[0]) &&
+         (encoded_instructions[1] == sqwave_instructions[1]) &&
+         (encoded_instructions[2] == sqwave_instructions[2]));
+
+  smp = pioSmAlloc(block, 0U, TEST_IRQ_PRIORITY, NULL, NULL);
+  report("SM0 allocated", smp != NULL);
+  if (smp == NULL) {
+    goto summary;
+  }
+
+  sq_off = pioProgramLoad(block, &encoded_program);
+  report("program loaded", sq_off >= 0);
+  sqwave_start(smp, (uint32_t)sq_off);
+  edges = count_edges(TEST_GPIO);
+  report("square wave from the encoded program",
+         (edges >= EDGES_LO) && (edges <= EDGES_HI));
+
+  pioSmDisableX(smp);
+  pioProgramUnload(block, sq_off, encoded_program.length);
   pioSmFree(smp);
 
   /*


### PR DESCRIPTION
## Summary

`pioSmExecX()` and `rp_pio_program_t` instruction arrays take raw instruction words and the driver gives no way to build one, so every consumer hand-assembles literals: `0xE081`, `0x6020`, `0xC003` — the PIO-VALIDATION suite is full of them, downstream drivers carry their own (the nanoFramework CYW43 PIO-SPI driver, the PIO binding in nanoframework/nf-interpreter#3449), and the driver itself was doing it in two places. Hand-assembly is unreadable and easy to get wrong; the `PULL`-encoded-as-`PUSH` bug fixed during the TX FIFO drain review (#168) is exactly the class of mistake an encoder makes hard to write.

This PR:

- adds operand macros: `PIO_DEST_*`, `PIO_SRC_*`, `PIO_MOV_*`, all eight `PIO_JMP_*` conditions, `PIO_WAIT_*` sources (`PIO_WAIT_JMPPIN` gated to the RP2350, where it exists), and `PIO_IRQ_INDEX_REL` for machine-relative flag addressing. EXEC is deliberately not a single constant: OUT encodes it as 7 and MOV as 4, so `PIO_OUT_DEST_EXEC` and `PIO_MOV_DEST_EXEC` are separate and cannot be crossed;
- adds `pioEncodeJmp/Wait/In/Out/Push/Pull/Mov/Irq/Set/Nop()`, `__STATIC_INLINE` with `osalDbgCheck`ed operand ranges. The checks catch the two classic encoding traps: IN/OUT bit count 32 is encoded as 0 (validated as 1..32, emitted masked), and MOV op 3 is reserved (rejected);
- adds the delay/side-set field combinators `pioEncodeDelay()` and `pioEncodeSideSet()`, ORed into any instruction. The delay field shrinks as side-set bits are configured, so both take the configured side-set width and validate the value fits instead of silently corrupting the neighbouring field; `pioEncodeSideSet()` handles the optional (SIDE_EN) enable bit placement;
- converts the driver's two internal hand-assembled sites: `pioSmSetPCX()` now emits `pioEncodeJmp(PIO_JMP_ALWAYS, ...)` and `pioSmSetConsecutivePindirsX()` emits `pioEncodeSet(PIO_DEST_PINDIRS, ...)`. The emitted instructions are bit-identical, and the existing `PIO_INSTR_*` constants are untouched.

Functionally this is `pio_encode_*` in the pico-sdk; the encodings follow the datasheet instruction set tables (RP2040/RP2350 §3.4).

PIO-VALIDATION grows test 22: seventeen asserts checking every encoder against the hand-assembled words the suite and the driver already use (`pioEncodeSet(PIO_DEST_PINDIRS, 1) == 0xE081`, `pioEncodeNop() == PIO_INSTR_NOP`, `pioEncodePull(false, false) == PIO_INSTR_PULL_NOBLOCK`, ...), pure computation that gives full signal without a board, plus a behavioral leg: the reference square wave rebuilt from encoders alone, verified word-identical to the literal program and then run on the pin. The RP2350 leg adds a `PIO_WAIT_JMPPIN` encoding check. Test numbers 15..22 are reserved across this PIO API series; this branch carries only its own test.

## Related

- Issue(s): —
- Notes for reviewers: two conventions worth your call. (1) The encoders carry no X suffix — they are pure functions with no register effect, following the precedent of `PIO_INSTR_NOP` and `PIO_SM_CLKDIV()`; a rename is mechanical if you prefer X. (2) `pioEncodeIrq()` takes the flag index with `PIO_IRQ_INDEX_REL` ORed in (checked < 32) rather than a separate `bool rel` parameter, so the signature survives the RP2350 index-mode extensions unchanged. Last PR of the series (#222 block level APIs, #223 runtime setters/readback, #224 patching/synchronized enable), independent of the other three.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files (`tools/style/stylecheck.py` on `rp_pio.h` and both `main.c`)
- [x] Build check passed: RP2040 PIO-VALIDATION (Cortex-M0+), RP2350 PIO-VALIDATION (Cortex-M33) and RP2350 PIO-VALIDATION-RISCV compile clean

## Testing

- [ ] Test run successfully locally
- The three PIO-VALIDATION legs compile clean; the device run of the suite is pending on Pico/Pico2 hardware and results will be reported in this thread. Most of test 22 is pure computation (encoder words vs. known literals) and gives full signal on any run; the encoder-built square wave leg needs the board.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

Additive, plus two internal call sites converted with bit-identical emitted instructions. The encoders validate operand ranges, not per-instruction operand legality (e.g. `SET` accepts any `PIO_DEST_*` value in range even though the hardware only implements four destinations); full legality tables are documented as the datasheet's domain, matching the existing `PIO_DEST_*` doc note.
