### PR TITLE
XHAL: split byte queues from I/O synchronization

### DIFF
--- a/os/xhal/include/hal_queues.h
+++ b/os/xhal/include/hal_queues.h
@@ -53,6 +53,11 @@
 /*===========================================================================*/
 
 /**
+ * @brief   Type of a generic non-blocking byte queue structure.
+ */
+typedef struct plain_queue plain_queue_t;
+
+/**
  * @brief   Type of a generic I/O queue structure.
  */
 typedef struct io_queue io_queue_t;
@@ -65,6 +70,20 @@ typedef struct io_queue io_queue_t;
 typedef void (*qnotify_t)(io_queue_t *qp);
 
 /**
+ * @brief   Generic non-blocking byte queue structure.
+ * @details Access synchronization is delegated to the queue owner. All
+ *          operations except initialization are I-class functions.
+ */
+struct plain_queue {
+  volatile size_t       q_counter;  /**< @brief Stored bytes counter.       */
+  uint8_t               *q_buffer;  /**< @brief Pointer to the queue buffer.*/
+  uint8_t               *q_top;     /**< @brief Pointer to the first
+                                         location after the buffer.         */
+  uint8_t               *q_wrptr;   /**< @brief Write pointer.              */
+  uint8_t               *q_rdptr;   /**< @brief Read pointer.               */
+};
+
+/**
  * @brief   Generic I/O queue structure.
  * @details This structure represents a generic Input or Output asymmetrical
  *          queue. The queue is asymmetrical because one end is meant to be
@@ -73,13 +92,8 @@ typedef void (*qnotify_t)(io_queue_t *qp);
  *          lock zone and is non-blocking.
  */
 struct io_queue {
+  plain_queue_t         q_queue;    /**< @brief Embedded byte queue.        */
   threads_queue_t       q_waiting;  /**< @brief Queue of waiting threads.   */
-  volatile size_t       q_counter;  /**< @brief Resources counter.          */
-  uint8_t               *q_buffer;  /**< @brief Pointer to the queue buffer.*/
-  uint8_t               *q_top;     /**< @brief Pointer to the first
-                                         location after the buffer.         */
-  uint8_t               *q_wrptr;   /**< @brief Write pointer.              */
-  uint8_t               *q_rdptr;   /**< @brief Read pointer.               */
   qnotify_t             q_notify;   /**< @brief Data notification callback. */
   void                  *q_link;    /**< @brief Application defined field.  */
 };
@@ -119,7 +133,7 @@ typedef io_queue_t output_queue_t;
 /**
  * @brief   Returns the queue's buffer size.
  *
- * @param[in] qp        pointer to a @p io_queue_t structure
+ * @param[in] qp        pointer to a @p plain_queue_t structure
  * @return              The buffer size.
  *
  * @xclass
@@ -130,16 +144,50 @@ typedef io_queue_t output_queue_t;
   /*lint -restore*/
 
 /**
- * @brief   Queue space.
- * @details Returns the used space if used on an input queue or the empty
- *          space if used on an output queue.
+ * @brief   Returns the filled space in a queue.
  *
- * @param[in] qp        pointer to a @p io_queue_t structure
- * @return              The buffer space.
+ * @param[in] qp        pointer to a @p plain_queue_t structure
+ * @return              The number of full bytes in the queue.
+ * @retval 0            if the queue is empty.
  *
  * @iclass
  */
-#define qSpaceI(qp) ((qp)->q_counter)
+#define qGetFullI(qp) ((qp)->q_counter)
+
+/**
+ * @brief   Returns the empty space in a queue.
+ *
+ * @param[in] qp        pointer to a @p plain_queue_t structure
+ * @return              The number of empty bytes in the queue.
+ * @retval 0            if the queue is full.
+ *
+ * @iclass
+ */
+#define qGetEmptyI(qp) (qSizeX(qp) - qGetFullI(qp))
+
+/**
+ * @brief   Evaluates to @p true if the specified queue is empty.
+ *
+ * @param[in] qp        pointer to a @p plain_queue_t structure
+ * @return              The queue status.
+ * @retval false        if the queue is not empty.
+ * @retval true         if the queue is empty.
+ *
+ * @iclass
+ */
+#define qIsEmptyI(qp) ((bool)(qGetFullI(qp) == 0U))
+
+/**
+ * @brief   Evaluates to @p true if the specified queue is full.
+ *
+ * @param[in] qp        pointer to a @p plain_queue_t structure
+ * @return              The queue status.
+ * @retval false        if the queue is not full.
+ * @retval true         if the queue is full.
+ *
+ * @iclass
+ */
+#define qIsFullI(qp) ((bool)(qGetEmptyI(qp) == 0U))
 
 /**
  * @brief   Returns the queue application-defined link.
@@ -172,7 +220,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define iqGetFullI(iqp) qSpaceI(iqp)
+#define iqGetFullI(iqp) qGetFullI(&(iqp)->q_queue)
 
 /**
  * @brief   Returns the empty space into an input queue.
@@ -183,7 +231,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define iqGetEmptyI(iqp) (qSizeX(iqp) - qSpaceI(iqp))
+#define iqGetEmptyI(iqp) qGetEmptyI(&(iqp)->q_queue)
 
 /**
  * @brief   Evaluates to @p true if the specified input queue is empty.
@@ -195,7 +243,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define iqIsEmptyI(iqp) ((bool)(qSpaceI(iqp) == 0U))
+#define iqIsEmptyI(iqp) qIsEmptyI(&(iqp)->q_queue)
 
 /**
  * @brief   Evaluates to @p true if the specified input queue is full.
@@ -207,10 +255,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define iqIsFullI(iqp)                                                      \
-  /*lint -save -e9007 [13.5] No side effects, a pointer is passed.*/        \
-  ((bool)(((iqp)->q_wrptr == (iqp)->q_rdptr) && ((iqp)->q_counter != 0U)))  \
-  /*lint -restore*/
+#define iqIsFullI(iqp) qIsFullI(&(iqp)->q_queue)
 
 /**
  * @brief   Input queue read.
@@ -235,7 +280,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define oqGetFullI(oqp) (qSizeX(oqp) - qSpaceI(oqp))
+#define oqGetFullI(oqp) qGetFullI(&(oqp)->q_queue)
 
 /**
  * @brief   Returns the empty space into an output queue.
@@ -246,7 +291,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define oqGetEmptyI(oqp) qSpaceI(oqp)
+#define oqGetEmptyI(oqp) qGetEmptyI(&(oqp)->q_queue)
 
 /**
  * @brief   Evaluates to @p true if the specified output queue is empty.
@@ -258,10 +303,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define oqIsEmptyI(oqp)                                                     \
-  /*lint -save -e9007 [13.5] No side effects, a pointer is passed.*/        \
-  ((bool)(((oqp)->q_wrptr == (oqp)->q_rdptr) && ((oqp)->q_counter != 0U)))  \
-  /*lint -restore*/
+#define oqIsEmptyI(oqp) qIsEmptyI(&(oqp)->q_queue)
 
 /**
  * @brief   Evaluates to @p true if the specified output queue is full.
@@ -273,7 +315,7 @@ typedef io_queue_t output_queue_t;
  *
  * @iclass
  */
-#define oqIsFullI(oqp) ((bool)(qSpaceI(oqp) == 0U))
+#define oqIsFullI(oqp) qIsFullI(&(oqp)->q_queue)
 
 /**
  * @brief   Output queue write.
@@ -299,6 +341,13 @@ typedef io_queue_t output_queue_t;
 #ifdef __cplusplus
 extern "C" {
 #endif
+  void qObjectInit(plain_queue_t *qp, uint8_t *bp, size_t size);
+  void qResetI(plain_queue_t *qp);
+  msg_t qPutI(plain_queue_t *qp, uint8_t b);
+  msg_t qGetI(plain_queue_t *qp);
+  size_t qReadI(plain_queue_t *qp, uint8_t *bp, size_t n);
+  size_t qWriteI(plain_queue_t *qp, const uint8_t *bp, size_t n);
+
   void iqObjectInit(input_queue_t *iqp, uint8_t *bp, size_t size,
                     qnotify_t infy, void *link);
   void iqResetI(input_queue_t *iqp);

--- a/os/xhal/src/hal_queues.c
+++ b/os/xhal/src/hal_queues.c
@@ -24,6 +24,8 @@
  *          (lower driver, it is usually an interrupt service routine) and an
  *          upper side (upper driver, accessed by the application threads).<br>
  *          There are several kind of queues:<br>
+ *          - <b>Queue</b>, non-blocking byte queue without notifications or
+ *            thread synchronization.
  *          - <b>Input queue</b>, unidirectional queue where the writer is the
  *            lower side and the reader is the upper side.
  *          - <b>Output queue</b>, unidirectional queue where the writer is the
@@ -40,124 +42,200 @@
 #include "hal.h"
 
 /*===========================================================================*/
-/* Driver local definitions.                                                 */
+/* Driver exported functions.                                                */
 /*===========================================================================*/
 
 /**
- * @brief   Non-blocking input queue read.
- * @details The function reads data from an input queue into a buffer. The
+ * @brief   Non-blocking queue read.
+ * @details The function reads data from a queue into a buffer. The
  *          operation completes when the specified amount of data has been
- *          transferred or when the input queue has been emptied.
+ *          transferred or when the queue has been emptied.
  *
- * @param[in] iqp       pointer to an @p input_queue_t structure
+ * @param[in] qp        pointer to a @p plain_queue_t structure
  * @param[out] bp       pointer to the data buffer
  * @param[in] n         the maximum amount of data to be transferred, the
  *                      value 0 is reserved
  * @return              The number of bytes effectively transferred.
  *
- * @notapi
+ * @iclass
  */
-static size_t iq_read(input_queue_t *iqp, uint8_t *bp, size_t n) {
+size_t qReadI(plain_queue_t *qp, uint8_t *bp, size_t n) {
   size_t s1, s2;
 
+  chDbgCheckClassI();
   chDbgCheck(n > 0U);
 
   /* Number of bytes that can be read in a single atomic operation.*/
-  if (n > iqGetFullI(iqp)) {
-    n = iqGetFullI(iqp);
+  if (n > qGetFullI(qp)) {
+    n = qGetFullI(qp);
   }
 
   /* Number of bytes before buffer limit.*/
   /*lint -save -e9033 [10.8] Checked to be safe.*/
-  s1 = (size_t)(iqp->q_top - iqp->q_rdptr);
+  s1 = (size_t)(qp->q_top - qp->q_rdptr);
   /*lint -restore*/
   if (n < s1) {
-    memcpy((void *)bp, (void *)iqp->q_rdptr, n);
-    iqp->q_rdptr += n;
+    memcpy((void *)bp, (void *)qp->q_rdptr, n);
+    qp->q_rdptr += n;
   }
   else if (n > s1) {
-    memcpy((void *)bp, (void *)iqp->q_rdptr, s1);
+    memcpy((void *)bp, (void *)qp->q_rdptr, s1);
     bp += s1;
     s2 = n - s1;
-    memcpy((void *)bp, (void *)iqp->q_buffer, s2);
-    iqp->q_rdptr = iqp->q_buffer + s2;
+    memcpy((void *)bp, (void *)qp->q_buffer, s2);
+    qp->q_rdptr = qp->q_buffer + s2;
   }
   else {
-    memcpy((void *)bp, (void *)iqp->q_rdptr, n);
-    iqp->q_rdptr = iqp->q_buffer;
+    memcpy((void *)bp, (void *)qp->q_rdptr, n);
+    qp->q_rdptr = qp->q_buffer;
   }
 
-  iqp->q_counter -= n;
+  qp->q_counter -= n;
   return n;
 }
 
 /**
- * @brief   Non-blocking output queue write.
- * @details The function writes data from a buffer to an output queue. The
+ * @brief   Non-blocking queue write.
+ * @details The function writes data from a buffer to a queue. The
  *          operation completes when the specified amount of data has been
- *          transferred or when the output queue has been filled.
+ *          transferred or when the queue has been filled.
  *
- * @param[in] oqp       pointer to an @p output_queue_t structure
+ * @param[in] qp        pointer to a @p plain_queue_t structure
  * @param[in] bp        pointer to the data buffer
  * @param[in] n         the maximum amount of data to be transferred, the
  *                      value 0 is reserved
  * @return              The number of bytes effectively transferred.
  *
- * @notapi
+ * @iclass
  */
-static size_t oq_write(output_queue_t *oqp, const uint8_t *bp, size_t n) {
+size_t qWriteI(plain_queue_t *qp, const uint8_t *bp, size_t n) {
   size_t s1, s2;
 
+  chDbgCheckClassI();
   chDbgCheck(n > 0U);
 
   /* Number of bytes that can be written in a single atomic operation.*/
-  if (n > oqGetEmptyI(oqp)) {
-    n = oqGetEmptyI(oqp);
+  if (n > qGetEmptyI(qp)) {
+    n = qGetEmptyI(qp);
   }
 
   /* Number of bytes before buffer limit.*/
   /*lint -save -e9033 [10.8] Checked to be safe.*/
-  s1 = (size_t)(oqp->q_top - oqp->q_wrptr);
+  s1 = (size_t)(qp->q_top - qp->q_wrptr);
   /*lint -restore*/
   if (n < s1) {
-    memcpy((void *)oqp->q_wrptr, (const void *)bp, n);
-    oqp->q_wrptr += n;
+    memcpy((void *)qp->q_wrptr, (const void *)bp, n);
+    qp->q_wrptr += n;
   }
   else if (n > s1) {
-    memcpy((void *)oqp->q_wrptr, (const void *)bp, s1);
+    memcpy((void *)qp->q_wrptr, (const void *)bp, s1);
     bp += s1;
     s2 = n - s1;
-    memcpy((void *)oqp->q_buffer, (const void *)bp, s2);
-    oqp->q_wrptr = oqp->q_buffer + s2;
+    memcpy((void *)qp->q_buffer, (const void *)bp, s2);
+    qp->q_wrptr = qp->q_buffer + s2;
   }
   else {
-    memcpy((void *)oqp->q_wrptr, (const void *)bp, n);
-    oqp->q_wrptr = oqp->q_buffer;
+    memcpy((void *)qp->q_wrptr, (const void *)bp, n);
+    qp->q_wrptr = qp->q_buffer;
   }
 
-  oqp->q_counter -= n;
+  qp->q_counter += n;
   return n;
 }
 
-/*===========================================================================*/
-/* Driver exported variables.                                                */
-/*===========================================================================*/
+/**
+ * @brief   Initializes a non-blocking byte queue.
+ *
+ * @param[out] qp       pointer to a @p plain_queue_t structure
+ * @param[in] bp        pointer to a memory area allocated as queue buffer
+ * @param[in] size      size of the queue buffer
+ *
+ * @init
+ */
+void qObjectInit(plain_queue_t *qp, uint8_t *bp, size_t size) {
 
-/*===========================================================================*/
-/* Driver local variables and types.                                         */
-/*===========================================================================*/
+  chDbgCheck((qp != NULL) && (bp != NULL) && (size > 0U));
 
-/*===========================================================================*/
-/* Driver local functions.                                                   */
-/*===========================================================================*/
+  qp->q_counter = 0U;
+  qp->q_buffer  = bp;
+  qp->q_rdptr   = bp;
+  qp->q_wrptr   = bp;
+  qp->q_top     = bp + size;
+}
 
-/*===========================================================================*/
-/* Driver interrupt handlers.                                                */
-/*===========================================================================*/
+/**
+ * @brief   Resets a non-blocking byte queue.
+ * @details All queued data is erased. The queue does not perform any thread
+ *          wakeup or notification.
+ *
+ * @param[in] qp        pointer to a @p plain_queue_t structure
+ *
+ * @iclass
+ */
+void qResetI(plain_queue_t *qp) {
 
-/*===========================================================================*/
-/* Driver exported functions.                                                */
-/*===========================================================================*/
+  chDbgCheckClassI();
+
+  qp->q_counter = 0U;
+  qp->q_rdptr   = qp->q_buffer;
+  qp->q_wrptr   = qp->q_buffer;
+}
+
+/**
+ * @brief   Non-blocking queue write.
+ *
+ * @param[in] qp        pointer to a @p plain_queue_t structure
+ * @param[in] b         byte value to be written
+ * @return              The operation status.
+ * @retval MSG_OK       if the operation succeeded.
+ * @retval MSG_TIMEOUT  if the queue is full.
+ *
+ * @iclass
+ */
+msg_t qPutI(plain_queue_t *qp, uint8_t b) {
+
+  chDbgCheckClassI();
+
+  if (!qIsFullI(qp)) {
+    qp->q_counter++;
+    *qp->q_wrptr++ = b;
+    if (qp->q_wrptr >= qp->q_top) {
+      qp->q_wrptr = qp->q_buffer;
+    }
+
+    return MSG_OK;
+  }
+
+  return MSG_TIMEOUT;
+}
+
+/**
+ * @brief   Non-blocking queue read.
+ *
+ * @param[in] qp        pointer to a @p plain_queue_t structure
+ * @return              A byte value from the queue.
+ * @retval MSG_TIMEOUT  if the queue is empty.
+ *
+ * @iclass
+ */
+msg_t qGetI(plain_queue_t *qp) {
+
+  chDbgCheckClassI();
+
+  if (!qIsEmptyI(qp)) {
+    uint8_t b;
+
+    qp->q_counter--;
+    b = *qp->q_rdptr++;
+    if (qp->q_rdptr >= qp->q_top) {
+      qp->q_rdptr = qp->q_buffer;
+    }
+
+    return (msg_t)b;
+  }
+
+  return MSG_TIMEOUT;
+}
 
 /**
  * @brief   Initializes an input queue.
@@ -177,14 +255,10 @@ static size_t oq_write(output_queue_t *oqp, const uint8_t *bp, size_t n) {
 void iqObjectInit(input_queue_t *iqp, uint8_t *bp, size_t size,
                   qnotify_t infy, void *link) {
 
+  qObjectInit(&iqp->q_queue, bp, size);
   chThdQueueObjectInit(&iqp->q_waiting);
-  iqp->q_counter = 0;
-  iqp->q_buffer  = bp;
-  iqp->q_rdptr   = bp;
-  iqp->q_wrptr   = bp;
-  iqp->q_top     = bp + size;
-  iqp->q_notify  = infy;
-  iqp->q_link    = link;
+  iqp->q_notify = infy;
+  iqp->q_link   = link;
 }
 
 /**
@@ -202,9 +276,7 @@ void iqResetI(input_queue_t *iqp) {
 
   chDbgCheckClassI();
 
-  iqp->q_rdptr = iqp->q_buffer;
-  iqp->q_wrptr = iqp->q_buffer;
-  iqp->q_counter = 0;
+  qResetI(&iqp->q_queue);
   chThdDequeueAllI(&iqp->q_waiting, MSG_RESET);
 }
 
@@ -222,23 +294,16 @@ void iqResetI(input_queue_t *iqp) {
  * @iclass
  */
 msg_t iqPutI(input_queue_t *iqp, uint8_t b) {
+  msg_t msg;
 
   chDbgCheckClassI();
 
-  /* Queue space check.*/
-  if (!iqIsFullI(iqp)) {
-    iqp->q_counter++;
-    *iqp->q_wrptr++ = b;
-    if (iqp->q_wrptr >= iqp->q_top) {
-      iqp->q_wrptr = iqp->q_buffer;
-    }
-
+  msg = qPutI(&iqp->q_queue, b);
+  if (msg == MSG_OK) {
     chThdDequeueNextI(&iqp->q_waiting, MSG_OK);
-
-    return MSG_OK;
   }
 
-  return MSG_TIMEOUT;
+  return msg;
 }
 
 /**
@@ -256,29 +321,19 @@ msg_t iqPutI(input_queue_t *iqp, uint8_t b) {
  * @iclass
  */
 msg_t iqGetI(input_queue_t *iqp) {
+  msg_t msg;
 
   chDbgCheckClassI();
 
-  /* Queue data check.*/
-  if (!iqIsEmptyI(iqp)) {
-    uint8_t b;
-
-    /* Getting the character from the queue.*/
-    iqp->q_counter--;
-    b = *iqp->q_rdptr++;
-    if (iqp->q_rdptr >= iqp->q_top) {
-      iqp->q_rdptr = iqp->q_buffer;
-    }
-
+  msg = qGetI(&iqp->q_queue);
+  if (msg >= MSG_OK) {
     /* Inform the low side that the queue has at least one slot available.*/
     if (iqp->q_notify != NULL) {
       iqp->q_notify(iqp);
     }
-
-    return (msg_t)b;
   }
 
-  return MSG_TIMEOUT;
+  return msg;
 }
 
 /**
@@ -302,13 +357,13 @@ msg_t iqGetI(input_queue_t *iqp) {
  * @api
  */
 msg_t iqGetTimeout(input_queue_t *iqp, sysinterval_t timeout) {
-  uint8_t b;
+  msg_t msg;
 
   chSysLock();
 
   /* Waiting until there is a character available or a timeout occurs.*/
   while (iqIsEmptyI(iqp)) {
-    msg_t msg = chThdEnqueueTimeoutS(&iqp->q_waiting, timeout);
+    msg = chThdEnqueueTimeoutS(&iqp->q_waiting, timeout);
     if (msg < MSG_OK) {
       chSysUnlock();
       return msg;
@@ -316,11 +371,7 @@ msg_t iqGetTimeout(input_queue_t *iqp, sysinterval_t timeout) {
   }
 
   /* Getting the character from the queue.*/
-  iqp->q_counter--;
-  b = *iqp->q_rdptr++;
-  if (iqp->q_rdptr >= iqp->q_top) {
-    iqp->q_rdptr = iqp->q_buffer;
-  }
+  msg = qGetI(&iqp->q_queue);
 
   /* Inform the low side that the queue has at least one slot available.*/
   if (iqp->q_notify != NULL) {
@@ -329,7 +380,7 @@ msg_t iqGetTimeout(input_queue_t *iqp, sysinterval_t timeout) {
 
   chSysUnlock();
 
-  return (msg_t)b;
+  return msg;
 }
 
 /**
@@ -351,9 +402,9 @@ size_t iqReadI(input_queue_t *iqp, uint8_t *bp, size_t n) {
 
   chDbgCheckClassI();
 
-  rd = iq_read(iqp, bp, n);
+  rd = qReadI(&iqp->q_queue, bp, n);
 
-  /* Inform the low side that the queue has at least one character
+  /* Inform the low side that the queue has at least one empty slot
      available.*/
   if ((rd > (size_t)0) && (nfy != NULL)) {
     nfy(iqp);
@@ -396,12 +447,12 @@ size_t iqReadTimeout(input_queue_t *iqp, uint8_t *bp,
 
   chSysLock();
 
-  done = iq_read(iqp, bp, n);
+  done = qReadI(&iqp->q_queue, bp, n);
   if (done == (size_t)0) {
     msg_t msg = chThdEnqueueTimeoutS(&iqp->q_waiting, timeout);
 
     if (msg == MSG_OK) {
-      done = iq_read(iqp, bp, n);
+      done = qReadI(&iqp->q_queue, bp, n);
     }
   }
 
@@ -433,14 +484,10 @@ size_t iqReadTimeout(input_queue_t *iqp, uint8_t *bp,
 void oqObjectInit(output_queue_t *oqp, uint8_t *bp, size_t size,
                   qnotify_t onfy, void *link) {
 
+  qObjectInit(&oqp->q_queue, bp, size);
   chThdQueueObjectInit(&oqp->q_waiting);
-  oqp->q_counter = size;
-  oqp->q_buffer  = bp;
-  oqp->q_rdptr   = bp;
-  oqp->q_wrptr   = bp;
-  oqp->q_top     = bp + size;
-  oqp->q_notify  = onfy;
-  oqp->q_link    = link;
+  oqp->q_notify = onfy;
+  oqp->q_link   = link;
 }
 
 /**
@@ -458,9 +505,7 @@ void oqResetI(output_queue_t *oqp) {
 
   chDbgCheckClassI();
 
-  oqp->q_rdptr = oqp->q_buffer;
-  oqp->q_wrptr = oqp->q_buffer;
-  oqp->q_counter = qSizeX(oqp);
+  qResetI(&oqp->q_queue);
   chThdDequeueAllI(&oqp->q_waiting, MSG_RESET);
 }
 
@@ -479,27 +524,19 @@ void oqResetI(output_queue_t *oqp) {
  * @iclass
  */
 msg_t oqPutI(output_queue_t *oqp, uint8_t b) {
+  msg_t msg;
 
   chDbgCheckClassI();
 
-  /* Queue space check.*/
-  while (!oqIsFullI(oqp)) {
-    /* Putting the character into the queue.*/
-    oqp->q_counter--;
-    *oqp->q_wrptr++ = b;
-    if (oqp->q_wrptr >= oqp->q_top) {
-      oqp->q_wrptr = oqp->q_buffer;
-    }
-
+  msg = qPutI(&oqp->q_queue, b);
+  if (msg == MSG_OK) {
     /* Inform the low side that the queue has at least one character available.*/
     if (oqp->q_notify != NULL) {
       oqp->q_notify(oqp);
     }
-
-    return MSG_OK;
   }
 
-  return MSG_TIMEOUT;
+  return msg;
 }
 
 /**
@@ -525,12 +562,13 @@ msg_t oqPutI(output_queue_t *oqp, uint8_t b) {
  * @api
  */
 msg_t oqPutTimeout(output_queue_t *oqp, uint8_t b, sysinterval_t timeout) {
+  msg_t msg;
 
   chSysLock();
 
   /* Waiting until there is a slot available or a timeout occurs.*/
   while (oqIsFullI(oqp)) {
-    msg_t msg = chThdEnqueueTimeoutS(&oqp->q_waiting, timeout);
+    msg = chThdEnqueueTimeoutS(&oqp->q_waiting, timeout);
     if (msg < MSG_OK) {
       chSysUnlock();
       return msg;
@@ -538,11 +576,7 @@ msg_t oqPutTimeout(output_queue_t *oqp, uint8_t b, sysinterval_t timeout) {
   }
 
   /* Putting the character into the queue.*/
-  oqp->q_counter--;
-  *oqp->q_wrptr++ = b;
-  if (oqp->q_wrptr >= oqp->q_top) {
-    oqp->q_wrptr = oqp->q_buffer;
-  }
+  msg = qPutI(&oqp->q_queue, b);
 
   /* Inform the low side that the queue has at least one character available.*/
   if (oqp->q_notify != NULL) {
@@ -551,7 +585,7 @@ msg_t oqPutTimeout(output_queue_t *oqp, uint8_t b, sysinterval_t timeout) {
 
   chSysUnlock();
 
-  return MSG_OK;
+  return msg;
 }
 
 /**
@@ -566,25 +600,16 @@ msg_t oqPutTimeout(output_queue_t *oqp, uint8_t b, sysinterval_t timeout) {
  * @iclass
  */
 msg_t oqGetI(output_queue_t *oqp) {
+  msg_t msg;
 
   chDbgCheckClassI();
 
-  /* Queue data check.*/
-  if (!oqIsEmptyI(oqp)) {
-    uint8_t b;
-
-    oqp->q_counter++;
-    b = *oqp->q_rdptr++;
-    if (oqp->q_rdptr >= oqp->q_top) {
-      oqp->q_rdptr = oqp->q_buffer;
-    }
-
+  msg = qGetI(&oqp->q_queue);
+  if (msg >= MSG_OK) {
     chThdDequeueNextI(&oqp->q_waiting, MSG_OK);
-
-    return (msg_t)b;
   }
 
-  return MSG_TIMEOUT;
+  return msg;
 }
 
 /**
@@ -606,7 +631,7 @@ size_t oqWriteI(output_queue_t *oqp, const uint8_t *bp, size_t n) {
 
   chDbgCheckClassI();
 
-  wr = oq_write(oqp, bp, n);
+  wr = qWriteI(&oqp->q_queue, bp, n);
 
   /* Inform the low side that the queue has at least one character
      available.*/
@@ -651,12 +676,12 @@ size_t oqWriteTimeout(output_queue_t *oqp, const uint8_t *bp,
 
   chSysLock();
 
-  done = oq_write(oqp, bp, n);
+  done = qWriteI(&oqp->q_queue, bp, n);
   if (done == (size_t)0) {
     msg_t msg = chThdEnqueueTimeoutS(&oqp->q_waiting, timeout);
 
     if (msg == MSG_OK) {
-      done = oq_write(oqp, bp, n);
+      done = qWriteI(&oqp->q_queue, bp, n);
     }
   }
 


### PR DESCRIPTION
Summary

- add a plain, non-blocking byte queue under the existing q namespace
- aggregate the plain queue into input and output queues
- keep callbacks and thread synchronization in the I/O queue layer

This deliberately changes only the XHAL queue module; POSIX TTY and sandbox demo changes are not included.

Testing

- make -j8 in demos/STM32/RT-XHAL-STM32G474RE-NUCLEO64
- git diff --check