### PR TITLE
RP: reject unsafe ARMv8-M spinlock overrides

### DIFF
--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
@@ -61,6 +61,9 @@
 
 /**
  * @brief   Spinlock to be used by the port layer.
+ * @details RP2350-E2 permits unrelated SIO writes to release certain
+ *          spinlocks on A2, A3, and A4 silicon. The default selects an
+ *          unconditionally safe lock number.
  */
 #if !defined(PORT_SPINLOCK_NUMBER)
 #define PORT_SPINLOCK_NUMBER            31
@@ -80,6 +83,9 @@
 
 /**
  * @brief   Spinlock serializing core-lockout requesters.
+ * @details RP2350-E2 permits unrelated SIO writes to release certain
+ *          spinlocks on A2, A3, and A4 silicon. The default selects an
+ *          unconditionally safe lock number.
  */
 #if !defined(PORT_LOCKOUT_SPINLOCK_NUMBER)
 #define PORT_LOCKOUT_SPINLOCK_NUMBER    30
@@ -138,8 +144,27 @@
   #error "invalid PORT_SPINLOCK_NUMBER value"
 #endif
 
+/* RP2350-E2: only these spinlocks are immune to false releases caused by
+   unrelated SIO writes on all affected mask revisions.*/
+#if (PORT_SPINLOCK_NUMBER != 5)  && (PORT_SPINLOCK_NUMBER != 6)  &&       \
+    (PORT_SPINLOCK_NUMBER != 7)  && (PORT_SPINLOCK_NUMBER != 10) &&       \
+    (PORT_SPINLOCK_NUMBER != 11) && (PORT_SPINLOCK_NUMBER < 18)
+  #error "PORT_SPINLOCK_NUMBER is unsafe on RP2350 A2/A3/A4 (RP2350-E2)"
+#endif
+
 #if (PORT_LOCKOUT_SPINLOCK_NUMBER < 0) || (PORT_LOCKOUT_SPINLOCK_NUMBER > 31)
   #error "invalid PORT_LOCKOUT_SPINLOCK_NUMBER value"
+#endif
+
+/* Applying the same restriction to the requester-serialization lock because
+   the erratum is in the SIO address decoder, independently of bus manager.*/
+#if (PORT_LOCKOUT_SPINLOCK_NUMBER != 5)  &&                           \
+    (PORT_LOCKOUT_SPINLOCK_NUMBER != 6)  &&                           \
+    (PORT_LOCKOUT_SPINLOCK_NUMBER != 7)  &&                           \
+    (PORT_LOCKOUT_SPINLOCK_NUMBER != 10) &&                           \
+    (PORT_LOCKOUT_SPINLOCK_NUMBER != 11) &&                           \
+    (PORT_LOCKOUT_SPINLOCK_NUMBER < 18)
+  #error "PORT_LOCKOUT_SPINLOCK_NUMBER is unsafe on RP2350 A2/A3/A4 (RP2350-E2)"
 #endif
 
 #if PORT_LOCKOUT_SPINLOCK_NUMBER == PORT_SPINLOCK_NUMBER

--- a/test/rt-ports/testbuild/check_rp2350_spinlocks.sh
+++ b/test/rt-ports/testbuild/check_rp2350_spinlocks.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+set -eu
+
+test_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+root_dir=$(CDPATH= cd -- "$test_dir/../../.." && pwd)
+header="$root_dir/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h"
+cc=${CC:-cc}
+
+preprocess_spinlocks() {
+  kernel_lock=$1
+  lockout_lock=$2
+
+  "$cc" -E -x c -include "$header" \
+    -DPORT_SPINLOCK_NUMBER="$kernel_lock" \
+    -DPORT_LOCKOUT_SPINLOCK_NUMBER="$lockout_lock" \
+    /dev/null >/dev/null
+}
+
+expect_pass() {
+  label=$1
+  shift
+
+  if ! preprocess_spinlocks "$@"; then
+    echo "unexpected rejected configuration: $label" >&2
+    exit 1
+  fi
+}
+
+expect_fail() {
+  label=$1
+  expected=$2
+  output=
+  shift 2
+
+  if output=$(preprocess_spinlocks "$@" 2>&1); then
+    echo "unexpected accepted configuration: $label" >&2
+    exit 1
+  fi
+  case "$output" in
+  *"$expected"*)
+    ;;
+  *)
+    echo "unexpected rejection reason: $label" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
+    ;;
+  esac
+}
+
+expect_pass "safe lower override"           5 18
+expect_pass "safe singleton override"      10 30
+expect_fail "unsafe kernel boundary" \
+  "PORT_SPINLOCK_NUMBER is unsafe"         17 30
+expect_fail "unsafe lockout gap" \
+  "PORT_LOCKOUT_SPINLOCK_NUMBER is unsafe" 31 8
+expect_fail "conflicting safe locks" \
+  "PORT_LOCKOUT_SPINLOCK_NUMBER conflicts" 30 30
+
+echo "RP2350 spinlock configuration checks passed"


### PR DESCRIPTION
## Summary

- apply the RP2350-E2 always-safe spinlock set to both ARMv8-M SMP lock settings
- reject unsafe kernel-lock and flash-lockout overrides at compile time
- add focused configuration checks for safe, unsafe, boundary, and conflicting selections

Fixes #246

## Root cause

RP2350-E2 is in the SIO address decoder rather than in Hazard3. A Cortex-M33 write to an SIO register at offset `0x180` or above can therefore alias a spinlock release just as a Hazard3 write can. Both the kernel lock and the flash-lockout requester lock require the documented always-safe set: 5, 6, 7, 10, 11, and 18 through 31.

## Validation

- reproduced on RP2350 rev 2: Cortex-M33 claimed spinlock 0, wrote zero to `DOORBELL_OUT_SET`, and observed spinlock 0 become unclaimed
- exhaustive preprocessing matrix confirmed the expected result for values 0 through 31 in both lock roles
- focused regression script passes with host `cc` and `arm-none-eabi-gcc`
- RP2350 dual-core XHAL with safe overrides 5/18 and state checks/assertions enabled: RT suite passed and OSLIB suite passed
- post-run debug state: both instance counters zero, system running
- reciprocal SWD bench topology verified and RP2350 restored to debugprobe firmware
- repository style checker and `git diff --check` pass
- CodeRabbit: zero findings
- Claude adversarial review: boundary and diagnostic-specific test feedback incorporated
