### PR TITLE
STM32: use SystemCoreClock for DWT safety timeouts

### DIFF
--- a/os/hal/ports/STM32/STM32C5xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32C5xx/hal_lld.h
@@ -183,7 +183,7 @@ typedef struct {
 /**
  * @brief   Real time counter frequency exported to the safety module.
  */
-#define HAL_LLD_GET_CNT_FREQUENCY()         STM32_HCLK_CLOCK
+#define HAL_LLD_GET_CNT_FREQUENCY()         SystemCoreClock
 
 /**
  * @brief   Real time counter value exported to the safety module.

--- a/os/hal/ports/STM32/STM32U3xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32U3xx/hal_lld.h
@@ -2439,7 +2439,7 @@ typedef uint32_t halcnt_t;
  * @note    The counter is the internal DWS cycles counter so in runs at
  *          the same frequency of CPU.
  */
-#define HAL_LLD_GET_CNT_FREQUENCY()         hal_lld_get_clock_point(CLK_HCLK)
+#define HAL_LLD_GET_CNT_FREQUENCY()         SystemCoreClock
 
 /**
  * @brief   Real time counter value exported to the safety module.
@@ -2482,7 +2482,6 @@ typedef uint32_t halcnt_t;
 /* Various helpers.*/
 #include "nvic.h"
 #include "cache.h"
-//#include "mpu_v8m.h"
 #include "stm32_isr.h"
 #include "stm32_dma3.h"
 #include "stm32_exti.h"

--- a/os/hal/ports/STM32/STM32U5xx/hal_lld.h
+++ b/os/hal/ports/STM32/STM32U5xx/hal_lld.h
@@ -539,7 +539,7 @@ typedef struct {
  * @note    The counter is the internal DWT cycles counter so it runs at the
  *          same frequency as the CPU.
  */
-#define HAL_LLD_GET_CNT_FREQUENCY()         hal_lld_get_clock_point(CLK_HCLK)
+#define HAL_LLD_GET_CNT_FREQUENCY()         SystemCoreClock
 
 /**
  * @brief   Real time counter value exported to the safety module.

--- a/os/xhal/ports/STM32/STM32H5xx/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32H5xx/hal_lld.h
@@ -3612,7 +3612,7 @@ typedef uint32_t halcnt_t;
  * @note    The counter is the internal DWS cycles counter so in runs at
  *          the same frequency of CPU.
  */
-#define HAL_LLD_GET_CNT_FREQUENCY()         hal_lld_get_clock_point(CLK_HCLK)
+#define HAL_LLD_GET_CNT_FREQUENCY()         SystemCoreClock
 
 /**
  * @brief   Real time counter value exported to the safety module.
@@ -3681,7 +3681,6 @@ typedef uint32_t halcnt_t;
 /* Various helpers.*/
 #include "nvic.h"
 #include "cache.h"
-//#include "mpu_v8m.h"
 #include "stm32_isr.h"
 #include "stm32_dma3.h"
 #include "stm32_exti.h"

--- a/os/xhal/ports/STM32/STM32U3xx/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32U3xx/hal_lld.h
@@ -510,7 +510,7 @@ typedef uint32_t halcnt_t;
  * @note    The counter is the internal DWS cycles counter so in runs at
  *          the same frequency of CPU.
  */
-#define HAL_LLD_GET_CNT_FREQUENCY()         hal_lld_get_clock_point(CLK_HCLK)
+#define HAL_LLD_GET_CNT_FREQUENCY()         SystemCoreClock
 
 /**
  * @brief   Real time counter value exported to the safety module.

--- a/os/xhal/ports/STM32/STM32U3xx_OLD/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32U3xx_OLD/hal_lld.h
@@ -2432,7 +2432,7 @@ typedef uint32_t halcnt_t;
  * @note    The counter is the internal DWS cycles counter so in runs at
  *          the same frequency of CPU.
  */
-#define HAL_LLD_GET_CNT_FREQUENCY()         hal_lld_get_clock_point(CLK_HCLK)
+#define HAL_LLD_GET_CNT_FREQUENCY()         SystemCoreClock
 
 /**
  * @brief   Real time counter value exported to the safety module.

--- a/os/xhal/ports/STM32/STM32U5xx/hal_lld.h
+++ b/os/xhal/ports/STM32/STM32U5xx/hal_lld.h
@@ -539,7 +539,7 @@ typedef struct {
  * @note    The counter is the internal DWT cycles counter so it runs at the
  *          same frequency as the CPU.
  */
-#define HAL_LLD_GET_CNT_FREQUENCY()         hal_lld_get_clock_point(CLK_HCLK)
+#define HAL_LLD_GET_CNT_FREQUENCY()         SystemCoreClock
 
 /**
  * @brief   Real time counter value exported to the safety module.


### PR DESCRIPTION
## Summary

- Use `SystemCoreClock` as the DWT safety-counter frequency across STM32 ports that use `DWT->CYCCNT`.
- Apply the correction to HAL U5, U3, and C5, and to XHAL U5, U3, U3 old, and H5.
- Remove two stale commented-out includes from newly touched headers so the repository style checker remains clean.

## Rationale

The DWT cycle counter runs at the current CPU/HCLK frequency. A clock-point lookup is unsafe during early clock startup because startup executes before initialized data can be relied upon, so a dynamic `clock_points[]` table can contain zero or retained runtime state during oscillator, regulator, and clock-switch waits.

The affected ports initialize `SystemCoreClock` to the known post-reset frequency before timed startup waits and update it after clock changes. It therefore describes the running DWT counter without depending on initialized clock-point storage. C5 previously used the final static `STM32_HCLK_CLOCK`; using `SystemCoreClock` also keeps timeout scaling correct before and during clock transitions.

G4 and HAL H5 already followed this convention. Timer-backed C0, G0, and U0 counters remain unchanged because their exported counter frequency is fixed at 1 MHz.

## Related

- Issue(s): None.
- PR #268 was composed into the STM32U5F7 custom board validation tree only to remove an unrelated WSPI-enabled build blocker; this PR does not depend functionally on OCTOSPI.

## Target Branch Check

- [x] This PR targets `master`; all changes land on `master` first.

## Mechanical Checks

- [x] `tools/style/stylecheck.py` passed for all changed headers.
- [x] `git diff --check` passed.
- [x] Representative ARM builds passed.

Successful HAL builds:

- `stm32u385rg_nucleo64`
- `stm32h563zi_nucleo144`
- `stm32u575zi_nucleo144`
- `stm32c562re_nucleo64`

Successful XHAL builds:

- `stm32u385rg_nucleo64`
- `stm32h563zi_nucleo144`

## Hardware Testing

The original U5 change passed 20 consecutive NRST boots on STM32U5F7 hardware. It also booted after the complete `clock_points` array was deliberately cleared in SRAM before reset; the previous frequency source would have read zero in that test.

## Compatibility and Risk

No public API or ABI changes. The change only alters safety-timeout scaling to follow the currently running DWT clock instead of initialized clock-point storage or a final static configuration value.
