### PR TITLE
RT: Calibrate time measurements per instance

### DIFF
--- a/os/rt/dox/rt_arch.dox
+++ b/os/rt/dox/rt_arch.dox
@@ -76,7 +76,7 @@
  *   }
  * 
  *   class tm_calibration_t {
- *     ~ offset : sysinterval_t
+ *     ~ offset : rtcnt_t
  *     ~ __tm_calibration_object_init()
  *   }
  * 
@@ -126,7 +126,6 @@
  *   class ch_system_t {
  *     + state : ch_system_state_t
  *     - reglist : registry_t
- *     - tmc : tm_calibration_t
  *     - instances[] : os_instance_t *
  *     + {static} chSysInit()
  *     + {static} chSysLock()
@@ -137,13 +136,13 @@
  *   }
  *   ch_system_t .u.> "Port Layer" : use
  *   ch_system_t *-- "1" registry_t : SMP\nonly
- *   ch_system_t *-r- "1" tm_calibration_t
  *   ch_system_t "1" o-- "1..*" os_instance_t : registered\ninstances\none for\neach core
  * 
  *   class os_instance_t {
  *     ~ core_id : core_id_t
  *     ~ rlist : ready_list_t
  *     ~ vtlist : virtual_timers_list_t
+ *     ~ tmc : tm_calibration_t
  *     ~ reglist : registry_t
  *     ~ mainthread : thread_t
  *     ~ dbg : system_debug_t
@@ -155,6 +154,7 @@
  *   }
  *   os_instance_t *-- "1" thread_t : Main\nThread
  *   os_instance_t *-- "1" registry_t : Non-SMP\nonly
+ *   os_instance_t *-- "1" tm_calibration_t
  *   os_instance_t *-- "1" system_debug_t
  *   os_instance_t *-- "1" trace_buffer_t
  *   os_instance_t *-- "1" kernel_stats_t

--- a/os/rt/include/chobjects.h
+++ b/os/rt/include/chobjects.h
@@ -451,6 +451,12 @@ struct ch_os_instance {
    * @brief   Virtual timers delta list header.
    */
   virtual_timers_list_t         vtlist;
+#if (CH_CFG_USE_TM == TRUE) || defined(__DOXYGEN__)
+  /**
+   * @brief   Time measurement calibration data for this instance.
+   */
+  tm_calibration_t              tmc;
+#endif
 #if ((CH_CFG_USE_REGISTRY == TRUE) && (CH_CFG_SMP_MODE == FALSE)) ||        \
     defined(__DOXYGEN__)
   /**
@@ -526,12 +532,6 @@ typedef struct ch_system {
    * @brief   Initialized OS instances or @p NULL.
    */
   os_instance_t                 *instances[PORT_CORES_NUMBER];
-#if (CH_CFG_USE_TM == TRUE) || defined(__DOXYGEN__)
-  /**
-   * @brief   Time measurement calibration data.
-   */
-  tm_calibration_t              tmc;
-#endif
 #if ((CH_CFG_USE_REGISTRY == TRUE) && (CH_CFG_SMP_MODE == TRUE)) ||         \
     defined(__DOXYGEN__)
   /**

--- a/os/rt/include/chtm.h
+++ b/os/rt/include/chtm.h
@@ -94,6 +94,7 @@ typedef struct {
 #ifdef __cplusplus
 extern "C" {
 #endif
+  void __tm_calibration_object_init(os_instance_t *oip);
   void chTMObjectInit(time_measurement_t *tmp);
   void chTMObjectDispose(time_measurement_t *tmp);
   NOINLINE void chTMStartMeasurementX(time_measurement_t *tmp);
@@ -103,36 +104,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-/*===========================================================================*/
-/* Module inline functions.                                                  */
-/*===========================================================================*/
-
-/**
- * @brief   Time measurement initialization.
- * @note    Internal use only.
- *
- * @param[out] tcp      pointer to a @p tm_calibration_t object
- *
- * @notapi
- */
-static inline void __tm_calibration_object_init(tm_calibration_t *tcp) {
-  unsigned i;
-  time_measurement_t tm;
-
-  /* Time Measurement subsystem calibration, it does a null measurement
-     and calculates the call overhead which is subtracted to real
-     measurements.*/
-  tcp->offset = (rtcnt_t)0;
-  chTMObjectInit(&tm);
-  i = TM_CALIBRATION_LOOP;
-  do {
-    chTMStartMeasurementX(&tm);
-    chTMStopMeasurementX(&tm);
-    i--;
-  } while (i > 0U);
-  tcp->offset = tm.best;
-}
 
 #endif /* CH_CFG_USE_TM == TRUE */
 

--- a/os/rt/src/chinstances.c
+++ b/os/rt/src/chinstances.c
@@ -108,6 +108,11 @@ void chInstanceObjectInit(os_instance_t *oip,
               "instance already registered");
   ch_system.instances[core_id] = oip;
 
+#if CH_CFG_USE_TM == TRUE
+  /* Time Measurement calibration for this instance.*/
+  __tm_calibration_object_init(oip);
+#endif
+
   /* Ready list initialization.*/
   ch_pqueue_init(&oip->rlist.pqueue);
 

--- a/os/rt/src/chsys.c
+++ b/os/rt/src/chsys.c
@@ -163,11 +163,6 @@ void chSysInit(void) {
     ch_system.instances[i] = NULL;
   }
 
-#if CH_CFG_USE_TM == TRUE
-  /* Time Measurement calibration.*/
-  __tm_calibration_object_init(&ch_system.tmc);
-#endif
-
 #if (CH_CFG_USE_REGISTRY == TRUE) && (CH_CFG_SMP_MODE == TRUE)
   /* Registry initialization when SMP mode is enabled.*/
   __reg_object_init(&ch_system.reglist);

--- a/os/rt/src/chtm.c
+++ b/os/rt/src/chtm.c
@@ -78,6 +78,35 @@ static inline void tm_stop(time_measurement_t *tmp,
 /*===========================================================================*/
 
 /**
+ * @brief   Initializes the time measurement calibration for an OS instance.
+ * @pre     The port must be initialized and @p oip must be registered as the
+ *          current core's OS instance.
+ *
+ * @param[in,out] oip   pointer to the current @p os_instance_t object
+ *
+ * @notapi
+ */
+void __tm_calibration_object_init(os_instance_t *oip) {
+  unsigned i;
+  time_measurement_t tm;
+
+  chDbgAssert(oip == currcore, "invalid instance");
+
+  /* Time Measurement subsystem calibration, it does a null measurement
+     and calculates the call overhead which is subtracted to real
+     measurements.*/
+  oip->tmc.offset = (rtcnt_t)0;
+  chTMObjectInit(&tm);
+  i = TM_CALIBRATION_LOOP;
+  do {
+    chTMStartMeasurementX(&tm);
+    chTMStopMeasurementX(&tm);
+    i--;
+  } while (i > 0U);
+  oip->tmc.offset = tm.best;
+}
+
+/**
  * @brief   Initializes a @p time_measurement_t object.
  *
  * @param[out] tmp      pointer to a @p time_measurement_t object
@@ -142,7 +171,7 @@ NOINLINE void chTMStartMeasurementX(time_measurement_t *tmp) {
  */
 NOINLINE void chTMStopMeasurementX(time_measurement_t *tmp) {
 
-  tm_stop(tmp, chSysGetRealtimeCounterX(), ch_system.tmc.offset);
+  tm_stop(tmp, chSysGetRealtimeCounterX(), currcore->tmc.offset);
 }
 
 /**

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -977,11 +977,11 @@ test_assert(tm2.worst == tm2.last, "invalid worst");]]></value>
               <code>
                 <value><![CDATA[chTMObjectInit(&tm2);
 chSysLock();
-offset = ch_system.tmc.offset;
-ch_system.tmc.offset = (rtcnt_t)-1;
+offset = currcore->tmc.offset;
+currcore->tmc.offset = (rtcnt_t)-1;
 chTMStartMeasurementX(&tm2);
 chTMStopMeasurementX(&tm2);
-ch_system.tmc.offset = offset;
+currcore->tmc.offset = offset;
 chSysUnlock();
 
 test_assert(tm2.n == (ucnt_t)1, "invalid counter");

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -264,11 +264,11 @@ static void rt_test_003_003_execute(void) {
   {
     chTMObjectInit(&tm2);
     chSysLock();
-    offset = ch_system.tmc.offset;
-    ch_system.tmc.offset = (rtcnt_t)-1;
+    offset = currcore->tmc.offset;
+    currcore->tmc.offset = (rtcnt_t)-1;
     chTMStartMeasurementX(&tm2);
     chTMStopMeasurementX(&tm2);
-    ch_system.tmc.offset = offset;
+    currcore->tmc.offset = offset;
     chSysUnlock();
 
     test_assert(tm2.n == (ucnt_t)1, "invalid counter");


### PR DESCRIPTION
Summary:
- Move time-measurement calibration data from the global system object into each OS instance.
- Calibrate each instance after its port initialization and registration, ensuring that the local realtime counter is running and currcore is valid.
- Make chTMStopMeasurementX use the current instance calibration instead of assuming identical measurement overhead across cores.
- Move the calibration helper implementation into chtm.c and document its initialization contract.
- Update the TM regression test and RT architecture diagram for the per-instance data model.

Rationale:
Realtime counters and measurement overhead can be core-local. A calibration performed once before core 0 port initialization can observe a stopped counter, and sharing that result assumes equal performance across all cores.

Testing:
- Default POSIX simulator RT and OSLIB suites: PASS.
- POSIX simulator with system-state checking, checks, and assertions enabled: PASS.
- POSIX build with CH_CFG_USE_TM disabled: PASS.
- Dual-core RP2350 Cortex-M33 demo build: PASS.
- Style checks on all changed C and header files: PASS.