### PR TITLE
RT: remove redundant system-state publication hooks

### DIFF
--- a/os/common/ports/RISCV-HAZARD3/chcore.h
+++ b/os/common/ports/RISCV-HAZARD3/chcore.h
@@ -250,21 +250,6 @@
 #define PORT_INFO                       "Compact kernel mode"
 /** @} */
 
-/**
- * @brief   Publishes initialization performed before a shared state flag.
- * @details The RP2350 cores are coherent, but RVWMO still requires an explicit
- *          release/acquire pair for message-passing through ordinary volatile
- *          storage.
- */
-#define PORT_SYSTEM_STATE_RELEASE()                                        \
-  __asm__ volatile ("fence rw, rw" : : : "memory")
-
-/**
- * @brief   Acquires initialization after observing a shared state flag.
- */
-#define PORT_SYSTEM_STATE_ACQUIRE()                                        \
-  __asm__ volatile ("fence rw, rw" : : : "memory")
-
 /*===========================================================================*/
 /* SMP support.                                                              */
 /*===========================================================================*/

--- a/os/rt/src/chsys.c
+++ b/os/rt/src/chsys.c
@@ -129,8 +129,11 @@ const os_instance_config_t ch_core1_cfg = {
 
 /**
  * @brief   Waits for the system state to be equal to the specified one.
- * @note    Can be called before @p chSchObjectInit() in order to wait
+ * @note    Can be called before @p chInstanceObjectInit() in order to wait
  *          for system initialization by another core.
+ * @note    This operation does not enter a critical section. During SMP
+ *          startup, @p chInstanceObjectInit() establishes the initial I-Lock
+ *          state before shared kernel objects are accessed.
  *
  * @special
  */
@@ -138,12 +141,6 @@ void chSysWaitSystemState(system_state_t state) {
 
   while (ch_system.state != state) {
   }
-
-#if defined(PORT_SYSTEM_STATE_ACQUIRE)
-  /* Pairs with the publishing core's release operation so that observing the
-     requested state also makes the preceding system initialization visible.*/
-  PORT_SYSTEM_STATE_ACQUIRE();
-#endif
 }
 
 /**
@@ -191,10 +188,6 @@ void chSysInit(void) {
   chInstanceObjectInit(&ch0, &ch_core0_cfg);
 
   /* It is alive now.*/
-#if defined(PORT_SYSTEM_STATE_RELEASE)
-  /* Publish all preceding initialization before changing the shared state.*/
-  PORT_SYSTEM_STATE_RELEASE();
-#endif
   ch_system.state = ch_sys_running;
   chSysUnlock();
 }


### PR DESCRIPTION
## Summary

- remove the optional `PORT_SYSTEM_STATE_RELEASE()` and `PORT_SYSTEM_STATE_ACQUIRE()` calls from RT startup
- remove the Hazard3 definitions which supplied the only merged implementation
- document that `chSysWaitSystemState()` observes the state value but does not itself enter a critical section

## Rationale

The hooks were introduced with the Hazard3 port in `861b12c3d6a`, before the initial SMP lock ownership correction in #241. At that time the state transition was being used as a publication handoff because instance startup did not acquire the shared kernel spinlock.

After #241, every merged secondary-core startup waits for `ch_sys_running` and immediately calls `chInstanceObjectInit()`. Its first port operation acquires the shared kernel spinlock. The primary stores `ch_sys_running` while owning that lock and then releases it through the final `chSysUnlock()`.

The spinlock release/acquire pair is therefore the authoritative synchronization point:

- it serializes primary and secondary instance startup
- its barriers publish the primary's preceding initialization before the secondary accesses shared kernel objects
- the state variable only tells the secondary when it may begin attempting instance initialization

Hazard3 already executes full fences in `port_spinlock_release()` and `port_spinlock_take()`. The separate state fences duplicate that ordering. ARM SMP startup follows the same lock handoff without defining these hooks.

@emolitor, please review in particular whether removing the original Hazard3 fences matches the intended post-#241 startup model.

## Validation

- `tools/style/stylecheck.py` on both changed files
- `demos/various/RT-Posix-Simulator`
- `demos/RP/RT-RP2040-PICO`
- `demos/RP/RT-RP2350-PICO2`

All build trees were cleaned after validation.
