### PR TITLE
RT: establish initial SMP kernel lock ownership

### DIFF
--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -104,13 +104,17 @@ static volatile uint32_t port_lockout_msg_count[PORT_CORES_NUMBER];
 /*===========================================================================*/
 
 static void port_local_halt(void) {
+  os_instance_t *oip;
   const char *reason = "remote panic";
 
   port_disable();
+  oip = currcore;
 
   __trace_halt("remote panic");
 
-  currcore->dbg.panic_msg = reason;
+  if (oip != NULL) {
+    oip->dbg.panic_msg = reason;
+  }
 
   CH_CFG_SYSTEM_HALT_HOOK(reason);
 

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -337,10 +337,15 @@ CH_IRQ_HANDLER(Vector80) {
 
 /**
  * @brief   SMP-related port initialization.
+ * @details Acquires the global kernel lock which is released by the final
+ *          @p chSysUnlock() in the instance startup path.
  *
  * @param[in, out] oip  pointer to the @p os_instance_t structure
  */
 void __port_smp_init(os_instance_t *oip) {
+
+  /* Entering the initial global I-Lock state.*/
+  port_spinlock_take();
 
 #if CH_CFG_ST_TIMEDELTA > 0
   /* Activating timer for this instance.*/

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
@@ -167,6 +167,8 @@
  * @brief   SMP-related port initialization.
  * @note    The port checks on presence of this macro so this
  *          must be a macro.
+ * @post    The global kernel lock is acquired and is released by the final
+ *          @p chSysUnlock() in the instance startup path.
  *
  * @param[in, out] oip  pointer to the @p os_instance_t structure
  */

--- a/os/common/ports/ARMv7-M-ALT/chcore.c
+++ b/os/common/ports/ARMv7-M-ALT/chcore.c
@@ -184,6 +184,10 @@ void port_init(os_instance_t *oip) {
 
   (void)oip;
 
+#if defined(port_smp_init)
+  port_smp_init(oip);
+#endif
+
   /* Starting in a known IRQ configuration.*/
   port_suspend();
 
@@ -222,10 +226,6 @@ void port_init(os_instance_t *oip) {
   DWT->LAR = 0xC5ACCE55U;
 #endif
   DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-
-#if defined(port_smp_init)
-  port_smp_init(oip);
-#endif
 
   /* Initialization of the system vectors used by the port.*/
   NVIC_SetPriority(SVCall_IRQn, CORTEX_PRIORITY_SVCALL);

--- a/os/common/ports/ARMv7-M/chcore.c
+++ b/os/common/ports/ARMv7-M/chcore.c
@@ -136,6 +136,10 @@ void port_init(os_instance_t *oip) {
 
   (void)oip;
 
+#if defined(port_smp_init)
+  port_smp_init(oip);
+#endif
+
   /* Starting in a known IRQ configuration.*/
   port_suspend();
 
@@ -159,10 +163,6 @@ void port_init(os_instance_t *oip) {
   DWT->LAR = 0xC5ACCE55U;
 #endif
   DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-
-#if defined(port_smp_init)
-  port_smp_init(oip);
-#endif
 
   /* Initialization of the system vectors used by the port.*/
 #if CORTEX_SIMPLIFIED_PRIORITY == FALSE

--- a/os/common/ports/ARMv8-M-ML-ALT/chcore.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/chcore.c
@@ -181,6 +181,10 @@ void port_init(os_instance_t *oip) {
 
   (void)oip;
 
+#if defined(port_smp_init)
+  port_smp_init(oip);
+#endif
+
   /* Starting in a known IRQ configuration.*/
   port_suspend();
 
@@ -216,10 +220,6 @@ void port_init(os_instance_t *oip) {
   /* DWT cycle counter enable.*/
   CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
   DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-
-#if defined(port_smp_init)
-  port_smp_init(oip);
-#endif
 
   /* Initialization of the system vectors used by the port.*/
   NVIC_SetPriority(SVCall_IRQn, CORTEX_PRIORITY_SVCALL);

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -305,10 +305,15 @@ CH_IRQ_HANDLER(VectorA4) {
 
 /**
  * @brief   SMP-related port initialization.
+ * @details Acquires the global kernel lock which is released by the final
+ *          @p chSysUnlock() in the instance startup path.
  *
  * @param[in, out] oip  pointer to the @p os_instance_t structure
  */
 void __port_smp_init(os_instance_t *oip) {
+
+  /* Entering the initial global I-Lock state.*/
+  port_spinlock_take();
 
 #if CH_CFG_ST_TIMEDELTA > 0
   /* Activating timer for this instance.*/

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -94,13 +94,17 @@ static volatile uint32_t port_lockout_msg_count[PORT_CORES_NUMBER];
 /*===========================================================================*/
 
 static void port_local_halt(void) {
+  os_instance_t *oip;
   const char *reason = "remote panic";
 
   port_disable();
+  oip = currcore;
 
   __trace_halt("remote panic");
 
-  currcore->dbg.panic_msg = reason;
+  if (oip != NULL) {
+    oip->dbg.panic_msg = reason;
+  }
 
   CH_CFG_SYSTEM_HALT_HOOK(reason);
 

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
@@ -167,6 +167,8 @@
  * @brief   SMP-related port initialization.
  * @note    The port checks on presence of this macro so this
  *          must be a macro.
+ * @post    The global kernel lock is acquired and is released by the final
+ *          @p chSysUnlock() in the instance startup path.
  *
  * @param[in, out] oip  pointer to the @p os_instance_t structure
  */

--- a/os/common/ports/ARMv8-M-ML/chcore.c
+++ b/os/common/ports/ARMv8-M-ML/chcore.c
@@ -127,6 +127,10 @@ void port_init(os_instance_t *oip) {
 
   (void)oip;
 
+#if defined(port_smp_init)
+  port_smp_init(oip);
+#endif
+
   /* Starting in a known IRQ configuration.*/
   port_suspend();
 
@@ -148,10 +152,6 @@ void port_init(os_instance_t *oip) {
   CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
 //  DWT->LAR = 0xC5ACCE55U;
   DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-
-#if defined(port_smp_init)
-  port_smp_init(oip);
-#endif
 
   /* Initialization of the system vectors used by the port.*/
 #if CORTEX_SIMPLIFIED_PRIORITY == FALSE

--- a/os/common/ports/RISCV-HAZARD3/chcore.c
+++ b/os/common/ports/RISCV-HAZARD3/chcore.c
@@ -300,6 +300,10 @@ void port_init(os_instance_t *oip) {
 
   (void)oip;
 
+#if defined(port_smp_init)
+  port_smp_init(oip);
+#endif
+
   /* Starting in a known IRQ configuration.*/
   port_suspend();
 
@@ -365,9 +369,6 @@ void port_init(os_instance_t *oip) {
   }
 #endif
 
-#if defined(port_smp_init)
-  port_smp_init(oip);
-#endif
 }
 
 #if (CH_DBG_ENABLE_STACK_CHECK == TRUE) && (PORT_ENABLE_GUARD_PAGES == TRUE)

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
@@ -62,13 +62,17 @@ static bool port_is_panic_pending(void) {
 }
 
 static void port_local_halt(void) {
+  os_instance_t *oip;
   const char *reason = "remote panic";
 
   port_disable();
+  oip = currcore;
 
   __trace_halt("remote panic");
 
-  currcore->dbg.panic_msg = reason;
+  if (oip != NULL) {
+    oip->dbg.panic_msg = reason;
+  }
 
   CH_CFG_SYSTEM_HALT_HOOK(reason);
 

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.c
@@ -162,10 +162,15 @@ void __port_smp_notify_panic(void) {
 
 /**
  * @brief   SMP-related port initialization.
+ * @details Acquires the global kernel lock which is released by the final
+ *          @p chSysUnlock() in the instance startup path.
  *
  * @param[in, out] oip  pointer to the @p os_instance_t structure
  */
 void __port_smp_init(os_instance_t *oip) {
+
+  /* Entering the initial global I-Lock state.*/
+  port_spinlock_take();
 
 #if CH_CFG_ST_TIMEDELTA > 0
   /* Activating timer for this instance.*/

--- a/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
+++ b/os/common/ports/RISCV-HAZARD3/smp/rp2/chcoresmp.h
@@ -157,6 +157,8 @@
  * @brief   SMP-related port initialization.
  * @note    The port checks on presence of this macro so this
  *          must be a macro.
+ * @post    The global kernel lock is acquired and is released by the final
+ *          @p chSysUnlock() in the instance startup path.
  *
  * @param[in, out] oip  pointer to the @p os_instance_t structure
  */

--- a/os/rt/src/chinstances.c
+++ b/os/rt/src/chinstances.c
@@ -89,23 +89,24 @@ void chInstanceObjectInit(os_instance_t *oip,
                           const os_instance_config_t *oicp) {
   core_id_t core_id;
 
-  /* Registering into the global system structure.*/
+  /* Core associated to this instance.*/
 #if CH_CFG_SMP_MODE == TRUE
   core_id = port_get_core_id();
 #else
   core_id = 0U;
 #endif
-  chDbgAssert(ch_system.instances[core_id] == NULL, "instance already registered");
-  ch_system.instances[core_id] = oip;
-
-  /* Core associated to this instance.*/
   oip->core_id = core_id;
 
   /* Keeping a reference to the configuration data.*/
   oip->config = oicp;
 
-  /* Port initialization for the current instance.*/
+  /* Port initialization and entering the initial physical I-Lock state.*/
   port_init(oip);
+
+  /* Registering into the global system structure.*/
+  chDbgAssert(ch_system.instances[core_id] == NULL,
+              "instance already registered");
+  ch_system.instances[core_id] = oip;
 
   /* Ready list initialization.*/
   ch_pqueue_init(&oip->rlist.pqueue);

--- a/os/rt/src/chsys.c
+++ b/os/rt/src/chsys.c
@@ -212,14 +212,18 @@ void chSysInit(void) {
  * @special
  */
 void chSysHalt(const char *reason) {
+  os_instance_t *oip;
 
   port_disable();
+  oip = currcore;
 
   /* Logging the event.*/
   __trace_halt(reason);
 
   /* Pointing to the passed message.*/
-  currcore->dbg.panic_msg = reason;
+  if (oip != NULL) {
+    oip->dbg.panic_msg = reason;
+  }
 
   /* Halt hook code, usually empty.*/
   CH_CFG_SYSTEM_HALT_HOOK(reason);

--- a/os/rt/src/chtrace.c
+++ b/os/rt/src/chtrace.c
@@ -193,8 +193,9 @@ void __trace_isr_leave(const char *isr) {
 void __trace_halt(const char *reason) {
   os_instance_t *oip = currcore;
 
-  /* Halt can be reached before trace buffer initialization.*/
-  if ((ch_system.state == ch_sys_running) &&
+  /* Halt can be reached before instance and trace buffer initialization.*/
+  if ((oip != NULL) &&
+      (ch_system.state == ch_sys_running) &&
       ((oip->trace_buffer.suspended & CH_DBG_TRACE_MASK_HALT) == 0U)) {
     oip->trace_buffer.ptr->type          = CH_TRACE_TYPE_HALT;
     oip->trace_buffer.ptr->state         = 0;


### PR DESCRIPTION
## Summary

- initialize the port before publishing an RT instance globally
- require the SMP initialization hook to establish startup lock ownership early
- make all three RP SMP back ends acquire the kernel hardware spinlock in `port_smp_init()`
- keep the simulator SMP port's first-unlock rendezvous as a valid alternate startup protocol

## Correctness rationale

RT instance initialization starts with the debug and statistics state representing an I-locked critical section, and its final `chSysUnlock()` releases the port lock. The merged RP SMP ports did not acquire that hardware spinlock during startup, so one core could release a lock held by the other while their instance initialization overlapped.

`chInstanceObjectInit()` now assigns the private core/configuration fields and calls `port_init()` before publishing the instance. The RP `port_smp_init()` implementations acquire the global kernel lock as their first operation, and the existing final `chSysUnlock()` is the matching release. Optional Cortex-M SMP hooks are also moved to the beginning of `port_init()`; ARMv7-R retains its prerequisite platform initialization first.

The simulator SMP branch does not use `port_smp_init()`. Its special first-unlock primary/secondary rendezvous already provides equivalent startup serialization, so it is intentionally unchanged.

## Validation

- `demos/RP/RT-RP2040-PICO`: ARMv6-M SMP build with optimization and LTO
- `demos/RP/RT-RP2350-PICO2`: ARMv8-M-ML-ALT SMP build with optimization and LTO
- `origin/chibios-smp-sim-dev/test/rt_smp`: full startup, kernel-lock stress, and IPI stress test with the generic instance-publication reorder applied
- `git diff --check origin/master...HEAD`

The Hazard3/RP2 path was source-checked; its cross compiler is not available in the current environment.
