### PR TITLE
RT: Correct realtime counter conversions

### DIFF
--- a/os/rt/include/chsys.h
+++ b/os/rt/include/chsys.h
@@ -163,6 +163,7 @@
  * @brief   Seconds to realtime counter.
  * @details Converts from seconds to realtime counter cycles.
  * @note    The macro assumes that @p freq >= @p 1.
+ * @note    The arguments must produce a result representable in @p rttime_t.
  *
  * @param[in] freq      clock frequency, in Hz, of the realtime counter
  * @param[in] sec       number of seconds
@@ -170,13 +171,16 @@
  *
  * @api
  */
-#define S2RTC(freq, sec) ((freq) * (sec))
+#define S2RTC(freq, sec)                                                     \
+  ((rtcnt_t)((rttime_t)(sec) * (rttime_t)(freq)))
 
 /**
  * @brief   Milliseconds to realtime counter.
  * @details Converts from milliseconds to realtime counter cycles.
  * @note    The result is rounded upward to the next millisecond boundary.
  * @note    The macro assumes that @p freq >= @p 1000.
+ * @note    The arguments must produce an intermediate result representable
+ *          in @p rttime_t.
  *
  * @param[in] freq      clock frequency, in Hz, of the realtime counter
  * @param[in] msec      number of milliseconds
@@ -184,13 +188,17 @@
  *
  * @api
  */
-#define MS2RTC(freq, msec) (rtcnt_t)((((freq) + 999UL) / 1000UL) * (msec))
+#define MS2RTC(freq, msec)                                                   \
+  ((rtcnt_t)((((rttime_t)(msec) * (rttime_t)(freq)) +                       \
+              (rttime_t)999) / (rttime_t)1000))
 
 /**
  * @brief   Microseconds to realtime counter.
  * @details Converts from microseconds to realtime counter cycles.
  * @note    The result is rounded upward to the next microsecond boundary.
  * @note    The macro assumes that @p freq >= @p 1000000.
+ * @note    The arguments must produce an intermediate result representable
+ *          in @p rttime_t.
  *
  * @param[in] freq      clock frequency, in Hz, of the realtime counter
  * @param[in] usec      number of microseconds
@@ -198,13 +206,17 @@
  *
  * @api
  */
-#define US2RTC(freq, usec) (rtcnt_t)((((freq) + 999999UL) / 1000000UL) * (usec))
+#define US2RTC(freq, usec)                                                   \
+  ((rtcnt_t)((((rttime_t)(usec) * (rttime_t)(freq)) +                       \
+              (rttime_t)999999) / (rttime_t)1000000))
 
 /**
  * @brief   Realtime counter cycles to seconds.
  * @details Converts from realtime counter cycles number to seconds.
  * @note    The result is rounded up to the next second boundary.
  * @note    The macro assumes that @p freq >= @p 1.
+ * @note    The arguments must produce an intermediate result representable
+ *          in @p rttime_t.
  *
  * @param[in] freq      clock frequency, in Hz, of the realtime counter
  * @param[in] n         number of cycles
@@ -212,13 +224,17 @@
  *
  * @api
  */
-#define RTC2S(freq, n) ((((n) - 1UL) / (freq)) + 1UL)
+#define RTC2S(freq, n)                                                       \
+  ((rtcnt_t)(((rttime_t)(n) + (rttime_t)(freq) - (rttime_t)1) /             \
+             (rttime_t)(freq)))
 
 /**
  * @brief   Realtime counter cycles to milliseconds.
  * @details Converts from realtime counter cycles number to milliseconds.
  * @note    The result is rounded up to the next millisecond boundary.
  * @note    The macro assumes that @p freq >= @p 1000.
+ * @note    The arguments must produce an intermediate result representable
+ *          in @p rttime_t.
  *
  * @param[in] freq      clock frequency, in Hz, of the realtime counter
  * @param[in] n         number of cycles
@@ -226,13 +242,17 @@
  *
  * @api
  */
-#define RTC2MS(freq, n) ((((n) - 1UL) / ((freq) / 1000UL)) + 1UL)
+#define RTC2MS(freq, n)                                                      \
+  ((rtcnt_t)((((rttime_t)(n) * (rttime_t)1000) +                            \
+              (rttime_t)(freq) - (rttime_t)1) / (rttime_t)(freq)))
 
 /**
  * @brief   Realtime counter cycles to microseconds.
  * @details Converts from realtime counter cycles number to microseconds.
  * @note    The result is rounded up to the next microsecond boundary.
  * @note    The macro assumes that @p freq >= @p 1000000.
+ * @note    The arguments must produce an intermediate result representable
+ *          in @p rttime_t.
  *
  * @param[in] freq      clock frequency, in Hz, of the realtime counter
  * @param[in] n         number of cycles
@@ -240,7 +260,9 @@
  *
  * @api
  */
-#define RTC2US(freq, n) ((((n) - 1UL) / ((freq) / 1000000UL)) + 1UL)
+#define RTC2US(freq, n)                                                      \
+  ((rtcnt_t)((((rttime_t)(n) * (rttime_t)1000000) +                         \
+              (rttime_t)(freq) - (rttime_t)1) / (rttime_t)(freq)))
 /** @} */
 
 /**

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -728,6 +728,11 @@ chSysEnable();]]></value>
       <shared_code>
         <value><![CDATA[#include "ch.h"
 
+enum {
+  RTC_MS_CONSTEXPR = MS2RTC(32768U, 1000U),
+  RTC_2MS_CONSTEXPR = RTC2MS(32768U, 32768U)
+};
+
 #if CH_CFG_USE_TM || defined(__DOXYGEN__)
 static time_measurement_t tm1, tm2;
 #endif
@@ -1163,6 +1168,85 @@ test_assert(listdelta == TIME_INFINITE,
                 <value><![CDATA[delta = chVTGetCurrentDelta();
 test_assert(delta >= (sysinterval_t)CH_CFG_ST_TIMEDELTA,
             "invalid current delta");]]></value>
+              </code>
+            </step>
+          </steps>
+        </case>
+        <case>
+          <brief>
+            <value>Realtime counter conversions.</value>
+          </brief>
+          <description>
+            <value>Realtime counter conversion boundaries and rounding are
+              tested.</value>
+          </description>
+          <condition>
+            <value />
+          </condition>
+          <various_code>
+            <setup_code>
+              <value />
+            </setup_code>
+            <teardown_code>
+              <value />
+            </teardown_code>
+            <local_variables>
+              <value />
+            </local_variables>
+          </various_code>
+          <steps>
+            <step>
+              <description>
+                <value>Zero is converted in both directions.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[test_assert(S2RTC(1U, 0U) == (rtcnt_t)0, "S2RTC zero");
+test_assert(MS2RTC(1000U, 0U) == (rtcnt_t)0, "MS2RTC zero");
+test_assert(US2RTC(1000000U, 0U) == (rtcnt_t)0, "US2RTC zero");
+test_assert(RTC2S(1U, 0U) == (rtcnt_t)0, "RTC2S zero");
+test_assert(RTC2MS(1000U, 0U) == (rtcnt_t)0, "RTC2MS zero");
+test_assert(RTC2US(1000000U, 0U) == (rtcnt_t)0, "RTC2US zero");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Exact and non-divisible frequencies are converted
+                  with upward rounding.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[test_assert(MS2RTC(32768U, 1000U) == (rtcnt_t)32768,
+            "MS2RTC non-divisible");
+test_assert(RTC2MS(32768U, 32768U) == (rtcnt_t)1000,
+            "RTC2MS non-divisible");
+test_assert(MS2RTC(32768U, 1U) == (rtcnt_t)33,
+            "MS2RTC rounding");
+test_assert(RTC2MS(32768U, 1U) == (rtcnt_t)1,
+            "RTC2MS rounding");
+test_assert(US2RTC(1000001U, 1000000U) == (rtcnt_t)1000001,
+            "US2RTC non-divisible");
+test_assert(RTC2US(1000001U, 1000001U) == (rtcnt_t)1000000,
+            "RTC2US non-divisible");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>Constant arguments are usable as integer constant
+                  expressions.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[test_assert(RTC_MS_CONSTEXPR == 32768,
+            "MS2RTC constant expression");
+test_assert(RTC_2MS_CONSTEXPR == 1000,
+            "RTC2MS constant expression");]]></value>
               </code>
             </step>
           </steps>

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -36,6 +36,7 @@
  * - @subpage rt_test_003_004
  * - @subpage rt_test_003_005
  * - @subpage rt_test_003_006
+ * - @subpage rt_test_003_007
  * .
  */
 
@@ -44,6 +45,11 @@
 /*===========================================================================*/
 
 #include "ch.h"
+
+enum {
+  RTC_MS_CONSTEXPR = MS2RTC(32768U, 1000U),
+  RTC_2MS_CONSTEXPR = RTC2MS(32768U, 32768U)
+};
 
 #if CH_CFG_USE_TM || defined(__DOXYGEN__)
 static time_measurement_t tm1, tm2;
@@ -488,6 +494,69 @@ static const testcase_t rt_test_003_006 = {
 };
 #endif /* CH_CFG_ST_TIMEDELTA > 0 */
 
+/**
+ * @page rt_test_003_007 [3.7] Realtime counter conversions
+ *
+ * <h2>Description</h2>
+ * Realtime counter conversion boundaries and rounding are tested.
+ *
+ * <h2>Test Steps</h2>
+ * - [3.7.1] Zero is converted in both directions.
+ * - [3.7.2] Exact and non-divisible frequencies are converted with
+ *   upward rounding.
+ * - [3.7.3] Constant arguments are usable as integer constant expressions.
+ * .
+ */
+
+static void rt_test_003_007_execute(void) {
+
+  /* [3.7.1] Zero is converted in both directions.*/
+  test_set_step(1);
+  {
+    test_assert(S2RTC(1U, 0U) == (rtcnt_t)0, "S2RTC zero");
+    test_assert(MS2RTC(1000U, 0U) == (rtcnt_t)0, "MS2RTC zero");
+    test_assert(US2RTC(1000000U, 0U) == (rtcnt_t)0, "US2RTC zero");
+    test_assert(RTC2S(1U, 0U) == (rtcnt_t)0, "RTC2S zero");
+    test_assert(RTC2MS(1000U, 0U) == (rtcnt_t)0, "RTC2MS zero");
+    test_assert(RTC2US(1000000U, 0U) == (rtcnt_t)0, "RTC2US zero");
+  }
+  test_end_step(1);
+
+  /* [3.7.2] Exact and non-divisible frequencies are converted with
+     upward rounding.*/
+  test_set_step(2);
+  {
+    test_assert(MS2RTC(32768U, 1000U) == (rtcnt_t)32768,
+                "MS2RTC non-divisible");
+    test_assert(RTC2MS(32768U, 32768U) == (rtcnt_t)1000,
+                "RTC2MS non-divisible");
+    test_assert(MS2RTC(32768U, 1U) == (rtcnt_t)33,
+                "MS2RTC rounding");
+    test_assert(RTC2MS(32768U, 1U) == (rtcnt_t)1,
+                "RTC2MS rounding");
+    test_assert(US2RTC(1000001U, 1000000U) == (rtcnt_t)1000001,
+                "US2RTC non-divisible");
+    test_assert(RTC2US(1000001U, 1000001U) == (rtcnt_t)1000000,
+                "RTC2US non-divisible");
+  }
+  test_end_step(2);
+
+  /* [3.7.3] Constant arguments are usable as integer constant expressions.*/
+  test_set_step(3);
+  {
+    test_assert(RTC_MS_CONSTEXPR == 32768, "MS2RTC constant expression");
+    test_assert(RTC_2MS_CONSTEXPR == 1000, "RTC2MS constant expression");
+  }
+  test_end_step(3);
+}
+
+static const testcase_t rt_test_003_007 = {
+  "Realtime counter conversions",
+  NULL,
+  NULL,
+  rt_test_003_007_execute
+};
+
 /*===========================================================================*/
 /* Exported data.                                                            */
 /*===========================================================================*/
@@ -511,6 +580,7 @@ const testcase_t * const rt_test_sequence_003_array[] = {
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
   &rt_test_003_006,
 #endif
+  &rt_test_003_007,
   NULL
 };
 


### PR DESCRIPTION
## Summary

- compute realtime-counter conversions over the complete value using widened `rttime_t` arithmetic
- return zero for zero-cycle inverse conversions while retaining upward rounding
- preserve integer constant expression use and add compile-time/runtime regression coverage

Like the conversions in `chtime.h`, inputs are required to fit their widened intermediate representation.

## Tests

- `make -C test/rt/testbuild -j4` and full RT/OSLIB simulator run (64-bit)
- `make -C test/rt/testbuild -j4 SIM_BITS=32` and full RT/OSLIB simulator run (32-bit)
- `xmllint --noout test/rt/configuration.xml`
- `git diff --check`