### PR TITLE
ARMCRx: add the TI AM67/J722S R5F startup device

### DIFF
--- a/os/common/startup/ARMCRx/compilers/GCC/mk/startup_am67r5f.mk
+++ b/os/common/startup/ARMCRx/compilers/GCC/mk/startup_am67r5f.mk
@@ -1,0 +1,17 @@
+# List of the ChibiOS TI AM67/J722S Cortex-R5F startup and CMSIS files.
+STARTUPSRC = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/crt1.c
+
+STARTUPASM = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/crt0_v7r.S \
+             $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/vectors.S
+
+STARTUPINC = $(CHIBIOS)/os/common/portability/GCC \
+             $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC \
+             $(CHIBIOS)/os/common/startup/ARMCRx/devices/AM67R5F \
+             $(CHIBIOS)/os/common/ext/ARM/CMSIS6/Include
+
+STARTUPLD  = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/ld
+
+# Shared variables
+ALLXASMSRC += $(STARTUPASM)
+ALLCSRC    += $(STARTUPSRC)
+ALLINC     += $(STARTUPINC)

--- a/os/common/startup/ARMCRx/devices/AM67R5F/am67r5f.h
+++ b/os/common/startup/ARMCRx/devices/AM67R5F/am67r5f.h
@@ -1,0 +1,54 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    AM67R5F/am67r5f.h
+ * @brief   ARM Cortex-R5 CMSIS device header for the TI AM67/J722S R5F.
+ *
+ * @addtogroup ARMCRx_AM67R5F
+ * @{
+ */
+
+#ifndef AM67R5F_H
+#define AM67R5F_H
+
+#include "crparams.h"
+
+#define __CR5_REV              0x0000U
+#define __FPU_PRESENT          CORTEX_HAS_FPU
+#define __VIC_PRESENT          CORTEX_HAS_VIC
+#define __GIC_PRESENT          CORTEX_HAS_GIC
+#define __MPU_PRESENT          CORTEX_HAS_MPU
+#define __ICACHE_PRESENT       CORTEX_HAS_ICACHE
+#define __DCACHE_PRESENT       CORTEX_HAS_DCACHE
+#define __DTCM_PRESENT         CORTEX_HAS_DTCM
+#define __ECC_PRESENT          CORTEX_HAS_ECC
+
+/**
+ * @brief   Placeholder interrupt number type.
+ * @details AM67 interrupt lines are routed by the TI VIM and are handled by
+ *          the ARMv7-R AM67 sub-port, so the CMSIS @p IRQn_Type enumeration
+ *          is not used for the SoC interrupt map.
+ */
+typedef enum {
+  AM67R5F_GenericIRQ0_IRQn = 0
+} IRQn_Type;
+
+#include "core_cr5.h"
+
+#endif /* AM67R5F_H */
+
+/** @} */

--- a/os/common/startup/ARMCRx/devices/AM67R5F/crparams.h
+++ b/os/common/startup/ARMCRx/devices/AM67R5F/crparams.h
@@ -1,0 +1,91 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    AM67R5F/crparams.h
+ * @brief   ARM Cortex-R5 parameters for the TI AM67/J722S R5F.
+ *
+ * @defgroup ARMCRx_AM67R5F AM67 R5F Specific Parameters
+ * @ingroup ARMCRx_SPECIFIC
+ * @details This file contains the Cortex-R5 specific parameters for the
+ *          TI AM67/J722S MCU domain R5F subsystem.
+ * @{
+ */
+
+#ifndef CRPARAMS_H
+#define CRPARAMS_H
+
+/**
+ * @brief   Cortex core model.
+ */
+#define CORTEX_MODEL            5
+
+/**
+ * @brief   Vector Base Address Register presence.
+ * @note    The Cortex-R5 has no VBAR, the vector base is fixed at address 0.
+ */
+#define CORTEX_HAS_VBAR         0
+
+/**
+ * @brief   Floating Point unit presence.
+ */
+#define CORTEX_HAS_FPU          1
+
+/**
+ * @brief   Generic Interrupt Controller presence.
+ * @note    Interrupts are routed by the TI VIM, which is neither the ARM GIC
+ *          nor the ARM VIC. It is handled by the AM67 sub-port.
+ */
+#define CORTEX_HAS_GIC          0
+
+/**
+ * @brief   Vectored Interrupt Controller presence.
+ */
+#define CORTEX_HAS_VIC          0
+
+/**
+ * @brief   MPU presence.
+ */
+#define CORTEX_HAS_MPU          1
+
+/**
+ * @brief   Number of MPU regions.
+ */
+#define CORTEX_MPU_REGIONS      16
+
+/**
+ * @brief   Instruction cache presence.
+ */
+#define CORTEX_HAS_ICACHE       1
+
+/**
+ * @brief   Data cache presence.
+ */
+#define CORTEX_HAS_DCACHE       1
+
+/**
+ * @brief   DTCM presence.
+ */
+#define CORTEX_HAS_DTCM         1
+
+/**
+ * @brief   ECC presence.
+ */
+#define CORTEX_HAS_ECC          1
+
+#endif /* CRPARAMS_H */
+
+/** @} */


### PR DESCRIPTION
## Summary

Adds an `AM67R5F` startup device for the TI AM67/J722S MCU-domain Cortex-R5F,
alongside the existing `ARMCR5`, `ARMCR8` and `RZV2H` devices.

The generic `ARMCR5` device describes a bare Cortex-R5: no FPU, no MPU, no caches,
no TCM. The AM67/J722S R5F has all of them, and startup behaviour is driven by the
device's declared capabilities, so a part with this feature set needs its own device
rather than a generic one adjusted from the outside.

Capabilities are taken from the TI J722S TRM: FPU, MPU with 16 regions, separate
instruction and data caches, TCM and ECC. VBAR is absent, which is what the
Cortex-R5 requires and what the shared startup keys its vector base initialization
on. GIC and VIC are both absent: AM67 interrupts are routed by the TI VIM, which is
neither, and which the ARMv7-R AM67 sub-port handles.

`__CR5_REV` is left at the generic `0x0000U`. The silicon revision has not been read
back from a part and nothing in CMSIS acts on it here.

## Related

- Issue(s): none
- Notes for reviewers: three new files, nothing existing is modified. This is the
  base of a series adding the TI AM67 XHAL port; the following PRs stack on it.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files — `tools/style/stylecheck.py` on
      both new headers: no findings
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile) —
      `RT-Posix-Simulator` links, `test/rt-ports/testbuild` ARMv7-M target builds and
      `RT-ARMCR8-GENERIC` builds clean (text 4884) with `arm-none-eabi-gcc 13.2.1`

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? This PR adds no `main()` and no demo, so it
  produces no flashable image on its own. Two checks were run against the device
  directly: assembling `crt0_v7r.S` with `-mcpu=cortex-r5` and these device
  parameters emits no VBAR access, and forcing `CRT0_VBAR_INIT` on with this device
  fails at compile time as the shared startup intends.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided — not applicable
- [x] Risks/limitations are documented below

Three new files under a new device directory. No existing device, startup source or
demo is modified, and the generic `ARMCR5` device is unchanged and remains the right
choice for an R5 without a vendor header.

The capability values come from the TI J722S TRM and are exercised by the port
running on the part; they have not been re-read from silicon ID registers.