### PR TITLE
RT: validate explicit thread affinity

### DIFF
--- a/os/rt/include/chthreads.h
+++ b/os/rt/include/chthreads.h
@@ -89,6 +89,8 @@ typedef struct {
   void                          *arg;
   /**
    * @brief         OS instance affinity or @p NULL for current one.
+   * @note          A non-NULL pointer must reference an initialized instance
+   *                registered in @p ch_system.instances[].
    */
   os_instance_t                 *owner;
 } thread_descriptor_t;
@@ -248,7 +250,8 @@ typedef struct {
  * @param[in] tprio     thread priority
  * @param[in] tfunc     thread function pointer
  * @param[in] targ      thread function argument
- * @param[in] towner    thread owner OS instance or @p NULL
+ * @param[in] towner    initialized OS instance owning the thread or @p NULL
+ *                      for the current one
  */
 #define __THD_DECL_DATA(tname, twbase, twend, tprio, tfunc, targ, towner) { \
   .name         = (tname),                                                  \
@@ -270,7 +273,8 @@ typedef struct {
  * @param[in] tprio     thread priority
  * @param[in] tfunc     thread function pointer
  * @param[in] targ      thread function argument
- * @param[in] towner    thread owner OS instance or @p NULL
+ * @param[in] towner    initialized OS instance owning the thread or @p NULL
+ *                      for the current one
  */
 #define THD_DECL(var, tname, twbase, twend, tprio,                          \
                  tfunc, targ, towner)                                       \
@@ -291,7 +295,8 @@ typedef struct {
  * @param[in] tprio     thread priority
  * @param[in] tfunc     thread function pointer
  * @param[in] targ      thread function argument
- * @param[in] towner    thread owner OS instance or @p NULL
+ * @param[in] towner    initialized OS instance owning the thread or @p NULL
+ *                      for the current one
  */
 #define THD_DECL_STATIC(var, tname, twname, tprio,                          \
                         tfunc, targ, towner)                                \
@@ -312,7 +317,8 @@ typedef struct {
  * @param[in] tprio     thread priority
  * @param[in] tfunc     thread function pointer
  * @param[in] targ      thread function argument
- * @param[in] towner    thread owner OS instance or @p NULL
+ * @param[in] towner    initialized OS instance owning the thread or @p NULL
+ *                      for the current one
  *
  * @deprecated
  */
@@ -337,7 +343,8 @@ typedef struct {
  * @param[in] tprio     thread priority
  * @param[in] tfunc     thread function pointer
  * @param[in] targ      thread function argument
- * @param[in] towner    thread owner OS instance or @p NULL
+ * @param[in] towner    initialized OS instance owning the thread or @p NULL
+ *                      for the current one
  *
  * @deprecated
  */
@@ -370,7 +377,8 @@ typedef struct {
  * @param[in] tprio     thread priority
  * @param[in] tfunc     thread function pointer
  * @param[in] targ      thread function argument
- * @param[in] oip       owner OS instance or @p NULL
+ * @param[in] oip       initialized owner OS instance or @p NULL for the
+ *                      current one
  *
  * @deprecated
  */

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -141,6 +141,14 @@ thread_t *chThdObjectInit(thread_t *tp,
   chDbgCheck(tp != NULL);
   chDbgCheck(tdp != NULL);
 
+#if (CH_DBG_ENABLE_ASSERTS == TRUE) && (CH_CFG_SMP_MODE == TRUE)
+  if (tdp->owner != NULL) {
+    chDbgAssert((tdp->owner->core_id < (core_id_t)PORT_CORES_NUMBER) &&
+                (ch_system.instances[tdp->owner->core_id] == tdp->owner),
+                "instance not registered");
+  }
+#endif
+
   /* Stack boundaries.*/
   tp->wabase = (void *)tdp->wbase;
   tp->waend  = (void *)tdp->wend;


### PR DESCRIPTION
## Summary

- document that a non-NULL thread affinity owner must be an initialized OS instance registered in `ch_system.instances[]`
- add an SMP debug assertion that the explicit owner has a valid core ID and exactly matches its root registration slot
- preserve `NULL` as the existing shorthand for the current instance

## Correctness rationale

An explicit descriptor owner can currently name an instance which has not completed registration. A creation path can then insert the new thread into an uninitialized ready queue, or a later instance initialization can reinitialize that queue and disconnect the already-ready thread.

The root `ch_system.instances[]` table is the authoritative initialization marker. `chThdObjectInit()` now diagnoses an explicit owner unless:

```c
ch_system.instances[owner->core_id] == owner
```

The equality check also rejects a zero-initialized or mismatched instance whose uninitialized `core_id` happens to select another non-NULL slot. The check is compiled only when both SMP mode and kernel assertions are enabled. It introduces no waiting and no release-build runtime cost.

## Validation

- RP2040 ARMv6-M SMP demo build with optimization, LTO, and `CH_DBG_ENABLE_ASSERTS=TRUE`
- RP2350 ARMv8-M-ML-ALT SMP demo build with optimization, LTO, and `CH_DBG_ENABLE_ASSERTS=TRUE`
- full `origin/chibios-smp-sim-dev/test/rt_smp` runtime suite with assertions enabled, exercising explicit `&ch1` thread descriptors
- `git diff --check origin/master...HEAD`
