### PR TITLE
ARMCRx: make startup capabilities device-defined

### DIFF
--- a/demos/various/RT-ARMCR8-GENERIC/Makefile
+++ b/demos/various/RT-ARMCR8-GENERIC/Makefile
@@ -187,12 +187,6 @@ CPPWARN = -Wall -Wextra -Wundef
 # List all user C define here, like -D_DEBUG=1
 UDEFS =
 
-# The generic Renode Cortex-R8 model has an FPU. When the demo is built with
-# USE_FPU enabled then declare the generic device as FPU-capable.
-ifneq ($(USE_FPU),no)
-  UDEFS += -DARMCR8_HAS_FPU=1
-endif
-
 # Define ASM defines here
 UADEFS =
 

--- a/os/common/ports/ARMv7-R/compilers/GCC/mk/port_simulator.mk
+++ b/os/common/ports/ARMv7-R/compilers/GCC/mk/port_simulator.mk
@@ -6,9 +6,8 @@ include $(CHIBIOS)/os/common/ports/ARMv7-R/compilers/GCC/mk/port.mk
 # Simulator interrupt controller support.
 include $(CHIBIOS)/os/common/ports/ARM-common/GICv2/gicv2.mk
 
-DDEFS += -DARMCR8_HAS_GIC=1                                   \
-         -DPORT_HAS_PLATFORM=TRUE                             \
-         -DGICV2_INTERFACE_BASE=0xAE000100U                    \
+DDEFS += -DPORT_HAS_PLATFORM=TRUE                             \
+         -DGICV2_INTERFACE_BASE=0xAE000100U                   \
          -DGICV2_DISTRIBUTOR_BASE=0xAE001000U
 
 PORTSIMSRC = $(CHIBIOS)/os/common/ports/ARMv7-R/platforms/simulator/port_platform.c

--- a/os/common/startup/ARMCRx/compilers/GCC/crt0_v7r.S
+++ b/os/common/startup/ARMCRx/compilers/GCC/crt0_v7r.S
@@ -22,6 +22,8 @@
  * @{
  */
 
+#include "crparams.h"
+
 /*===========================================================================*/
 /* Module constants.                                                         */
 /*===========================================================================*/
@@ -57,7 +59,11 @@
  * @details VBAR is initialized to point to the vectors table.
  */
 #if !defined(CRT0_VBAR_INIT) || defined(__DOXYGEN__)
-#define CRT0_VBAR_INIT                      TRUE
+#define CRT0_VBAR_INIT                      CORTEX_HAS_VBAR
+#endif
+
+#if (CRT0_VBAR_INIT == TRUE) && (CORTEX_HAS_VBAR == FALSE)
+#error "CRT0_VBAR_INIT requires VBAR support"
 #endif
 
 /**

--- a/os/common/startup/ARMCRx/devices/ARMCR5/armcr5.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR5/armcr5.h
@@ -28,14 +28,14 @@
 #include "crparams.h"
 
 #define __CR5_REV              0x0000U
-#define __FPU_PRESENT          ARMCR5_HAS_FPU
-#define __VIC_PRESENT          ARMCR5_HAS_VIC
-#define __GIC_PRESENT          ARMCR5_HAS_GIC
-#define __MPU_PRESENT          ARMCR5_HAS_MPU
-#define __ICACHE_PRESENT       ARMCR5_HAS_ICACHE
-#define __DCACHE_PRESENT       ARMCR5_HAS_DCACHE
-#define __DTCM_PRESENT         ARMCR5_HAS_DTCM
-#define __ECC_PRESENT          ARMCR5_HAS_ECC
+#define __FPU_PRESENT          CORTEX_HAS_FPU
+#define __VIC_PRESENT          CORTEX_HAS_VIC
+#define __GIC_PRESENT          CORTEX_HAS_GIC
+#define __MPU_PRESENT          CORTEX_HAS_MPU
+#define __ICACHE_PRESENT       CORTEX_HAS_ICACHE
+#define __DCACHE_PRESENT       CORTEX_HAS_DCACHE
+#define __DTCM_PRESENT         CORTEX_HAS_DTCM
+#define __ECC_PRESENT          CORTEX_HAS_ECC
 
 /**
  * @brief   Placeholder interrupt number type.

--- a/os/common/startup/ARMCRx/devices/ARMCR5/crparams.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR5/crparams.h
@@ -39,73 +39,49 @@
 /**
  * @brief   Floating Point unit presence.
  */
-#if !defined(ARMCR5_HAS_FPU) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_FPU          0
-#endif
-
-#define CORTEX_HAS_FPU          ARMCR5_HAS_FPU
+#define CORTEX_HAS_FPU          0
 
 /**
  * @brief   Generic Interrupt Controller presence.
  */
-#if !defined(ARMCR5_HAS_GIC) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_GIC          0
-#endif
+#define CORTEX_HAS_GIC          0
 
 /**
  * @brief   Vectored Interrupt Controller presence.
  */
-#if !defined(ARMCR5_HAS_VIC) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_VIC          0
-#endif
+#define CORTEX_HAS_VIC          0
 
 /**
  * @brief   MPU presence.
  */
-#if !defined(ARMCR5_HAS_MPU) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_MPU          0
-#endif
-
-#define CORTEX_HAS_MPU          ARMCR5_HAS_MPU
+#define CORTEX_HAS_MPU          0
 
 /**
  * @brief   Number of MPU regions.
  * @note    The Cortex-R5 MPU can be configured with 12 or 16 regions,
- *          the actual number must be taken from the SoC documentation.
+ *          this generic configuration selects 16 regions.
  */
-#if !defined(ARMCR5_MPU_REGIONS) || defined(__DOXYGEN__)
-#define ARMCR5_MPU_REGIONS      16
-#endif
-
-#define CORTEX_MPU_REGIONS      ARMCR5_MPU_REGIONS
+#define CORTEX_MPU_REGIONS      16
 
 /**
  * @brief   Instruction cache presence.
  */
-#if !defined(ARMCR5_HAS_ICACHE) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_ICACHE       0
-#endif
+#define CORTEX_HAS_ICACHE       0
 
 /**
  * @brief   Data cache presence.
  */
-#if !defined(ARMCR5_HAS_DCACHE) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_DCACHE       0
-#endif
+#define CORTEX_HAS_DCACHE       0
 
 /**
  * @brief   DTCM presence.
  */
-#if !defined(ARMCR5_HAS_DTCM) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_DTCM         0
-#endif
+#define CORTEX_HAS_DTCM         0
 
 /**
  * @brief   ECC presence.
  */
-#if !defined(ARMCR5_HAS_ECC) || defined(__DOXYGEN__)
-#define ARMCR5_HAS_ECC          0
-#endif
+#define CORTEX_HAS_ECC          0
 
 #endif /* CRPARAMS_H */
 

--- a/os/common/startup/ARMCRx/devices/ARMCR5/crparams.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR5/crparams.h
@@ -32,6 +32,11 @@
 #define CORTEX_MODEL            5
 
 /**
+ * @brief   Vector Base Address Register presence.
+ */
+#define CORTEX_HAS_VBAR         0
+
+/**
  * @brief   Floating Point unit presence.
  */
 #if !defined(ARMCR5_HAS_FPU) || defined(__DOXYGEN__)

--- a/os/common/startup/ARMCRx/devices/ARMCR8/armcr8.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR8/armcr8.h
@@ -28,14 +28,14 @@
 #include "crparams.h"
 
 #define __CR8_REV              0x0000U
-#define __FPU_PRESENT          ARMCR8_HAS_FPU
-#define __VIC_PRESENT          ARMCR8_HAS_VIC
-#define __GIC_PRESENT          ARMCR8_HAS_GIC
-#define __MPU_PRESENT          ARMCR8_HAS_MPU
-#define __ICACHE_PRESENT       ARMCR8_HAS_ICACHE
-#define __DCACHE_PRESENT       ARMCR8_HAS_DCACHE
-#define __DTCM_PRESENT         ARMCR8_HAS_DTCM
-#define __ECC_PRESENT          ARMCR8_HAS_ECC
+#define __FPU_PRESENT          CORTEX_HAS_FPU
+#define __VIC_PRESENT          CORTEX_HAS_VIC
+#define __GIC_PRESENT          CORTEX_HAS_GIC
+#define __MPU_PRESENT          CORTEX_HAS_MPU
+#define __ICACHE_PRESENT       CORTEX_HAS_ICACHE
+#define __DCACHE_PRESENT       CORTEX_HAS_DCACHE
+#define __DTCM_PRESENT         CORTEX_HAS_DTCM
+#define __ECC_PRESENT          CORTEX_HAS_ECC
 
 /**
  * @brief   Placeholder interrupt number type.

--- a/os/common/startup/ARMCRx/devices/ARMCR8/crparams.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR8/crparams.h
@@ -32,6 +32,11 @@
 #define CORTEX_MODEL            8
 
 /**
+ * @brief   Vector Base Address Register presence.
+ */
+#define CORTEX_HAS_VBAR         0
+
+/**
  * @brief   Floating Point unit presence.
  */
 #if !defined(ARMCR8_HAS_FPU) || defined(__DOXYGEN__)

--- a/os/common/startup/ARMCRx/devices/ARMCR8/crparams.h
+++ b/os/common/startup/ARMCRx/devices/ARMCR8/crparams.h
@@ -39,71 +39,47 @@
 /**
  * @brief   Floating Point unit presence.
  */
-#if !defined(ARMCR8_HAS_FPU) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_FPU          0
-#endif
-
-#define CORTEX_HAS_FPU          ARMCR8_HAS_FPU
+#define CORTEX_HAS_FPU          1
 
 /**
  * @brief   Generic Interrupt Controller presence.
  */
-#if !defined(ARMCR8_HAS_GIC) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_GIC          0
-#endif
+#define CORTEX_HAS_GIC          0
 
 /**
  * @brief   Vectored Interrupt Controller presence.
  */
-#if !defined(ARMCR8_HAS_VIC) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_VIC          0
-#endif
+#define CORTEX_HAS_VIC          0
 
 /**
  * @brief   MPU presence.
  */
-#if !defined(ARMCR8_HAS_MPU) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_MPU          0
-#endif
-
-#define CORTEX_HAS_MPU          ARMCR8_HAS_MPU
+#define CORTEX_HAS_MPU          0
 
 /**
  * @brief   Number of MPU regions.
  */
-#if !defined(ARMCR8_MPU_REGIONS) || defined(__DOXYGEN__)
-#define ARMCR8_MPU_REGIONS      24
-#endif
-
-#define CORTEX_MPU_REGIONS      ARMCR8_MPU_REGIONS
+#define CORTEX_MPU_REGIONS      24
 
 /**
  * @brief   Instruction cache presence.
  */
-#if !defined(ARMCR8_HAS_ICACHE) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_ICACHE       0
-#endif
+#define CORTEX_HAS_ICACHE       0
 
 /**
  * @brief   Data cache presence.
  */
-#if !defined(ARMCR8_HAS_DCACHE) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_DCACHE       0
-#endif
+#define CORTEX_HAS_DCACHE       0
 
 /**
  * @brief   DTCM presence.
  */
-#if !defined(ARMCR8_HAS_DTCM) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_DTCM         0
-#endif
+#define CORTEX_HAS_DTCM         0
 
 /**
  * @brief   ECC presence.
  */
-#if !defined(ARMCR8_HAS_ECC) || defined(__DOXYGEN__)
-#define ARMCR8_HAS_ECC          0
-#endif
+#define CORTEX_HAS_ECC          0
 
 #endif /* CRPARAMS_H */
 

--- a/os/common/startup/ARMCRx/devices/RZV2H/crparams.h
+++ b/os/common/startup/ARMCRx/devices/RZV2H/crparams.h
@@ -41,50 +41,47 @@
 /**
  * @brief   Floating Point unit presence.
  */
-#define ARMCR8_HAS_FPU          1
-#define CORTEX_HAS_FPU          ARMCR8_HAS_FPU
+#define CORTEX_HAS_FPU          1
 
 /**
  * @brief   Generic Interrupt Controller presence.
  */
-#define ARMCR8_HAS_GIC          1
+#define CORTEX_HAS_GIC          1
 
 /**
  * @brief   Vectored Interrupt Controller presence.
  */
-#define ARMCR8_HAS_VIC          0
+#define CORTEX_HAS_VIC          0
 
 /**
  * @brief   MPU presence.
  */
-#define ARMCR8_HAS_MPU          1
-#define CORTEX_HAS_MPU          ARMCR8_HAS_MPU
+#define CORTEX_HAS_MPU          1
 
 /**
  * @brief   Number of MPU regions.
  */
-#define ARMCR8_MPU_REGIONS      16
-#define CORTEX_MPU_REGIONS      ARMCR8_MPU_REGIONS
+#define CORTEX_MPU_REGIONS      16
 
 /**
  * @brief   Instruction cache presence.
  */
-#define ARMCR8_HAS_ICACHE       1
+#define CORTEX_HAS_ICACHE       1
 
 /**
  * @brief   Data cache presence.
  */
-#define ARMCR8_HAS_DCACHE       1
+#define CORTEX_HAS_DCACHE       1
 
 /**
  * @brief   DTCM presence.
  */
-#define ARMCR8_HAS_DTCM         1
+#define CORTEX_HAS_DTCM         1
 
 /**
  * @brief   ECC presence.
  */
-#define ARMCR8_HAS_ECC          1
+#define CORTEX_HAS_ECC          1
 
 #endif /* CRPARAMS_H */
 

--- a/os/common/startup/ARMCRx/devices/RZV2H/crparams.h
+++ b/os/common/startup/ARMCRx/devices/RZV2H/crparams.h
@@ -34,6 +34,11 @@
 #define CORTEX_MODEL            8
 
 /**
+ * @brief   Vector Base Address Register presence.
+ */
+#define CORTEX_HAS_VBAR         0
+
+/**
  * @brief   Floating Point unit presence.
  */
 #define ARMCR8_HAS_FPU          1

--- a/os/common/startup/ARMCRx/devices/RZV2H/rzv2h.h
+++ b/os/common/startup/ARMCRx/devices/RZV2H/rzv2h.h
@@ -28,14 +28,14 @@
 #include "crparams.h"
 
 #define __CR8_REV              0x0003U
-#define __FPU_PRESENT          ARMCR8_HAS_FPU
-#define __VIC_PRESENT          ARMCR8_HAS_VIC
-#define __GIC_PRESENT          ARMCR8_HAS_GIC
-#define __MPU_PRESENT          ARMCR8_HAS_MPU
-#define __ICACHE_PRESENT       ARMCR8_HAS_ICACHE
-#define __DCACHE_PRESENT       ARMCR8_HAS_DCACHE
-#define __DTCM_PRESENT         ARMCR8_HAS_DTCM
-#define __ECC_PRESENT          ARMCR8_HAS_ECC
+#define __FPU_PRESENT          CORTEX_HAS_FPU
+#define __VIC_PRESENT          CORTEX_HAS_VIC
+#define __GIC_PRESENT          CORTEX_HAS_GIC
+#define __MPU_PRESENT          CORTEX_HAS_MPU
+#define __ICACHE_PRESENT       CORTEX_HAS_ICACHE
+#define __DCACHE_PRESENT       CORTEX_HAS_DCACHE
+#define __DTCM_PRESENT         CORTEX_HAS_DTCM
+#define __ECC_PRESENT          CORTEX_HAS_ECC
 
 /* GIC base addresses. The Cortex-R8 GIC lives in the MPCore private space at
    PERIPHBASE = 0x12C10000 (CPU interface +0x100, distributor +0x1000). They


### PR DESCRIPTION
## Summary

Makes the shared ARMCRx startup derive VBAR initialization from an immutable
device capability and normalizes the ARMCR5, ARMCR8, and RZV2H capability
headers around the common `CORTEX_*` names.

The Cortex-R5 device added by #273 has no VBAR. Previously, `crt0_v7r.S`
enabled its VBAR write by default, so the R5 startup path could execute an
unsupported CP15 operation. The default is now `CORTEX_HAS_VBAR`, with a
compile-time error if a device without VBAR support explicitly enables the
operation.

Device properties are also no longer application-overridable. They describe
the selected core/device and must remain internally consistent with the CMSIS
presence macros. Platform-specific features belong in a concrete device
header rather than command-line overrides of the generic device model.

## Related

- Follow-up to #273.
- The assembler `.cpu cortex-r8` selection remains unchanged intentionally:
  shared assembly uses the supported instruction superset, while concrete
  capabilities are selected through conditional assembly.

## Testing

- `git diff --check origin/master...HEAD`
- `tools/style/stylecheck.py` on all changed headers
- `demos/various/RT-ARMCR8-GENERIC`: clean build with Arm GNU Toolchain 13.2.1
  (`text 4840`, `data 0`, `bss 262144`)
- Direct `crt0_v7r.S` assembly with `-mcpu=cortex-r5` and the ARMCR5 device
  parameters; disassembly confirms that no VBAR access is emitted

## Compatibility and risk

The shared startup now refuses the contradictory configuration that requests
VBAR initialization for a device declaring no VBAR. Existing in-tree ARMCRx
devices select their fixed capabilities from `crparams.h`; the Cortex-R8
generic demo continues to build successfully without command-line capability
overrides.
