### PR TITLE
VFS: LittleFS: translate missing-entry errors

### DIFF
--- a/os/vfs/drivers/littlefs/drvlittlefs_impl.inc
+++ b/os/vfs/drivers/littlefs/drvlittlefs_impl.inc
@@ -116,6 +116,10 @@ static msg_t translate_error(enum lfs_error res) {
     msg = CH_RET_ENOENT;
     break;
 
+  case LFS_ERR_NOENT:
+    msg = CH_RET_ENOENT;
+    break;
+
   case LFS_ERR_NAMETOOLONG:
     msg = CH_RET_ENAMETOOLONG;
     break;


### PR DESCRIPTION
## Summary

Map LittleFS `LFS_ERR_NOENT` results to `CH_RET_ENOENT` in the VFS adapter.

Without this case, operations on a missing path fall through to
`CH_RET_INNER_ERROR`, preventing callers from distinguishing normal path
absence from an unexpected filesystem or adapter failure.

## Related

- Issue(s): None.
- Notes for reviewers: This keeps the adapter's existing error-translation
  structure and changes no LittleFS or VFS API.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [ ] Style check passed on changed `.c`/`.h` files (not applicable: changed file is `.inc`)
- [x] `git diff --check` passed
- [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

The upstream simulator toolchain was not available in the submission
environment. The adapter change was compiled in both `hw_test` and `runtime`
STM32U5 application configurations with xPack GCC 15.2.1.

## Testing

- [x] Test run successfully locally
- Any other tests run on a device?

  Tested through the ChibiOS LittleFS/VFS driver on STM32U5 with dual
  W25Q256JV NOR devices. A read-only post-reset recovery inspector correctly
  returned the absent-file outcome instead of an internal error. The same
  inspector also verified complete deterministic files recovered after resets
  during repeated truncate/rewrite operations.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [x] Risks/limitations are documented below

Risk is limited to the corrected return value for LittleFS missing-entry
errors. Other LittleFS results retain their existing translations.
