### PR TITLE
ARMv7-R: avoid an alignment-increasing cast in port_setup_context()

### DIFF
--- a/os/common/ports/ARMv7-R/chcore.h
+++ b/os/common/ports/ARMv7-R/chcore.h
@@ -848,8 +848,8 @@ static inline void port_setup_context(struct port_context *ctxp,
 
   (void)wbase;
 
-  ctxp->sp = (struct port_intctx *)((uint8_t *)wtop -
-                                    sizeof (struct port_intctx));
+  ctxp->sp = (struct port_intctx *)(void *)((uint8_t *)wtop -
+                                            sizeof (struct port_intctx));
 #if CORTEX_USE_FPU == TRUE
   ctxp->sp->fpscr = 0U;
 #endif


### PR DESCRIPTION
## Summary

`port_setup_context()` is a `static inline` in `chcore.h`, so it is parsed and compiled in every translation unit that includes `ch.h`, including C++ ones. Its `uint8_t *` to `struct port_intctx *` cast trips `-Wcast-align`, which breaks any build compiling C++ with `-Wcast-align -Werror`:

```
os/common/ports/ARMv7-R/chcore.h:857:14: error: cast from 'uint8_t*' {aka 'unsigned char*'}
to 'port_intctx*' increases required alignment of target type [-Werror=cast-align]
  857 |   ctxp->sp = (struct port_intctx *)((uint8_t *)wtop -
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The predecessor `PORT_SETUP_CONTEXT` macro was only ever expanded inside the kernel's own C sources, so the same cast never reached those builds.

Casting through `void *` states the intent and generates identical code; the working area top is already suitably aligned.

Found while building ArduPilot (C++, `-Wcast-align -Werror`) against the port on a TI AM67A Cortex-R5F.

## Related

- Issue(s): none
- Notes for reviewers: one line. Confirmed with a control build — the same tree without this change fails to link, with it the firmware links and runs on hardware.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files — `tools/style/stylecheck.py` clean
      on `os/common/ports/ARMv7-R/chcore.h`
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile) —
      `RT-Posix-Simulator` links, `RT-ARMCR8-GENERIC` builds at text 4892 B with
      `arm-none-eabi-gcc 13.2.1`, unchanged from the unpatched tree

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? Yes. The resulting firmware runs on a T3 Gemstone O1
  (TI AM67A/J722S) MCU-domain Cortex-R5F: boots, the scheduler preempts, and the system
  tick holds exactly 1000 Hz over 96 s with zero drift.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided — not applicable
- [x] Risks/limitations are documented below

The generated code is identical; this only changes what the compiler is permitted to warn about. As a build-breakage fix for existing users it may be worth considering for a `stable-*` backport once merged here, but that is the maintainers' call.