### PR TITLE
SIM: Use monotonic POSIX clocks

### DIFF
--- a/os/common/ports/SIMIA32/chcore.c
+++ b/os/common/ports/SIMIA32/chcore.c
@@ -27,7 +27,8 @@
 #if defined(WIN32)
 #include <windows.h>
 #else
-#include <sys/time.h>
+#include <stdlib.h>
+#include <time.h>
 #endif
 
 #include "ch.h"
@@ -132,10 +133,14 @@ rtcnt_t port_rt_get_counter_value(void) {
 
   return (rtcnt_t)(n.QuadPart / 1000LL);
 #else
-  struct timeval tv;
+  struct timespec ts;
 
-  gettimeofday(&tv, NULL);
-  return ((rtcnt_t)tv.tv_sec * (rtcnt_t)1000000) + (rtcnt_t)tv.tv_usec;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    abort();
+  }
+
+  return ((rtcnt_t)ts.tv_sec * (rtcnt_t)1000000) +
+         (rtcnt_t)(ts.tv_nsec / 1000L);
 #endif
 }
 

--- a/os/common/ports/SIMX86_64/chcore.c
+++ b/os/common/ports/SIMX86_64/chcore.c
@@ -24,7 +24,8 @@
  * @{
  */
 
-#include <sys/time.h>
+#include <stdlib.h>
+#include <time.h>
 
 #include "ch.h"
 
@@ -119,10 +120,14 @@ void _port_thread_start(void (*pf)(void *), void *p) {
  * @return              The realtime counter value.
  */
 rtcnt_t port_rt_get_counter_value(void) {
-  struct timeval tv;
+  struct timespec ts;
 
-  gettimeofday(&tv, NULL);
-  return ((rtcnt_t)tv.tv_sec * (rtcnt_t)1000000) + (rtcnt_t)tv.tv_usec;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    abort();
+  }
+
+  return ((rtcnt_t)ts.tv_sec * (rtcnt_t)1000000) +
+         (rtcnt_t)(ts.tv_nsec / 1000L);
 }
 
 /** @} */

--- a/os/hal/ports/simulator/posix/hal_lld.c
+++ b/os/hal/ports/simulator/posix/hal_lld.c
@@ -24,9 +24,16 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/time.h>
+#include <time.h>
 
 #include "hal.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/* Monotonic clock resolution used for tick scheduling.*/
+#define SIM_NANOSECONDS_PER_SECOND      1000000000ULL
 
 /*===========================================================================*/
 /* Driver exported variables.                                                */
@@ -36,12 +43,35 @@
 /* Driver local variables and types.                                         */
 /*===========================================================================*/
 
-static struct timeval nextcnt;
-static struct timeval tick = {0UL, 1000000UL / OSAL_ST_FREQUENCY};
+/* Next tick deadline and fractional nanoseconds carried across periods.*/
+static uint64_t nextcnt;
+static uint64_t tick_fraction;
 
 /*===========================================================================*/
 /* Driver local functions.                                                   */
 /*===========================================================================*/
+
+static uint64_t get_monotonic_time_ns(void) {
+  struct timespec ts;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    abort();
+  }
+
+  return ((uint64_t)ts.tv_sec * SIM_NANOSECONDS_PER_SECOND) +
+         (uint64_t)ts.tv_nsec;
+}
+
+static void advance_tick(void) {
+
+  nextcnt += SIM_NANOSECONDS_PER_SECOND / (uint64_t)OSAL_ST_FREQUENCY;
+  tick_fraction += SIM_NANOSECONDS_PER_SECOND %
+                   (uint64_t)OSAL_ST_FREQUENCY;
+  if (tick_fraction >= (uint64_t)OSAL_ST_FREQUENCY) {
+    nextcnt++;
+    tick_fraction -= (uint64_t)OSAL_ST_FREQUENCY;
+  }
+}
 
 /*===========================================================================*/
 /* Driver interrupt handlers.                                                */
@@ -61,15 +91,16 @@ void hal_lld_init(void) {
 #else
   puts("ChibiOS/RT simulator (Linux)\n");
 #endif
-  gettimeofday(&nextcnt, NULL);
-  timeradd(&nextcnt, &tick, &nextcnt);
+  nextcnt = get_monotonic_time_ns();
+  tick_fraction = 0U;
+  advance_tick();
 }
 
 /**
  * @brief   Interrupt simulation.
  */
 void _sim_check_for_interrupts(void) {
-  struct timeval tv;
+  uint64_t now;
   bool int_occurred = false;
 
 #if HAL_USE_SERIAL
@@ -78,10 +109,10 @@ void _sim_check_for_interrupts(void) {
   }
 #endif
 
-  gettimeofday(&tv, NULL);
-  if (timercmp(&tv, &nextcnt, >=)) {
+  now = get_monotonic_time_ns();
+  if (now >= nextcnt) {
     int_occurred = true;
-    timeradd(&nextcnt, &tick, &nextcnt);
+    advance_tick();
 
     CH_IRQ_PROLOGUE();
 


### PR DESCRIPTION
Summary:
- use CLOCK_MONOTONIC for the POSIX SIMX86_64 and SIMIA32 realtime counters
- schedule POSIX simulator system ticks from monotonic nanosecond deadlines
- carry fractional nanoseconds between tick periods so arbitrary configured frequencies do not accumulate division drift
- preserve the existing one-overdue-tick-per-poll behavior and the Win32 paths

Rationale:
The POSIX realtime counters and system tick scheduler used gettimeofday, so host wall-clock corrections could create huge TM samples, stall system ticks, or trigger prolonged catch-up behavior. Realtime measurements and tick deadlines must use a clock that is independent of wall-clock adjustments.

Validation:
- SIMX86_64 RT suite: PASS
- SIMX86_64 OSLIB suite: PASS
- SIMIA32 RT suite: PASS
- SIMIA32 OSLIB suite: PASS
- style checks on all changed files: PASS
- git diff --check: PASS