### PR TITLE
RP: serialize flash-lockout startup readiness

### DIFF
--- a/os/common/ports/ARMv6-M/chcore.h
+++ b/os/common/ports/ARMv6-M/chcore.h
@@ -622,6 +622,11 @@ static inline void port_unlock(void) {
   port_spinlock_release();
 #endif
   __enable_irq();
+#if defined(PORT_UNLOCK_HOOK)
+  if (!port_is_isr_context()) {
+    PORT_UNLOCK_HOOK();
+  }
+#endif
 }
 
 /**

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.c
@@ -59,7 +59,7 @@
  * @note    A core which never started must not be waited for in the
  *          lockout handshake.
  */
-static volatile bool port_lockout_ready[PORT_CORES_NUMBER];
+static uint32_t port_lockout_ready[PORT_CORES_NUMBER];
 
 /**
  * @brief   Per-core lockout-in-progress flags.
@@ -370,8 +370,43 @@ void __port_smp_init(os_instance_t *oip) {
     chDbgAssert(false, "unexpected core id");
   }
 
-  /* This core can now be parked by the other one.*/
-  port_lockout_ready[port_get_core_id()] = true;
+}
+
+/**
+ * @brief   Marks this core as able to service flash-lockout requests.
+ * @details Called after the first startup unlock has lowered the local
+ *          interrupt mask. Subsequent unlocks leave the one-shot state
+ *          unchanged.
+ */
+CC_NO_INLINE CC_SECTION(".ramtext")
+void __port_smp_startup_complete(void) {
+  core_id_t core_id;
+  uint32_t primask;
+
+  core_id = (core_id_t)SIO->CPUID;
+  if (__atomic_load_n(&port_lockout_ready[core_id],
+                      __ATOMIC_RELAXED) == 0U) {
+    primask = __get_PRIMASK();
+    __disable_irq();
+
+    if (__atomic_load_n(&port_lockout_ready[core_id],
+                        __ATOMIC_RELAXED) == 0U) {
+      /* Admission is held through the complete flash operation. Waiting
+         here in RAM keeps this core off XIP until the operation ends. It
+         is intentionally unbounded like port_fifo_lockout_wait(): the
+         holder can be completing a legitimate long flash operation.*/
+      while (SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] == 0U) {
+      }
+      __DMB();
+
+      __atomic_store_n(&port_lockout_ready[core_id], 1U, __ATOMIC_RELEASE);
+
+      __DMB();
+      SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] = (uint32_t)SIO;
+    }
+
+    __set_PRIMASK(primask);
+  }
 }
 
 /**
@@ -419,7 +454,7 @@ void __port_flash_lockout(void) {
   /* A core which never initialized cannot acknowledge and does not need
      parking. The decision is recorded for the unlock side, the flag may
      rise in the meantime.*/
-  if (!port_lockout_ready[port_get_core_id() ^ 1U]) {
+  if (!__port_lockout_other_ready()) {
     port_lockout_parked = false;
     return;
   }
@@ -503,7 +538,8 @@ void __port_flash_unlockout(void) {
  */
 bool __port_lockout_other_ready(void) {
 
-  return port_lockout_ready[port_get_core_id() ^ 1U];
+  return __atomic_load_n(&port_lockout_ready[port_get_core_id() ^ 1U],
+                         __ATOMIC_ACQUIRE) != 0U;
 }
 
 /**

--- a/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv6-M/smp/rp2/chcoresmp.h
@@ -164,6 +164,11 @@
   } while (false)
 
 /**
+ * @brief   Publishes flash-lockout readiness after the first IRQ unmask.
+ */
+#define PORT_UNLOCK_HOOK() __port_smp_startup_complete()
+
+/**
  * @brief   SMP-related port initialization.
  * @note    The port checks on presence of this macro so this
  *          must be a macro.
@@ -182,6 +187,7 @@
 extern "C" {
 #endif
   void __port_smp_init(os_instance_t *oip);
+  void __port_smp_startup_complete(void);
   void __port_spinlock_take(void);
   void __port_spinlock_release(void);
   void __port_flash_lockout(void);

--- a/os/common/ports/ARMv8-M-ML-ALT/chcore.h
+++ b/os/common/ports/ARMv8-M-ML-ALT/chcore.h
@@ -1102,6 +1102,11 @@ __STATIC_FORCEINLINE void port_unlock(void) {
   port_spinlock_release();
 #endif
   __set_BASEPRI(CORTEX_BASEPRI_DISABLED);
+#if defined(PORT_UNLOCK_HOOK)
+  if (!port_is_isr_context()) {
+    PORT_UNLOCK_HOOK();
+  }
+#endif
 }
 
 /**

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.c
@@ -49,7 +49,7 @@
  * @note    A core which never started must not be waited for in the
  *          lockout handshake.
  */
-static volatile bool port_lockout_ready[PORT_CORES_NUMBER];
+static uint32_t port_lockout_ready[PORT_CORES_NUMBER];
 
 /**
  * @brief   Per-core lockout-in-progress flags.
@@ -329,10 +329,44 @@ void __port_smp_init(os_instance_t *oip) {
   NVIC_SetPriority(SIO_IRQ_FIFOn, CORTEX_MINIMUM_PRIORITY);
   NVIC_EnableIRQ(SIO_IRQ_FIFOn);
 
-  /* This core can now be parked by the other one.*/
-  port_lockout_ready[port_get_core_id()] = true;
-
   (void)oip;
+}
+
+/**
+ * @brief   Marks this core as able to service flash-lockout requests.
+ * @details Called after the first startup unlock has lowered the local
+ *          interrupt mask. Subsequent unlocks leave the one-shot state
+ *          unchanged.
+ */
+CC_NO_INLINE CC_SECTION(".ramtext")
+void __port_smp_startup_complete(void) {
+  core_id_t core_id;
+  uint32_t primask;
+
+  core_id = (core_id_t)SIO->CPUID;
+  if (__atomic_load_n(&port_lockout_ready[core_id],
+                      __ATOMIC_RELAXED) == 0U) {
+    primask = __get_PRIMASK();
+    __disable_irq();
+
+    if (__atomic_load_n(&port_lockout_ready[core_id],
+                        __ATOMIC_RELAXED) == 0U) {
+      /* Admission is held through the complete flash operation. Waiting
+         here in RAM keeps this core off XIP until the operation ends. It
+         is intentionally unbounded like port_fifo_lockout_wait(): the
+         holder can be completing a legitimate long flash operation.*/
+      while (SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] == 0U) {
+      }
+      __DMB();
+
+      __atomic_store_n(&port_lockout_ready[core_id], 1U, __ATOMIC_RELEASE);
+
+      __DMB();
+      SIO->SPINLOCK[PORT_LOCKOUT_SPINLOCK_NUMBER] = (uint32_t)SIO;
+    }
+
+    __set_PRIMASK(primask);
+  }
 }
 
 /**
@@ -381,7 +415,7 @@ void __port_flash_lockout(void) {
   /* A core which never initialized cannot acknowledge and does not need
      parking. The decision is recorded for the unlock side, the flag may
      rise in the meantime.*/
-  if (!port_lockout_ready[port_get_core_id() ^ 1U]) {
+  if (!__port_lockout_other_ready()) {
     port_lockout_parked = false;
     return;
   }
@@ -465,7 +499,8 @@ void __port_flash_unlockout(void) {
  */
 bool __port_lockout_other_ready(void) {
 
-  return port_lockout_ready[port_get_core_id() ^ 1U];
+  return __atomic_load_n(&port_lockout_ready[port_get_core_id() ^ 1U],
+                         __ATOMIC_ACQUIRE) != 0U;
 }
 
 /**

--- a/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
+++ b/os/common/ports/ARMv8-M-ML-ALT/smp/rp2/chcoresmp.h
@@ -164,6 +164,11 @@
   } while (false)
 
 /**
+ * @brief   Publishes flash-lockout readiness after the first IRQ unmask.
+ */
+#define PORT_UNLOCK_HOOK() __port_smp_startup_complete()
+
+/**
  * @brief   SMP-related port initialization.
  * @note    The port checks on presence of this macro so this
  *          must be a macro.
@@ -182,6 +187,7 @@
 extern "C" {
 #endif
   void __port_smp_init(os_instance_t *oip);
+  void __port_smp_startup_complete(void);
   void __port_spinlock_take(void);
   void __port_spinlock_release(void);
   void __port_flash_lockout(void);

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/c1_main.c
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/c1_main.c
@@ -30,6 +30,8 @@ void c1_main(void) {
    * system initialization on the other side.
    */
   chSysWaitSystemState(ch_sys_running);
+  while (c0_delay_armed == 0U) {
+  }
   chInstanceObjectInit(&ch1, &ch_core1_cfg);
 
   /* It is alive now.*/

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/chconf.h
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/cfg/chconf.h
@@ -712,9 +712,11 @@
  *
  * @param[in] oip       pointer to the @p os_instance_t structure
  */
-#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
-  /* Add OS instance initialization code here.*/                            \
-} while (false)
+#if !defined(_FROM_ASM_)
+void eflSmpInstanceInitHook(void *oip);
+#endif
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip)                                   \
+  eflSmpInstanceInitHook(oip)
 
 /**
  * @brief   Threads descriptor structure extension.

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/efl_smp_lockout.h
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/efl_smp_lockout.h
@@ -30,9 +30,13 @@ extern volatile uint32_t c1_cycles;
 extern volatile uint32_t c1_errors;
 extern volatile uint32_t c1_go;
 extern volatile uint32_t c1_done;
+extern volatile uint32_t c0_delay_armed;
+extern volatile uint32_t c1_init_entered;
+extern volatile uint32_t c1_init_release;
 
 extern semaphore_t c1_ready_sem;
 
+void eflSmpInstanceInitHook(void *oip);
 uint32_t flash_cycle(uint8_t pattern);
 
 #endif /* EFL_SMP_LOCKOUT_H */

--- a/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2040/EFL-SMP-LOCKOUT/main.c
@@ -45,6 +45,9 @@ volatile uint32_t c1_cycles;
 volatile uint32_t c1_errors;
 volatile uint32_t c1_go;
 volatile uint32_t c1_done;
+volatile uint32_t c0_delay_armed;
+volatile uint32_t c1_init_entered;
+volatile uint32_t c1_init_release;
 
 /* Statically initialized: core 1 can signal it before core 0's main()
    runs any code after chSysInit().*/
@@ -58,6 +61,16 @@ static BaseSequentialStream *chp = (BaseSequentialStream *)&SIOD0;
 
 static unsigned pass_count;
 static unsigned fail_count;
+
+void eflSmpInstanceInitHook(void *oip) {
+
+  (void)oip;
+  if (SIO->CPUID == 1U) {
+    c1_init_entered = 1U;
+    while (c1_init_release == 0U) {
+    }
+  }
+}
 
 static void report(const char *name, bool ok) {
 
@@ -154,10 +167,52 @@ static THD_FUNCTION(HeartbeatThread, arg) {
 int main(void) {
   uint32_t hb_before, c1hb_before;
   uint32_t my_errors;
+  bool init_entered, init_not_ready, not_ready_during_lockout;
+  bool ready_after_unlock;
   unsigned i;
 
   halInit();
   chSysInit();
+
+  /* Holding core 1 inside its instance hook beyond the lockout timeout.
+     The system timer is masked because core 1 owns the kernel lock.*/
+  nvicDisableVector(RP_TIMER0_IRQ0_NUMBER);
+  c0_delay_armed = 1U;
+  {
+    uint32_t start;
+
+    start = TIMER0->TIMERAWL;
+    while ((c1_init_entered == 0U) &&
+           ((TIMER0->TIMERAWL - start) <= PORT_LOCKOUT_TIMEOUT_US)) {
+    }
+    init_entered = c1_init_entered != 0U;
+
+    start = TIMER0->TIMERAWL;
+    while ((TIMER0->TIMERAWL - start) <=
+           (PORT_LOCKOUT_TIMEOUT_US + 10000U)) {
+    }
+    init_not_ready = !__port_lockout_other_ready();
+
+    /* Starting an actual lockout while core 1 is unready. It does not
+       perform a FIFO handshake but keeps admission closed until unlock.*/
+    __port_flash_lockout();
+    c1_init_release = 1U;
+
+    start = TIMER0->TIMERAWL;
+    while ((TIMER0->TIMERAWL - start) <=
+           (PORT_LOCKOUT_TIMEOUT_US + 10000U)) {
+    }
+    not_ready_during_lockout = !__port_lockout_other_ready();
+
+    __port_flash_unlockout();
+    start = TIMER0->TIMERAWL;
+    while (!__port_lockout_other_ready() &&
+           ((TIMER0->TIMERAWL - start) <= PORT_LOCKOUT_TIMEOUT_US)) {
+    }
+    ready_after_unlock = __port_lockout_other_ready();
+  }
+  nvicEnableVector(RP_TIMER0_IRQ0_NUMBER,
+                   RP_IRQ_TIMER0_ALARM0_PRIORITY);
 
   /* UART0 console on GPIO0/GPIO1.*/
   palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
@@ -170,6 +225,11 @@ int main(void) {
   chprintf(chp, "*** Flash sector under test: %u\r\n", TEST_SECTOR);
 
   eflStart(&EFLD1, NULL);
+  report("core 1 entered delayed init", init_entered);
+  report("core 1 not ready during delayed init", init_not_ready);
+  report("core 1 stayed unready during lockout",
+         not_ready_during_lockout);
+  report("core 1 ready after startup unlock", ready_after_unlock);
 
   chThdCreateStatic(waHeartbeat, sizeof(waHeartbeat),
                     NORMALPRIO - 1, HeartbeatThread, NULL);

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/c1_main.c
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/c1_main.c
@@ -30,6 +30,8 @@ void c1_main(void) {
    * system initialization on the other side.
    */
   chSysWaitSystemState(ch_sys_running);
+  while (c0_delay_armed == 0U) {
+  }
   chInstanceObjectInit(&ch1, &ch_core1_cfg);
 
   /* It is alive now.*/

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/chconf.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/chconf.h
@@ -723,9 +723,11 @@
  *
  * @param[in] oip       pointer to the @p os_instance_t structure
  */
-#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
-  /* Add OS instance initialization code here.*/                            \
-} while (false)
+#if !defined(_FROM_ASM_)
+void eflSmpInstanceInitHook(void *oip);
+#endif
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip)                                   \
+  eflSmpInstanceInitHook(oip)
 
 /**
  * @brief   Threads descriptor structure extension.

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/mcuconf.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/cfg/mcuconf.h
@@ -45,12 +45,14 @@
 
 /*
  * IRQ system settings.
+ * Priorities zero and one are reserved as fast by PORT_FAST_PRIORITIES,
+ * therefore kernel-aware system timer IRQs start at priority three.
  */
-#define RP_IRQ_SYSTICK_PRIORITY             2
-#define RP_IRQ_TIMER0_ALARM0_PRIORITY       2
-#define RP_IRQ_TIMER0_ALARM1_PRIORITY       2
-#define RP_IRQ_TIMER0_ALARM2_PRIORITY       2
-#define RP_IRQ_TIMER0_ALARM3_PRIORITY       2
+#define RP_IRQ_SYSTICK_PRIORITY             3
+#define RP_IRQ_TIMER0_ALARM0_PRIORITY       3
+#define RP_IRQ_TIMER0_ALARM1_PRIORITY       3
+#define RP_IRQ_TIMER0_ALARM2_PRIORITY       3
+#define RP_IRQ_TIMER0_ALARM3_PRIORITY       3
 #define RP_IRQ_UART0_PRIORITY               3
 #define RP_IRQ_UART1_PRIORITY               3
 #define RP_IRQ_SPI0_PRIORITY                2

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/efl_smp_lockout.h
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/efl_smp_lockout.h
@@ -30,10 +30,14 @@ extern volatile uint32_t c1_cycles;
 extern volatile uint32_t c1_errors;
 extern volatile uint32_t c1_go;
 extern volatile uint32_t c1_done;
+extern volatile uint32_t c0_delay_armed;
+extern volatile uint32_t c1_init_entered;
+extern volatile uint32_t c1_init_release;
 extern volatile uint32_t fastirq_count;
 
 extern semaphore_t c1_ready_sem;
 
+void eflSmpInstanceInitHook(void *oip);
 uint32_t flash_cycle(uint8_t pattern);
 
 #endif /* EFL_SMP_LOCKOUT_H */

--- a/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
+++ b/testhal/RP/RP2350/EFL-SMP-LOCKOUT/main.c
@@ -45,6 +45,9 @@ volatile uint32_t c1_cycles;
 volatile uint32_t c1_errors;
 volatile uint32_t c1_go;
 volatile uint32_t c1_done;
+volatile uint32_t c0_delay_armed;
+volatile uint32_t c1_init_entered;
+volatile uint32_t c1_init_release;
 volatile uint32_t fastirq_count;
 
 /* Statically initialized: core 1 can signal it before core 0's main()
@@ -59,6 +62,16 @@ static BaseSequentialStream *chp = (BaseSequentialStream *)&SIOD0;
 
 static unsigned pass_count;
 static unsigned fail_count;
+
+void eflSmpInstanceInitHook(void *oip) {
+
+  (void)oip;
+  if (SIO->CPUID == 1U) {
+    c1_init_entered = 1U;
+    while (c1_init_release == 0U) {
+    }
+  }
+}
 
 static void report(const char *name, bool ok) {
 
@@ -180,10 +193,52 @@ static THD_FUNCTION(HeartbeatThread, arg) {
 int main(void) {
   uint32_t hb_before, fi_before, c1hb_before;
   uint32_t my_errors;
+  bool init_entered, init_not_ready, not_ready_during_lockout;
+  bool ready_after_unlock;
   unsigned i;
 
   halInit();
   chSysInit();
+
+  /* Holding core 1 inside its instance hook beyond the lockout timeout.
+     The system timer is masked because core 1 owns the kernel lock.*/
+  nvicDisableVector(RP_TIMER0_IRQ0_NUMBER);
+  c0_delay_armed = 1U;
+  {
+    uint32_t start;
+
+    start = TIMER0->TIMERAWL;
+    while ((c1_init_entered == 0U) &&
+           ((TIMER0->TIMERAWL - start) <= PORT_LOCKOUT_TIMEOUT_US)) {
+    }
+    init_entered = c1_init_entered != 0U;
+
+    start = TIMER0->TIMERAWL;
+    while ((TIMER0->TIMERAWL - start) <=
+           (PORT_LOCKOUT_TIMEOUT_US + 10000U)) {
+    }
+    init_not_ready = !__port_lockout_other_ready();
+
+    /* Starting an actual lockout while core 1 is unready. It does not
+       perform a FIFO handshake but keeps admission closed until unlock.*/
+    __port_flash_lockout();
+    c1_init_release = 1U;
+
+    start = TIMER0->TIMERAWL;
+    while ((TIMER0->TIMERAWL - start) <=
+           (PORT_LOCKOUT_TIMEOUT_US + 10000U)) {
+    }
+    not_ready_during_lockout = !__port_lockout_other_ready();
+
+    __port_flash_unlockout();
+    start = TIMER0->TIMERAWL;
+    while (!__port_lockout_other_ready() &&
+           ((TIMER0->TIMERAWL - start) <= PORT_LOCKOUT_TIMEOUT_US)) {
+    }
+    ready_after_unlock = __port_lockout_other_ready();
+  }
+  nvicEnableVector(RP_TIMER0_IRQ0_NUMBER,
+                   RP_IRQ_TIMER0_ALARM0_PRIORITY);
 
   /* UART0 console on GPIO0/GPIO1.*/
   palSetLineMode(0U, PAL_MODE_ALTERNATE_UART);
@@ -196,6 +251,11 @@ int main(void) {
   chprintf(chp, "*** Flash sector under test: %u\r\n", TEST_SECTOR);
 
   eflStart(&EFLD1, NULL);
+  report("core 1 entered delayed init", init_entered);
+  report("core 1 not ready during delayed init", init_not_ready);
+  report("core 1 stayed unready during lockout",
+         not_ready_during_lockout);
+  report("core 1 ready after startup unlock", ready_after_unlock);
 
   fastirq_start();
 


### PR DESCRIPTION
## Summary

- publish RP SMP flash-lockout readiness only after the first thread-context startup unlock makes the FIFO IRQ serviceable
- serialize readiness publication with lockout admission and keep a late-starting core in RAM while an unparked flash operation is active
- use release/acquire ordering for the cross-core readiness state
- extend the RP2040 and RP2350 EFL SMP lockout tests with delayed-startup and admission-race coverage
- correct the RP2350 test's kernel-aware timer priorities after reserving priorities 0-1 for fast IRQs

## Root cause

The RP SMP port published readiness from `__port_smp_init()` while interrupts were still masked and before the instance initialization hook and final startup unlock. Another core could therefore start a FIFO lockout handshake that the initializing core could not yet service. Readiness publication also needs to be serialized with lockout admission so that a core observed as unready cannot resume executing from XIP during an already-active unparked flash operation.

## Validation

- RP2040 EFL-SMP-LOCKOUT clean build
- RP2350 EFL-SMP-LOCKOUT clean build
- RP2040 bench run using the RP2350 Pico debug probe: 11 pass, 0 fail
- RP2350 bench run using the RP2040 Pico debug probe: 11 pass, 0 fail
- linker verification that both startup publication functions reside in `.ramtext`
- final CodeRabbit review: 0 findings
- Claude Code adversarial review; actionable concurrency feedback addressed and remaining claims checked against the EFL safety layer

Closes #242
