### PR TITLE
Fix STM32 TIM channels 5 and 6 mode encoding

### DIFF
--- a/os/hal/ports/STM32/LLD/TIMv1/stm32_tim.h
+++ b/os/hal/ports/STM32/LLD/TIMv1/stm32_tim.h
@@ -356,7 +356,7 @@
 
 #define STM32_TIM_CCMR3_OC5M_MASK           ((7U << 4) | (1U << 16))
 #define STM32_TIM_CCMR3_OC5M(n)             ((((n) & 7) << 4) |             \
-                                             (((n) >> 2) << 16))
+                                             (((n) >> 3) << 16))
 
 #define STM32_TIM_CCMR3_OC5CE               (1U << 7)
 
@@ -365,7 +365,7 @@
 
 #define STM32_TIM_CCMR3_OC6M_MASK           ((7U << 12) | (1U << 24))
 #define STM32_TIM_CCMR3_OC6M(n)             ((((n) & 7) << 12) |            \
-                                             (((n) >> 2) << 24))
+                                             (((n) >> 3) << 24))
 
 #define STM32_TIM_CCMR3_OC6CE               (1U << 15)
 /** @} */

--- a/os/xhal/ports/STM32/LLD/TIMv1/stm32_tim.h
+++ b/os/xhal/ports/STM32/LLD/TIMv1/stm32_tim.h
@@ -356,7 +356,7 @@
 
 #define STM32_TIM_CCMR3_OC5M_MASK           ((7U << 4) | (1U << 16))
 #define STM32_TIM_CCMR3_OC5M(n)             ((((n) & 7) << 4) |             \
-                                             (((n) >> 2) << 16))
+                                             (((n) >> 3) << 16))
 
 #define STM32_TIM_CCMR3_OC5CE               (1U << 7)
 
@@ -365,7 +365,7 @@
 
 #define STM32_TIM_CCMR3_OC6M_MASK           ((7U << 12) | (1U << 24))
 #define STM32_TIM_CCMR3_OC6M(n)             ((((n) & 7) << 12) |            \
-                                             (((n) >> 2) << 24))
+                                             (((n) >> 3) << 24))
 
 #define STM32_TIM_CCMR3_OC6CE               (1U << 15)
 /** @} */


### PR DESCRIPTION
## Summary

- Encode the OC5M and OC6M extension bit from mode bit 3 instead of bit 2.
- Keep the HAL and XHAL TIMv1 register definitions aligned.
- Restore PWM mode 1 programming for timer channels 5 and 6.

## Problem

The PWM low-level driver passes mode 6 to the CCMR3 helpers. The helpers duplicated mode bit 2 into the non-contiguous extension positions, producing CCMR3 value 0x01016868 instead of 0x00006868.

## Testing

- Compile-time assertions for modes 6 and 8 and the complete PWM CCMR3 expression.
- make -j4 in testhal/STM32/STM32F7xx/PWM-ICU.