### PR TITLE
RT: Clarify time measurement contracts and statistics limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@
 
 ## Build & Test Hygiene
 - Clean projects after test builds unless otherwise specified.
+- Source code generated from XML must only be modified by regeneration. Never
+  edit generated source files directly; update the XML and/or generator
+  template, regenerate the outputs, then verify that a second regeneration
+  produces no diff.
 - For generated or updater-managed configuration files such as `mcuconf.h`, `xmcuconf.h`, `halconf.h`, `xhalconf.h`, and similar outputs, update the corresponding `.ftl` templates and/or updater scripts as part of the same change; otherwise a regeneration pass may overwrite manual edits.
 - When changing XHAL driver settings, update both the `.ftl` templates and the generated `xhalconf.h`/`xmcuconf.h` files.
 - Each demo or test must contain its own configuration files in its local `cfg/` directory. Do not use cross-demo or cross-test include shims for `chconf.h`, `halconf.h`, `xhalconf.h`, `mcuconf.h`, `xmcuconf.h`, or similar configuration headers.

--- a/os/common/ports/templates/chcore.h
+++ b/os/common/ports/templates/chcore.h
@@ -39,6 +39,9 @@
  */
 /**
  * @brief   This port supports a realtime counter.
+ * @note    SMP ports should preferably use a hardware counter coherent across
+ *          all cores. Ports using non-coherent per-core counters must
+ *          document this limitation.
  */
 #define PORT_SUPPORTS_RT                FALSE
 
@@ -428,6 +431,8 @@ static inline void port_setup_context(struct port_context *ctxp,
 
 /**
  * @brief   Returns the current value of the realtime counter.
+ * @note    On SMP systems, a shared coherent hardware counter is the
+ *          preferred implementation.
  *
  * @return              The realtime counter value.
  */

--- a/os/rt/include/chstats.h
+++ b/os/rt/include/chstats.h
@@ -51,10 +51,15 @@
 
 /**
  * @brief   Type of a kernel statistics structure.
+ * @note    The event counters are modular and wrap on overflow. Long-running
+ *          monitoring must periodically snapshot them and account for wrap,
+ *          or reset the statistics while synchronized with all writers.
  */
 typedef struct {
-  ucnt_t                n_irq;      /**< @brief Number of IRQs.             */
-  ucnt_t                n_ctxswc;   /**< @brief Number of context switches. */
+  ucnt_t                n_irq;      /**< @brief Number of IRQs, wraps on
+                                                overflow.                   */
+  ucnt_t                n_ctxswc;   /**< @brief Number of context switches,
+                                                wraps on overflow.          */
   time_measurement_t    m_crit_thd; /**< @brief Measurement of threads
                                                 critical zones duration.    */
   time_measurement_t    m_crit_isr; /**< @brief Measurement of ISRs critical
@@ -72,7 +77,6 @@ typedef struct {
 #ifdef __cplusplus
 extern "C" {
 #endif
-  void __stats_init(void);
   void __stats_increase_irq(void);
   void __stats_ctxswc(thread_t *ntp, thread_t *otp);
   void __stats_start_measure_crit_thd(void);

--- a/os/rt/include/chsys.h
+++ b/os/rt/include/chsys.h
@@ -188,7 +188,7 @@
  *
  * @api
  */
-#define MS2RTC(freq, msec)                                                   \
+#define MS2RTC(freq, msec)                                                  \
   ((rtcnt_t)((((rttime_t)(msec) * (rttime_t)(freq)) +                       \
               (rttime_t)999) / (rttime_t)1000))
 
@@ -206,7 +206,7 @@
  *
  * @api
  */
-#define US2RTC(freq, usec)                                                   \
+#define US2RTC(freq, usec)                                                  \
   ((rtcnt_t)((((rttime_t)(usec) * (rttime_t)(freq)) +                       \
               (rttime_t)999999) / (rttime_t)1000000))
 
@@ -224,7 +224,7 @@
  *
  * @api
  */
-#define RTC2S(freq, n)                                                       \
+#define RTC2S(freq, n)                                                      \
   ((rtcnt_t)(((rttime_t)(n) + (rttime_t)(freq) - (rttime_t)1) /             \
              (rttime_t)(freq)))
 
@@ -242,7 +242,7 @@
  *
  * @api
  */
-#define RTC2MS(freq, n)                                                      \
+#define RTC2MS(freq, n)                                                     \
   ((rtcnt_t)((((rttime_t)(n) * (rttime_t)1000) +                            \
               (rttime_t)(freq) - (rttime_t)1) / (rttime_t)(freq)))
 
@@ -260,7 +260,7 @@
  *
  * @api
  */
-#define RTC2US(freq, n)                                                      \
+#define RTC2US(freq, n)                                                     \
   ((rtcnt_t)((((rttime_t)(n) * (rttime_t)1000000) +                         \
               (rttime_t)(freq) - (rttime_t)1) / (rttime_t)(freq)))
 /** @} */
@@ -269,6 +269,8 @@
  * @brief   Returns the current value of the system real time counter.
  * @note    This function is only available if the port layer supports the
  *          option @p PORT_SUPPORTS_RT.
+ * @note    On SMP systems, counter coherence across cores depends on the port
+ *          implementation. A shared coherent hardware counter is preferred.
  *
  * @return              The value of the system realtime counter of
  *                      type rtcnt_t.

--- a/os/rt/include/chtm.h
+++ b/os/rt/include/chtm.h
@@ -74,12 +74,22 @@ typedef struct {
  *          of few cycles depending on the compiler and target architecture.
  * @note    Interrupts can affect measurement if the measurement is performed
  *          with interrupts enabled.
+ * @note    On SMP systems, cross-core measurements require realtime counters
+ *          coherent across all cores. A shared coherent hardware counter is
+ *          the preferred port implementation. With non-coherent per-core
+ *          counters, each measured segment must begin and end, by stopping or
+ *          chaining, on the same core.
+ * @note    The measurements counter @p n is modular and wraps on overflow.
+ *          Long-running users requiring valid averages must periodically
+ *          snapshot and reinitialize the object before this occurs. Such
+ *          operations must be synchronized with measurement updates.
  */
 typedef struct {
   rtcnt_t               best;           /**< @brief Best measurement.       */
   rtcnt_t               worst;          /**< @brief Worst measurement.      */
   rtcnt_t               last;           /**< @brief Last measurement.       */
-  ucnt_t                n;              /**< @brief Number of measurements. */
+  ucnt_t                n;              /**< @brief Number of measurements,
+                                                wraps on overflow.          */
   rttime_t              cumulative;     /**< @brief Cumulative measurement. */
 } time_measurement_t;
 

--- a/os/rt/src/chtm.c
+++ b/os/rt/src/chtm.c
@@ -177,12 +177,22 @@ NOINLINE void chTMStopMeasurementX(time_measurement_t *tmp) {
 /**
  * @brief   Stops a measurement and chains to the next one using the same time
  *          stamp.
+ * @note    No calibration offset is subtracted from the measurement stopped
+ *          in @p tmp1, this preserves continuity between chained
+ *          measurements.
+ * @note    Ordinary stopped measurements and chained measurements have
+ *          different calibration semantics, mixing them in the same object
+ *          makes the collected statistics non-homogeneous.
+ * @note    @p tmp1 and @p tmp2 may point to the same object.
+ * @pre     @p tmp1 must contain an active measurement started using
+ *          @p chTMStartMeasurementX() or a preceding chain operation.
+ * @pre     @p tmp2 must be an initialized @p time_measurement_t object.
+ * @pre     The measurement objects must not be modified concurrently.
  *
  * @param[in,out] tmp1  pointer to the @p time_measurement_t object to be
  *                      stopped
  * @param[in,out] tmp2  pointer to the @p time_measurement_t object to be
  *                      started
- *
  *
  * @xclass
  */

--- a/os/rt/src/chtm.c
+++ b/os/rt/src/chtm.c
@@ -149,6 +149,8 @@ void chTMObjectDispose(time_measurement_t *tmp) {
 /**
  * @brief   Starts a measurement.
  * @pre     The @p time_measurement_t object must be initialized.
+ * @pre     On SMP systems with non-coherent per-core realtime counters, the
+ *          matching stop or chain operation must execute on the same core.
  *
  * @param[in,out] tmp   pointer to a @p time_measurement_t object
  *
@@ -164,6 +166,8 @@ NOINLINE void chTMStartMeasurementX(time_measurement_t *tmp) {
  * @note    A raw interval not exceeding the calibrated measurement overhead
  *          is recorded as zero.
  * @pre     The @p time_measurement_t object must be initialized.
+ * @pre     On SMP systems with non-coherent per-core realtime counters, the
+ *          measurement must have been started on the same core.
  *
  * @param[in,out] tmp   pointer to a @p time_measurement_t object
  *
@@ -188,6 +192,8 @@ NOINLINE void chTMStopMeasurementX(time_measurement_t *tmp) {
  *          @p chTMStartMeasurementX() or a preceding chain operation.
  * @pre     @p tmp2 must be an initialized @p time_measurement_t object.
  * @pre     The measurement objects must not be modified concurrently.
+ * @pre     On SMP systems with non-coherent per-core realtime counters, the
+ *          measurement in @p tmp1 must have been started on the same core.
  *
  * @param[in,out] tmp1  pointer to the @p time_measurement_t object to be
  *                      stopped

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -2275,9 +2275,7 @@ test_assert_sequence("BA", "ready list not reordered");]]></value>
               trace a defined MSG_OK ready message.</value>
           </description>
           <condition>
-            <value><![CDATA[(CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&
-((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&
-(CH_CFG_USE_WAITEXIT == TRUE)]]></value>
+            <value><![CDATA[(CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) && ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) && (CH_CFG_USE_WAITEXIT == TRUE)]]></value>
           </condition>
           <various_code>
             <setup_code>

--- a/test/rt/configuration.xml
+++ b/test/rt/configuration.xml
@@ -734,7 +734,7 @@ enum {
 };
 
 #if CH_CFG_USE_TM || defined(__DOXYGEN__)
-static time_measurement_t tm1, tm2;
+static time_measurement_t tm1, tm2, tm3;
 #endif
 
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
@@ -900,14 +900,16 @@ test_assert(b == false, "in range");
           <various_code>
             <setup_code>
               <value><![CDATA[chTMObjectInit(&tm1);
-chTMObjectInit(&tm2);]]></value>
+chTMObjectInit(&tm2);
+chTMObjectInit(&tm3);]]></value>
             </setup_code>
             <teardown_code>
               <value><![CDATA[chTMObjectDispose(&tm1);
-chTMObjectDispose(&tm2);]]></value>
+chTMObjectDispose(&tm2);
+chTMObjectDispose(&tm3);]]></value>
             </teardown_code>
             <local_variables>
-              <value><![CDATA[rtcnt_t first;
+              <value><![CDATA[rttime_t cumulative;
 rtcnt_t offset;]]></value>
             </local_variables>
           </various_code>
@@ -944,31 +946,69 @@ test_assert(tm1.n == (ucnt_t)1, "invalid counter");
 test_assert(tm1.last > (rtcnt_t)0, "invalid last");
 test_assert(tm1.best == tm1.last, "invalid best");
 test_assert(tm1.worst == tm1.last, "invalid worst");
-test_assert(tm1.cumulative == (rttime_t)tm1.last, "invalid cumulative");
-first = tm1.last;]]></value>
+test_assert(tm1.cumulative == (rttime_t)tm1.last, "invalid cumulative");]]></value>
               </code>
             </step>
             <step>
               <description>
-                <value>The first measurement is chained to the second one
-                  and both objects are verified.</value>
+                <value>A measurement is chained to another object and both
+                  objects are verified.</value>
               </description>
               <tags>
                 <value />
               </tags>
               <code>
-                <value><![CDATA[chTMChainMeasurementToX(&tm1, &tm2);
+                <value><![CDATA[chSysLock();
+offset = currcore->tmc.offset;
+currcore->tmc.offset = (rtcnt_t)-1;
+chTMStartMeasurementX(&tm2);
+chSysPolledDelayX((rtcnt_t)100);
+chTMChainMeasurementToX(&tm2, &tm3);
 chSysPolledDelayX((rtcnt_t)10);
-chTMStopMeasurementX(&tm2);
+chTMStopMeasurementX(&tm3);
+currcore->tmc.offset = offset;
+chSysUnlock();
 
-test_assert(tm1.n == (ucnt_t)2, "invalid counter");
-test_assert(tm1.last > (rtcnt_t)0, "invalid last");
-test_assert(tm1.best <= tm1.worst, "invalid range");
-test_assert(tm1.cumulative >= (rttime_t)first, "invalid cumulative");
 test_assert(tm2.n == (ucnt_t)1, "invalid counter");
 test_assert(tm2.last > (rtcnt_t)0, "invalid last");
 test_assert(tm2.best == tm2.last, "invalid best");
-test_assert(tm2.worst == tm2.last, "invalid worst");]]></value>
+test_assert(tm2.worst == tm2.last, "invalid worst");
+test_assert(tm2.cumulative == (rttime_t)tm2.last, "invalid cumulative");
+test_assert(tm3.n == (ucnt_t)1, "invalid counter");
+test_assert(tm3.last == (rtcnt_t)0, "invalid last");
+test_assert(tm3.best == (rtcnt_t)0, "invalid best");
+test_assert(tm3.worst == (rtcnt_t)0, "invalid worst");
+test_assert(tm3.cumulative == (rttime_t)0, "invalid cumulative");]]></value>
+              </code>
+            </step>
+            <step>
+              <description>
+                <value>A measurement is chained to itself and the object is
+                  verified.</value>
+              </description>
+              <tags>
+                <value />
+              </tags>
+              <code>
+                <value><![CDATA[chTMObjectInit(&tm3);
+chTMStartMeasurementX(&tm3);
+chSysPolledDelayX((rtcnt_t)100);
+chTMChainMeasurementToX(&tm3, &tm3);
+
+test_assert(tm3.n == (ucnt_t)1, "invalid counter");
+test_assert(tm3.best > (rtcnt_t)0, "invalid best");
+test_assert(tm3.worst == tm3.best, "invalid worst");
+test_assert(tm3.cumulative == (rttime_t)tm3.best, "invalid cumulative");
+cumulative = tm3.cumulative;
+
+chSysPolledDelayX((rtcnt_t)10);
+chTMStopMeasurementX(&tm3);
+
+test_assert(tm3.n == (ucnt_t)2, "invalid counter");
+test_assert(tm3.last > (rtcnt_t)0, "invalid last");
+test_assert(tm3.best <= tm3.worst, "invalid range");
+test_assert(tm3.cumulative == cumulative + (rttime_t)tm3.last,
+            "invalid cumulative");]]></value>
               </code>
             </step>
             <step>

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -197,11 +197,12 @@ static const testcase_t rt_test_003_002 = {
  * <h2>Test Steps</h2>
  * - [3.3.1] The initialized measurement objects are verified.
  * - [3.3.2] A measurement is performed and its result is verified.
- * - [3.3.3] A measurement is chained to another object and both objects are
+ * - [3.3.3] A measurement is chained to another object and both
+ *   objects are verified.
+ * - [3.3.4] A measurement is chained to itself and the object is
  *   verified.
- * - [3.3.4] A measurement is chained to itself and the object is verified.
- * - [3.3.5] A measurement shorter than the calibration offset is verified
- *   to saturate at zero.
+ * - [3.3.5] A measurement shorter than the calibration offset is
+ *   verified to saturate at zero.
  * .
  */
 
@@ -247,8 +248,8 @@ static void rt_test_003_003_execute(void) {
   }
   test_end_step(2);
 
-  /* [3.3.3] A measurement is chained to another object and both objects are
-     verified.*/
+  /* [3.3.3] A measurement is chained to another object and both
+     objects are verified.*/
   test_set_step(3);
   {
     chSysLock();
@@ -275,7 +276,8 @@ static void rt_test_003_003_execute(void) {
   }
   test_end_step(3);
 
-  /* [3.3.4] A measurement is chained to itself and the object is verified.*/
+  /* [3.3.4] A measurement is chained to itself and the object is
+     verified.*/
   test_set_step(4);
   {
     chTMObjectInit(&tm3);
@@ -300,8 +302,8 @@ static void rt_test_003_003_execute(void) {
   }
   test_end_step(4);
 
-  /* [3.3.5] A measurement shorter than the calibration offset is verified
-     to saturate at zero.*/
+  /* [3.3.5] A measurement shorter than the calibration offset is
+     verified to saturate at zero.*/
   test_set_step(5);
   {
     chTMObjectInit(&tm2);
@@ -414,8 +416,7 @@ static const testcase_t rt_test_003_004 = {
 };
 #endif /* CH_CFG_ST_TIMEDELTA > 0 */
 
-#if ((CH_CFG_ST_TIMEDELTA > 0) && (CH_CFG_USE_RFCU == TRUE)) ||            \
-    defined(__DOXYGEN__)
+#if ((CH_CFG_ST_TIMEDELTA > 0) && (CH_CFG_USE_RFCU == TRUE)) || defined(__DOXYGEN__)
 /**
  * @page rt_test_003_005 [3.5] Tickless timer interval overflow
  *
@@ -540,7 +541,8 @@ static const testcase_t rt_test_003_006 = {
  * - [3.7.1] Zero is converted in both directions.
  * - [3.7.2] Exact and non-divisible frequencies are converted with
  *   upward rounding.
- * - [3.7.3] Constant arguments are usable as integer constant expressions.
+ * - [3.7.3] Constant arguments are usable as integer constant
+ *   expressions.
  * .
  */
 
@@ -577,11 +579,14 @@ static void rt_test_003_007_execute(void) {
   }
   test_end_step(2);
 
-  /* [3.7.3] Constant arguments are usable as integer constant expressions.*/
+  /* [3.7.3] Constant arguments are usable as integer constant
+     expressions.*/
   test_set_step(3);
   {
-    test_assert(RTC_MS_CONSTEXPR == 32768, "MS2RTC constant expression");
-    test_assert(RTC_2MS_CONSTEXPR == 1000, "RTC2MS constant expression");
+    test_assert(RTC_MS_CONSTEXPR == 32768,
+                "MS2RTC constant expression");
+    test_assert(RTC_2MS_CONSTEXPR == 1000,
+                "RTC2MS constant expression");
   }
   test_end_step(3);
 }
@@ -609,8 +614,7 @@ const testcase_t * const rt_test_sequence_003_array[] = {
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
   &rt_test_003_004,
 #endif
-#if ((CH_CFG_ST_TIMEDELTA > 0) && (CH_CFG_USE_RFCU == TRUE)) ||            \
-    defined(__DOXYGEN__)
+#if ((CH_CFG_ST_TIMEDELTA > 0) && (CH_CFG_USE_RFCU == TRUE)) || defined(__DOXYGEN__)
   &rt_test_003_005,
 #endif
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)

--- a/test/rt/source/test/rt_test_sequence_003.c
+++ b/test/rt/source/test/rt_test_sequence_003.c
@@ -52,7 +52,7 @@ enum {
 };
 
 #if CH_CFG_USE_TM || defined(__DOXYGEN__)
-static time_measurement_t tm1, tm2;
+static time_measurement_t tm1, tm2, tm3;
 #endif
 
 #if (CH_CFG_ST_TIMEDELTA > 0) || defined(__DOXYGEN__)
@@ -197,9 +197,10 @@ static const testcase_t rt_test_003_002 = {
  * <h2>Test Steps</h2>
  * - [3.3.1] The initialized measurement objects are verified.
  * - [3.3.2] A measurement is performed and its result is verified.
- * - [3.3.3] The first measurement is chained to the second one and
- *   both objects are verified.
- * - [3.3.4] A measurement shorter than the calibration offset is verified
+ * - [3.3.3] A measurement is chained to another object and both objects are
+ *   verified.
+ * - [3.3.4] A measurement is chained to itself and the object is verified.
+ * - [3.3.5] A measurement shorter than the calibration offset is verified
  *   to saturate at zero.
  * .
  */
@@ -207,15 +208,17 @@ static const testcase_t rt_test_003_002 = {
 static void rt_test_003_003_setup(void) {
   chTMObjectInit(&tm1);
   chTMObjectInit(&tm2);
+  chTMObjectInit(&tm3);
 }
 
 static void rt_test_003_003_teardown(void) {
   chTMObjectDispose(&tm1);
   chTMObjectDispose(&tm2);
+  chTMObjectDispose(&tm3);
 }
 
 static void rt_test_003_003_execute(void) {
-  rtcnt_t first;
+  rttime_t cumulative;
   rtcnt_t offset;
 
   /* [3.3.1] The initialized measurement objects are verified.*/
@@ -241,32 +244,65 @@ static void rt_test_003_003_execute(void) {
     test_assert(tm1.best == tm1.last, "invalid best");
     test_assert(tm1.worst == tm1.last, "invalid worst");
     test_assert(tm1.cumulative == (rttime_t)tm1.last, "invalid cumulative");
-    first = tm1.last;
   }
   test_end_step(2);
 
-  /* [3.3.3] The first measurement is chained to the second one and
-     both objects are verified.*/
+  /* [3.3.3] A measurement is chained to another object and both objects are
+     verified.*/
   test_set_step(3);
   {
-    chTMChainMeasurementToX(&tm1, &tm2);
+    chSysLock();
+    offset = currcore->tmc.offset;
+    currcore->tmc.offset = (rtcnt_t)-1;
+    chTMStartMeasurementX(&tm2);
+    chSysPolledDelayX((rtcnt_t)100);
+    chTMChainMeasurementToX(&tm2, &tm3);
     chSysPolledDelayX((rtcnt_t)10);
-    chTMStopMeasurementX(&tm2);
+    chTMStopMeasurementX(&tm3);
+    currcore->tmc.offset = offset;
+    chSysUnlock();
 
-    test_assert(tm1.n == (ucnt_t)2, "invalid counter");
-    test_assert(tm1.last > (rtcnt_t)0, "invalid last");
-    test_assert(tm1.best <= tm1.worst, "invalid range");
-    test_assert(tm1.cumulative >= (rttime_t)first, "invalid cumulative");
     test_assert(tm2.n == (ucnt_t)1, "invalid counter");
     test_assert(tm2.last > (rtcnt_t)0, "invalid last");
     test_assert(tm2.best == tm2.last, "invalid best");
     test_assert(tm2.worst == tm2.last, "invalid worst");
+    test_assert(tm2.cumulative == (rttime_t)tm2.last, "invalid cumulative");
+    test_assert(tm3.n == (ucnt_t)1, "invalid counter");
+    test_assert(tm3.last == (rtcnt_t)0, "invalid last");
+    test_assert(tm3.best == (rtcnt_t)0, "invalid best");
+    test_assert(tm3.worst == (rtcnt_t)0, "invalid worst");
+    test_assert(tm3.cumulative == (rttime_t)0, "invalid cumulative");
   }
   test_end_step(3);
 
-  /* [3.3.4] A measurement shorter than the calibration offset is verified
-     to saturate at zero.*/
+  /* [3.3.4] A measurement is chained to itself and the object is verified.*/
   test_set_step(4);
+  {
+    chTMObjectInit(&tm3);
+    chTMStartMeasurementX(&tm3);
+    chSysPolledDelayX((rtcnt_t)100);
+    chTMChainMeasurementToX(&tm3, &tm3);
+
+    test_assert(tm3.n == (ucnt_t)1, "invalid counter");
+    test_assert(tm3.best > (rtcnt_t)0, "invalid best");
+    test_assert(tm3.worst == tm3.best, "invalid worst");
+    test_assert(tm3.cumulative == (rttime_t)tm3.best, "invalid cumulative");
+    cumulative = tm3.cumulative;
+
+    chSysPolledDelayX((rtcnt_t)10);
+    chTMStopMeasurementX(&tm3);
+
+    test_assert(tm3.n == (ucnt_t)2, "invalid counter");
+    test_assert(tm3.last > (rtcnt_t)0, "invalid last");
+    test_assert(tm3.best <= tm3.worst, "invalid range");
+    test_assert(tm3.cumulative == cumulative + (rttime_t)tm3.last,
+                "invalid cumulative");
+  }
+  test_end_step(4);
+
+  /* [3.3.5] A measurement shorter than the calibration offset is verified
+     to saturate at zero.*/
+  test_set_step(5);
   {
     chTMObjectInit(&tm2);
     chSysLock();
@@ -283,7 +319,7 @@ static void rt_test_003_003_execute(void) {
     test_assert(tm2.worst == (rtcnt_t)0, "invalid worst");
     test_assert(tm2.cumulative == (rttime_t)0, "invalid cumulative");
   }
-  test_end_step(4);
+  test_end_step(5);
 }
 
 static const testcase_t rt_test_003_003 = {

--- a/test/rt/source/test/rt_test_sequence_005.c
+++ b/test/rt/source/test/rt_test_sequence_005.c
@@ -651,11 +651,12 @@ static const testcase_t rt_test_005_006 = {
  * - [5.7.1] The current thread registry name is changed and then
  *   restored.
  * - [5.7.2] A static thread is created then retrieved by name, pointer
- *   and working area while an unnamed thread is in the registry. Its initial
- *   reference is released and reacquired through the registry.
- * - [5.7.3] When debug assertions are enabled, creation conflict checks are
- *   exercised for a live thread object, a partially overlapping working area,
- *   disjoint resources and permitted cross-type overlaps.
+ *   and working area while an unnamed thread is in the registry. Its
+ *   initial reference is released and reacquired through the registry.
+ * - [5.7.3] When debug assertions are enabled, creation conflict
+ *   checks are exercised for a live thread object, a partially
+ *   overlapping working area, disjoint resources and permitted
+ *   cross-type overlaps.
  * - [5.7.4] The registry is scanned forward until the end and the
  *   created thread is found in the scan.
  * .
@@ -688,7 +689,9 @@ static void rt_test_005_007_execute(void) {
   test_end_step(1);
 
   /* [5.7.2] A static thread is created then retrieved by name, pointer
-     and working area while an unnamed thread is in the registry.*/
+     and working area while an unnamed thread is in the registry. Its
+     initial reference is released and reacquired through the
+     registry.*/
   test_set_step(2);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()-1, thread, "R");
@@ -730,9 +733,10 @@ static void rt_test_005_007_execute(void) {
   }
   test_end_step(2);
 
-  /* [5.7.3] When debug assertions are enabled, creation conflict checks are
-     exercised for a live thread object, a partially overlapping working area,
-     disjoint resources and permitted cross-type overlaps.*/
+  /* [5.7.3] When debug assertions are enabled, creation conflict
+     checks are exercised for a live thread object, a partially
+     overlapping working area, disjoint resources and permitted
+     cross-type overlaps.*/
   test_set_step(3);
   {
 #if CH_DBG_ENABLE_ASSERTS == TRUE
@@ -870,29 +874,30 @@ static const testcase_t rt_test_005_008 = {
   rt_test_005_008_execute
 };
 
-#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
-     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) && ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) && (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
 /**
  * @page rt_test_005_009 [5.9] Lifecycle ready trace messages
  *
  * <h2>Description</h2>
- * Lifecycle transitions into the ready state are verified to trace a defined
- * @p MSG_OK ready message.
+ * Lifecycle transitions into the ready state are verified to trace a
+ * defined MSG_OK ready message.
  *
  * <h2>Conditions</h2>
- * This test is only executed if ready tracing and thread-wait support are
- * enabled.
+ * This test is only executed if the following preprocessor condition
+ * evaluates to true:
+ * - (CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) && ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) && (CH_CFG_USE_WAITEXIT == TRUE)
+ * .
  *
  * <h2>Test Steps</h2>
- * - [5.9.1] A suspended external thread object is initialized and started
- *   through I-class APIs. Its initialized and traced messages are checked.
- * - [5.9.2] A running external thread is spawned through an I-class API and
- *   its ready trace is checked.
- * - [5.9.3] A running embedded thread is created through an I-class API and
- *   its ready trace is checked.
- * - [5.9.4] A thread exit wakes its waiter and the waiter's ready trace is
- *   checked.
+ * - [5.9.1] A suspended external thread object is initialized and
+ *   started through I-class APIs. Its initialized and traced messages
+ *   are checked.
+ * - [5.9.2] A running external thread is spawned through an I-class
+ *   API and its ready trace is checked.
+ * - [5.9.3] A running embedded thread is created through an I-class
+ *   API and its ready trace is checked.
+ * - [5.9.4] A thread exit wakes its waiter and the waiter's ready
+ *   trace is checked.
  * .
  */
 
@@ -906,8 +911,9 @@ static void rt_test_005_009_execute(void) {
   msg_t initmsg, tracemsg = MSG_RESET;
   bool found;
 
-  /* [5.9.1] A suspended external thread object is initialized and started
-     through I-class APIs. Its initialized and traced messages are checked.*/
+  /* [5.9.1] A suspended external thread object is initialized and
+     started through I-class APIs. Its initialized and traced messages
+     are checked.*/
   test_set_step(1);
   {
     setup_thread_descriptor(&td, "trace-start-i",
@@ -929,8 +935,8 @@ static void rt_test_005_009_execute(void) {
   }
   test_end_step(1);
 
-  /* [5.9.2] A running external thread is spawned through an I-class API and
-     its ready trace is checked.*/
+  /* [5.9.2] A running external thread is spawned through an I-class
+     API and its ready trace is checked.*/
   test_set_step(2);
   {
     setup_thread_descriptor(&td, "trace-spawn-i",
@@ -949,8 +955,8 @@ static void rt_test_005_009_execute(void) {
   }
   test_end_step(2);
 
-  /* [5.9.3] A running embedded thread is created through an I-class API and
-     its ready trace is checked.*/
+  /* [5.9.3] A running embedded thread is created through an I-class
+     API and its ready trace is checked.*/
   test_set_step(3);
   {
     setup_thread_descriptor(&td, "trace-create-i",
@@ -968,8 +974,8 @@ static void rt_test_005_009_execute(void) {
   }
   test_end_step(3);
 
-  /* [5.9.4] A thread exit wakes its waiter and the waiter's ready trace is
-     checked.*/
+  /* [5.9.4] A thread exit wakes its waiter and the waiter's ready
+     trace is checked.*/
   test_set_step(4);
   {
     self = chThdGetSelfX();
@@ -994,7 +1000,7 @@ static const testcase_t rt_test_005_009 = {
   rt_test_005_009_teardown,
   rt_test_005_009_execute
 };
-#endif
+#endif /* (CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) && ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) && (CH_CFG_USE_WAITEXIT == TRUE) */
 
 /*===========================================================================*/
 /* Exported data.                                                            */
@@ -1016,9 +1022,7 @@ const testcase_t * const rt_test_sequence_005_array[] = {
   &rt_test_005_007,
 #endif
   &rt_test_005_008,
-#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) &&             \
-     (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
+#if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) && ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U) && (CH_CFG_USE_WAITEXIT == TRUE)) || defined(__DOXYGEN__)
   &rt_test_005_009,
 #endif
   NULL

--- a/test/rt/source/test/rt_test_sequence_006.c
+++ b/test/rt/source/test/rt_test_sequence_006.c
@@ -181,9 +181,9 @@ static const testcase_t rt_test_006_001 = {
  * - [6.2.1] A threads queue is initialized, tested as empty, then
  *   touched with empty dequeue operations.
  * - [6.2.2] Immediate timeout enqueue is tested on an empty queue.
- * - [6.2.3] One queued thread's queue owner is verified, then it is resumed
- *   using chThdDequeueNextI() and, when enabled, its ready trace message is
- *   tested.
+ * - [6.2.3] One queued thread's queue owner is verified, then it is
+ *   resumed using chThdDequeueNextI() and, when enabled, its ready
+ *   trace message is tested.
  * - [6.2.4] Two queued threads are resumed using chThdDequeueAllI().
  * .
  */
@@ -204,7 +204,7 @@ static void rt_test_006_002_execute(void) {
   bool empty;
   bool owned;
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+       ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
   msg_t tracemsg;
   bool found;
 #endif
@@ -234,9 +234,9 @@ static void rt_test_006_002_execute(void) {
   }
   test_end_step(2);
 
-  /* [6.2.3] One queued thread's queue owner is verified, then it is resumed
-     using chThdDequeueNextI() and, when enabled, its ready trace message is
-     tested.*/
+  /* [6.2.3] One queued thread's queue owner is verified, then it is
+     resumed using chThdDequeueNextI() and, when enabled, its ready
+     trace message is tested.*/
   test_set_step(3);
   {
     qmsg1 = MSG_OK;
@@ -249,14 +249,14 @@ static void rt_test_006_002_execute(void) {
             (threads[0]->u.wtqueuep == &tq1);
     chThdDequeueNextI(&tq1, MSG_RESET);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     found = test_find_ready_trace(threads[0], CH_STATE_QUEUED, &tracemsg);
 #endif
     chSysUnlock();
     test_assert(!empty, "queue empty");
     test_assert(owned, "invalid queue owner");
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     test_assert(found, "ready trace not found");
     test_assert(tracemsg == MSG_RESET, "invalid ready trace message");
 #endif

--- a/test/rt/source/test/rt_test_sequence_007.c
+++ b/test/rt/source/test/rt_test_sequence_007.c
@@ -159,20 +159,21 @@ static const testcase_t rt_test_007_001 = {
  * @page rt_test_007_002 [7.2] Semaphore enqueuing test
  *
  * <h2>Description</h2>
- * Mixed-priority threads are enqueued then awakened one at time to verify
- * signal selection. Equal-priority threads are then released together to
- * verify that reset preserves peer order.
+ * Mixed-priority threads are enqueued then awakened one at time to
+ * verify signal selection. Equal-priority threads are then released
+ * together to verify that reset preserves peer order.
  *
  * <h2>Test Steps</h2>
  * - [7.2.1] Five threads are created with mixed priority levels (not
  *   increasing nor decreasing). Threads enqueue on a semaphore
  *   initialized to zero.
- * - [7.2.2] The semaphore is signaled 5 times, first through the I-class
- *   API. The thread activation sequence and, when enabled, a ready trace
- *   message are tested.
- * - [7.2.3] Five equal-priority threads are enqueued then released using
- *   a semaphore reset with a non-default message. The thread activation
- *   sequence and, when enabled, the ready trace message are tested.
+ * - [7.2.2] The semaphore is signaled 5 times, first through the
+ *   I-class API. The thread activation sequence and, when enabled, a
+ *   ready trace message are tested.
+ * - [7.2.3] Five equal-priority threads are enqueued then released
+ *   using a semaphore reset with a non-default message. The thread
+ *   activation sequence and, when enabled, the ready trace message are
+ *   tested.
  * .
  */
 
@@ -186,7 +187,7 @@ static void rt_test_007_002_teardown(void) {
 
 static void rt_test_007_002_execute(void) {
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+       ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
   msg_t tracemsg;
   bool found;
 #endif
@@ -204,21 +205,21 @@ static void rt_test_007_002_execute(void) {
   }
   test_end_step(1);
 
-  /* [7.2.2] The semaphore is signaled 5 times, first through the I-class
-     API. The thread activation sequence and, when enabled, a ready trace
-     message are tested.*/
+  /* [7.2.2] The semaphore is signaled 5 times, first through the
+     I-class API. The thread activation sequence and, when enabled, a
+     ready trace message are tested.*/
   test_set_step(2);
   {
     chSysLock();
     chSemSignalI(&sem1);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
 #endif
     chSchRescheduleS();
     chSysUnlock();
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     test_assert(found, "ready trace not found");
     test_assert(tracemsg == MSG_OK, "invalid ready trace message");
 #endif
@@ -235,9 +236,10 @@ static void rt_test_007_002_execute(void) {
   }
   test_end_step(2);
 
-  /* [7.2.3] Five equal-priority threads are enqueued then released using
-     a semaphore reset with a non-default message. The thread activation
-     sequence and, when enabled, the ready trace message are tested.*/
+  /* [7.2.3] Five equal-priority threads are enqueued then released
+     using a semaphore reset with a non-default message. The thread
+     activation sequence and, when enabled, the ready trace message are
+     tested.*/
   test_set_step(3);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()+1, thread1, "A");
@@ -247,7 +249,7 @@ static void rt_test_007_002_execute(void) {
     threads[4] = chThdCreateStatic(wa[4], WA_SIZE, chThdGetPriorityX()+1, thread1, "E");
     chSemResetWithMessage(&sem1, 0, MSG_TIMEOUT);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     chSysLock();
     found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
     chSysUnlock();
@@ -271,14 +273,14 @@ static const testcase_t rt_test_007_002 = {
  * @page rt_test_007_003 [7.3] Semaphore timeout test
  *
  * <h2>Description</h2>
- * Immediate, successful, and expired timed semaphore waits are explored.
- * The test expects that the semaphore wait function returns the correct
- * value and that the semaphore structure status is correct after each
- * operation.
+ * Immediate, successful, and expired timed semaphore waits are
+ * explored. The test expects that the semaphore wait function returns
+ * the correct value and that the semaphore structure status is correct
+ * after each operation.
  *
  * <h2>Test Steps</h2>
- * - [7.3.1] Immediate waits are tested with one available unit and with an
- *   empty semaphore.
+ * - [7.3.1] Immediate waits are tested with one available unit and
+ *   with an empty semaphore.
  * - [7.3.2] Testing non-timeout condition.
  * - [7.3.3] Testing timeout condition.
  * .
@@ -297,8 +299,8 @@ static void rt_test_007_003_execute(void) {
   systime_t target_time;
   msg_t msg;
 
-  /* [7.3.1] Immediate waits are tested with one available unit and with an
-     empty semaphore.*/
+  /* [7.3.1] Immediate waits are tested with one available unit and
+     with an empty semaphore.*/
   test_set_step(1);
   {
     chSemSignal(&sem1);
@@ -363,8 +365,8 @@ static const testcase_t rt_test_007_003 = {
  * <h2>Test Steps</h2>
  * - [7.4.1] A thread is created, it goes to wait on the semaphore.
  * - [7.4.2] The semaphore counter is increased by two, it is then
- *   tested to be one, the thread must have completed and, when enabled,
- *   its ready trace message is tested.
+ *   tested to be one, the thread must have completed and, when
+ *   enabled, its ready trace message is tested.
  * .
  */
 
@@ -378,7 +380,7 @@ static void rt_test_007_004_teardown(void) {
 
 static void rt_test_007_004_execute(void) {
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+       ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
   msg_t tracemsg;
   bool found;
 #endif
@@ -391,20 +393,20 @@ static void rt_test_007_004_execute(void) {
   test_end_step(1);
 
   /* [7.4.2] The semaphore counter is increased by two, it is then
-     tested to be one, the thread must have completed and, when enabled,
-     its ready trace message is tested.*/
+     tested to be one, the thread must have completed and, when
+     enabled, its ready trace message is tested.*/
   test_set_step(2);
   {
     chSysLock();
     chSemAddCounterI(&sem1, 2);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
 #endif
     chSchRescheduleS();
     chSysUnlock();
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     test_assert(found, "ready trace not found");
     test_assert(tracemsg == MSG_OK, "invalid ready trace message");
 #endif
@@ -428,19 +430,19 @@ static const testcase_t rt_test_007_004 = {
  * <h2>Description</h2>
  * This test case explicitly addresses the @p chSemWaitSignal()
  * function. A thread is created that performs a wait on the signal
- * semaphore then signals the wait semaphore. The tester thread is awakened
- * from an atomic wait/signal operation. The test expects that the semaphore
- * wait function returns the correct value and that both semaphore structures
- * are correct after each operation.
+ * semaphore then signals the wait semaphore. The tester thread is
+ * awakened from an atomic wait/signal operation. The test expects that
+ * the semaphore wait function returns the correct value and that both
+ * semaphore structures are correct after each operation.
  *
  * <h2>Test Steps</h2>
- * - [7.5.1] A higher priority thread is created that waits on the signal
- *   semaphore then signals the wait semaphore.
- * - [7.5.2] The function chSemSignalWait() is invoked with distinct signal
- *   and wait semaphores. Their counters and, when enabled, the signaled
- *   thread's ready trace message are tested on exit.
- * - [7.5.3] The wait semaphore is pre-signaled, then chSemSignalWait() is
- *   invoked again and verified to complete without blocking.
+ * - [7.5.1] A higher priority thread is created that waits on the
+ *   signal semaphore then signals the wait semaphore.
+ * - [7.5.2] The function chSemSignalWait() is invoked with distinct
+ *   signal and wait semaphores. Their counters and, when enabled, the
+ *   signaled thread's ready trace message are tested on exit.
+ * - [7.5.3] The wait semaphore is pre-signaled, then chSemSignalWait()
+ *   is invoked again and verified to complete without blocking.
  * .
  */
 
@@ -458,27 +460,27 @@ static void rt_test_007_005_teardown(void) {
 static void rt_test_007_005_execute(void) {
   msg_t msg;
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+       ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
   msg_t tracemsg;
   bool found;
 #endif
 
-  /* [7.5.1] A higher priority thread is created that waits on the signal
-     semaphore then signals the wait semaphore.*/
+  /* [7.5.1] A higher priority thread is created that waits on the
+     signal semaphore then signals the wait semaphore.*/
   test_set_step(1);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, chThdGetPriorityX()+1, thread3, 0);
   }
   test_end_step(1);
 
-  /* [7.5.2] The function chSemSignalWait() is invoked with distinct signal
-     and wait semaphores. Their counters and, when enabled, the signaled
-     thread's ready trace message are tested on exit.*/
+  /* [7.5.2] The function chSemSignalWait() is invoked with distinct
+     signal and wait semaphores. Their counters and, when enabled, the
+     signaled thread's ready trace message are tested on exit.*/
   test_set_step(2);
   {
     msg = chSemSignalWait(&sem1, &sem2);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     chSysLock();
     found = test_find_ready_trace(threads[0], CH_STATE_WTSEM, &tracemsg);
     chSysUnlock();
@@ -492,8 +494,8 @@ static void rt_test_007_005_execute(void) {
   }
   test_end_step(2);
 
-  /* [7.5.3] The wait semaphore is pre-signaled, then chSemSignalWait() is
-     invoked again and verified to complete without blocking.*/
+  /* [7.5.3] The wait semaphore is pre-signaled, then chSemSignalWait()
+     is invoked again and verified to complete without blocking.*/
   test_set_step(3);
   {
     chSemSignal(&sem2);
@@ -614,13 +616,13 @@ static const testcase_t rt_test_007_006 = {
  * @page rt_test_007_007 [7.7] Semaphore counter boundaries
  *
  * <h2>Description</h2>
- * The representable semaphore counter boundaries and the operations that
- * can validly reach them are tested.
+ * The representable semaphore counter boundaries and the operations
+ * that can validly reach them are tested.
  *
  * <h2>Test Steps</h2>
  * - [7.7.1] The public counter and waiter limits are checked.
- * - [7.7.2] Signal, add-counter, and fast operations are exercised up to
- *   the maximum counter value.
+ * - [7.7.2] Signal, add-counter, and fast operations are exercised up
+ *   to the maximum counter value.
  * - [7.7.3] A distinct-object signal/wait operation is verified at the
  *   maximum signal counter value.
  * .
@@ -652,8 +654,8 @@ static void rt_test_007_007_execute(void) {
   }
   test_end_step(1);
 
-  /* [7.7.2] Signal, add-counter, and fast operations are exercised up to
-     the maximum counter value.*/
+  /* [7.7.2] Signal, add-counter, and fast operations are exercised up
+     to the maximum counter value.*/
   test_set_step(2);
   {
     chSemReset(&sem1, SEMAPHORE_MAX_COUNT - (cnt_t)1);

--- a/test/rt/source/test/rt_test_sequence_008.c
+++ b/test/rt/source/test/rt_test_sequence_008.c
@@ -1155,7 +1155,7 @@ static void rt_test_008_009_teardown(void) {
 
 static void rt_test_008_009_execute(void) {
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+       ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
   msg_t tracemsg;
   bool found;
 #endif
@@ -1180,7 +1180,7 @@ static void rt_test_008_009_execute(void) {
   {
     chCondBroadcast(&c1);
 #if ((CH_DBG_TRACE_MASK != CH_DBG_TRACE_MASK_DISABLED) &&                 \
-     ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
+         ((CH_DBG_TRACE_MASK & CH_DBG_TRACE_MASK_READY) != 0U))
     chSysLock();
     found = test_find_ready_trace(threads[0], CH_STATE_WTCOND, &tracemsg);
     chSysUnlock();

--- a/test/rt/source/test/rt_test_sequence_009.c
+++ b/test/rt/source/test/rt_test_sequence_009.c
@@ -351,16 +351,17 @@ static const testcase_t rt_test_009_004 = {
  * @page rt_test_009_005 [9.5] Messages lifecycle closure
  *
  * <h2>Description</h2>
- * Message senders remain linked to their receiver until release. Explicit
- * receiver cleanup rejects selected and queued senders before termination,
- * and sending to an already terminated receiver is rejected immediately.
+ * Message senders remain linked to their receiver until release.
+ * Explicit receiver cleanup rejects selected and queued senders before
+ * termination, and sending to an already terminated receiver is
+ * rejected immediately.
  *
  * <h2>Test Steps</h2>
- * - [9.5.1] A selected sender remains queued and can be released by identity
- *   after a higher-priority sender is inserted ahead of it.
+ * - [9.5.1] A selected sender remains queued and can be released by
+ *   identity after a higher-priority sender is inserted ahead of it.
  * - [9.5.2] Sending to a final thread returns MSG_RESET immediately.
- * - [9.5.3] A receiver rejects a selected sender using chMsgReleaseAllI()
- *   before exiting.
+ * - [9.5.3] A receiver rejects a selected sender using
+ *   chMsgReleaseAllI() before exiting.
  * - [9.5.4] A receiver rejects multiple queued senders using
  *   chMsgReleaseAllI() before exiting.
  * .
@@ -442,8 +443,8 @@ static void rt_test_009_005_execute(void) {
   }
   test_end_step(2);
 
-  /* [9.5.3] A receiver rejects a selected sender using chMsgReleaseAllI()
-     before exiting.*/
+  /* [9.5.3] A receiver rejects a selected sender using
+     chMsgReleaseAllI() before exiting.*/
   test_set_step(3);
   {
     threads[0] = chThdCreateStatic(wa[0], WA_SIZE, prio + 1,


### PR DESCRIPTION
## Summary

- document time-measurement chaining preconditions and its intentional uncalibrated boundary semantics
- correct the TM regression sequence, including valid two-object chaining, forced offset behavior, and self-chaining
- document SMP realtime-counter coherence as a port property, recommending a shared coherent hardware source and requiring same-core measurement segments otherwise
- document modular measurement/statistics counters and remove the dead `__stats_init()` declaration
- resynchronize RT sources generated from XML and correct a case condition that previously regenerated into an invalid multi-line directive
- add a contributor rule requiring XML-derived source changes to be made through regeneration
- include the requested realtime-conversion macro alignment cleanup in `chsys.h`

## Validation

- full RT and OSLIB simulator suites, 64-bit: PASS
- full RT and OSLIB simulator suites, 32-bit: PASS
- regenerated-source builds after drift cleanup, 64-bit and 32-bit: PASS
- second FMPP regeneration produces no diff
- `xmllint --noout test/rt/configuration.xml`
- style checks and `git diff --check`