### PR TITLE
RT: detect ARMv8-M state-check config mismatch

### DIFF
--- a/os/common/ports/ARMv8-M-ML-ALT/chcore.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/chcore.c
@@ -34,6 +34,16 @@
 /* Module exported variables.                                                */
 /*===========================================================================*/
 
+/*
+ * Configuration marker used by the assembly module for link-time consistency
+ * checks. Only the symbol matching the C view is defined.
+ */
+#if CH_DBG_SYSTEM_STATE_CHECK == TRUE
+const char __ch_debug_state_check_enabled = 0;
+#else
+const char __ch_debug_state_check_disabled = 0;
+#endif
+
 #if (PORT_SWITCHED_REGIONS_NUMBER > 0) || defined(__DOXYGEN__)
 /**
  * @brief   Default MPU regions table.

--- a/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/chcoreasm.S
+++ b/os/common/ports/ARMv8-M-ML-ALT/compilers/GCC/chcoreasm.S
@@ -217,6 +217,14 @@
                 .thumb_func
                 .globl  SVC_Handler
 SVC_Handler:
+                /* Enforcing a consistent C/assembly state checker
+                   configuration. The no-op relocation leaves code unchanged
+                   but requires the marker matching this module's view.*/
+#if CH_DBG_SYSTEM_STATE_CHECK
+                .reloc  ., R_ARM_NONE, __ch_debug_state_check_enabled
+#else
+                .reloc  ., R_ARM_NONE, __ch_debug_state_check_disabled
+#endif
 #if PORT_USE_SYSCALL
                 mrs     r12, CONTROL
                 tst     r12, #1


### PR DESCRIPTION
## Summary
- add a port-local link-time marker for `CH_DBG_SYSTEM_STATE_CHECK`
- require the preprocessed assembly and C sources to agree on the setting
- turn a silently inconsistent image into a deterministic link error

Fixes #205

## Root cause
On current master, including #241 and #244, the issue reproducer enabled the debug options through C-only `UDEFS`. `chdebug.c` therefore tracked the lock state, while `chcoreasm.S` omitted the matching `__dbg_check_unlock` call. The first affected path then reached the state checker with `lock_cnt == 1` and raised `SV#4`. With matching `UDEFS`/`UADEFS`, the original runtime failure no longer reproduces.

## Validation
- rebased and tested on `14efbc024d` (includes #244)
- ARMv8-M-ML-ALT build matrix: off/off passes; on/on passes; either mixed configuration fails at link time
- RP2350 Pico 2 dual-core XHAL with state checks, checks, and assertions: RT suite passes; OSLIB suite passes
- post-test `ch0.dbg` and `ch1.dbg` counters are zero and the system remains running
- reciprocal bench validation: RP2040 debugged/flashed RP2350; restored RP2350 debugprobe then connected to RP2040 over SWD
- CodeRabbit review: zero findings
- Claude adversarial review: port scope and relocation placement feedback incorporated