### PR TITLE
STM32 OCTOSPIv2: fix DHQC config, uninitialized DCR2 prescaler and ISR race (by Bob)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,12 @@ applied to a maintenance branch are marked *(backported to 21.11.6)*.
 
 ### Fixed
 
+- [STM32] OCTOSPIv2 WSPI driver had three defects: the OCTOSPI2 initialization
+  used the OCTOSPI1 DHQC option bit, a non-full-init start wrote an
+  uninitialized DCR2 prescaler, and the transfer-complete ISR invoked the
+  portable ISR code (whose callback may start a new transaction) before
+  waiting for MDMA completion
+  ([#227](https://github.com/chibios-upstream/chibios/pull/227)).
 - [ARMV6M] ARMv6-M could fail to link with `-flto` (an "undefined reference" to the
   interrupt handler body) once an image grew large enough for the LTO
   partitioner to split it; the `PORT_IRQ_HANDLER` body now has external

--- a/os/hal/ports/STM32/LLD/OCTOSPIv2/hal_wspi_lld.c
+++ b/os/hal/ports/STM32/LLD/OCTOSPIv2/hal_wspi_lld.c
@@ -127,7 +127,7 @@ void wspi_lld_init(void) {
 #if STM32_WSPI_OCTOSPI2_SSHIFT
                     | OCTOSPI_TCR_SSHIFT
 #endif
-#if STM32_WSPI_OCTOSPI1_DHQC
+#if STM32_WSPI_OCTOSPI2_DHQC
                     | OCTOSPI_TCR_DHQC
 #endif
                     ;
@@ -147,7 +147,18 @@ void wspi_lld_init(void) {
  * @notapi
  */
 void wspi_lld_start(WSPIDriver *wspip) {
-  uint32_t dcr2;
+  uint32_t dcr2 = 0U;
+
+#if STM32_WSPI_USE_OCTOSPI1
+  if (&WSPID1 == wspip) {
+    dcr2 = STM32_DCR2_PRESCALER(STM32_WSPI_OCTOSPI1_PRESCALER_VALUE - 1U);
+  }
+#endif
+#if STM32_WSPI_USE_OCTOSPI2
+  if (&WSPID2 == wspip) {
+    dcr2 = STM32_DCR2_PRESCALER(STM32_WSPI_OCTOSPI2_PRESCALER_VALUE - 1U);
+  }
+#endif
 
   /* If in stopped state then full initialization.*/
   if (wspip->state == WSPI_STOP) {
@@ -159,7 +170,6 @@ void wspi_lld_start(WSPIDriver *wspip) {
       osalDbgAssert(wspip->mdma != NULL, "unable to allocate MDMA channel");
       rccEnableOCTOSPI1(true);
       mdmaChannelSetTrigModeX(wspip->mdma, MDMA_REQUEST_OCTOSPI1_FIFO_TH);
-      dcr2 = STM32_DCR2_PRESCALER(STM32_WSPI_OCTOSPI1_PRESCALER_VALUE - 1U);
     }
 #endif
 
@@ -171,7 +181,6 @@ void wspi_lld_start(WSPIDriver *wspip) {
       osalDbgAssert(wspip->mdma != NULL, "unable to allocate MDMA channel");
       rccEnableOCTOSPI2(true);
       mdmaChannelSetTrigModeX(wspip->mdma, MDMA_REQUEST_OCTOSPI2_FIFO_TH);
-      dcr2 = STM32_DCR2_PRESCALER(STM32_WSPI_OCTOSPI2_PRESCALER_VALUE - 1U);
     }
 #endif
   }
@@ -432,15 +441,16 @@ void wspi_lld_serve_interrupt(WSPIDriver *wspip) {
   wspip->ospi->FCR = OCTOSPI_FCR_CTEF | OCTOSPI_FCR_CTCF |
                      OCTOSPI_FCR_CSMF | OCTOSPI_FCR_CTOF;
 
-  /* Portable WSPI ISR code defined in the high level driver, note, it is
-     a macro.*/
-  _wspi_isr_code(wspip);
-
-  /* Stop everything, we need to give DMA enough time to complete the ongoing
-     operation. Race condition hidden here.*/
+  /* The OCTOSPI transfer-complete flag can precede MDMA completion. Wait
+     before invoking the portable ISR code because its callback is allowed
+     to start another transaction on this driver.*/
   while (mdmaChannelIsEnabled(wspip->mdma)) {
     /* Waiting for MDMA transaction completion.*/
   }
+
+  /* Portable WSPI ISR code defined in the high level driver, note, it is
+     a macro.*/
+  _wspi_isr_code(wspip);
 }
 
 #endif /* HAL_USE_WSPI */


### PR DESCRIPTION
**Ownership:** these fixes are authored by **Bob Anderson** (@CInsights, ChibiOS project member); the sheriff is only opening the PR on his behalf since they arrived as a bare patch. Please reassign to @CInsights.

Three defects in the STM32 OCTOSPIv2 WSPI low-level driver:

1. **DHQC config bit** — `wspi_lld_init()` gated the OCTOSPI2 `DHQC` option on `STM32_WSPI_OCTOSPI1_DHQC` instead of `STM32_WSPI_OCTOSPI2_DHQC` (copy-paste).
2. **Uninitialized DCR2 prescaler** — `wspi_lld_start()` computed the `DCR2` prescaler only inside the `WSPI_STOP` (full-init) branch, but `wspip->ospi->DCR2 = wspip->config->dcr2 | dcr2;` runs unconditionally afterwards, so a non-full-init start wrote an uninitialized prescaler. `dcr2` is now initialized to 0 and computed for the active instance in all paths.
3. **ISR/MDMA race** — `wspi_lld_serve_interrupt()` invoked the portable `_wspi_isr_code()` (whose callback may start a new transaction on the driver) *before* waiting for the MDMA channel to finish; the original code even flagged "Race condition hidden here". It now waits for MDMA completion first.

### Gates
- `tools/style/stylecheck.py` clean on the changed file.
- `testhal/STM32/multi/WSPI-MFS` on `stm32h735ig_discovery` (OCTOSPIv2) builds clean, ARM GCC 14.3.1.

---
🤖 chibios-sheriff — opened on behalf of the author. A human maintainer decides on merge; the sheriff does not review or merge its own PRs.
