### PR TITLE
RT: report missed sleep deadlines through RFCU

### DIFF
--- a/os/rt/include/chrfcu.h
+++ b/os/rt/include/chrfcu.h
@@ -40,6 +40,7 @@
 #define CH_RFCU_VT_INSUFFICIENT_DELTA       1U
 #define CH_RFCU_VT_SKIPPED_DEADLINE         2U
 #define CH_RFCU_VT_INTERVAL_OVERFLOW        4U
+#define CH_RFCU_THD_MISSED_DEADLINE         8U
 /** @} */
 
 /**

--- a/os/rt/src/chthreads.c
+++ b/os/rt/src/chthreads.c
@@ -1174,6 +1174,8 @@ void chThdSleepUntil(systime_t time) {
  * @note    The system time is assumed to be between @p prev and @p next
  *          else the call is assumed to have been called outside the
  *          allowed time interval, in this case no sleep is performed.
+ * @note    If @p CH_CFG_USE_RFCU is @p TRUE then a call outside the allowed
+ *          time interval reports @p CH_RFCU_THD_MISSED_DEADLINE.
  * @see     chThdSleepUntil()
  *
  * @param[in] prev      absolute system time of the previous deadline
@@ -1190,6 +1192,11 @@ systime_t chThdSleepUntilWindowed(systime_t prev, systime_t next) {
   if (likely(chTimeIsInRangeX(time, prev, next))) {
     chThdSleepS(chTimeDiffX(time, next));
   }
+#if CH_CFG_USE_RFCU == TRUE
+  else {
+    chRFCUCollectFaultsI(CH_RFCU_THD_MISSED_DEADLINE);
+  }
+#endif
   chSysUnlock();
 
   return next;

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -1399,6 +1399,38 @@ test_assert_time_window(time,
                         "out of time window");]]></value>
               </code>
             </step>
+            <step>
+              <description>
+                <value>With RFCU enabled, a missed window is reported
+                  and the next deadline is returned.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[#if CH_CFG_USE_RFCU == TRUE
+rfcu_mask_t mask;
+systime_t next;
+
+chSysLock();
+(void) chRFCUGetAndClearFaultsI(CH_RFCU_THD_MISSED_DEADLINE);
+chSysUnlock();
+
+time = chVTGetSystemTimeX();
+next = chTimeAddX(time, (sysinterval_t)1);
+chThdSleep((sysinterval_t)2);
+time = chThdSleepUntilWindowed(time, next);
+
+chSysLock();
+mask = chRFCUGetAndClearFaultsI(CH_RFCU_THD_MISSED_DEADLINE);
+chSysUnlock();
+
+test_assert(time == next, "invalid returned deadline");
+test_assert((mask & CH_RFCU_THD_MISSED_DEADLINE) != (rfcu_mask_t)0,
+            "missed deadline not reported");
+#endif]]></value>
+              </code>
+            </step>
           </steps>
         </case>
         <case>

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -112,6 +112,8 @@ static void setup_thread_descriptor(thread_descriptor_t *tdp,
  *   "now" + 100 ticks.
  * - [5.1.6] Function chThdSleepUntilWindowed() is tested with an
  *   active time window.
+ * - [5.1.7] With RFCU enabled, a missed window is reported and the
+ *   next deadline is returned.
  * .
  */
 
@@ -192,6 +194,34 @@ static void rt_test_005_001_execute(void) {
                             "out of time window");
   }
   test_end_step(6);
+
+  /* [5.1.7] With RFCU enabled, a missed window is reported and the
+     next deadline is returned.*/
+  test_set_step(7);
+  {
+#if CH_CFG_USE_RFCU == TRUE
+    rfcu_mask_t mask;
+    systime_t next;
+
+    chSysLock();
+    (void) chRFCUGetAndClearFaultsI(CH_RFCU_THD_MISSED_DEADLINE);
+    chSysUnlock();
+
+    time = chVTGetSystemTimeX();
+    next = chTimeAddX(time, (sysinterval_t)1);
+    chThdSleep((sysinterval_t)2);
+    time = chThdSleepUntilWindowed(time, next);
+
+    chSysLock();
+    mask = chRFCUGetAndClearFaultsI(CH_RFCU_THD_MISSED_DEADLINE);
+    chSysUnlock();
+
+    test_assert(time == next, "invalid returned deadline");
+    test_assert((mask & CH_RFCU_THD_MISSED_DEADLINE) != (rfcu_mask_t)0,
+                "missed deadline not reported");
+#endif
+  }
+  test_end_step(7);
 }
 
 static const testcase_t rt_test_005_001 = {


### PR DESCRIPTION
## Summary

- add CH_RFCU_THD_MISSED_DEADLINE
- collect the fault when chThdSleepUntilWindowed() is called outside its [prev, next) window
- preserve the existing immediate-return behavior when RFCU is disabled
- add regression coverage for fault collection and returned deadline

## Testing

- full RT and OSLIB simulator test suites with RFCU enabled
- RT simulator build with CH_CFG_USE_RFCU=FALSE
- git diff --check