### PR TITLE
RT: Saturate calibrated time measurements

### DIFF
--- a/os/rt/src/chtm.c
+++ b/os/rt/src/chtm.c
@@ -54,9 +54,16 @@
 static inline void tm_stop(time_measurement_t *tmp,
                            rtcnt_t now,
                            rtcnt_t offset) {
+  rtcnt_t delta;
 
   tmp->n++;
-  tmp->last = (now - tmp->last) - offset;
+  delta = now - tmp->last;
+  if (delta > offset) {
+    tmp->last = delta - offset;
+  }
+  else {
+    tmp->last = (rtcnt_t)0;
+  }
   tmp->cumulative += (rttime_t)tmp->last;
   if (tmp->last > tmp->worst) {
     tmp->worst = tmp->last;
@@ -125,6 +132,8 @@ NOINLINE void chTMStartMeasurementX(time_measurement_t *tmp) {
 
 /**
  * @brief   Stops a measurement.
+ * @note    A raw interval not exceeding the calibrated measurement overhead
+ *          is recorded as zero.
  * @pre     The @p time_measurement_t object must be initialized.
  *
  * @param[in,out] tmp   pointer to a @p time_measurement_t object

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -902,7 +902,8 @@ chTMObjectInit(&tm2);]]></value>
 chTMObjectDispose(&tm2);]]></value>
             </teardown_code>
             <local_variables>
-              <value><![CDATA[rtcnt_t first;]]></value>
+              <value><![CDATA[rtcnt_t first;
+rtcnt_t offset;]]></value>
             </local_variables>
           </various_code>
           <steps>
@@ -963,6 +964,31 @@ test_assert(tm2.n == (ucnt_t)1, "invalid counter");
 test_assert(tm2.last > (rtcnt_t)0, "invalid last");
 test_assert(tm2.best == tm2.last, "invalid best");
 test_assert(tm2.worst == tm2.last, "invalid worst");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A measurement shorter than the calibration offset is
+                  verified to saturate at zero.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chTMObjectInit(&tm2);
+chSysLock();
+offset = ch_system.tmc.offset;
+ch_system.tmc.offset = (rtcnt_t)-1;
+chTMStartMeasurementX(&tm2);
+chTMStopMeasurementX(&tm2);
+ch_system.tmc.offset = offset;
+chSysUnlock();
+
+test_assert(tm2.n == (ucnt_t)1, "invalid counter");
+test_assert(tm2.last == (rtcnt_t)0, "invalid last");
+test_assert(tm2.best == (rtcnt_t)0, "invalid best");
+test_assert(tm2.worst == (rtcnt_t)0, "invalid worst");
+test_assert(tm2.cumulative == (rttime_t)0, "invalid cumulative");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -193,6 +193,8 @@ static const testcase_t rt_test_003_002 = {
  * - [3.3.2] A measurement is performed and its result is verified.
  * - [3.3.3] The first measurement is chained to the second one and
  *   both objects are verified.
+ * - [3.3.4] A measurement shorter than the calibration offset is verified
+ *   to saturate at zero.
  * .
  */
 
@@ -208,6 +210,7 @@ static void rt_test_003_003_teardown(void) {
 
 static void rt_test_003_003_execute(void) {
   rtcnt_t first;
+  rtcnt_t offset;
 
   /* [3.3.1] The initialized measurement objects are verified.*/
   test_set_step(1);
@@ -254,6 +257,27 @@ static void rt_test_003_003_execute(void) {
     test_assert(tm2.worst == tm2.last, "invalid worst");
   }
   test_end_step(3);
+
+  /* [3.3.4] A measurement shorter than the calibration offset is verified
+     to saturate at zero.*/
+  test_set_step(4);
+  {
+    chTMObjectInit(&tm2);
+    chSysLock();
+    offset = ch_system.tmc.offset;
+    ch_system.tmc.offset = (rtcnt_t)-1;
+    chTMStartMeasurementX(&tm2);
+    chTMStopMeasurementX(&tm2);
+    ch_system.tmc.offset = offset;
+    chSysUnlock();
+
+    test_assert(tm2.n == (ucnt_t)1, "invalid counter");
+    test_assert(tm2.last == (rtcnt_t)0, "invalid last");
+    test_assert(tm2.best == (rtcnt_t)0, "invalid best");
+    test_assert(tm2.worst == (rtcnt_t)0, "invalid worst");
+    test_assert(tm2.cumulative == (rttime_t)0, "invalid cumulative");
+  }
+  test_end_step(4);
 }
 
 static const testcase_t rt_test_003_003 = {


### PR DESCRIPTION
Summary:
- Compute the raw realtime-counter delta before applying calibration.
- Saturate samples at zero when the raw interval does not exceed the calibrated overhead, preventing unsigned wrap from corrupting cumulative and worst measurements.
- Document the zero-duration result.
- Add RT test 3.3.4 using an injected calibration offset, updating both the XML test source and generated C file.

Testing:
- Default POSIX simulator RT and OSLIB suites: PASS.
- POSIX simulator with system-state checking, checks, and assertions enabled: PASS.