### PR TITLE
RP: fit HAZARD3-VALIDATION beside the core-local instance data

### DIFF
--- a/testhal/RP/RP2350/HAZARD3-VALIDATION/Makefile
+++ b/testhal/RP/RP2350/HAZARD3-VALIDATION/Makefile
@@ -54,13 +54,13 @@ endif
 # Stack size to be allocated to the RISC-V process stack. This stack is
 # the stack used by the main() thread.
 ifeq ($(USE_PROCESS_STACKSIZE),)
-  USE_PROCESS_STACKSIZE = 0x800
+  USE_PROCESS_STACKSIZE = 0x400
 endif
 
 # Stack size to the allocated to the RISC-V main/exceptions stack. This
 # stack is used for processing interrupts and exceptions.
 ifeq ($(USE_EXCEPTIONS_STACKSIZE),)
-  USE_EXCEPTIONS_STACKSIZE = 0x800
+  USE_EXCEPTIONS_STACKSIZE = 0x400
 endif
 
 #


### PR DESCRIPTION
Fixes #254

## Summary

- align the HAZARD3-VALIDATION per-core stacks to the 0x400+0x400 split established by `d81018df66` for the startup defaults and the RISC-V blink demo

Since `d81018df66` the core-local BSS annotations are live on the Hazard3 RP2 port, so the per-core kernel instances (1056 bytes each) share the 4 KiB scratch banks with the stacks. This Makefile still pinned 0x800+0x800, which fills the banks exactly and has made the default configuration fail to link ever since.

## Validation

- default configuration links with xPack riscv-none-elf-gcc 15.2.0 and with a riscv-collab GCC 16.1.0 nightly; both previously failed with identical 1056-byte `ram4`/`ram5` overflows
- full suite re-run on the Pico 2 bench in RISC-V mode with the reduced stacks; the configuration keeps `CH_DBG_ENABLE_STACK_CHECK=TRUE` and the PMP stack guard active, so undersized stacks would fault rather than pass silently
- no conflict with #251: that PR touches different hunks of this Makefile (regression-mode source selection); the branches merge cleanly in either order
