### PR TITLE
octospiv3-add-cr-options-and-u5-irqs

### DIFF
--- a/os/hal/ports/STM32/LLD/OCTOSPIv3/hal_wspi_lld.c
+++ b/os/hal/ports/STM32/LLD/OCTOSPIv3/hal_wspi_lld.c
@@ -260,7 +260,8 @@ void wspi_lld_start(WSPIDriver *wspip) {
   wspip->ospi->DCR2 = wspip->config->dcr2 | dcr2;
   wspip->ospi->DCR3 = wspip->config->dcr3;
   wspip->ospi->DCR4 = wspip->config->dcr4;
-  wspip->ospi->CR   = OCTOSPI_CR_TCIE  | OCTOSPI_CR_DMAEN | OCTOSPI_CR_EN;
+  wspip->ospi->CR   = wspip->config->cr | OCTOSPI_CR_TCIE |
+                      OCTOSPI_CR_DMAEN | OCTOSPI_CR_EN;
   wspip->ospi->FCR  = OCTOSPI_FCR_CTEF | OCTOSPI_FCR_CTCF |
                       OCTOSPI_FCR_CSMF | OCTOSPI_FCR_CTOF;
 }
@@ -461,7 +462,8 @@ void wspi_lld_unmap_flash(WSPIDriver *wspip) {
   }
 
   /* Disabling memory mapped mode and re-enabling DMA and IRQs.*/
-  wspip->ospi->CR = OCTOSPI_CR_TCIE | OCTOSPI_CR_DMAEN | OCTOSPI_CR_EN;
+  wspip->ospi->CR = wspip->config->cr | OCTOSPI_CR_TCIE |
+                    OCTOSPI_CR_DMAEN | OCTOSPI_CR_EN;
 }
 #endif /* WSPI_SUPPORTS_MEMMAP == TRUE */
 

--- a/os/hal/ports/STM32/LLD/OCTOSPIv3/hal_wspi_lld.h
+++ b/os/hal/ports/STM32/LLD/OCTOSPIv3/hal_wspi_lld.h
@@ -313,6 +313,8 @@ typedef struct {
  * @brief   Low level fields of the WSPI configuration structure.
  */
 #define wspi_lld_config_fields                                              \
+  /* CR register additional initialization bits.*/                         \
+  uint32_t                      cr;                                         \
   /* DCR1 register initialization data.*/                                   \
   uint32_t                      dcr1;                                       \
   /* DCR2 register initialization data. The prescaler field is internally   \

--- a/os/hal/ports/STM32/STM32U5xx/stm32_isr.c
+++ b/os/hal/ports/STM32/STM32U5xx/stm32_isr.c
@@ -93,6 +93,9 @@
 #include "stm32_sdmmc1.inc"
 #include "stm32_sdmmc2.inc"
 
+#include "stm32_octospi1.inc"
+#include "stm32_octospi2.inc"
+
 #include "stm32_tim1.inc"
 #include "stm32_tim2.inc"
 #include "stm32_tim3.inc"
@@ -170,6 +173,9 @@ void irqInit(void) {
   sdmmc1_irq_init();
   sdmmc2_irq_init();
 
+  octospi1_irq_init();
+  octospi2_irq_init();
+
   tim1_irq_init();
   tim2_irq_init();
   tim3_irq_init();
@@ -243,6 +249,9 @@ void irqDeinit(void) {
 
   sdmmc1_irq_deinit();
   sdmmc2_irq_deinit();
+
+  octospi1_irq_deinit();
+  octospi2_irq_deinit();
 
   tim1_irq_deinit();
   tim2_irq_deinit();


### PR DESCRIPTION
 ## Summary

  Add configurable OCTOSPI control-register mode bits to the STM32 OCTOSPIv3 WSPI driver and register the OCTOSPI1/2
  interrupt handlers in the STM32U5 IRQ dispatcher.

  The OCTOSPIv3 driver previously constructed `OCTOSPI_CR` exclusively from its internal enable, DMA, and transfer-
  complete interrupt bits. This prevented board configurations from retaining additional hardware mode bits.

  This change:

  - Adds a `uint32_t cr` field to the low-level portion of `WSPIConfig`.
  - Combines the configured value with the driver-owned `OCTOSPI_CR_TCIE`, `OCTOSPI_CR_DMAEN`, and `OCTOSPI_CR_EN` bits.
  - Reapplies the configured bits when starting the driver and when leaving memory-mapped mode.
  - Includes and initializes the OCTOSPI1 and OCTOSPI2 interrupt handlers in the STM32U5 IRQ dispatcher.
  - Deinitializes both handlers from `irqDeinit()`.

  This is required for configurations such as dual-memory mode, where `OCTOSPI_CR_DMM` must remain set throughout normal
  driver state transitions.

  Existing designated `WSPIConfig` initializers that omit `.cr` initialize the field to zero and retain the existing
  single-memory behavior.

  ## Related

  - Issue(s): None
  - Notes for reviewers:
    - The change is confined to the OCTOSPIv3 low-level WSPI configuration and STM32U5 OCTOSPI IRQ registration.
    - Winbond flash descriptors and SFLASH behavior are separate changes and are not included in this PR.
    - Configured CR bits are ORed with the bits owned by the driver.
    - Additional upstream testing of both OCTOSPI instances and existing configurations with `.cr` omitted would be
    useful.

  ## Target Branch Check

  - [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
        `stable-*` branches only receive maintainer-selected backports of commits already
        merged on `master`

  ## Scope

  - [x] Change is focused and does not bundle unrelated work
  - [x] I reviewed impact on other ports/configurations where relevant

  ## Mechanical Checks

  - [ ] Style check passed on changed `.c`/`.h` files
  - [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

  The patch passed the following checks against upstream `master`:
  git apply --check 0001-stm32-octospiv3-add-cr-options-and-u5-irqs.patch
  git apply --check --whitespace=error-all 0001-stm32-octospiv3-add-cr-options-and-u5-irqs.patch

  Both completed without errors. The relevant STM32U5 target was built and tested, but the POSIX simulator was not
  built.

  ## Testing

  - [x] Test run successfully locally
  - Any other tests run on a device?

  Tested on an STM32U5F7 board connected to two W25Q256JV NOR flash devices in OCTOSPI dual-memory mode.

  Device testing included:

  - SFLASH API device identification.
  - Validation of the combined dual-memory geometry.
  - Erase, write, and read operations on several selected sectors.
  - Restoration of the selected sectors after testing.
  - Verification that dual-memory mode remains operational through the relevant driver state transitions.

  ## Compatibility and Risk

  - [ ] No intentional public API/ABI break
  - [x] If API/ABI changed, rationale and migration notes are provided
  - [x] Risks/limitations are documented below

  WSPIConfig gains a low-level uint32_t cr member. This changes the structure layout and therefore its ABI.

  Designated initializers that omit .cr remain source-compatible because the field is initialized to zero. Positional
  initializers may require updating to include a zero value for the new field.

  A zero value preserves the existing behavior. Nonzero values are the responsibility of the board configuration and
  should contain only control-register mode bits appropriate for the selected OCTOSPI instance.