### PR TITLE
STM32 FDCAN: Add timestamp counter configuration

### DIFF
--- a/os/hal/ports/STM32/LLD/FDCANv1/hal_can_lld.c
+++ b/os/hal/ports/STM32/LLD/FDCANv1/hal_can_lld.c
@@ -289,6 +289,7 @@ bool can_lld_start(CANDriver *canp) {
   canp->fdcan->NBTP = canp->config->NBTP;
   canp->fdcan->DBTP = canp->config->DBTP;
   canp->fdcan->TDCR = canp->config->TDCR;
+  canp->fdcan->TSCC = canp->config->TSCC;
   canp->fdcan->CCCR |= canp->config->CCCR;
 
   /* TEST is only writable when FDCAN_CCCR_TEST is set and FDCAN is still in

--- a/os/hal/ports/STM32/LLD/FDCANv1/hal_can_lld.h
+++ b/os/hal/ports/STM32/LLD/FDCANv1/hal_can_lld.h
@@ -305,7 +305,7 @@ typedef struct {
           uint32_t          ESI:1;      /**< @brief Error state indicator.  */
         } common;
       };
-      uint32_t              RXTS:16;    /**< @brief TX time stamp.          */
+      uint32_t              RXTS:16;    /**< @brief Receive timestamp.      */
       uint32_t              DLC:4;      /**< @brief Data length code.       */
       uint32_t              BRS:1;      /**< @brief Bit rate switch.        */
       uint32_t              FDF:1;      /**< @brief FDCAN frame format.     */
@@ -476,6 +476,10 @@ typedef struct hal_can_config {
    * @brief   Global filter configuration register.
    */
   uint32_t                  RXGFC;
+  /**
+   * @brief   Timestamp counter configuration register.
+   */
+  uint32_t                  TSCC;
 } CANConfig;
 
 /**

--- a/os/hal/ports/STM32/LLD/FDCANv1/stm32_fdcan.h
+++ b/os/hal/ports/STM32/LLD/FDCANv1/stm32_fdcan.h
@@ -196,6 +196,18 @@
 #define FDCAN_CONFIG_TDCR_TDCO(n)        ((FDCAN_CONFIG_TDCR_TDCO_Msk & ((n) << FDCAN_CONFIG_TDCR_TDCO_Pos)))
 /** @} */
 
+/**
+ * @name    Timestamp counter configuration register.
+ * @{
+ */
+#define FDCAN_CONFIG_TSCC_TSS_Pos        (0)
+#define FDCAN_CONFIG_TSCC_TSS_Msk        (0x3u << FDCAN_CONFIG_TSCC_TSS_Pos)
+#define FDCAN_CONFIG_TSCC_TSS(n)         ((FDCAN_CONFIG_TSCC_TSS_Msk & ((n) << FDCAN_CONFIG_TSCC_TSS_Pos)))
+#define FDCAN_CONFIG_TSCC_TCP_Pos        (16)
+#define FDCAN_CONFIG_TSCC_TCP_Msk        (0xFu << FDCAN_CONFIG_TSCC_TCP_Pos)
+#define FDCAN_CONFIG_TSCC_TCP(n)         ((FDCAN_CONFIG_TSCC_TCP_Msk & ((n) << FDCAN_CONFIG_TSCC_TCP_Pos)))
+/** @} */
+
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/

--- a/os/hal/ports/STM32/LLD/FDCANv2/hal_can_lld.c
+++ b/os/hal/ports/STM32/LLD/FDCANv2/hal_can_lld.c
@@ -427,6 +427,7 @@ bool can_lld_start(CANDriver *canp) {
   canp->fdcan->NBTP = canp->config->NBTP;
   canp->fdcan->DBTP = canp->config->DBTP;
   canp->fdcan->TDCR = canp->config->TDCR;
+  canp->fdcan->TSCC = canp->config->TSCC;
   canp->fdcan->CCCR |= canp->config->CCCR;
 
   /* TEST is only writable when FDCAN_CCCR_TEST is set and FDCAN is still in

--- a/os/hal/ports/STM32/LLD/FDCANv2/hal_can_lld.h
+++ b/os/hal/ports/STM32/LLD/FDCANv2/hal_can_lld.h
@@ -289,7 +289,7 @@ typedef struct {
           uint32_t          ESI:1;      /**< @brief Error state indicator.  */
         } common;
       };
-      uint32_t              RXTS:16;    /**< @brief TX time stamp.          */
+      uint32_t              RXTS:16;    /**< @brief Receive timestamp.      */
       uint32_t              DLC:4;      /**< @brief Data length code.       */
       uint32_t              BRS:1;      /**< @brief Bit rate switch.        */
       uint32_t              FDF:1;      /**< @brief FDCAN frame format.     */
@@ -460,6 +460,10 @@ typedef struct hal_can_config {
    * @brief   Global filter configuration register.
    */
   uint32_t                  RXGFC;
+  /**
+   * @brief   Timestamp counter configuration register.
+   */
+  uint32_t                  TSCC;
 } CANConfig;
 
 /**

--- a/os/hal/ports/STM32/LLD/FDCANv2/stm32_fdcan.h
+++ b/os/hal/ports/STM32/LLD/FDCANv2/stm32_fdcan.h
@@ -274,6 +274,19 @@
 #define FDCAN_CONFIG_TDCR_TDCO_Msk       (0x7Fu << FDCAN_CONFIG_TDCR_TDCO_Pos)
 #define FDCAN_CONFIG_TDCR_TDCO(n)        ((FDCAN_CONFIG_TDCR_TDCO_Msk & ((n) << FDCAN_CONFIG_TDCR_TDCO_Pos)))
 /** @} */
+
+/**
+ * @name    Timestamp counter configuration register.
+ * @{
+ */
+#define FDCAN_CONFIG_TSCC_TSS_Pos        (0)
+#define FDCAN_CONFIG_TSCC_TSS_Msk        (0x3u << FDCAN_CONFIG_TSCC_TSS_Pos)
+#define FDCAN_CONFIG_TSCC_TSS(n)         ((FDCAN_CONFIG_TSCC_TSS_Msk & ((n) << FDCAN_CONFIG_TSCC_TSS_Pos)))
+#define FDCAN_CONFIG_TSCC_TCP_Pos        (16)
+#define FDCAN_CONFIG_TSCC_TCP_Msk        (0xFu << FDCAN_CONFIG_TSCC_TCP_Pos)
+#define FDCAN_CONFIG_TSCC_TCP(n)         ((FDCAN_CONFIG_TSCC_TCP_Msk & ((n) << FDCAN_CONFIG_TSCC_TCP_Pos)))
+/** @} */
+
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/

--- a/os/xhal/ports/STM32/LLD/FDCANv1/hal_can_lld.c
+++ b/os/xhal/ports/STM32/LLD/FDCANv1/hal_can_lld.c
@@ -300,6 +300,7 @@ msg_t can_lld_start(hal_can_driver_c *canp) {
   canp->fdcan->NBTP = config->NBTP;
   canp->fdcan->DBTP = config->DBTP;
   canp->fdcan->TDCR = config->TDCR;
+  canp->fdcan->TSCC = config->TSCC;
   canp->fdcan->CCCR |= config->CCCR;
 
   /* TEST is only writable when FDCAN_CCCR_TEST is set and FDCAN is still in

--- a/os/xhal/ports/STM32/LLD/FDCANv1/hal_can_lld.h
+++ b/os/xhal/ports/STM32/LLD/FDCANv1/hal_can_lld.h
@@ -284,7 +284,7 @@ typedef struct {
           uint32_t          ESI:1;      /**< @brief Error state indicator.  */
         } common;
       };
-      uint32_t              RXTS:16;    /**< @brief TX time stamp.          */
+      uint32_t              RXTS:16;    /**< @brief Receive timestamp.      */
       uint32_t              DLC:4;      /**< @brief Data length code.       */
       uint32_t              BRS:1;      /**< @brief Bit rate switch.        */
       uint32_t              FDF:1;      /**< @brief FDCAN frame format.     */
@@ -437,7 +437,8 @@ typedef struct {
   uint32_t                  TDCR;                                           \
   uint32_t                  CCCR;                                           \
   uint32_t                  TEST;                                           \
-  uint32_t                  RXGFC
+  uint32_t                  RXGFC;                                          \
+  uint32_t                  TSCC
 
 /**
  * @brief   Platform-dependent CAN driver fields.

--- a/os/xhal/ports/STM32/LLD/FDCANv1/stm32_fdcan.h
+++ b/os/xhal/ports/STM32/LLD/FDCANv1/stm32_fdcan.h
@@ -196,6 +196,18 @@
 #define FDCAN_CONFIG_TDCR_TDCO(n)        ((FDCAN_CONFIG_TDCR_TDCO_Msk & ((n) << FDCAN_CONFIG_TDCR_TDCO_Pos)))
 /** @} */
 
+/**
+ * @name    Timestamp counter configuration register.
+ * @{
+ */
+#define FDCAN_CONFIG_TSCC_TSS_Pos        (0)
+#define FDCAN_CONFIG_TSCC_TSS_Msk        (0x3u << FDCAN_CONFIG_TSCC_TSS_Pos)
+#define FDCAN_CONFIG_TSCC_TSS(n)         ((FDCAN_CONFIG_TSCC_TSS_Msk & ((n) << FDCAN_CONFIG_TSCC_TSS_Pos)))
+#define FDCAN_CONFIG_TSCC_TCP_Pos        (16)
+#define FDCAN_CONFIG_TSCC_TCP_Msk        (0xFu << FDCAN_CONFIG_TSCC_TCP_Pos)
+#define FDCAN_CONFIG_TSCC_TCP(n)         ((FDCAN_CONFIG_TSCC_TCP_Msk & ((n) << FDCAN_CONFIG_TSCC_TCP_Pos)))
+/** @} */
+
 /*===========================================================================*/
 /* Driver pre-compile time settings.                                         */
 /*===========================================================================*/

--- a/testhal/STM32/STM32G4xx/CAN/main.c
+++ b/testhal/STM32/STM32G4xx/CAN/main.c
@@ -54,7 +54,8 @@ static const CANConfig cancfg = {
   0,          /* TDCR */
   0,          /* CCCR */
   0,          /* TEST */
-  0           /* RXGFC */
+  0,          /* RXGFC */
+  0           /* TSCC */
 };
 
 /*
@@ -179,4 +180,3 @@ int main(void) {
     chThdSleepMilliseconds(500);
   }
 }
-

--- a/testhal/STM32/STM32H7xx/CAN/main.c
+++ b/testhal/STM32/STM32H7xx/CAN/main.c
@@ -49,7 +49,8 @@ static const CANConfig cancfg = {
   0,                               /* TDCR */
   0,                               /* CCCR */
   0,                               /* TEST */
-  0                                /* GFC */
+  0,                               /* GFC */
+  0                                /* TSCC */
 };
 
 /*


### PR DESCRIPTION
## Summary

- expose the `TSCC` register in classic FDCANv1, classic FDCANv2, and XHAL FDCANv1 configurations
- program `TSCC` while the controller is in configuration mode
- add portable `FDCAN_CONFIG_TSCC_TSS()` and `FDCAN_CONFIG_TSCC_TCP()` helpers
- document `CANRxFrame.RXTS` as the receive timestamp and align the in-tree FDCAN test configurations

## Rationale

The receive paths already copy the complete FDCAN message header, including `RXTS`, but the drivers never configure `FDCAN_TSCC`. Its reset value disables the timestamp counter, so applications cannot obtain useful receive timestamps through the existing frame field.

`TSCC` is appended to the configuration structure rather than inserted among the existing fields. This preserves the meaning of positional initializers in application code; omitted trailing fields continue to initialize to zero and retain the previous disabled behavior.

This is per-instance runtime state, so no `mcuconf.h` setting or updater change is required.

Closes #234.

## Validation

- built `testhal/STM32/STM32G4xx/CAN` (classic FDCANv1)
- built `testhal/STM32/STM32H7xx/CAN` (classic FDCANv2)
- built `demos/STM32/RT-XHAL-STM32G474RE-NUCLEO64` with a temporary CAN-enabled XHAL configuration
- passed `git diff --check`
- passed the CI-equivalent changed-line `stylecheck.py` gate