### PR TITLE
Add Cortex-R5 support to ARMv7-R port

### DIFF
--- a/os/common/ports/ARMv7-R/chcore.h
+++ b/os/common/ports/ARMv7-R/chcore.h
@@ -85,6 +85,7 @@
  * @name    ARMv7-R variants
  * @{
  */
+#define ARM_CORE_CORTEX_R5              5
 #define ARM_CORE_CORTEX_R8              8
 /** @} */
 
@@ -102,6 +103,11 @@
   #define PORT_ARCHITECTURE_ARM_CORTEXR8
   #define PORT_ARCHITECTURE_NAME        "ARMv7-R"
   #define PORT_CORE_VARIANT_NAME        "ARM Cortex-R8"
+
+#elif CORTEX_MODEL == ARM_CORE_CORTEX_R5
+  #define PORT_ARCHITECTURE_ARM_CORTEXR5
+  #define PORT_ARCHITECTURE_NAME        "ARMv7-R"
+  #define PORT_CORE_VARIANT_NAME        "ARM Cortex-R5"
 
 #else
   #error "unknown or unsupported ARMv7-R core"

--- a/os/common/startup/ARMCRx/compilers/GCC/mk/startup_armcr5.mk
+++ b/os/common/startup/ARMCRx/compilers/GCC/mk/startup_armcr5.mk
@@ -1,0 +1,17 @@
+# List of the ChibiOS generic Cortex-R5 startup files.
+STARTUPSRC = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/crt1.c
+
+STARTUPASM = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/crt0_v7r.S \
+             $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/vectors.S
+
+STARTUPINC = $(CHIBIOS)/os/common/portability/GCC \
+             $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC \
+             $(CHIBIOS)/os/common/startup/ARMCRx/devices/ARMCR5 \
+             $(CHIBIOS)/os/common/ext/ARM/CMSIS6/Include
+
+STARTUPLD  = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/ld
+
+# Shared variables
+ALLXASMSRC += $(STARTUPASM)
+ALLCSRC    += $(STARTUPSRC)
+ALLINC     += $(STARTUPINC)

--- a/os/common/startup/ARMCRx/devices/ARMCR5/armcr5.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR5/armcr5.h
@@ -1,0 +1,54 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARMCR5/armcr5.h
+ * @brief   Generic ARM Cortex-R5 CMSIS device header.
+ *
+ * @addtogroup ARMCRx_ARMCR5
+ * @{
+ */
+
+#ifndef ARMCR5_H
+#define ARMCR5_H
+
+#include "crparams.h"
+
+#define __CR5_REV              0x0000U
+#define __FPU_PRESENT          ARMCR5_HAS_FPU
+#define __VIC_PRESENT          ARMCR5_HAS_VIC
+#define __GIC_PRESENT          ARMCR5_HAS_GIC
+#define __MPU_PRESENT          ARMCR5_HAS_MPU
+#define __ICACHE_PRESENT       ARMCR5_HAS_ICACHE
+#define __DCACHE_PRESENT       ARMCR5_HAS_DCACHE
+#define __DTCM_PRESENT         ARMCR5_HAS_DTCM
+#define __ECC_PRESENT          ARMCR5_HAS_ECC
+
+/**
+ * @brief   Placeholder interrupt number type.
+ * @details This is intentionally minimal. Real platforms are expected to
+ *          replace this header with the vendor device header, or to extend
+ *          it with the platform interrupt map.
+ */
+typedef enum {
+  ARMCR5_GenericIRQ0_IRQn = 0
+} IRQn_Type;
+
+#include "core_cr5.h"
+
+#endif /* ARMCR5_H */
+
+/** @} */

--- a/os/common/startup/ARMCRx/devices/ARMCR5/crparams.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR5/crparams.h
@@ -1,0 +1,107 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARMCR5/crparams.h
+ * @brief   Generic ARM Cortex-R5 parameters.
+ *
+ * @defgroup ARMCRx_ARMCR5 ARMCR5 Generic Parameters
+ * @ingroup ARMCRx_SPECIFIC
+ * @{
+ */
+
+#ifndef CRPARAMS_H
+#define CRPARAMS_H
+
+/**
+ * @brief   Cortex core model.
+ */
+#define CORTEX_MODEL            5
+
+/**
+ * @brief   Floating Point unit presence.
+ */
+#if !defined(ARMCR5_HAS_FPU) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_FPU          0
+#endif
+
+#define CORTEX_HAS_FPU          ARMCR5_HAS_FPU
+
+/**
+ * @brief   Generic Interrupt Controller presence.
+ */
+#if !defined(ARMCR5_HAS_GIC) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_GIC          0
+#endif
+
+/**
+ * @brief   Vectored Interrupt Controller presence.
+ */
+#if !defined(ARMCR5_HAS_VIC) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_VIC          0
+#endif
+
+/**
+ * @brief   MPU presence.
+ */
+#if !defined(ARMCR5_HAS_MPU) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_MPU          0
+#endif
+
+#define CORTEX_HAS_MPU          ARMCR5_HAS_MPU
+
+/**
+ * @brief   Number of MPU regions.
+ * @note    The Cortex-R5 MPU can be configured with 12 or 16 regions,
+ *          the actual number must be taken from the SoC documentation.
+ */
+#if !defined(ARMCR5_MPU_REGIONS) || defined(__DOXYGEN__)
+#define ARMCR5_MPU_REGIONS      16
+#endif
+
+#define CORTEX_MPU_REGIONS      ARMCR5_MPU_REGIONS
+
+/**
+ * @brief   Instruction cache presence.
+ */
+#if !defined(ARMCR5_HAS_ICACHE) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_ICACHE       0
+#endif
+
+/**
+ * @brief   Data cache presence.
+ */
+#if !defined(ARMCR5_HAS_DCACHE) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_DCACHE       0
+#endif
+
+/**
+ * @brief   DTCM presence.
+ */
+#if !defined(ARMCR5_HAS_DTCM) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_DTCM         0
+#endif
+
+/**
+ * @brief   ECC presence.
+ */
+#if !defined(ARMCR5_HAS_ECC) || defined(__DOXYGEN__)
+#define ARMCR5_HAS_ECC          0
+#endif
+
+#endif /* CRPARAMS_H */
+
+/** @} */


### PR DESCRIPTION
## Summary

Adds Cortex-R5 support to the existing ARMv7-R port and an `ARMCR5` startup device
beside the existing `ARMCR8` and `RZV2H` devices.

The ARMv7-R port already supports the Cortex-R8. The R5 differs from the R8 only in
ways the startup and device layers handle, so the port itself needs just the variant
selection: an `ARM_CORE_CORTEX_R5` constant and its `PORT_CORE_VARIANT_NAME` branch,
six lines in `chcore.h`.

The startup side follows the existing `ARMCR8` device layout exactly. The Cortex-R5
has no VBAR, so the reset vector must live at address 0; `crparams.h` reflects that.
The shared `ARMCRx` startup files (`crt0_v7r.S`, `vectors.S`, `crt1.c`, the linker
rules and `arm-none-eabi.mk`) are **not touched** — the contribution is purely
additive.

Found and validated while bringing up a TI AM67A (J722S) Cortex-R5F on top of this
port; we are the second user of the ARMv7-R port after the R8 validation.

## Related

- Issue(s): none
- Notes for reviewers: this is the first of a stacked series adding a TI AM67 XHAL
  port. It has no dependencies and stands alone. The follow-up PRs build on it and
  should be merged in order.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files — `tools/style/stylecheck.py` on
      all 3 changed `.c`/`.h` files: no findings
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile) —
      `RT-Posix-Simulator` links; `test/rt-ports/testbuild` ARMv7-M target builds;
      `RT-ARMCR8-GENERIC` builds at **text 4900 B, byte-identical to the unpatched
      tree**, which is the evidence that the R5 work does not alter the existing R8
      path. Toolchain `arm-none-eabi-gcc 13.2.1` (Arm GNU Toolchain 13.2.rel1).
      Rebased onto and verified against `master` on 2026-08-30.

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? This PR adds no `main()` and no demo, so it
  produces no flashable image on its own. The ARMCR5 startup device it adds is
  exercised on real silicon by the demo added later in this series: on a T3 Gemstone
  O1 (AM67A/J722S) R5F, 2026-08-06, the RTOS heartbeat ran 96 iterations exactly
  1000 ms apart over 96 s with zero drift, which requires this startup device to have
  brought the core up correctly.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided — not applicable
- [x] Risks/limitations are documented below

Risk is low: every change is additive. No existing constant, macro or file changes
meaning, and the identical `RT-ARMCR8-GENERIC` binary size demonstrates that existing
configurations generate the same code as before.