### PR TITLE
shell: prevent empty history line under-read

### DIFF
--- a/os/various/shell/shell.c
+++ b/os/various/shell/shell.c
@@ -143,7 +143,7 @@ static void save_history(ShellHistory *shp, char *line, int length) {
   if (length > shp->sh_size - 2)
     return;
 
-  while ((*(line + length -1) == ' ') && (length > 0))
+  while ((length > 0) && (*(line + length - 1) == ' '))
     length--;
 
   if (length <= 0)


### PR DESCRIPTION
## Summary

- Check the history-line length before inspecting its final character.
- Prevent `save_history()` from reading `line[-1]` when Enter is pressed at an empty prompt with shell history enabled.
- Reported by Arslan via email.

## Related

- Issue(s): None.
- Notes for reviewers: XShell is not affected because it handles empty input without this unchecked final-character access.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [x] Test run successfully locally
- Focused AddressSanitizer reproduction reports the original stack-buffer-underflow and passes with the reordered condition.
- `demos/RP/RT-RP2040-PICO` builds with `SHELL_USE_HISTORY=TRUE`.
- `demos/various/RT-Posix-Simulator` builds successfully.
- Any other tests run on a device? No.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

Risk is minimal: the change only reorders the existing short-circuit checks so a zero-length line returns before dereferencing the buffer.