### PR TITLE
Fix STM32U5 dynamic clock register handling

### DIFF
--- a/os/hal/ports/STM32/STM32U5xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U5xx/hal_lld.c
@@ -64,6 +64,13 @@
 
 #define STM32_WS_THRESHOLDS             16U
 
+/* Writable configuration fields in RCC_ICSCR1. The MSICALx fields contain
+   factory calibration values and must be preserved.*/
+#define STM32_RCC_ICSCR1_CFG_MASK       (RCC_ICSCR1_MSIBIAS_Msk |          \
+                                         RCC_ICSCR1_MSIRGSEL_Msk |         \
+                                         RCC_ICSCR1_MSIKRANGE_Msk |        \
+                                         RCC_ICSCR1_MSISRANGE_Msk)
+
 #if (STM32_CLOCKTREE_VARIANT_U595 == TRUE) ||                               \
     (STM32_CLOCKTREE_VARIANT_U5A5 == TRUE)
 #define STM32_RCC_CFGR2_FIXED_BITS      0x00006000U
@@ -554,8 +561,11 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   halRegWrite32X(&FLASH->ACR, FLASH_ACR_LATENCY_15WS, true);
 
   /* Enter a known MSIS-based state before applying the requested tree.*/
-  halRegWrite32X(&RCC->ICSCR1, STM32_RCC_ICSCR1_RESET, true);
-  halRegWrite32X(&RCC->CR,     STM32_RCC_CR_RESET, true);
+  halRegModify32X(&RCC->ICSCR1,
+                  STM32_RCC_ICSCR1_RESET,
+                  STM32_RCC_ICSCR1_CFG_MASK & ~STM32_RCC_ICSCR1_RESET,
+                  true);
+  halRegWrite32X(&RCC->CR, STM32_RCC_CR_RESET, false);
   if (halRegWaitAllSet32X(&RCC->CR,
                           RCC_CR_MSISRDY | RCC_CR_MSIKRDY,
                           STM32_OSCILLATORS_STARTUP_TIME,
@@ -565,7 +575,7 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
 
   halRegWrite32X(&RCC->CFGR2, STM32_RCC_CFGR2_RESET, true);
   halRegWrite32X(&RCC->CFGR3, STM32_RCC_CFGR3_RESET, true);
-  halRegWrite32X(&RCC->CFGR1, STM32_RCC_CFGR1_RESET, true);
+  halRegWrite32X(&RCC->CFGR1, STM32_RCC_CFGR1_RESET, false);
   if (halRegWaitMatch32X(&RCC->CFGR1,
                          RCC_CFGR1_SWS_Msk,
                          0U,
@@ -582,9 +592,9 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
 #if defined(PWR_VOSR_USBPWREN)
   halRegWrite32X(&PWR->VOSR,
                  (ccp->pwr_vosr & ~PWR_VOSR_BOOSTEN) | usbpower,
-                 true);
+                 false);
 #else
-  halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr & ~PWR_VOSR_BOOSTEN, true);
+  halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr & ~PWR_VOSR_BOOSTEN, false);
 #endif
   if (halRegWaitAllSet32X(&PWR->VOSR,
                           PWR_VOSR_VOSRDY,
@@ -594,12 +604,14 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   }
 
   /* MSI ranges and bias selection. MSIRGSEL is enforced for determinism.*/
-  halRegWrite32X(&RCC->ICSCR1,
-                 ccp->rcc_icscr1 | RCC_ICSCR1_MSIRGSEL_ICSCR1,
-                 true);
+  halRegModify32X(&RCC->ICSCR1,
+                  ccp->rcc_icscr1 | RCC_ICSCR1_MSIRGSEL_ICSCR1,
+                  STM32_RCC_ICSCR1_CFG_MASK &
+                  ~(ccp->rcc_icscr1 | RCC_ICSCR1_MSIRGSEL_ICSCR1),
+                  true);
 
   /* Backup-domain clock sources and selectors.*/
-  halRegWrite32X(&RCC->BDCR, ccp->rcc_bdcr, true);
+  halRegWrite32X(&RCC->BDCR, ccp->rcc_bdcr, false);
   wtmask = 0U;
   if ((ccp->rcc_bdcr & RCC_BDCR_LSEON) != 0U) {
     wtmask |= RCC_BDCR_LSERDY;
@@ -620,9 +632,9 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   if ((cr & (RCC_CR_HSEON | RCC_CR_HSEBYP)) ==
       (RCC_CR_HSEON | RCC_CR_HSEBYP)) {
     /* HSEBYP must be latched while HSEON is still cleared.*/
-    halRegWrite32X(&RCC->CR, cr & ~RCC_CR_HSEON, true);
+    halRegWrite32X(&RCC->CR, cr & ~RCC_CR_HSEON, false);
   }
-  halRegWrite32X(&RCC->CR, cr, true);
+  halRegWrite32X(&RCC->CR, cr, false);
 
   wtmask = RCC_CR_MSISRDY;
   if ((ccp->rcc_cr & RCC_CR_MSIKON) != 0U) {
@@ -654,9 +666,9 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
 
   if ((ccp->pwr_vosr & PWR_VOSR_BOOSTEN) != 0U) {
 #if defined(PWR_VOSR_USBPWREN)
-    halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr | usbpower, true);
+    halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr | usbpower, false);
 #else
-    halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr, true);
+    halRegWrite32X(&PWR->VOSR, ccp->pwr_vosr, false);
 #endif
     if (halRegWaitAllSet32X(&PWR->VOSR,
                             PWR_VOSR_BOOSTRDY,
@@ -667,7 +679,7 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   }
 
   cr = ccp->rcc_cr | RCC_CR_MSISON;
-  halRegWrite32X(&RCC->CR, cr, true);
+  halRegWrite32X(&RCC->CR, cr, false);
 
   wtmask = 0U;
   if ((ccp->rcc_cr & RCC_CR_PLL1ON) != 0U) {
@@ -690,7 +702,7 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   halRegWrite32X(&RCC->CFGR2, ccp->rcc_cfgr2, true);
   halRegWrite32X(&RCC->CFGR3, ccp->rcc_cfgr3, true);
   halRegWrite32X(&FLASH->ACR, ccp->flash_acr, true);
-  halRegWrite32X(&RCC->CFGR1, ccp->rcc_cfgr1, true);
+  halRegWrite32X(&RCC->CFGR1, ccp->rcc_cfgr1, false);
   if (halRegWaitMatch32X(&RCC->CFGR1,
                          RCC_CFGR1_SWS_Msk,
                          (ccp->rcc_cfgr1 & RCC_CFGR1_SW_Msk) << RCC_CFGR1_SWS_Pos,
@@ -700,7 +712,7 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
   }
 
   /* MSIS can be disabled now if it is not part of the requested tree.*/
-  halRegWrite32X(&RCC->CR, ccp->rcc_cr, true);
+  halRegWrite32X(&RCC->CR, ccp->rcc_cr, false);
 
   return false;
 }


### PR DESCRIPTION
  ## Summary

  Correct STM32U5 clock-tree configuration writes that were being verified
  against complete register values even where the registers contain read-only or
  hardware-controlled status fields.

  The affected RCC and PWR writes now disable whole-register readback
  verification where the written value cannot be expected to match the complete
  register contents. Existing explicit readiness and clock-switch timeout checks
  remain in place and continue to verify the actual hardware transitions.

  `RCC_ICSCR1` is handled separately because it contains both configuration
  fields and factory-programmed MSI calibration fields. The change:

  - defines a mask containing only the writable MSI configuration fields;
  - updates those fields using `halRegModify32X()`;
  - preserves the factory-programmed `MSICALx` calibration values;
  - continues to verify the writable configuration fields;
  - retains the existing bounded waits for oscillator, regulator, PLL and
    system-clock transitions.

  This is needed because full-register verification can incorrectly fail when
  read-only status bits change asynchronously, and writing all of `ICSCR1` can
  overwrite factory calibration data.

  ## Related

  - Issue(s): None
  - Notes for reviewers:
    - The change is confined to the STM32U5 dynamic clock configuration path.
    - Readback verification is disabled only for registers containing
      hardware-controlled or read-only fields.
    - Explicit bounded readiness checks remain unchanged.
    - `ICSCR1` configuration fields are still verified through the masked
      modify operation.
    - Factory `MSICALx` fields are deliberately preserved.

  ## Target Branch Check

  - [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
        `stable-*` branches only receive maintainer-selected backports of commits already
        merged on `master`

  ## Scope

  - [x] Change is focused and does not bundle unrelated work
  - [x] I reviewed impact on other ports/configurations where relevant

  The implementation changes only
  `os/hal/ports/STM32/STM32U5xx/hal_lld.c`. Other STM32 ports are unaffected.

  ## Mechanical Checks

  - [x] Style check passed on changed `.c`/`.h` files
  - [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

  The relevant STM32U5 ARM configurations compile successfully. The POSIX
  simulator was not rebuilt because this change is confined to the STM32U5 HAL
  clock code.

  ## Testing

  - [x] Test run successfully locally
  - Any other tests run on a device?

  Tested through STM32U5 firmware builds and hardware startup. The STM32U5 clock
  configuration completes without the previous false register-verification halt,
  and the device proceeds through HAL initialization and normal operation.

  ## Compatibility and Risk

  - [x] No intentional public API/ABI break
  - [ ] If API/ABI changed, rationale and migration notes are provided
  - [x] Risks/limitations are documented below

  No public interfaces or configuration structures are changed.

  The main risk is reduced immediate whole-register verification for the
  affected RCC and PWR writes. This is intentional because those registers
  contain status or read-only fields that make exact readback invalid. Critical
  state changes remain protected by the existing bounded waits for readiness and
  source-switch status.

  The `ICSCR1` write remains masked and verified because its writable
  configuration fields can be checked safely while preserving the factory
  calibration fields.
