### PR TITLE
shell: prevent empty history line under-read (21.11.x)

### DIFF
--- a/os/various/shell/shell.c
+++ b/os/various/shell/shell.c
@@ -143,7 +143,7 @@ static void save_history(ShellHistory *shp, char *line, int length) {
   if (length > shp->sh_size - 2)
     return;
 
-  while ((*(line + length -1) == ' ') && (length > 0))
+  while ((length > 0) && (*(line + length - 1) == ' '))
     length--;
 
   if (length <= 0)


### PR DESCRIPTION
## Summary

- Backport the legacy-shell empty-history-line guard to `stable-21.11.x`.
- Check the line length before inspecting its final character, preventing `save_history()` from reading `line[-1]` on an empty prompt.
- Reported by Arslan via email.

## Related

- Issue(s): None.
- Notes for reviewers: Backport of master PR #256 (master commit `fe5fee6a13`). Keep this PR in draft and do not merge it until #256 has landed, per the upstream-first policy.

## Target Branch Check

- [ ] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

This PR intentionally targets `stable-21.11.x` as the dependent backport of #256.

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [x] Test run successfully locally
- Focused AddressSanitizer reproduction reports the original stack-buffer-underflow and passes with the reordered condition.
- `demos/various/RT-Posix-Simulator` builds with `SHELL_USE_HISTORY=TRUE`.
- `demos/STM32/RT-STM32F429-DISCOVERY` builds with `SHELL_USE_HISTORY=TRUE`.
- Any other tests run on a device? No.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

Risk is minimal: the backport only reorders the existing short-circuit checks so a zero-length line returns before dereferencing the buffer.