### PR TITLE
hal: stm32: fix ADCv4 boost threshold ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,7 +199,8 @@ applied to a maintenance branch are marked *(backported to 21.11.6)*.
   in ascending order, so any clock above 6.25 MHz selected BOOST level 1 and
   levels 2 and 3 were never reached (under-boosting the analog stage above
   12.5 MHz). The ADC12 and ADC3 thresholds are now tested in descending order
-  ([#260](https://github.com/chibios-upstream/chibios/pull/260)).
+  ([#260](https://github.com/chibios-upstream/chibios/pull/260))
+  *(backported to 21.11.6)*.
 - [STM32] OCTOSPIv2 WSPI driver had three defects: the OCTOSPI2 initialization
   used the OCTOSPI1 DHQC option bit, a non-full-init start wrote an
   uninitialized DCR2 prescaler, and the transfer-complete ISR invoked the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,11 @@ applied to a maintenance branch are marked *(backported to 21.11.6)*.
 
 ### Fixed
 
+- [STM32] ADCv4 (STM32H7) boost-level selection tested the ADC clock thresholds
+  in ascending order, so any clock above 6.25 MHz selected BOOST level 1 and
+  levels 2 and 3 were never reached (under-boosting the analog stage above
+  12.5 MHz). The ADC12 and ADC3 thresholds are now tested in descending order
+  ([#260](https://github.com/chibios-upstream/chibios/pull/260)).
 - [STM32] OCTOSPIv2 WSPI driver had three defects: the OCTOSPI2 initialization
   used the OCTOSPI1 DHQC option bit, a non-full-init start wrote an
   uninitialized DCR2 prescaler, and the transfer-complete ISR invoked the

--- a/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.h
+++ b/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.h
@@ -438,22 +438,22 @@
 #endif
 
 /* ADC boost checks.*/
-#if   STM32_ADC12_CLOCK >  6250000
-#define STM32_ADC12_BOOST               (1U << 8U)
+#if   STM32_ADC12_CLOCK > 25000000
+#define STM32_ADC12_BOOST               (3U << 8U)
 #elif STM32_ADC12_CLOCK > 12500000
 #define STM32_ADC12_BOOST               (2U << 8U)
-#elif STM32_ADC12_CLOCK > 25000000
-#define STM32_ADC12_BOOST               (3U << 8U)
+#elif STM32_ADC12_CLOCK >  6250000
+#define STM32_ADC12_BOOST               (1U << 8U)
 #else
 #define STM32_ADC12_BOOST               (0U << 8U)
 #endif
 
-#if   STM32_ADC3_CLOCK >  6250000
-#define STM32_ADC3_BOOST                (1U << 8U)
+#if   STM32_ADC3_CLOCK > 25000000
+#define STM32_ADC3_BOOST                (3U << 8U)
 #elif STM32_ADC3_CLOCK > 12500000
 #define STM32_ADC3_BOOST                (2U << 8U)
-#elif STM32_ADC3_CLOCK > 25000000
-#define STM32_ADC3_BOOST                (3U << 8U)
+#elif STM32_ADC3_CLOCK >  6250000
+#define STM32_ADC3_BOOST                (1U << 8U)
 #else
 #define STM32_ADC3_BOOST                (0U << 8U)
 #endif


### PR DESCRIPTION
## Summary

Fix the ADCv4 boost level selection.

The ADCv4 boost checks are ordered from the lowest threshold upwards, so any clock above 6.25 MHz selects BOOST level 1 and the higher levels are never reached.

Check the thresholds in descending order for both ADC12 and ADC3.

## Target Branch Check

<!-- put a x instead of the space in the [ ] to check the box [x] -->

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? no

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below
