### PR TITLE
ARM: Drop unsupported Cortex-A support

### DIFF
--- a/os/common/ports/ARM/chcore.h
+++ b/os/common/ports/ARM/chcore.h
@@ -57,9 +57,9 @@
  * @{
  */
 /**
- * @brief   This port supports a realtime counter.
+ * @brief   This port does not support a realtime counter.
  */
-#define PORT_SUPPORTS_RT                TRUE
+#define PORT_SUPPORTS_RT                FALSE
 
 /**
  * @brief   Natural alignment constant.
@@ -86,10 +86,6 @@
  */
 #define ARM_CORE_ARM7TDMI               7
 #define ARM_CORE_ARM9                   9
-#define ARM_CORE_CORTEX_A5              105
-#define ARM_CORE_CORTEX_A7              107
-#define ARM_CORE_CORTEX_A8              108
-#define ARM_CORE_CORTEX_A9              109
 /** @} */
 
 /**
@@ -112,26 +108,6 @@
   #define PORT_ARCHITECTURE_NAME        "ARMv5T"
   #define PORT_CORE_VARIANT_NAME        "ARM9"
 
-#elif ARM_CORE == ARM_CORE_CORTEX_A5
-  #define PORT_ARCHITECTURE_ARM_CORTEXA5
-  #define PORT_ARCHITECTURE_NAME        "ARMv7"
-  #define PORT_CORE_VARIANT_NAME        "ARM Cortex-A5"
-
-#elif ARM_CORE == ARM_CORE_CORTEX_A7
-  #define PORT_ARCHITECTURE_ARM_CORTEXA5
-  #define PORT_ARCHITECTURE_NAME        "ARMv7"
-  #define PORT_CORE_VARIANT_NAME        "ARM Cortex-A7"
-
-#elif ARM_CORE == ARM_CORE_CORTEX_A8
-  #define PORT_ARCHITECTURE_ARM_CORTEXA8
-  #define PORT_ARCHITECTURE_NAME        "ARMv7"
-  #define PORT_CORE_VARIANT_NAME        "ARM Cortex-A8"
-
-#elif ARM_CORE == ARM_CORE_CORTEX_A9
-  #define PORT_ARCHITECTURE_ARM_CORTEXA9
-  #define PORT_ARCHITECTURE_NAME        "ARMv7"
-  #define PORT_CORE_VARIANT_NAME        "ARM Cortex-A9"
-
 #else
   #error "unknown or unsupported ARM core"
 #endif
@@ -146,15 +122,6 @@
   #define PORT_INFO                     "Pure ARM mode"
 #endif
 
-#if ARM_CORE < 100
-  #define ARM_CORE_CLASSIC              1
-  #define ARM_CORE_CORTEX_A             0
-#elif ARM_CORE < 200
-  #define ARM_CORE_CLASSIC              0
-  #define ARM_CORE_CORTEX_A             1
-#else
-  #error "unknown or unsupported ARM core"
-#endif
 /** @} */
 
 /*===========================================================================*/
@@ -529,24 +496,6 @@ static inline void port_enable(void) {
   __asm volatile ("bl      __port_enable_thumb" : : : "r3", "lr", "memory");
 #else
   __asm volatile ("msr     CPSR_c, #0x1F" : : : "memory");
-#endif
-}
-
-/**
- * @brief   Returns the current value of the realtime counter.
- *
- * @return              The realtime counter value.
- */
-static inline rtcnt_t port_rt_get_counter_value(void) {
-
-#if ARM_CORE_CORTEX_A
-  rtcnt_t cyc;
-
-  __asm volatile("mrc p15, 0, %[p0], c9, c13, 0" : [p0] "=r" (cyc) :);
-
-  return cyc;
-#else
-  return 0;
 #endif
 }
 


### PR DESCRIPTION
Summary:
- limit the generic ARM port to ARM7 and ARM9
- report that the port has no realtime counter
- remove the ineffective classic-ARM counter and dormant Cortex-A PMU path
- remove Cortex-A selectors and architecture definitions from this port

Rationale:
The generic port advertised realtime-counter support even though ARM7/ARM9 returned a constant zero. Its Cortex-A path directly read PMCCNTR without establishing a complete Cortex-A port contract. Cortex-A support should be introduced later as a dedicated port with explicit counter initialization and architecture handling.

Validation:
- RT-ARM7-GENERIC builds successfully
- tools/style/stylecheck.py passes for chcore.h
- git diff --check passes