### PR TITLE
STM32U3: Omit unused clock helper

### DIFF
--- a/os/hal/ports/STM32/STM32U3xx/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U3xx/hal_lld.c
@@ -335,6 +335,8 @@ __STATIC_INLINE void hal_lld_set_static_clocks(void) {
                  true);
 }
 
+#if !STM32_NO_INIT || defined(HAL_LLD_USE_CLOCK_MANAGEMENT) ||              \
+    defined(__DOXYGEN__)
 /**
  * @brief   Switches to a different clock configuration.
  *
@@ -519,6 +521,7 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
 
   return false;
 }
+#endif
 
 #if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
 /**

--- a/os/hal/ports/STM32/STM32U3xx_TEST/hal_lld.c
+++ b/os/hal/ports/STM32/STM32U3xx_TEST/hal_lld.c
@@ -296,6 +296,8 @@ __STATIC_INLINE void hal_lld_set_static_clocks(void) {
                  true);
 }
 
+#if !STM32_NO_INIT || defined(HAL_LLD_USE_CLOCK_MANAGEMENT) ||              \
+    defined(__DOXYGEN__)
 /**
  * @brief   Switches to a different clock configuration.
  *
@@ -480,6 +482,7 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
 
   return false;
 }
+#endif
 
 #if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
 /**

--- a/os/xhal/ports/STM32/STM32U3xx/hal_lld.c
+++ b/os/xhal/ports/STM32/STM32U3xx/hal_lld.c
@@ -335,6 +335,8 @@ __STATIC_INLINE void hal_lld_set_static_clocks(void) {
                  true);
 }
 
+#if !STM32_NO_INIT || defined(HAL_LLD_USE_CLOCK_MANAGEMENT) ||              \
+    defined(__DOXYGEN__)
 /**
  * @brief   Switches to a different clock configuration.
  *
@@ -519,6 +521,7 @@ static bool hal_lld_clock_configure(const halclkcfg_t *ccp) {
 
   return false;
 }
+#endif
 
 #if defined(HAL_LLD_USE_CLOCK_MANAGEMENT) || defined(__DOXYGEN__)
 /**


### PR DESCRIPTION
## Summary

- compile the internal clock-configuration helper only when startup clock initialization or dynamic clock management can use it
- apply the same guard to classic HAL U3, the U3 clock-tree test port, and XHAL U3

## Root cause

With `STM32_NO_INIT=TRUE` and dynamic clock management disabled, both call sites for `hal_lld_clock_configure()` are compiled out while the static function itself remains. GCC consequently reports `-Wunused-function`, which becomes a build failure under `-Werror`.

## Impact

Static/no-init U3 configurations no longer emit the unused-function warning. Dynamic clock configurations still compile the helper and retain the existing clock-switch behavior.

## Validation

- classic HAL U3 static/no-init full build with `-Werror -Wundef`
- XHAL U3 static/no-init full build with `-Werror -Wundef`
- classic HAL U3 and XHAL U3 dynamic/no-init full builds with `-Werror -Wundef`
- U3 clock-tree test static/no-init full build from the PR merge result, including #238, with `-Werror -Wundef`
- style checker on all three modified sources
- `git diff --check`