### PR TITLE
STM32 ADCv4: fix boost-level threshold ordering [21.11] (backport of #260)

### DIFF
--- a/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.h
+++ b/os/hal/ports/STM32/LLD/ADCv4/hal_adc_lld.h
@@ -438,22 +438,22 @@
 #endif
 
 /* ADC boost checks.*/
-#if   STM32_ADC12_CLOCK >  6250000
-#define STM32_ADC12_BOOST               (1U << 8U)
+#if   STM32_ADC12_CLOCK > 25000000
+#define STM32_ADC12_BOOST               (3U << 8U)
 #elif STM32_ADC12_CLOCK > 12500000
 #define STM32_ADC12_BOOST               (2U << 8U)
-#elif STM32_ADC12_CLOCK > 25000000
-#define STM32_ADC12_BOOST               (3U << 8U)
+#elif STM32_ADC12_CLOCK >  6250000
+#define STM32_ADC12_BOOST               (1U << 8U)
 #else
 #define STM32_ADC12_BOOST               (0U << 8U)
 #endif
 
-#if   STM32_ADC3_CLOCK >  6250000
-#define STM32_ADC3_BOOST                (1U << 8U)
+#if   STM32_ADC3_CLOCK > 25000000
+#define STM32_ADC3_BOOST                (3U << 8U)
 #elif STM32_ADC3_CLOCK > 12500000
 #define STM32_ADC3_BOOST                (2U << 8U)
-#elif STM32_ADC3_CLOCK > 25000000
-#define STM32_ADC3_BOOST                (3U << 8U)
+#elif STM32_ADC3_CLOCK >  6250000
+#define STM32_ADC3_BOOST                (1U << 8U)
 #else
 #define STM32_ADC3_BOOST                (0U << 8U)
 #endif

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,11 @@
 *****************************************************************************
 
 *** 21.11.6 ***
+- FIX: STM32 ADCv4 (STM32H7) boost-level selection tested the ADC clock
+       thresholds in ascending order, so any clock above 6.25 MHz selected
+       BOOST level 1 and levels 2 and 3 were never reached (under-boosting the
+       analog stage above 12.5 MHz). The ADC12 and ADC3 thresholds are now
+       tested in descending order (backport of github PR #260).
 - FIX: Serial over USB input remained inactive after an USB suspend/wakeup
        cycle on STM32 OTG devices. The generic USB driver terminates all
        pending transactions on suspend and the OTG LLD also disables the


### PR DESCRIPTION
Backport of #260 to `stable-21.11.x`. The ADCv4 (STM32H7) boost-level bug is present identically on this branch.

The `#if/#elif` ladder tested the ADC clock thresholds **ascending** (`> 6.25 MHz` first), so any clock above 6.25 MHz selected `BOOST` level 1 and levels 2 and 3 were never reached — under-boosting the analog stage for `fADC > 12.5 MHz`. ADC12 and ADC3 thresholds are now tested descending, matching RM0433 `ADC_CR.BOOST[1:0]` (00 ≤6.25, 01 ≤12.5, 10 ≤25, 11 ≤50 MHz).

Original fix by **markuspetermann** (#260); the sheriff is opening the backport.

### Gates (run locally — stable has no CI)
- `tools/style/stylecheck.py` clean on the changed file.
- `testhal/STM32/multi/ADC` on `stm32h743zi_nucleo144` builds clean, ARM GCC 14.3.1.
- `readme.txt` `*** 21.11.6 ***` entry added.

---
🤖 chibios-sheriff — backport opened on behalf of the author. A human maintainer decides on merge.
