### PR TITLE
hal: fully deactivate STM32 SPI on stop

### DIFF
--- a/os/hal/ports/STM32/LLD/SPIv3/hal_spi_v2_lld.c
+++ b/os/hal/ports/STM32/LLD/SPIv3/hal_spi_v2_lld.c
@@ -990,6 +990,13 @@ void spi_lld_stop(SPIDriver *spip) {
     /* Just in case this has been called uncleanly.*/
     (void) spi_lld_stop_abort(spip);
 
+    /* SPI cleanup.*/
+    spip->spi->CR1  = 0U;
+    spip->spi->CR2  = 0U;
+    spip->spi->CFG1 = 0U;
+    spip->spi->CFG2 = 0U;
+    spip->spi->IER  = 0U;
+
 #if defined(STM32_SPI_DMA_REQUIRED) && defined(STM32_SPI_BDMA_REQUIRED)
     if (spip->is_bdma)
 #endif

--- a/os/hal/ports/STM32/LLD/SPIv4/hal_spi_v2_lld.c
+++ b/os/hal/ports/STM32/LLD/SPIv4/hal_spi_v2_lld.c
@@ -637,6 +637,13 @@ void spi_lld_stop(SPIDriver *spip) {
     /* Just in case this has been called uncleanly.*/
     (void) spi_lld_stop_abort(spip);
 
+    /* SPI cleanup.*/
+    spip->spi->CR1  = 0U;
+    spip->spi->CR2  = 0U;
+    spip->spi->CFG1 = 0U;
+    spip->spi->CFG2 = 0U;
+    spip->spi->IER  = 0U;
+
     /* Releasing DMA channels.*/
     dma3ChannelFreeI(spip->dmarx);
     dma3ChannelFreeI(spip->dmatx);


### PR DESCRIPTION
## Summary

- clear the STM32 SPIv3 peripheral control, configuration, and interrupt-enable registers during `spiStop()`
- apply the same full-stop cleanup to STM32 SPIv4

## Root cause

The SPIv3 and SPIv4 low-level stop paths call `spi_lld_stop_abort()`. That helper resets the peripheral but then reconfigures it so abort and error-recovery paths can continue using the driver. In the full driver-stop path this left `SPI_CR1_SPE` and DMA-related configuration enabled while the peripheral clock was gated.

On STM32U375 this can prevent Standby from reaching its expected low-power state after SPI has been used. The issue was reported at https://forum.chibios.org/viewtopic.php?t=6710.

## Impact

After `spiStop()`, SPIv3 and SPIv4 peripherals are now fully disabled before their DMA resources and clocks are released. Abort and error-recovery behavior is unchanged.

## Validation

- `testhal/STM32/multi/SPI`: STM32H743 Nucleo144 build (SPIv3)
- `testhal/STM32/multi/SPI`: STM32H563ZI Nucleo144 build (SPIv4)
- `git diff --check`
