### PR TITLE
T3_GEM_O1: add the XHAL port for the Cortex-R5F, the board and the demo

### DIFF
--- a/demos/various/RT-XHAL-T3-GEM-O1/AM67_R5F.ld
+++ b/demos/various/RT-XHAL-T3-GEM-O1/AM67_R5F.ld
@@ -1,0 +1,152 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/*
+ * T3 Gemstone O1 (TI AM67A/J722S) Cortex-R5F memory setup.
+ *
+ * The image is loaded by the Linux k3-r5 remoteproc driver, addresses are
+ * device addresses as seen by the R5F core and must match the reserved
+ * memory carveouts in the host device tree.
+ */
+
+__und_stack_size__ = DEFINED(__und_stack_size__) ? __und_stack_size__ : 0x100;
+__abt_stack_size__ = DEFINED(__abt_stack_size__) ? __abt_stack_size__ : 0x100;
+__fiq_stack_size__ = DEFINED(__fiq_stack_size__) ? __fiq_stack_size__ : 0x100;
+__irq_stack_size__ = DEFINED(__irq_stack_size__) ? __irq_stack_size__ : 0x400;
+__svc_stack_size__ = DEFINED(__svc_stack_size__) ? __svc_stack_size__ : 0x100;
+__sys_stack_size__ = DEFINED(__sys_stack_size__) ? __sys_stack_size__ : 0x800;
+
+MEMORY
+{
+    /* The MCU domain core has a single usable TCM, mapped at address 0 by
+       ti,loczrama = <0> (the ATCM lands at 0x41010000 and is left disabled
+       by ti,atcm-enable = <0>). Vectors, the pre-MPU boot code and the
+       banked mode stacks therefore share it.
+
+       It is split into two regions so that the vectors are guaranteed to
+       land at address 0, where the Cortex-R5 fetches its reset vector (it
+       has no VBAR). A single region would not do: the sections below are
+       allocated in script order, so .tcm_probe would take address 0 and
+       push the vectors out of reach.
+
+       The top 64 bytes are left out of both regions, reserved for the boot
+       witness and fault blocks written by board.c and for the temporary
+       boot stack that grows down from there.*/
+    tcm_vec   (rx)  : org = 0x00000000, len = 256
+    tcm_code  (rx)  : org = 0x00000100, len = 1k
+    tcm       (rw)  : org = 0x00000500, len = 32k - 256 - 1k - 64
+    ddr_rsc   (rw)  : org = 0xA1100000, len = 4k    /* resource table      */
+    ddr_trace (rw)  : org = 0xA1110000, len = 16k   /* remoteproc trace    */
+    /* Code and data get separate regions so that the linker can emit a
+       read-execute segment and a read-write one instead of merging both
+       into a single RWX PT_LOAD. Nothing else depends on the boundary:
+       the MPU covers the whole of DDR with one region, and the split
+       stays inside the same remoteproc carveout.*/
+    ddr_code  (rx)  : org = 0xA1240000, len = 256k   /* text, rodata       */
+    ddr_data  (rw)  : org = 0xA1280000, len = 13824k /* data, bss, heap    */
+
+    /* Unused regions referenced by the generic memory rules.*/
+    flash0 (rx) : org = 0x00000000, len = 0
+    flash1 (rx) : org = 0x00000000, len = 0
+    flash2 (rx) : org = 0x00000000, len = 0
+    flash3 (rx) : org = 0x00000000, len = 0
+    flash4 (rx) : org = 0x00000000, len = 0
+    flash5 (rx) : org = 0x00000000, len = 0
+    flash6 (rx) : org = 0x00000000, len = 0
+    flash7 (rx) : org = 0x00000000, len = 0
+    ram0   (wx) : org = 0x00000000, len = 0
+    ram1   (wx) : org = 0x00000000, len = 0
+    ram2   (wx) : org = 0x00000000, len = 0
+    ram3   (wx) : org = 0x00000000, len = 0
+    ram4   (wx) : org = 0x00000000, len = 0
+    ram5   (wx) : org = 0x00000000, len = 0
+    ram6   (wx) : org = 0x00000000, len = 0
+    ram7   (wx) : org = 0x00000000, len = 0
+}
+
+/* For each data/text section two region are defined, a virtual region
+   and a load region (_LMA suffix).*/
+
+/* Region to be used for exception vectors.*/
+REGION_ALIAS("VECTORS_FLASH", tcm_vec);
+REGION_ALIAS("VECTORS_FLASH_LMA", tcm_vec);
+
+/* Region to be used for constructors and destructors.*/
+REGION_ALIAS("XTORS_FLASH", ddr_code);
+REGION_ALIAS("XTORS_FLASH_LMA", ddr_code);
+
+/* Region to be used for code text.*/
+REGION_ALIAS("TEXT_FLASH", ddr_code);
+REGION_ALIAS("TEXT_FLASH_LMA", ddr_code);
+
+/* Region to be used for read only data.*/
+REGION_ALIAS("RODATA_FLASH", ddr_code);
+REGION_ALIAS("RODATA_FLASH_LMA", ddr_code);
+
+/* Region to be used for various.*/
+REGION_ALIAS("VARIOUS_FLASH", ddr_code);
+REGION_ALIAS("VARIOUS_FLASH_LMA", ddr_code);
+
+/* Region to be used for RAM(n) initialization data.*/
+REGION_ALIAS("RAM_INIT_FLASH_LMA", ddr_code);
+
+/* RAM region to be used for the banked mode stacks.*/
+REGION_ALIAS("STACKS_RAM", tcm);
+REGION_ALIAS("C1_STACKS_RAM", tcm);
+
+/* RAM region to be used for data segment.*/
+REGION_ALIAS("DATA_RAM", ddr_data);
+REGION_ALIAS("DATA_RAM_LMA", ddr_data);
+
+/* RAM region to be used for BSS segment.*/
+REGION_ALIAS("BSS_RAM", ddr_data);
+
+/* RAM region to be used for the default heap.*/
+REGION_ALIAS("HEAP_RAM", ddr_data);
+
+/* RemoteProc sections at fixed device addresses.*/
+SECTIONS
+{
+    .resource_table : ALIGN(4)
+    {
+        KEEP(*(.resource_table))
+    } > ddr_rsc
+
+    .trace (NOLOAD) : ALIGN(4)
+    {
+        KEEP(*(.trace))
+    } > ddr_trace
+
+    /* Bring-up boot probe, runs from TCM before any DDR execution, the
+       banked mode stacks are allocated after it by rules_stacks.ld.*/
+    .tcm_probe : ALIGN(4)
+    {
+        KEEP(*(.tcm_probe))
+    } > tcm_code
+}
+
+/* Stack rules inclusion.*/
+INCLUDE rules_stacks.ld
+INCLUDE rules_stacks_c1.ld
+
+/* Code rules inclusion.*/
+INCLUDE rules_code.ld
+
+/* Data rules inclusion.*/
+INCLUDE rules_data.ld
+
+/* Memory rules inclusion.*/
+INCLUDE rules_memory.ld

--- a/demos/various/RT-XHAL-T3-GEM-O1/Makefile
+++ b/demos/various/RT-XHAL-T3-GEM-O1/Makefile
@@ -1,0 +1,223 @@
+##############################################################################
+# Build global options
+# NOTE: Can be overridden externally.
+#
+
+# Compiler options here.
+ifeq ($(USE_OPT),)
+  USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
+endif
+
+# C specific options here (added to USE_OPT).
+ifeq ($(USE_COPT),)
+  USE_COPT =
+endif
+
+# C++ specific options here (added to USE_OPT).
+ifeq ($(USE_CPPOPT),)
+  USE_CPPOPT = -fno-rtti
+endif
+
+# Enable this if you want the linker to remove unused code and data.
+ifeq ($(USE_LINK_GC),)
+  USE_LINK_GC = yes
+endif
+
+# Linker extra options here. The ELF entry point is used as the R5F boot
+# vector by the Linux k3-r5 remoteproc driver and must be the vector table.
+ifeq ($(USE_LDOPT),)
+  USE_LDOPT = --entry=_vectors
+endif
+
+# Enable this if you want link time optimizations (LTO).
+ifeq ($(USE_LTO),)
+  USE_LTO = no
+endif
+
+# If enabled, this option allows to compile the application in THUMB mode.
+ifeq ($(USE_THUMB),)
+  USE_THUMB = no
+endif
+
+# Enable this if you want to see the full log while compiling.
+ifeq ($(USE_VERBOSE_COMPILE),)
+  USE_VERBOSE_COMPILE = no
+endif
+
+# If enabled, this option makes the build process faster by not compiling
+# modules not used in the current configuration.
+ifeq ($(USE_SMART_BUILD),)
+  USE_SMART_BUILD = yes
+endif
+
+#
+# Build global options
+##############################################################################
+
+##############################################################################
+# Architecture or project specific options
+#
+
+# Stack size to be allocated to the ARM System/User stack. This stack is
+# the stack used by the main() function before the RTOS is enabled.
+ifeq ($(USE_SYSTEM_STACKSIZE),)
+  USE_SYSTEM_STACKSIZE = 0x800
+endif
+
+# Stack size to the allocated to the ARM IRQ stack.
+ifeq ($(USE_IRQ_STACKSIZE),)
+  USE_IRQ_STACKSIZE = 0x400
+endif
+
+# Stack size to the allocated to the ARM FIQ stack.
+ifeq ($(USE_FIQ_STACKSIZE),)
+  USE_FIQ_STACKSIZE = 0x100
+endif
+
+# Stack size to the allocated to the ARM Supervisor stack.
+ifeq ($(USE_SUPERVISOR_STACKSIZE),)
+  USE_SUPERVISOR_STACKSIZE = 0x100
+endif
+
+# Stack size to the allocated to the ARM Undefined stack.
+ifeq ($(USE_UND_STACKSIZE),)
+  USE_UND_STACKSIZE = 0x100
+endif
+
+# Stack size to the allocated to the ARM Abort stack.
+ifeq ($(USE_ABT_STACKSIZE),)
+  USE_ABT_STACKSIZE = 0x100
+endif
+
+# Enables the use of FPU (no, softfp, hard). The R5F has a VFPv3-D16 FPU.
+ifeq ($(USE_FPU),)
+  USE_FPU = hard
+endif
+
+#
+# Architecture or project specific options
+##############################################################################
+
+##############################################################################
+# Project, target, sources and paths
+#
+
+# Define project name here.
+PROJECT = chibios-xhal-t3-gem-o1
+
+# Target settings.
+MCU = cortex-r5
+
+# Imported source files and paths.
+CHIBIOS  := ../../..
+CONFDIR  := ./cfg
+BUILDDIR := ./build
+DEPDIR   := ./.dep
+
+# Licensing files.
+include $(CHIBIOS)/os/license/license.mk
+# Startup files.
+include $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC/mk/startup_am67r5f.mk
+# OOP and utilities.
+include $(CHIBIOS)/os/common/oop/oop.mk
+include $(CHIBIOS)/os/common/utils/utils.mk
+# XHAL files.
+include $(CHIBIOS)/os/xhal/xhal.mk
+include $(CHIBIOS)/os/xhal/ports/TI/AM67/platform.mk
+include $(CHIBIOS)/os/hal/boards/T3_GEM_O1/board.mk
+# RTOS files (optional).
+include $(CHIBIOS)/os/rt/rt.mk
+include $(CHIBIOS)/os/common/ports/ARMv7-R/compilers/GCC/mk/port_am67.mk
+# Auto-build files in ./source recursively.
+include $(CHIBIOS)/tools/mk/autobuild.mk
+# Other files (optional).
+#include $(CHIBIOS)/os/test/test.mk
+#include $(CHIBIOS)/test/rt/rt_test.mk
+#include $(CHIBIOS)/test/oslib/oslib_test.mk
+
+# Define linker script file here.
+LDSCRIPT = AM67_R5F.ld
+
+# C sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CSRC = $(ALLCSRC) \
+       $(TESTSRC) \
+       main.c
+
+# C++ sources that can be compiled in ARM or THUMB mode depending on the global
+# setting.
+CPPSRC = $(ALLCPPSRC)
+
+# C sources to be compiled in ARM mode regardless of the global setting.
+ACSRC =
+
+# C++ sources to be compiled in ARM mode regardless of the global setting.
+ACPPSRC =
+
+# C sources to be compiled in THUMB mode regardless of the global setting.
+TCSRC =
+
+# C++ sources to be compiled in THUMB mode regardless of the global setting.
+TCPPSRC =
+
+# List ASM source files here.
+ASMSRC = $(ALLASMSRC)
+
+# List ASM with preprocessor source files here.
+ASMXSRC = $(ALLXASMSRC)
+
+# Inclusion directories.
+INCDIR = $(CONFDIR) $(ALLINC) $(TESTINC)
+
+# ARM-specific options here.
+AOPT = -marm
+
+# THUMB-specific options here.
+TOPT = -mthumb -DTHUMB
+
+# Define C warning options here.
+CWARN = -Wall -Wextra -Wundef -Wstrict-prototypes
+
+# Define C++ warning options here.
+CPPWARN = -Wall -Wextra -Wundef
+
+#
+# Project, target, sources and paths
+##############################################################################
+
+##############################################################################
+# Start of user section
+#
+
+# List all user C define here, like -D_DEBUG=1
+# The core feature set comes from the AM67R5F startup device, it is not
+# overridable from here.
+UDEFS =
+
+# Define ASM defines here
+UADEFS =
+
+# List all user directories here
+UINCDIR =
+
+# List the user directory to look for the libraries here
+ULIBDIR =
+
+# List all user libraries here
+ULIBS =
+
+#
+# End of user section
+##############################################################################
+
+##############################################################################
+# Common rules
+#
+
+RULESPATH = $(CHIBIOS)/os/common/startup/ARMCRx/compilers/GCC
+include $(RULESPATH)/mk/arm-none-eabi.mk
+include $(RULESPATH)/mk/rules.mk
+
+#
+# Common rules
+##############################################################################

--- a/demos/various/RT-XHAL-T3-GEM-O1/cfg/chconf.h
+++ b/demos/various/RT-XHAL-T3-GEM-O1/cfg/chconf.h
@@ -1,0 +1,869 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rt/templates/chconf.h
+ * @brief   Configuration file template.
+ * @details A copy of this file must be placed in each project directory, it
+ *          contains the application specific kernel settings.
+ *
+ * @addtogroup config
+ * @details Kernel related settings and hooks.
+ * @{
+ */
+
+#ifndef CHCONF_H
+#define CHCONF_H
+
+#define _CHIBIOS_RT_CONF_
+#define _CHIBIOS_RT_CONF_VER_8_0_
+
+/*===========================================================================*/
+/**
+ * @name System settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Handling of instances.
+ * @note    If enabled then threads assigned to various instances can
+ *          interact each other using the same synchronization objects.
+ *          If disabled then each OS instance is a separate world, no
+ *          direct interactions are handled by the OS.
+ */
+#if !defined(CH_CFG_SMP_MODE)
+#define CH_CFG_SMP_MODE                     FALSE
+#endif
+
+/**
+ * @brief   Runtime Faults Collection Unit.
+ * @details If enabled then detected runtime faults are collected and made
+ *          available to the application.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_RFCU)
+#define CH_CFG_USE_RFCU                     TRUE
+#endif
+
+/**
+ * @brief   Kernel hardening level.
+ * @details This option is the level of functional-safety checks enabled
+ *          in the kerkel. The meaning is:
+ *          - 0: No checks, maximum performance.
+ *          - 1: Reasonable checks.
+ *          - 2: All checks.
+ *          .
+ */
+#if !defined(CH_CFG_HARDENING_LEVEL)
+#define CH_CFG_HARDENING_LEVEL              0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name System timers settings
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System time counter resolution.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ * @note    In tick-less mode this value must match the physical system tick
+ *          timer counter width.
+ */
+#if !defined(CH_CFG_ST_RESOLUTION)
+#define CH_CFG_ST_RESOLUTION                32
+#endif
+
+/**
+ * @brief   System tick frequency.
+ * @details Frequency of the system timer that drives the system ticks. This
+ *          setting also defines the system tick time unit.
+ * @note    This must be a frequency that is obtainable from the system tick
+ *          timer frequency.
+ */
+#if !defined(CH_CFG_ST_FREQUENCY)
+#define CH_CFG_ST_FREQUENCY                 1000
+#endif
+
+/**
+ * @brief   Time intervals data size.
+ * @note    Allowed values are 16, 32 or 64 bits.
+ */
+#if !defined(CH_CFG_INTERVALS_SIZE)
+#define CH_CFG_INTERVALS_SIZE               32
+#endif
+
+/**
+ * @brief   Time types data size.
+ * @note    Allowed values are 16 or 32 bits.
+ */
+#if !defined(CH_CFG_TIME_TYPES_SIZE)
+#define CH_CFG_TIME_TYPES_SIZE              32
+#endif
+
+/**
+ * @brief   Time delta constant for the tick-less mode.
+ * @note    If this value is zero then the system uses the classic
+ *          periodic tick. This value represents the minimum number
+ *          of ticks that is safe to specify in a timeout directive.
+ *          The value one is not valid, timeouts are rounded up to
+ *          this value.
+ */
+#if !defined(CH_CFG_ST_TIMEDELTA)
+#define CH_CFG_ST_TIMEDELTA                 0
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel parameters and options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Round robin interval.
+ * @details This constant is the number of system ticks allowed for the
+ *          threads before preemption occurs. Setting this value to zero
+ *          disables the preemption for threads with equal priority and the
+ *          round robin becomes cooperative. Note that higher priority
+ *          threads can still preempt, the kernel is always preemptive.
+ * @note    Disabling the round robin preemption makes the kernel more compact
+ *          and generally faster.
+ * @note    The round robin preemption is not supported in tickless mode and
+ *          must be set to zero in that case.
+ */
+#if !defined(CH_CFG_TIME_QUANTUM)
+#define CH_CFG_TIME_QUANTUM                 0
+#endif
+
+/**
+ * @brief   Idle thread automatic spawn suppression.
+ * @details When this option is activated the function @p chSysInit()
+ *          does not spawn the idle thread. The application @p main()
+ *          function becomes the idle thread and must implement an
+ *          infinite loop.
+ */
+#if !defined(CH_CFG_NO_IDLE_THREAD)
+#define CH_CFG_NO_IDLE_THREAD               FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Performance options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   OS optimization.
+ * @details If enabled then time efficient rather than space efficient code
+ *          is used when two possible implementations exist.
+ *
+ * @note    This is not related to the compiler optimization options.
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_OPTIMIZE_SPEED)
+#define CH_CFG_OPTIMIZE_SPEED               TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Subsystem options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Time Measurement APIs.
+ * @details If enabled then the time measurement APIs are included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TM)
+#define CH_CFG_USE_TM                       FALSE
+#endif
+
+/**
+ * @brief   Time Stamps APIs.
+ * @details If enabled then the time stamps APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_TIMESTAMP)
+#define CH_CFG_USE_TIMESTAMP                TRUE
+#endif
+
+/**
+ * @brief   Threads registry APIs.
+ * @details If enabled then the registry APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_REGISTRY)
+#define CH_CFG_USE_REGISTRY                 TRUE
+#endif
+
+/**
+ * @brief   Threads synchronization APIs.
+ * @details If enabled then the @p chThdWait() function is included in
+ *          the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_WAITEXIT)
+#define CH_CFG_USE_WAITEXIT                 TRUE
+#endif
+
+/**
+ * @brief   Semaphores APIs.
+ * @details If enabled then the Semaphores APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES)
+#define CH_CFG_USE_SEMAPHORES               TRUE
+#endif
+
+/**
+ * @brief   Semaphores queuing mode.
+ * @details If enabled then the threads are enqueued on semaphores by
+ *          priority rather than in FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_SEMAPHORES_PRIORITY)
+#define CH_CFG_USE_SEMAPHORES_PRIORITY      FALSE
+#endif
+
+/**
+ * @brief   Mutexes APIs.
+ * @details If enabled then the mutexes APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MUTEXES)
+#define CH_CFG_USE_MUTEXES                  TRUE
+#endif
+
+/**
+ * @brief   Enables recursive behavior on mutexes.
+ * @note    Recursive mutexes are heavier and have an increased
+ *          memory footprint.
+ *
+ * @note    The default is @p FALSE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_MUTEXES_RECURSIVE)
+#define CH_CFG_USE_MUTEXES_RECURSIVE        FALSE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs.
+ * @details If enabled then the conditional variables APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MUTEXES.
+ */
+#if !defined(CH_CFG_USE_CONDVARS)
+#define CH_CFG_USE_CONDVARS                 TRUE
+#endif
+
+/**
+ * @brief   Conditional Variables APIs with timeout.
+ * @details If enabled then the conditional variables APIs with timeout
+ *          specification are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_CONDVARS.
+ */
+#if !defined(CH_CFG_USE_CONDVARS_TIMEOUT)
+#define CH_CFG_USE_CONDVARS_TIMEOUT         TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs.
+ * @details If enabled then the event flags APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_EVENTS)
+#define CH_CFG_USE_EVENTS                   TRUE
+#endif
+
+/**
+ * @brief   Events Flags APIs with timeout.
+ * @details If enabled then the events APIs with timeout specification
+ *          are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_EVENTS.
+ */
+#if !defined(CH_CFG_USE_EVENTS_TIMEOUT)
+#define CH_CFG_USE_EVENTS_TIMEOUT           TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages APIs.
+ * @details If enabled then the synchronous messages APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MESSAGES)
+#define CH_CFG_USE_MESSAGES                 TRUE
+#endif
+
+/**
+ * @brief   Synchronous Messages queuing mode.
+ * @details If enabled then messages are served by priority rather than in
+ *          FIFO order.
+ *
+ * @note    The default is @p FALSE. Enable this if you have special
+ *          requirements.
+ * @note    Requires @p CH_CFG_USE_MESSAGES.
+ */
+#if !defined(CH_CFG_USE_MESSAGES_PRIORITY)
+#define CH_CFG_USE_MESSAGES_PRIORITY        FALSE
+#endif
+
+/**
+ * @brief   Dynamic Threads APIs.
+ * @details If enabled then the dynamic threads creation APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_WAITEXIT.
+ * @note    Requires @p CH_CFG_USE_HEAP and/or @p CH_CFG_USE_MEMPOOLS.
+ */
+#if !defined(CH_CFG_USE_DYNAMIC)
+#define CH_CFG_USE_DYNAMIC                  TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name OSLIB options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Mailboxes APIs.
+ * @details If enabled then the asynchronous messages (mailboxes) APIs are
+ *          included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_SEMAPHORES.
+ */
+#if !defined(CH_CFG_USE_MAILBOXES)
+#define CH_CFG_USE_MAILBOXES                TRUE
+#endif
+
+/**
+ * @brief   Memory checks APIs.
+ * @details If enabled then the memory checks APIs are included in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCHECKS)
+#define CH_CFG_USE_MEMCHECKS                TRUE
+#endif
+
+/**
+ * @brief   Core Memory Manager APIs.
+ * @details If enabled then the core memory manager APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMCORE)
+#define CH_CFG_USE_MEMCORE                  TRUE
+#endif
+
+/**
+ * @brief   Managed RAM size.
+ * @details Size of the RAM area to be managed by the OS. If set to zero
+ *          then the whole available RAM is used. The core memory is made
+ *          available to the heap allocator and/or can be used directly through
+ *          the simplified core memory allocator.
+ *
+ * @note    In order to let the OS manage the whole RAM the linker script must
+ *          provide the @p __heap_base__ and @p __heap_end__ symbols.
+ * @note    Requires @p CH_CFG_USE_MEMCORE.
+ */
+#if !defined(CH_CFG_MEMCORE_SIZE)
+#define CH_CFG_MEMCORE_SIZE                 0
+#endif
+
+/**
+ * @brief   Heap Allocator APIs.
+ * @details If enabled then the memory heap allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ * @note    Requires @p CH_CFG_USE_MEMCORE and either @p CH_CFG_USE_MUTEXES or
+ *          @p CH_CFG_USE_SEMAPHORES.
+ * @note    Mutexes are recommended.
+ */
+#if !defined(CH_CFG_USE_HEAP)
+#define CH_CFG_USE_HEAP                     TRUE
+#endif
+
+/**
+ * @brief   Memory Pools Allocator APIs.
+ * @details If enabled then the memory pools allocator APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_MEMPOOLS)
+#define CH_CFG_USE_MEMPOOLS                 TRUE
+#endif
+
+/**
+ * @brief   Objects FIFOs APIs.
+ * @details If enabled then the objects FIFOs APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_FIFOS)
+#define CH_CFG_USE_OBJ_FIFOS                TRUE
+#endif
+
+/**
+ * @brief   Pipes APIs.
+ * @details If enabled then the pipes APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_PIPES)
+#define CH_CFG_USE_PIPES                    TRUE
+#endif
+
+/**
+ * @brief   Objects Caches APIs.
+ * @details If enabled then the objects caches APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_OBJ_CACHES)
+#define CH_CFG_USE_OBJ_CACHES               TRUE
+#endif
+
+/**
+ * @brief   Delegate threads APIs.
+ * @details If enabled then the delegate threads APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_DELEGATES)
+#define CH_CFG_USE_DELEGATES                TRUE
+#endif
+
+/**
+ * @brief   Jobs Queues APIs.
+ * @details If enabled then the jobs queues APIs are included
+ *          in the kernel.
+ *
+ * @note    The default is @p TRUE.
+ */
+#if !defined(CH_CFG_USE_JOBS)
+#define CH_CFG_USE_JOBS                     TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Objects factory options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Objects Factory APIs.
+ * @details If enabled then the objects factory APIs are included in the
+ *          kernel.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_CFG_USE_FACTORY)
+#define CH_CFG_USE_FACTORY                  TRUE
+#endif
+
+/**
+ * @brief   Maximum length for object names.
+ * @details If the specified length is zero then the name is stored by
+ *          pointer but this could have unintended side effects.
+ */
+#if !defined(CH_CFG_FACTORY_MAX_NAMES_LENGTH)
+#define CH_CFG_FACTORY_MAX_NAMES_LENGTH     8
+#endif
+
+/**
+ * @brief   Enables the registry of generic objects.
+ */
+#if !defined(CH_CFG_FACTORY_OBJECTS_REGISTRY)
+#define CH_CFG_FACTORY_OBJECTS_REGISTRY     TRUE
+#endif
+
+/**
+ * @brief   Enables factory for generic buffers.
+ */
+#if !defined(CH_CFG_FACTORY_GENERIC_BUFFERS)
+#define CH_CFG_FACTORY_GENERIC_BUFFERS      TRUE
+#endif
+
+/**
+ * @brief   Enables factory for semaphores.
+ */
+#if !defined(CH_CFG_FACTORY_SEMAPHORES)
+#define CH_CFG_FACTORY_SEMAPHORES           TRUE
+#endif
+
+/**
+ * @brief   Enables factory for mailboxes.
+ */
+#if !defined(CH_CFG_FACTORY_MAILBOXES)
+#define CH_CFG_FACTORY_MAILBOXES            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for objects FIFOs.
+ */
+#if !defined(CH_CFG_FACTORY_OBJ_FIFOS)
+#define CH_CFG_FACTORY_OBJ_FIFOS            TRUE
+#endif
+
+/**
+ * @brief   Enables factory for Pipes.
+ */
+#if !defined(CH_CFG_FACTORY_PIPES) || defined(__DOXYGEN__)
+#define CH_CFG_FACTORY_PIPES                TRUE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Debug options
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   Debug option, kernel statistics.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_STATISTICS)
+#define CH_DBG_STATISTICS                   FALSE
+#endif
+
+/**
+ * @brief   Debug option, system state check.
+ * @details If enabled the correct call protocol for system APIs is checked
+ *          at runtime.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_SYSTEM_STATE_CHECK)
+#define CH_DBG_SYSTEM_STATE_CHECK           FALSE
+#endif
+
+/**
+ * @brief   Debug option, parameters checks.
+ * @details If enabled then the checks on the API functions input
+ *          parameters are activated.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_CHECKS)
+#define CH_DBG_ENABLE_CHECKS                FALSE
+#endif
+
+/**
+ * @brief   Debug option, consistency checks.
+ * @details If enabled then all the assertions in the kernel code are
+ *          activated. This includes consistency checks inside the kernel,
+ *          runtime anomalies and port-defined checks.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_ENABLE_ASSERTS)
+#define CH_DBG_ENABLE_ASSERTS               FALSE
+#endif
+
+/**
+ * @brief   Debug option, trace buffer.
+ * @details If enabled then the trace buffer is activated.
+ *
+ * @note    The default is @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_MASK)
+#define CH_DBG_TRACE_MASK                   CH_DBG_TRACE_MASK_DISABLED
+#endif
+
+/**
+ * @brief   Trace buffer entries.
+ * @note    The trace buffer is only allocated if @p CH_DBG_TRACE_MASK is
+ *          different from @p CH_DBG_TRACE_MASK_DISABLED.
+ */
+#if !defined(CH_DBG_TRACE_BUFFER_SIZE)
+#define CH_DBG_TRACE_BUFFER_SIZE            128
+#endif
+
+/**
+ * @brief   Debug option, stack checks.
+ * @details If enabled then a runtime stack check is performed.
+ *
+ * @note    The default is @p FALSE.
+ * @note    The stack check is performed in a architecture/port dependent way.
+ *          It may not be implemented or some ports.
+ * @note    The default failure mode is to halt the system with the global
+ *          @p panic_msg variable set to @p NULL.
+ */
+/* Enabled deliberately: with this FALSE a stack overflow is not detected at
+   all, it silently corrupts adjacent memory and the whole system dies with no
+   message (cost us a debugging round -- the trace simply stopped after
+   "kernel started" with remoteproc still reporting "running"). Halting on
+   overflow is far easier to diagnose than silent corruption. */
+#if !defined(CH_DBG_ENABLE_STACK_CHECK)
+#define CH_DBG_ENABLE_STACK_CHECK           TRUE
+#endif
+
+/**
+ * @brief   Debug option, stacks initialization.
+ * @details If enabled then the threads working area is filled with a byte
+ *          value when a thread is created. This can be useful for the
+ *          runtime measurement of the used stack.
+ *
+ * @note    The default is @p FALSE.
+ */
+#if !defined(CH_DBG_FILL_THREADS)
+#define CH_DBG_FILL_THREADS                 FALSE
+#endif
+
+/**
+ * @brief   Debug option, threads profiling.
+ * @details If enabled then a field is added to the @p thread_t structure that
+ *          counts the system ticks occurred while executing the thread.
+ *
+ * @note    The default is @p FALSE.
+ * @note    This debug option is not currently compatible with the
+ *          tickless mode.
+ */
+#if !defined(CH_DBG_THREADS_PROFILING)
+#define CH_DBG_THREADS_PROFILING            FALSE
+#endif
+
+/** @} */
+
+/*===========================================================================*/
+/**
+ * @name Kernel hooks
+ * @{
+ */
+/*===========================================================================*/
+
+/**
+ * @brief   System structure extension.
+ * @details User fields added to the end of the @p ch_system_t structure.
+ */
+#define CH_CFG_SYSTEM_EXTRA_FIELDS                                          \
+  /* Add system custom fields here.*/
+
+/**
+ * @brief   System initialization hook.
+ * @details User initialization code added to the @p chSysInit() function
+ *          just before interrupts are enabled globally.
+ */
+#define CH_CFG_SYSTEM_INIT_HOOK() do {                                      \
+  /* Add system initialization code here.*/                                 \
+} while (false)
+
+/**
+ * @brief   OS instance structure extension.
+ * @details User fields added to the end of the @p os_instance_t structure.
+ */
+#define CH_CFG_OS_INSTANCE_EXTRA_FIELDS                                     \
+  /* Add OS instance custom fields here.*/
+
+/**
+ * @brief   OS instance initialization hook.
+ *
+ * @param[in] oip       pointer to the @p os_instance_t structure
+ */
+#define CH_CFG_OS_INSTANCE_INIT_HOOK(oip) do {                              \
+  /* Add OS instance initialization code here.*/                            \
+} while (false)
+
+/**
+ * @brief   Threads descriptor structure extension.
+ * @details User fields added to the end of the @p thread_t structure.
+ */
+#define CH_CFG_THREAD_EXTRA_FIELDS                                          \
+  /* Add threads custom fields here.*/
+
+/**
+ * @brief   Threads initialization hook.
+ * @details User initialization code added to the @p _thread_init() function.
+ *
+ * @note    It is invoked from within @p _thread_init() and implicitly from all
+ *          the threads creation APIs.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_INIT_HOOK(tp) do {                                    \
+  /* Add threads initialization code here.*/                                \
+} while (false)
+
+/**
+ * @brief   Threads finalization hook.
+ * @details User finalization code added to the @p chThdExit() API.
+ *
+ * @param[in] tp        pointer to the @p thread_t structure
+ */
+#define CH_CFG_THREAD_EXIT_HOOK(tp) do {                                    \
+  /* Add threads finalization code here.*/                                  \
+} while (false)
+
+/**
+ * @brief   Context switch hook.
+ * @details This hook is invoked just before switching between threads.
+ *
+ * @param[in] ntp       thread being switched in
+ * @param[in] otp       thread being switched out
+ */
+#define CH_CFG_CONTEXT_SWITCH_HOOK(ntp, otp) do {                           \
+  /* Context switch code here.*/                                            \
+} while (false)
+
+/**
+ * @brief   ISR enter hook.
+ */
+#define CH_CFG_IRQ_PROLOGUE_HOOK() do {                                     \
+  /* IRQ prologue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   ISR exit hook.
+ */
+#define CH_CFG_IRQ_EPILOGUE_HOOK() do {                                     \
+  /* IRQ epilogue code here.*/                                              \
+} while (false)
+
+/**
+ * @brief   Idle thread enter hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to activate a power saving mode.
+ */
+#define CH_CFG_IDLE_ENTER_HOOK() do {                                       \
+  /* Idle-enter code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle thread leave hook.
+ * @note    This hook is invoked within a critical zone, no OS functions
+ *          should be invoked from here.
+ * @note    This macro can be used to deactivate a power saving mode.
+ */
+#define CH_CFG_IDLE_LEAVE_HOOK() do {                                       \
+  /* Idle-leave code here.*/                                                \
+} while (false)
+
+/**
+ * @brief   Idle Loop hook.
+ * @details This hook is continuously invoked by the idle thread loop.
+ */
+#define CH_CFG_IDLE_LOOP_HOOK() do {                                        \
+  /* Idle loop code here.*/                                                 \
+} while (false)
+
+/**
+ * @brief   System tick event hook.
+ * @details This hook is invoked in the system tick handler immediately
+ *          after processing the virtual timers queue.
+ */
+#define CH_CFG_SYSTEM_TICK_HOOK() do {                                      \
+  /* System tick event code here.*/                                         \
+} while (false)
+
+/**
+ * @brief   System halt hook.
+ * @details This hook is invoked in case to a system halting error before
+ *          the system is halted.
+ */
+#define CH_CFG_SYSTEM_HALT_HOOK(reason) do {                                \
+  /* System halt code here.*/                                               \
+} while (false)
+
+/**
+ * @brief   Trace hook.
+ * @details This hook is invoked each time a new record is written in the
+ *          trace buffer.
+ */
+#define CH_CFG_TRACE_HOOK(tep) do {                                         \
+  /* Trace code here.*/                                                     \
+} while (false)
+
+/**
+ * @brief   Runtime Faults Collection Unit hook.
+ * @details This hook is invoked each time new faults are collected and stored.
+ */
+#define CH_CFG_RUNTIME_FAULTS_HOOK(mask) do {                               \
+  /* Faults handling code here.*/                                           \
+} while (false)
+
+/**
+ * @brief   Safety checks hook.
+ * @details This hook is invoked when there is a safety violation and the
+ *          system is going to stop.
+ */
+#define CH_CFG_SAFETY_CHECK_HOOK(l, f) do {                                 \
+  /* Safety handling code here.*/                                           \
+  chSysHalt(f);                                                             \
+} while (false)
+
+/** @} */
+
+/*===========================================================================*/
+/* Port-specific settings (override port settings defaulted in chcore.h).    */
+/*===========================================================================*/
+
+#endif  /* CHCONF_H */
+
+/** @} */

--- a/demos/various/RT-XHAL-T3-GEM-O1/cfg/xhalconf.h
+++ b/demos/various/RT-XHAL-T3-GEM-O1/cfg/xhalconf.h
@@ -1,0 +1,191 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    templates/xhalconf.h
+ * @brief   XHAL configuration header.
+ * @details XHAL configuration file, this file allows to enable or disable the
+ *          various device drivers from your application. You may also use
+ *          this file in order to override the device drivers default settings.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XHALCONF_H
+#define XHALCONF_H
+
+#define __CHIBIOS_XHAL_CONF__
+#define __CHIBIOS_XHAL_CONF_VER_1_0__
+
+#include "xmcuconf.h"
+
+/*===========================================================================*/
+/* HAL general settings.                                                     */
+/*===========================================================================*/
+
+#define HAL_USE_MUTUAL_EXCLUSION            TRUE
+#define HAL_USE_REGISTRY                    TRUE
+
+/*===========================================================================*/
+/* HAL enabled drivers.                                                      */
+/*===========================================================================*/
+
+#define HAL_USE_PAL                         FALSE
+#define HAL_USE_ADC                         FALSE
+#define HAL_USE_DAC                         FALSE
+#define HAL_USE_CAN                         FALSE
+#define HAL_USE_EFL                         FALSE
+#define HAL_USE_ETH                         FALSE
+#define HAL_USE_GPT                         FALSE
+#define HAL_USE_I2C                         FALSE
+#define HAL_USE_I2S                         FALSE
+#define HAL_USE_ICU                         FALSE
+#define HAL_USE_MMC_SPI                     FALSE
+#define HAL_USE_PWM                         FALSE
+#define HAL_USE_RTC                         FALSE
+#define HAL_USE_SDC                         FALSE
+#define HAL_USE_SIO                         TRUE
+#define HAL_USE_SPI                         FALSE
+#define HAL_USE_TRNG                        FALSE
+#define HAL_USE_USB                         FALSE
+#define HAL_USE_WDG                         FALSE
+#define HAL_USE_WSPI                        FALSE
+
+/*===========================================================================*/
+/* ADC driver settings.                                                      */
+/*===========================================================================*/
+
+#define ADC_USE_SYNCHRONIZATION             TRUE
+#define ADC_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* DAC driver settings.                                                      */
+/*===========================================================================*/
+
+#define DAC_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* CAN driver settings.                                                      */
+/*===========================================================================*/
+
+#define CAN_USE_SYNCHRONIZATION             TRUE
+#define CAN_USE_SLEEP_MODE                  TRUE
+#define CAN_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* GPT driver settings.                                                      */
+/*===========================================================================*/
+
+#define GPT_DEFAULT_FREQUENCY               1000000U
+#define GPT_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2C driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2C_USE_SYNCHRONIZATION             TRUE
+#define I2C_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* I2S driver settings.                                                      */
+/*===========================================================================*/
+
+#define I2S_USE_SYNCHRONIZATION             TRUE
+
+/*===========================================================================*/
+/* ICU driver settings.                                                      */
+/*===========================================================================*/
+
+#define ICU_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PWM driver settings.                                                      */
+/*===========================================================================*/
+
+#define PWM_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* PAL driver settings.                                                      */
+/*===========================================================================*/
+
+#define PAL_USE_CALLBACKS                   FALSE
+#define PAL_USE_WAIT                        FALSE
+
+/*===========================================================================*/
+/* ETH driver settings.                                                      */
+/*===========================================================================*/
+
+#define ETH_USE_SYNCHRONIZATION             TRUE
+#define ETH_USE_EVENTS                      FALSE
+#define ETH_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SDC driver settings.                                                      */
+/*===========================================================================*/
+
+#define SDC_USE_SYNCHRONIZATION             TRUE
+#define SDC_USE_CONFIGURATIONS              FALSE
+#define SDC_INIT_RETRY                      100
+#define SDC_MMC_SUPPORT                     FALSE
+#define SDC_NICE_WAITING                    TRUE
+#define SDC_INIT_OCR_V20                    0x50FF8000U
+#define SDC_INIT_OCR                        0x80100000U
+
+/*===========================================================================*/
+/* SIO driver settings.                                                      */
+/*===========================================================================*/
+
+#define SIO_DEFAULT_BITRATE                 115200
+#define SIO_USE_SYNCHRONIZATION             TRUE
+#define SIO_USE_STREAMS_INTERFACE           SIO_USE_SYNCHRONIZATION
+#define SIO_USE_BUFFERING                   TRUE
+#define SIO_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* SPI driver settings.                                                      */
+/*===========================================================================*/
+
+#define SPI_USE_SYNCHRONIZATION             TRUE
+#define SPI_USE_ASSERT_ON_ERROR             FALSE
+#define SPI_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* USB driver settings.                                                      */
+/*===========================================================================*/
+
+#define USB_USE_SYNCHRONIZATION             TRUE
+#define USB_USE_CONFIGURATIONS              FALSE
+
+/*===========================================================================*/
+/* Serial USB settings.                                                      */
+/*===========================================================================*/
+
+#define SERIAL_USB_USE_MODULE               FALSE
+#define SERIAL_USB_BUFFERS_SIZE             256U
+#define SERIAL_USB_BUFFERS_NUMBER           2U
+#define SERIAL_USB_SEND_ZLP                 TRUE
+#define SERIAL_USB_RX_PACKET_MODE           FALSE
+
+/*===========================================================================*/
+/* WSPI driver settings.                                                     */
+/*===========================================================================*/
+
+#define WSPI_USE_SYNCHRONIZATION            TRUE
+
+#endif /* XHALCONF_H */
+
+/** @} */

--- a/demos/various/RT-XHAL-T3-GEM-O1/cfg/xmcuconf.h
+++ b/demos/various/RT-XHAL-T3-GEM-O1/cfg/xmcuconf.h
@@ -1,0 +1,48 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    xmcuconf.h
+ * @brief   AM67 XHAL driver configuration.
+ * @details The R5F runs as a RemoteProc slave: clocks, power domains and
+ *          pin multiplexing belong to the Linux host, so there is no clock
+ *          tree configuration here. Only peripheral assignment and
+ *          interrupt priorities are the firmware's to choose.
+ *
+ * @addtogroup XHAL_CONF
+ * @{
+ */
+
+#ifndef XMCUCONF_H
+#define XMCUCONF_H
+
+#define AM67_MCUCONF
+
+/*
+ * VIM priorities, 0 is the most urgent and 15 the least. Same-priority
+ * lines cannot preempt each other, so peripherals share a level below the
+ * system tick, which keeps its default of 0.
+ */
+
+/*
+ * SIO driver system settings.
+ */
+#define AM67_SIO_USE_UART1                  TRUE
+#define AM67_SIO_UART1_IRQ_PRIORITY         8U
+
+#endif /* XMCUCONF_H */
+
+/** @} */

--- a/demos/various/RT-XHAL-T3-GEM-O1/main.c
+++ b/demos/various/RT-XHAL-T3-GEM-O1/main.c
@@ -63,7 +63,7 @@ static THD_FUNCTION(heartbeat, arg) {
   chRegSetThreadName("heartbeat");
 
   while (true) {
-    trace_printf("heartbeat %u t=%u ms", n, (unsigned)chVTGetSystemTimeX());
+    trace_printf("heartbeat %u t=%u ms\n", n, (unsigned)chVTGetSystemTimeX());
     console_write("heartbeat\r\n");
     n++;
     chThdSleepMilliseconds(1000);
@@ -98,7 +98,7 @@ int main(void) {
   chSysInit();
 
   trace_init();
-  trace_printf("RT-XHAL-T3-GEM-O1 starting");
+  trace_printf("RT-XHAL-T3-GEM-O1 starting\n");
 
   /* Console up.*/
   drvStart(&SIOD1, &sio_config);

--- a/demos/various/RT-XHAL-T3-GEM-O1/main.c
+++ b/demos/various/RT-XHAL-T3-GEM-O1/main.c
@@ -1,0 +1,115 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+#include <string.h>
+
+#include "ch.h"
+#include "hal.h"
+
+#include "trace.h"
+
+/*
+ * SIO configuration for the console. The default configuration would do,
+ * it is stated here so the demo shows what a board actually selects.
+ */
+static const SIOConfig sio_config = {
+  .baud                 = 115200U,
+  .lcr                  = TI_UART_LCR_8N1,
+  .fcr                  = TI_UART_FCR_FIFOEN | TI_UART_FCR_RXTRIGGER_8
+};
+
+/*
+ * Writes a string to the console, blocking until the last character has
+ * left the transmitter.
+ */
+static void console_write(const char *s) {
+  size_t n = strlen(s);
+
+  while (n > 0U) {
+    size_t wr = sioAsyncWriteX(&SIOD1, (const uint8_t *)s, n);
+
+    s += wr;
+    n -= wr;
+
+    if (n > 0U) {
+      /* TX FIFO full, let something else run before trying again.*/
+      chThdSleepMilliseconds(1);
+    }
+  }
+}
+
+/*
+ * Blinker thread, proves the scheduler preempts and the tick advances.
+ */
+static THD_WORKING_AREA(waHeartbeat, 512);
+static THD_FUNCTION(heartbeat, arg) {
+  unsigned n = 0U;
+
+  (void)arg;
+
+  chRegSetThreadName("heartbeat");
+
+  while (true) {
+    trace_printf("heartbeat %u t=%u ms", n, (unsigned)chVTGetSystemTimeX());
+    console_write("heartbeat\r\n");
+    n++;
+    chThdSleepMilliseconds(1000);
+  }
+}
+
+/*
+ * Echo loop, proves the receive path and the SIO synchronization API.
+ */
+static void echo_loop(void) {
+  uint8_t c;
+
+  while (true) {
+    msg_t msg = sioSynchronizeRX(&SIOD1, TIME_MS2I(1000));
+
+    if (msg == MSG_OK) {
+      while (sioAsyncReadX(&SIOD1, &c, 1U) == 1U) {
+        (void)sioAsyncWriteX(&SIOD1, &c, 1U);
+      }
+    }
+  }
+}
+
+int main(void) {
+
+  /* System initializations:
+     - HAL initialization, this also initializes the configured device
+       drivers and performs the board-specific initializations.
+     - Kernel initialization, the main() function becomes a thread and the
+       RTOS is active.*/
+  halInit();
+  chSysInit();
+
+  trace_init();
+  trace_printf("RT-XHAL-T3-GEM-O1 starting");
+
+  /* Console up.*/
+  drvStart(&SIOD1, &sio_config);
+
+  console_write("\r\n"
+                "ChibiOS/RT on " PLATFORM_NAME "\r\n"
+                "board: " BOARD_NAME "\r\n"
+                "type characters to have them echoed back\r\n");
+
+  chThdCreateStatic(waHeartbeat, sizeof (waHeartbeat),
+                    NORMALPRIO + 1, heartbeat, NULL);
+
+  echo_loop();
+}

--- a/demos/various/RT-XHAL-T3-GEM-O1/source/rsc_table.c
+++ b/demos/various/RT-XHAL-T3-GEM-O1/source/rsc_table.c
@@ -1,0 +1,66 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    rsc_table.c
+ * @brief   RemoteProc resource table.
+ * @details Minimal table declaring a single trace buffer, structures per
+ *          the Linux remoteproc firmware interface (linux/remoteproc.h).
+ *          The k3-r5 remoteproc driver reads this table from the ELF at
+ *          load time.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "board.h"
+
+#define RSC_TRACE               2U
+
+struct fw_rsc_trace {
+  uint32_t      type;
+  uint32_t      da;
+  uint32_t      len;
+  uint32_t      reserved;
+  uint8_t       name[32];
+};
+
+struct am67_resource_table {
+  /* Table header.*/
+  uint32_t      ver;
+  uint32_t      num;
+  uint32_t      reserved[2];
+  uint32_t      offset[1];
+  /* Entries.*/
+  struct fw_rsc_trace trace;
+};
+
+__attribute__((section(".resource_table"), used))
+const struct am67_resource_table resource_table = {
+  .ver          = 1U,
+  .num          = 1U,
+  .reserved     = {0U, 0U},
+  .offset       = {
+    offsetof(struct am67_resource_table, trace)
+  },
+  .trace        = {
+    .type       = RSC_TRACE,
+    .da         = AM67_TRACEBUF_BASE,
+    .len        = AM67_TRACEBUF_SIZE,
+    .reserved   = 0U,
+    .name       = "trace:mcu_r5fss0_0"
+  }
+};

--- a/demos/various/RT-XHAL-T3-GEM-O1/source/trace.c
+++ b/demos/various/RT-XHAL-T3-GEM-O1/source/trace.c
@@ -1,0 +1,146 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    trace.c
+ * @brief   RemoteProc trace buffer logging.
+ * @details Append-only character buffer in a non-cacheable DDR window, the
+ *          Linux remoteproc core exposes it through debugfs. Formatting is
+ *          intentionally minimal: %s, %c, %d, %u, %x and %% only.
+ */
+
+#include <stdarg.h>
+#include <stdint.h>
+
+#include "board.h"
+#include "trace.h"
+
+/* Plain CPSR-based critical section, usable from any context including
+   before kernel initialization, the ARMv7-R port has no recursive locks.*/
+static inline uint32_t irq_save(void) {
+  uint32_t cpsr;
+
+  __asm volatile ("mrs %0, cpsr" : "=r" (cpsr));
+  __asm volatile ("cpsid i" ::: "memory");
+  return cpsr;
+}
+
+static inline void irq_restore(uint32_t cpsr) {
+
+  if ((cpsr & 0x80U) == 0U) {
+    __asm volatile ("cpsie i" ::: "memory");
+  }
+}
+
+__attribute__((section(".trace"), used))
+static char trace_buffer[AM67_TRACEBUF_SIZE];
+
+/* The final 0x100 bytes hold the bring-up boot markers (see board.c), the
+   log never writes into or clears that area.*/
+#define TRACE_BOOTMARK_SIZE     0x100U
+#define TRACE_LOG_SIZE          (AM67_TRACEBUF_SIZE - TRACE_BOOTMARK_SIZE)
+
+static uint32_t trace_pos;
+
+static void trace_putc(char c) {
+
+  /* Last byte stays zero as terminator, logging stops when full.*/
+  if (trace_pos < (TRACE_LOG_SIZE - 1U)) {
+    trace_buffer[trace_pos++] = c;
+  }
+}
+
+static void trace_puts(const char *s) {
+
+  while (*s != '\0') {
+    trace_putc(*s++);
+  }
+}
+
+static void trace_putu(uint32_t value, uint32_t base) {
+  char digits[11];
+  uint32_t i = 0U;
+
+  do {
+    uint32_t d = value % base;
+    digits[i++] = (d < 10U) ? (char)('0' + d) : (char)('a' + d - 10U);
+    value /= base;
+  } while (value != 0U);
+
+  while (i > 0U) {
+    trace_putc(digits[--i]);
+  }
+}
+
+void trace_init(void) {
+  uint32_t i;
+
+  for (i = 0U; i < TRACE_LOG_SIZE; i++) {
+    trace_buffer[i] = '\0';
+  }
+  trace_pos = 0U;
+}
+
+void trace_printf(const char *fmt, ...) {
+  va_list ap;
+  uint32_t sts;
+
+  sts = irq_save();
+
+  va_start(ap, fmt);
+  while (*fmt != '\0') {
+    if (*fmt != '%') {
+      trace_putc(*fmt++);
+      continue;
+    }
+
+    fmt++;
+    switch (*fmt++) {
+    case 's':
+      trace_puts(va_arg(ap, const char *));
+      break;
+    case 'c':
+      trace_putc((char)va_arg(ap, int));
+      break;
+    case 'u':
+      trace_putu(va_arg(ap, uint32_t), 10U);
+      break;
+    case 'x':
+      trace_putu(va_arg(ap, uint32_t), 16U);
+      break;
+    case 'd': {
+      int32_t value = va_arg(ap, int32_t);
+      if (value < 0) {
+        trace_putc('-');
+        value = -value;
+      }
+      trace_putu((uint32_t)value, 10U);
+      break;
+    }
+    case '%':
+      trace_putc('%');
+      break;
+    default:
+      /* Unknown specifier, printed as-is to keep the log readable.*/
+      trace_putc('%');
+      trace_putc(*(fmt - 1));
+      break;
+    }
+  }
+  va_end(ap);
+
+  irq_restore(sts);
+}

--- a/demos/various/RT-XHAL-T3-GEM-O1/source/trace.c
+++ b/demos/various/RT-XHAL-T3-GEM-O1/source/trace.c
@@ -19,7 +19,13 @@
  * @brief   RemoteProc trace buffer logging.
  * @details Append-only character buffer in a non-cacheable DDR window, the
  *          Linux remoteproc core exposes it through debugfs. Formatting is
- *          intentionally minimal: %s, %c, %d, %u, %x and %% only.
+ *          intentionally minimal: %s, %c, %d, %u, %x and %% only, plus an
+ *          optional decimal width and a leading '0' zero-pad flag on
+ *          %d/%u/%x (e.g. %02x, %08x) -- board test 2026-08-10 found that
+ *          without width support, an unrecognised specifier like %02x
+ *          falls through to the "print as-is" default case, which both
+ *          drops the value silently and, worse, desyncs every va_arg()
+ *          after it in the same call.
  */
 
 #include <stdarg.h>
@@ -70,7 +76,16 @@ static void trace_puts(const char *s) {
   }
 }
 
-static void trace_putu(uint32_t value, uint32_t base) {
+/**
+ * @brief   Renders an unsigned value, left-padded to a minimum width.
+ *
+ * @param[in] value     the value to render
+ * @param[in] base      10 for %u/%d, 16 for %x
+ * @param[in] width     minimum field width, 0 for none
+ * @param[in] pad_char  '0' or ' ', ignored if @p width is 0
+ */
+static void trace_putu(uint32_t value, uint32_t base, uint32_t width,
+                       char pad_char) {
   char digits[11];
   uint32_t i = 0U;
 
@@ -79,6 +94,11 @@ static void trace_putu(uint32_t value, uint32_t base) {
     digits[i++] = (d < 10U) ? (char)('0' + d) : (char)('a' + d - 10U);
     value /= base;
   } while (value != 0U);
+
+  while (width > i) {
+    trace_putc(pad_char);
+    width--;
+  }
 
   while (i > 0U) {
     trace_putc(digits[--i]);
@@ -102,12 +122,30 @@ void trace_printf(const char *fmt, ...) {
 
   va_start(ap, fmt);
   while (*fmt != '\0') {
+    char pad_char;
+    uint32_t width;
+
     if (*fmt != '%') {
       trace_putc(*fmt++);
       continue;
     }
 
     fmt++;
+
+    /* Optional zero-pad flag, then optional decimal width -- e.g. %02x,
+       %08x. No other conversion flags are recognised, matching the
+       "intentionally minimal" scope stated in the file header.*/
+    pad_char = ' ';
+    if (*fmt == '0') {
+      pad_char = '0';
+      fmt++;
+    }
+    width = 0U;
+    while ((*fmt >= '0') && (*fmt <= '9')) {
+      width = (width * 10U) + (uint32_t)(*fmt - '0');
+      fmt++;
+    }
+
     switch (*fmt++) {
     case 's':
       trace_puts(va_arg(ap, const char *));
@@ -116,10 +154,10 @@ void trace_printf(const char *fmt, ...) {
       trace_putc((char)va_arg(ap, int));
       break;
     case 'u':
-      trace_putu(va_arg(ap, uint32_t), 10U);
+      trace_putu(va_arg(ap, uint32_t), 10U, width, pad_char);
       break;
     case 'x':
-      trace_putu(va_arg(ap, uint32_t), 16U);
+      trace_putu(va_arg(ap, uint32_t), 16U, width, pad_char);
       break;
     case 'd': {
       int32_t value = va_arg(ap, int32_t);
@@ -127,7 +165,7 @@ void trace_printf(const char *fmt, ...) {
         trace_putc('-');
         value = -value;
       }
-      trace_putu((uint32_t)value, 10U);
+      trace_putu((uint32_t)value, 10U, width, pad_char);
       break;
     }
     case '%':

--- a/demos/various/RT-XHAL-T3-GEM-O1/source/trace.h
+++ b/demos/various/RT-XHAL-T3-GEM-O1/source/trace.h
@@ -1,0 +1,36 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    trace.h
+ * @brief   RemoteProc trace buffer logging.
+ * @details Messages are readable on the Linux host through debugfs:
+ *          /sys/kernel/debug/remoteproc/remoteprocN/trace0
+ */
+
+#ifndef TRACE_H
+#define TRACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void trace_init(void);
+  void trace_printf(const char *fmt, ...);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TRACE_H */

--- a/os/common/ports/ARMv7-R/compilers/GCC/mk/port_am67.mk
+++ b/os/common/ports/ARMv7-R/compilers/GCC/mk/port_am67.mk
@@ -1,0 +1,14 @@
+# List of the ChibiOS/RT ARMv7-R TI AM67 port files.
+
+# Generic ARMv7-R port.
+include $(CHIBIOS)/os/common/ports/ARMv7-R/compilers/GCC/mk/port.mk
+
+DDEFS += -DPORT_HAS_PLATFORM=TRUE
+
+PORTAM67SRC = $(CHIBIOS)/os/common/ports/ARMv7-R/platforms/am67/port_platform.c
+
+PORTAM67INC = $(CHIBIOS)/os/common/ports/ARMv7-R/platforms/am67
+
+# Shared variables.
+ALLCSRC += $(PORTAM67SRC)
+ALLINC  += $(PORTAM67INC)

--- a/os/common/ports/ARMv7-R/platforms/am67/port_platform.c
+++ b/os/common/ports/ARMv7-R/platforms/am67/port_platform.c
@@ -1,0 +1,271 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARMv7-R/platforms/am67/port_platform.c
+ * @brief   ARMv7-R TI AM67 sub-port support code.
+ *
+ * @addtogroup ARMV7R_AM67
+ * @{
+ */
+
+#include "ch.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define VIM_IRQVEC                          0x018U
+#define VIM_ACTIRQ                          0x020U
+#define VIM_GROUP_RAW(j)                    (0x400U + ((((j) >> 5) & 0xFU) * 0x20U))
+#define VIM_GROUP_STS(j)                    (0x404U + ((((j) >> 5) & 0xFU) * 0x20U))
+#define VIM_GROUP_INT_EN(j)                 (0x408U + ((((j) >> 5) & 0xFU) * 0x20U))
+#define VIM_GROUP_INT_DIS(j)                (0x40CU + ((((j) >> 5) & 0xFU) * 0x20U))
+#define VIM_GROUP_INT_MAP(j)                (0x418U + ((((j) >> 5) & 0xFU) * 0x20U))
+#define VIM_GROUP_INT_TYPE(j)               (0x41CU + ((((j) >> 5) & 0xFU) * 0x20U))
+#define VIM_INT_PRI(j)                      (0x1000U + ((j) * 4U))
+#define VIM_INT_VEC(j)                      (0x2000U + ((j) * 4U))
+
+#define VIM_ACTIRQ_VALID                    0x80000000U
+#define VIM_BIT(j)                          (1U << ((j) & 0x1FU))
+
+/*===========================================================================*/
+/* Driver local types.                                                       */
+/*===========================================================================*/
+
+/**
+ * @brief   Type of a VIM handler table entry.
+ */
+typedef struct {
+  vim_handler_t         handler;
+  void                  *arg;
+} vim_entry_t;
+
+/*===========================================================================*/
+/* Driver local variables.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Handlers associated to the VIM interrupt lines.
+ */
+static vim_entry_t vim_handlers[AM67_VIM_NUM_IRQS];
+
+/**
+ * @brief   Controller initialization flag.
+ */
+static bool vim_initialized;
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static inline volatile uint32_t *vim_reg(uint32_t offset) {
+
+  return (volatile uint32_t *)(void *)(AM67_VIM_BASE + offset);
+}
+
+static inline void vim_barrier(void) {
+
+  __asm volatile ("isb" ::: "memory");
+  __asm volatile ("dsb" ::: "memory");
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   AM67 IRQ dispatcher.
+ * @details Reading IRQVEC latches the highest priority pending line and
+ *          raises the controller's internal priority mask; the matching
+ *          write releases it. Both accesses are mandatory, including on a
+ *          spurious activation, or the mask stays raised and no further
+ *          interrupt of equal or lower priority is ever delivered.
+ *
+ * @return              The preemption-required flag.
+ *
+ * @notapi
+ */
+bool __port_irq_dispatch(void) {
+  uint32_t actirq, irq;
+  bool preemption_required = false;
+
+  (void)*vim_reg(VIM_IRQVEC);
+
+  actirq = *vim_reg(VIM_ACTIRQ);
+  irq = actirq & (AM67_VIM_NUM_IRQS - 1U);
+  if ((actirq & VIM_ACTIRQ_VALID) != 0U) {
+
+    if (vim_handlers[irq].handler != NULL) {
+      preemption_required = vim_handlers[irq].handler(vim_handlers[irq].arg);
+    }
+
+    *vim_reg(VIM_GROUP_STS(irq)) = VIM_BIT(irq);
+  }
+
+  *vim_reg(VIM_IRQVEC) = irq;
+
+  return preemption_required;
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Initializes the AM67 interrupt controller.
+ * @details All lines are left disabled, level-sensitive, routed to IRQ and
+ *          at the least urgent priority. The core may have been used by a
+ *          previous boot stage, so in-service state is explicitly released.
+ * @note    One-shot on purpose. The HAL calls this from @p hal_lld_init()
+ *          and the port calls it again from @p __port_platform_init(), but
+ *          @p halInit() runs before @p chSysInit(): without the guard the
+ *          port pass would wipe the priorities and enables that drivers
+ *          registered during @p halInit(), starting with the system tick.
+ *
+ * @api
+ */
+void vimInit(void) {
+  uint32_t i;
+
+  if (vim_initialized) {
+    return;
+  }
+  vim_initialized = true;
+
+  for (i = 0U; i < AM67_VIM_NUM_IRQS; i++) {
+    *vim_reg(VIM_INT_PRI(i)) = AM67_VIM_LOWEST_PRIORITY;
+    *vim_reg(VIM_INT_VEC(i)) = 0U;
+  }
+
+  for (i = 0U; i < AM67_VIM_NUM_IRQS; i += 32U) {
+    *vim_reg(VIM_GROUP_INT_DIS(i))  = 0xFFFFFFFFU;
+    *vim_reg(VIM_GROUP_STS(i))      = 0xFFFFFFFFU;
+    *vim_reg(VIM_GROUP_INT_TYPE(i)) = 0U;
+    *vim_reg(VIM_GROUP_INT_MAP(i))  = 0U;
+  }
+
+  (void)*vim_reg(VIM_IRQVEC);
+  *vim_reg(VIM_IRQVEC) = 0U;
+}
+
+/**
+ * @brief   Platform-related port initialization.
+ *
+ * @param[in, out] oip  pointer to the @p os_instance_t structure
+ *
+ * @notapi
+ */
+void __port_platform_init(os_instance_t *oip) {
+
+  (void)oip;
+
+  vimInit();
+}
+
+/**
+ * @brief   Associates a handler to an interrupt line.
+ *
+ * @param[in] irq       interrupt line number
+ * @param[in] handler   handler function, @p NULL to remove the association
+ * @param[in] arg       argument passed to the handler
+ *
+ * @api
+ */
+void vimSetHandler(uint32_t irq, vim_handler_t handler, void *arg) {
+
+  chDbgCheck(irq < AM67_VIM_NUM_IRQS);
+
+  vim_handlers[irq].handler = handler;
+  vim_handlers[irq].arg     = arg;
+}
+
+/**
+ * @brief   Sets the priority of an interrupt line.
+ *
+ * @param[in] irq       interrupt line number
+ * @param[in] priority  priority level, 0 is the most urgent
+ *
+ * @api
+ */
+void vimSetPriority(uint32_t irq, uint32_t priority) {
+
+  chDbgCheck(irq < AM67_VIM_NUM_IRQS);
+
+  *vim_reg(VIM_INT_PRI(irq)) = priority & AM67_VIM_LOWEST_PRIORITY;
+}
+
+/**
+ * @brief   Enables an interrupt line.
+ *
+ * @param[in] irq       interrupt line number
+ *
+ * @api
+ */
+void vimEnableInterrupt(uint32_t irq) {
+
+  chDbgCheck(irq < AM67_VIM_NUM_IRQS);
+
+  vim_barrier();
+  *vim_reg(VIM_GROUP_INT_EN(irq)) = VIM_BIT(irq);
+}
+
+/**
+ * @brief   Disables an interrupt line.
+ *
+ * @param[in] irq       interrupt line number
+ *
+ * @api
+ */
+void vimDisableInterrupt(uint32_t irq) {
+
+  chDbgCheck(irq < AM67_VIM_NUM_IRQS);
+
+  *vim_reg(VIM_GROUP_INT_DIS(irq)) = VIM_BIT(irq);
+  vim_barrier();
+}
+
+/**
+ * @brief   Samples the controller state for one line.
+ * @details Distinguishes "the peripheral never raised its line" from "the
+ *          controller latched it but never dispatched it", which look
+ *          identical from a driver that simply timed out.
+ *
+ * @param[in] irq       interrupt line number
+ * @return              bit 0 raw (line asserted), bit 1 status (pending),
+ *                      bit 2 enabled.
+ *
+ * @api
+ */
+uint32_t vimGetLineState(uint32_t irq) {
+  uint32_t state = 0U;
+
+  chDbgCheck(irq < AM67_VIM_NUM_IRQS);
+
+  if ((*vim_reg(VIM_GROUP_RAW(irq)) & VIM_BIT(irq)) != 0U) {
+    state |= 1U;
+  }
+  if ((*vim_reg(VIM_GROUP_STS(irq)) & VIM_BIT(irq)) != 0U) {
+    state |= 2U;
+  }
+  if ((*vim_reg(VIM_GROUP_INT_EN(irq)) & VIM_BIT(irq)) != 0U) {
+    state |= 4U;
+  }
+
+  return state;
+}
+
+/** @} */

--- a/os/common/ports/ARMv7-R/platforms/am67/port_platform.h
+++ b/os/common/ports/ARMv7-R/platforms/am67/port_platform.h
@@ -1,0 +1,121 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    ARMv7-R/platforms/am67/port_platform.h
+ * @brief   ARMv7-R TI AM67 sub-port support.
+ * @details The AM67 R5F clusters use the TI VIM instead of an ARM GIC, so
+ *          the interrupt controller is part of the sub-port rather than of
+ *          the shared ARM-common code.
+ *
+ * @addtogroup ARMV7R_AM67
+ * @{
+ */
+
+#ifndef PORT_PLATFORM_H
+#define PORT_PLATFORM_H
+
+/*===========================================================================*/
+/* Module constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   VIM register block base address.
+ */
+#if !defined(AM67_VIM_BASE) || defined(__DOXYGEN__)
+#define AM67_VIM_BASE                       0x07FF0000U
+#endif
+
+/**
+ * @brief   Number of interrupt lines implemented by the VIM.
+ * @note    Must be a power of two, the dispatcher masks the active line
+ *          number with @p AM67_VIM_NUM_IRQS - 1.
+ */
+#if !defined(AM67_VIM_NUM_IRQS) || defined(__DOXYGEN__)
+#define AM67_VIM_NUM_IRQS                   512U
+#endif
+
+/**
+ * @brief   Least urgent VIM priority level.
+ * @note    On the VIM 0 is the most urgent level, unlike the NVIC.
+ */
+#define AM67_VIM_LOWEST_PRIORITY            0xFU
+
+/*===========================================================================*/
+/* Module pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if (AM67_VIM_NUM_IRQS & (AM67_VIM_NUM_IRQS - 1U)) != 0U
+#error "AM67_VIM_NUM_IRQS must be a power of two"
+#endif
+
+/*===========================================================================*/
+/* Module data structures and types.                                         */
+/*===========================================================================*/
+
+#if !defined(_FROM_ASM_)
+
+/**
+ * @brief   Type of a VIM interrupt handler.
+ *
+ * @param[in] arg       handler argument as registered
+ * @return              The preemption-required flag.
+ */
+typedef bool (*vim_handler_t)(void *arg);
+
+#endif /* !defined(_FROM_ASM_) */
+
+/*===========================================================================*/
+/* Module macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Platform-related port initialization.
+ * @note    The port checks on presence of this macro so this must be a macro.
+ *
+ * @param[in, out] oip  pointer to the @p os_instance_t structure
+ */
+#define port_platform_init(oip) __port_platform_init(oip)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if !defined(_FROM_ASM_)
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+  void __port_platform_init(os_instance_t *oip);
+  void vimInit(void);
+  void vimSetHandler(uint32_t irq, vim_handler_t handler, void *arg);
+  void vimSetPriority(uint32_t irq, uint32_t priority);
+  void vimEnableInterrupt(uint32_t irq);
+  void vimDisableInterrupt(uint32_t irq);
+  uint32_t vimGetLineState(uint32_t irq);
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !defined(_FROM_ASM_) */
+
+#endif /* PORT_PLATFORM_H */
+
+/** @} */

--- a/os/hal/boards/T3_GEM_O1/board.c
+++ b/os/hal/boards/T3_GEM_O1/board.c
@@ -273,7 +273,7 @@ void Reset_Handler(void) {
     "movt    r0, #0xA111               \n"
     "str     r1, [r0]                  \n"
     "dsb                               \n"
-    "movw    sp, #0x7FC0               \n"  /* temporary stack, TCM top  */
+    "movw    sp, #0x7FC0               \n"  /* Temporary stack, TCM top  */
     "movt    sp, #0x0000               \n"
     "bl      tcm_early_init            \n"
     "movw    r0, #:lower16:ddr_reset   \n"
@@ -305,8 +305,7 @@ void ddr_reset(void) {
 __attribute__((naked, used, section(".tcm_probe")))                         \
 void name(void) {                                                           \
                                                                             \
-  __asm volatile (                                                          \
-    "movw    r1, #" #type "            \n"                                  \
+  __asm volatile ("movw    r1, #" #type "            \n"                    \
     "movt    r1, #0xDEAD               \n"                                  \
     "mrc     p15, 0, r2, " fsr_op "    \n"                                  \
     "mrc     p15, 0, r3, " far_op "    \n"                                  \

--- a/os/hal/boards/T3_GEM_O1/board.c
+++ b/os/hal/boards/T3_GEM_O1/board.c
@@ -1,0 +1,369 @@
+/*
+    T3 Gemstone - Copyright (C) 2026 T3 Foundation (https://t3vakfi.org).
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    board.c
+ * @brief   T3 Gemstone O1 (AM67A/J722S) R5F early initialization.
+ * @details MPU region layout mirrors the proven NuttX am67 port, with one
+ *          additional non-cacheable window covering the RemoteProc resource
+ *          table and trace buffer so that the Linux host always sees fresh
+ *          data once the D-cache gets enabled.
+ *
+ *          MPU region priority grows with the region number, later regions
+ *          override earlier ones on overlap.
+ */
+
+#include <stdint.h>
+
+#include "board.h"
+
+/* DRSR is (size_exponent - 1) << 1 | enable, region size is 2^exponent.*/
+#define MPU_SIZE_32K            ((14U << 1) | 1U)
+#define MPU_SIZE_512K           ((18U << 1) | 1U)
+#define MPU_SIZE_1M             ((19U << 1) | 1U)
+#define MPU_SIZE_2G             ((30U << 1) | 1U)
+
+/* DRACR fields: B[0], C[1], S[2], TEX[5:3], AP[10:8], XN[12].*/
+#define MPU_AP_RWRW             (3U << 8)
+#define MPU_XN                  (1U << 12)
+#define MPU_STRONGLY_ORDERED    0U
+#define MPU_NORMAL_WBWA         ((1U << 3) | (1U << 1) | (1U << 0))
+#define MPU_NORMAL_NONCACHE     (1U << 3)
+#define MPU_SHARED              (1U << 2)
+
+#define SCTLR_M                 (1U << 0)
+#define SCTLR_C                 (1U << 2)
+#define SCTLR_Z                 (1U << 11)
+#define SCTLR_I                 (1U << 12)
+#define SCTLR_BR                (1U << 17)
+
+/* Bring-up boot markers, written into the top of the trace buffer so they
+   can be read from the Linux host over /dev/mem while debugging a silent
+   boot. Slots (word offsets from AM67_BOOTMARK_BASE):
+     +0x00 tcm_early_init entered    +0x04 MPU programmed
+     +0x08 caches enabled            +0x0C first DDR instruction
+     +0x10 __cpu_init reached        +0x14 __late_init reached
+     +0x20 fault type                +0x24 fault LR
+     +0x28 fault status (xFSR)       +0x2C fault address (xFAR)
+     +0x40 DDR store witness
+   The log area of the trace buffer ends below this block, trace_init()
+   never clears it (see trace.c).*/
+#define AM67_BOOTMARK_BASE      (AM67_TRACEBUF_BASE + AM67_TRACEBUF_SIZE - 0x100U)
+
+static inline void boot_mark(uint32_t slot, uint32_t value) {
+
+  *(volatile uint32_t *)(AM67_BOOTMARK_BASE + slot) = value;
+  __asm volatile ("dsb" ::: "memory");
+}
+
+static inline __attribute__((always_inline)) uint32_t sctlr_read(void) {
+  uint32_t value;
+
+  __asm volatile ("mrc p15, 0, %0, c1, c0, 0" : "=r" (value));
+  return value;
+}
+
+static inline __attribute__((always_inline)) void sctlr_write(uint32_t value) {
+
+  __asm volatile ("mcr p15, 0, %0, c1, c0, 0" :: "r" (value) : "memory");
+  __asm volatile ("dsb; isb" ::: "memory");
+}
+
+static inline __attribute__((always_inline))
+void mpu_set_region(uint32_t region, uint32_t base,
+                    uint32_t size, uint32_t access) {
+
+  __asm volatile ("mcr p15, 0, %0, c6, c2, 0" :: "r" (region));  /* RGNR  */
+  __asm volatile ("mcr p15, 0, %0, c6, c1, 0" :: "r" (base));    /* DRBAR */
+  __asm volatile ("mcr p15, 0, %0, c6, c1, 4" :: "r" (access));  /* DRACR */
+  __asm volatile ("mcr p15, 0, %0, c6, c1, 2" :: "r" (size));    /* DRSR  */
+}
+
+/* MPU and cache setup MUST execute from TCM: in the ARMv7-R default memory
+   map (MPU disabled) the upper 2GB is Execute-Never, so DDR code cannot
+   run until the MPU is enabled, and reconfiguring the MPU from DDR would
+   fault the moment it gets disabled.*/
+__attribute__((section(".tcm_probe")))
+static void mpu_init(void) {
+  uint32_t region;
+
+  /* MPU off and background region disabled while reconfiguring.*/
+  sctlr_write(sctlr_read() & ~(SCTLR_M | SCTLR_BR));
+
+  for (region = 0U; region < 16U; region++) {
+    mpu_set_region(region, 0U, 0U, 0U);
+  }
+
+  /* Region 0: SoC registers and everything below 2GB, strongly-ordered.*/
+  mpu_set_region(0U, 0x00000000U, MPU_SIZE_2G,
+                 MPU_STRONGLY_ORDERED | MPU_SHARED | MPU_AP_RWRW);
+
+  /* Region 1: TCM, normal write-back write-allocate. Only the block at
+     address 0 exists on this core, see board.h.*/
+  mpu_set_region(1U, AM67_TCM_BASE, MPU_SIZE_32K,
+                 MPU_NORMAL_WBWA | MPU_AP_RWRW);
+
+  /* Region 2: MCU MSRAM, normal write-back write-allocate.*/
+  mpu_set_region(2U, AM67_MSRAM_BASE, MPU_SIZE_512K,
+                 MPU_NORMAL_WBWA | MPU_AP_RWRW);
+
+  /* Region 3: DDR, normal write-back write-allocate, NON-shareable.
+
+     Deliberately not shareable. The Cortex-R5 has no hardware cache
+     coherency, and ARMv7-R permits an implementation to treat Normal
+     Shareable memory as Non-cacheable -- which this core does. Leaving
+     SHARED set here meant enabling SCTLR_C changed nothing measurable: the
+     cache was on and this region simply declined to use it.
+
+     Safe because this region holds only core-private memory -- code, data,
+     heap and the DDR thread stacks. Everything Linux touches lives in region
+     4 below, which stays NORMAL_NONCACHE and therefore coherent without any
+     maintenance.
+
+     ONE CONSEQUENCE WORTH KNOWING: reading R5F internal state from Linux via
+     /dev/mem -- the post-mortem thread-walk technique used to crack Q-32 --
+     now sees potentially stale data for anything in this region, because
+     writes may still be sitting in the D-cache. The trace buffer, IPC rings
+     and parameter storage are unaffected. If that technique is needed again,
+     either flush the cache first or boot a build with this line reverted.*/
+  mpu_set_region(3U, AM67_DDR_BASE, MPU_SIZE_2G,
+                 MPU_NORMAL_WBWA | MPU_AP_RWRW);
+
+  /* Region 4: resource table and trace buffer window, non-cacheable so
+     the Linux host sees coherent data, never executable.*/
+  mpu_set_region(4U, AM67_RSCTABLE_BASE, MPU_SIZE_1M,
+                 MPU_NORMAL_NONCACHE | MPU_SHARED | MPU_AP_RWRW | MPU_XN);
+
+  sctlr_write(sctlr_read() | SCTLR_M);
+}
+
+/*
+ * Invalidate the whole L1 data cache, by set and way.
+ *
+ * Mandatory before SCTLR_C is set: cache contents are UNKNOWN out of reset on
+ * ARMv7-R, so enabling the cache without invalidating first can serve
+ * fabricated lines for addresses that were never read. Geometry comes from
+ * CCSIDR rather than being hardcoded, because the Cortex-R5 D-cache size is a
+ * synthesis option and this must not silently under-invalidate on a part
+ * configured differently.
+ */
+__attribute__((section(".tcm_probe")))
+static void dcache_invalidate_all(void) {
+  uint32_t ccsidr, sets, ways, line_shift, way_shift;
+  int32_t set, way;
+
+  /* CSSELR = level 1, data/unified. */
+  __asm volatile ("mcr p15, 2, %0, c0, c0, 0" :: "r" (0U));
+  __asm volatile ("isb" ::: "memory");
+  __asm volatile ("mrc p15, 1, %0, c0, c0, 0" : "=r" (ccsidr));
+
+  /* CCSIDR: LineSize[2:0] = log2(words per line) - 2, Associativity[12:3]
+     and NumSets[27:13] are both "minus one" encodings. */
+  line_shift = (ccsidr & 7U) + 4U;
+  ways       = ((ccsidr >> 3) & 0x3FFU);
+  sets       = ((ccsidr >> 13) & 0x7FFFU);
+
+  /* Way index sits in the top bits of the DCISW operand, positioned so that
+     the widest way number just fits: 32 - log2ceil(ways + 1). */
+  way_shift = 32U;
+  {
+    uint32_t w = ways;
+    do {
+      way_shift--;
+      w >>= 1;
+    } while (w != 0U);
+    /* __builtin_clz is not usable here: this runs before any library init. */
+  }
+
+  for (set = (int32_t)sets; set >= 0; set--) {
+    for (way = (int32_t)ways; way >= 0; way--) {
+      const uint32_t op = ((uint32_t)way << way_shift) |
+                          ((uint32_t)set << line_shift);
+      __asm volatile ("mcr p15, 0, %0, c7, c6, 2" :: "r" (op) : "memory");
+    }
+  }
+  __asm volatile ("dsb; isb" ::: "memory");
+}
+
+__attribute__((section(".tcm_probe")))
+static void caches_init(void) {
+
+  /* Invalidate instruction cache and branch predictor.*/
+  __asm volatile ("mcr p15, 0, %0, c7, c5, 0" :: "r" (0));
+  __asm volatile ("mcr p15, 0, %0, c7, c5, 6" :: "r" (0));
+  __asm volatile ("dsb; isb" ::: "memory");
+
+  /*
+    Data cache on.
+
+    Safe only because mpu_init() above already puts every window shared with
+    Linux into region 4 as NORMAL_NONCACHE: the resource table (0xA1100000),
+    the RemoteProc trace buffer (0xA1110000, including the fault block at
+    0xA1113F20) and the IPC window (0xA1120000, carrying both the MAVLink
+    rings and the 16 KiB parameter-storage image). Region 4 spans
+    0xA1100000..0xA1200000 while code, data and heap start at 0xA1240000, so
+    nothing cacheable overlaps anything the host reads. That is why
+    ipc_ring.c and ipc_storage.c need only a DMB and no cache maintenance.
+
+    Until 2026-08-02 this bit was left clear "for bring-up", so every data
+    access ran at DDR latency. Cost measured before enabling it: the IMU
+    delivered 86 Hz against a configured 100 Hz, the main loop could not hold
+    50 Hz, and EKF3 added ~6 ms per iteration -- enough to starve telemetry
+    until QGC dropped the link.
+
+    If anything shared with Linux ever starts reading stale -- trace output
+    freezing, QGC losing the link, parameters not persisting -- suspect a new
+    allocation placed outside region 4 before suspecting this line.
+  */
+  dcache_invalidate_all();
+  sctlr_write(sctlr_read() | SCTLR_I | SCTLR_Z | SCTLR_C);
+}
+
+/*
+ * TCM-resident early initialization: called from Reset_Handler on a
+ * temporary stack at the top of BTCM, before any DDR code has executed.
+ */
+__attribute__((section(".tcm_probe"), noinline, used))
+void tcm_early_init(void) {
+
+  boot_mark(0x00U, 0xB0070001U);
+  mpu_init();
+  boot_mark(0x04U, 0xB0070002U);
+  caches_init();
+  boot_mark(0x08U, 0xB0070003U);
+}
+
+/*
+ * Boot entry, placed in TCM: in the ARMv7-R default memory map (MPU off)
+ * DDR is Execute-Never, so everything up to and including the MPU enable
+ * must run from TCM. Reset flow:
+ *   vectors (TCM) -> Reset_Handler (TCM) -> tcm_early_init (TCM, enables
+ *   MPU) -> ddr_reset (DDR) -> _crt0_entry.
+ * Witness markers written before any DDR execution:
+ *   TCM+0x7FF0 (host address 0x79027FF0): the core executed the vector
+ *   trace+0x3F40 (0xA1113F40): R5F stores to DDR actually land
+ * The temporary stack starts below the reserved debug block at the top of
+ * the TCM (0x7FC0..0x8000), which the linker script also keeps out of.
+ */
+__attribute__((naked, used, section(".tcm_probe")))
+void Reset_Handler(void) {
+
+  __asm volatile (
+    "movw    r0, #0x7FF0               \n"  /* TCM witness               */
+    "movt    r0, #0x0000               \n"
+    "movw    r1, #0x0A7C               \n"
+    "movt    r1, #0xB007               \n"
+    "str     r1, [r0]                  \n"
+    "dsb                               \n"
+    "movw    r0, #0x3F40               \n"  /* DDR store witness         */
+    "movt    r0, #0xA111               \n"
+    "str     r1, [r0]                  \n"
+    "dsb                               \n"
+    "movw    sp, #0x7FC0               \n"  /* temporary stack, TCM top  */
+    "movt    sp, #0x0000               \n"
+    "bl      tcm_early_init            \n"
+    "movw    r0, #:lower16:ddr_reset   \n"
+    "movt    r0, #:upper16:ddr_reset   \n"
+    "bx      r0                        \n");
+}
+
+/*
+ * First DDR instruction after the MPU is on, proves DDR execution works.
+ */
+__attribute__((naked, used))
+void ddr_reset(void) {
+
+  __asm volatile (
+    "movw    r0, #0x3F0C               \n"
+    "movt    r0, #0xA111               \n"
+    "movw    r1, #0x0004               \n"
+    "movt    r1, #0xB007               \n"
+    "str     r1, [r0]                  \n"
+    "dsb                               \n"
+    "b       _crt0_entry               \n");
+}
+
+/*
+ * Fault handlers: record the fault type, return address and fault status
+ * registers, then park the core.
+ */
+#define FAULT_HANDLER(name, type, fsr_op, far_op)                           \
+__attribute__((naked, used, section(".tcm_probe")))                         \
+void name(void) {                                                           \
+                                                                            \
+  __asm volatile (                                                          \
+    "movw    r1, #" #type "            \n"                                  \
+    "movt    r1, #0xDEAD               \n"                                  \
+    "mrc     p15, 0, r2, " fsr_op "    \n"                                  \
+    "mrc     p15, 0, r3, " far_op "    \n"                                  \
+    "movw    r0, #0x7FE0               \n"  /* TCM fault block */           \
+    "movt    r0, #0x0000               \n"                                  \
+    "str     r1, [r0]                  \n"                                  \
+    "str     lr, [r0, #4]              \n"                                  \
+    "str     r2, [r0, #8]              \n"                                  \
+    "str     r3, [r0, #12]             \n"                                  \
+    "dsb                               \n"                                  \
+    "movw    r0, #0x3F20               \n"  /* DDR fault block */           \
+    "movt    r0, #0xA111               \n"                                  \
+    "str     r1, [r0]                  \n"                                  \
+    "str     lr, [r0, #4]              \n"                                  \
+    "str     r2, [r0, #8]              \n"                                  \
+    "str     r3, [r0, #12]             \n"                                  \
+    "dsb                               \n"                                  \
+    "1:  b   1b                        \n");                                \
+}
+
+/* Undefined instructions have no fault status registers, the DFSR/DFAR
+   values recorded for them are stale leftovers.*/
+FAULT_HANDLER(Und_Handler,      0x0001, "c5, c0, 0", "c6, c0, 0")
+FAULT_HANDLER(Prefetch_Handler, 0x0002, "c5, c0, 1", "c6, c0, 2")  /* IFSR/IFAR */
+FAULT_HANDLER(Abort_Handler,    0x0003, "c5, c0, 0", "c6, c0, 0")  /* DFSR/DFAR */
+
+/*
+ * Startup hook invoked by crt0 right after the mode stacks and FPU setup:
+ * reaching it proves the banked stack pointers and FPU enable survived.
+ */
+void __cpu_init(void) {
+
+  boot_mark(0x10U, 0xB0070005U);
+}
+
+/*
+ * Startup hook invoked by crt0 before .data/.bss initialization. The MPU
+ * and caches are already configured by tcm_early_init(), which must run
+ * from TCM (see above), nothing left to do this early.
+ */
+void __early_init(void) {
+}
+
+/*
+ * Startup hook invoked by crt0 after .data/.bss initialization: reaching
+ * it proves the stack fill and the .data/.bss loops survived.
+ */
+void __late_init(void) {
+
+  boot_mark(0x14U, 0xB0070006U);
+}
+
+/*
+ * Board-specific initialization, invoked by halInit() after the drivers.
+ * Clocks and pinmux are owned by the Linux host on this board, the MPU
+ * and caches are configured by tcm_early_init() long before this point,
+ * nothing is left to do here.
+ */
+void boardInit(void) {
+}

--- a/os/hal/boards/T3_GEM_O1/board.h
+++ b/os/hal/boards/T3_GEM_O1/board.h
@@ -154,6 +154,17 @@
 #define AM67_ECAP1_BASE         0x23110000U
 #define AM67_ECAP2_BASE         0x23120000U
 
+/*
+ * Peripheral input clocks the XHAL drivers need from the board.
+ *
+ * These are board-level rather than SoC-level because the device tree owns
+ * the clock muxes: the same peripheral on another carrier can be parented
+ * differently. A wrong value shows up as a rate off by a clean integer
+ * ratio, not as a boot failure.
+ */
+#define AM67_ST_TIMER_CLOCK     AM67_TIMER0_CLK_HZ
+#define AM67_MAIN_UART1_CLOCK   48000000U
+
 #if !defined(_FROM_ASM_)
 #ifdef __cplusplus
 extern "C" {

--- a/os/hal/boards/T3_GEM_O1/board.h
+++ b/os/hal/boards/T3_GEM_O1/board.h
@@ -118,15 +118,14 @@
  * k3-am67a-t3-gem-o1-pwm-epwm0-gpio5.dtbo). The DT owns pinmux + the module
  * clock/power; the firmware only drives EPWM registers.
  *
- * AM67_EPWM0_CLK_HZ is the EPWM counter input clock (SYSCLKOUT), i.e. the
- * clock BEFORE the TBCTL HSPCLKDIV/CLKDIV prescale. It is the module "fck":
- * confirmed 250 MHz on this board via /sys/kernel/debug/clk/clk_summary and
- * the Linux pwm-tiehrpwm driver (it derives period/duty from clk_get_rate of
- * "fck"). The separate epwm_tbclk gate must be enabled for the counter to
- * run but is NOT a divider. Final confirmation pending scope measurement.
+ * The EPWM counter input clock (SYSCLKOUT) is the clock BEFORE the TBCTL
+ * HSPCLKDIV/CLKDIV prescale, i.e. the module "fck": confirmed 250 MHz on this
+ * board via /sys/kernel/debug/clk/clk_summary and the Linux pwm-tiehrpwm
+ * driver (it derives period/duty from clk_get_rate of "fck"). The separate
+ * epwm_tbclk gate must be enabled for the counter to run but is NOT a
+ * divider. The value itself lives in am67_registry.h as AM67_EPWM_CLOCK.
  */
 #define AM67_EPWM0_BASE         0x23000000U
-#define AM67_EPWM0_CLK_HZ       250000000U   /* Module fck, pre-prescale.     */
 
 /*
  * EPWM1 (eHRPWM) second instance: EHRPWM1_A -> GPIO6 (pin 31), EHRPWM1_B ->
@@ -161,6 +160,10 @@
  * the clock muxes: the same peripheral on another carrier can be parented
  * differently. A wrong value shows up as a rate off by a clean integer
  * ratio, not as a boot failure.
+ *
+ * The eHRPWM and eCAP counter clocks are NOT repeated here: they are owned
+ * by am67_registry.h (AM67_EPWM_CLOCK / AM67_ECAP_CLOCK), which is the single
+ * source of truth for them and what the XHAL PWM driver actually reads.
  */
 #define AM67_ST_TIMER_CLOCK     AM67_TIMER0_CLK_HZ
 #define AM67_MAIN_UART1_CLOCK   48000000U

--- a/os/hal/boards/T3_GEM_O1/board.h
+++ b/os/hal/boards/T3_GEM_O1/board.h
@@ -108,9 +108,9 @@
  */
 #define AM67_MAILBOX_BASE       0x29010000U
 #define AM67_MAILBOX_IRQ        241U
-#define AM67_MAILBOX_USER       2U      /* our interrupt user index          */
+#define AM67_MAILBOX_USER       2U      /* Our interrupt user index          */
 #define AM67_MAILBOX_RX_FIFO    1U      /* Linux writes here, we read it     */
-#define AM67_MAILBOX_TX_FIFO    0U      /* we write here, Linux reads it     */
+#define AM67_MAILBOX_TX_FIFO    0U      /* We write here, Linux reads it     */
 
 /*
  * EPWM0 (eHRPWM), first PWM output on EHRPWM0_A -> Gemstone 40-pin header
@@ -126,7 +126,7 @@
  * run but is NOT a divider. Final confirmation pending scope measurement.
  */
 #define AM67_EPWM0_BASE         0x23000000U
-#define AM67_EPWM0_CLK_HZ       250000000U   /* fck = SYSCLKOUT, pre-prescale. */
+#define AM67_EPWM0_CLK_HZ       250000000U   /* Module fck, pre-prescale.     */
 
 /*
  * EPWM1 (eHRPWM) second instance: EHRPWM1_A -> GPIO6 (pin 31), EHRPWM1_B ->

--- a/os/hal/boards/T3_GEM_O1/board.h
+++ b/os/hal/boards/T3_GEM_O1/board.h
@@ -1,0 +1,167 @@
+/*
+    T3 Gemstone - Copyright (C) 2026 T3 Foundation (https://t3vakfi.org).
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    board.h
+ * @brief   T3 Gemstone O1 (TI AM67A/J722S) Cortex-R5F board definitions.
+ * @details Addresses taken from the TI J722S TRM, cross-checked against the
+ *          NuttX am67 port and the TI MCU+ SDK (j722s).
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+/*
+ * Board identifier.
+ */
+#define BOARD_T3_GEM_O1
+#define BOARD_NAME              "T3 Gemstone O1 (AM67A/J722S) R5F"
+
+/*
+ * Memory map as seen by the MCU_R5FSS0 core 0, see
+ * cslr_mcu_r5fss0_baseaddress.h in the TI MCU+ SDK.
+ *
+ * Only one TCM is usable on this core. The Linux device tree gives it
+ * ti,loczrama = <0>, which puts the BTCM at address 0 and the ATCM at
+ * 0x41010000, and then ti,atcm-enable = <0> leaves the ATCM switched off.
+ * Address 0 is not negotiable: Cortex-R5 has no VBAR, so the vectors, the
+ * pre-MPU boot code and the banked mode stacks all share this 32K block.
+ * The Main domain core has the opposite layout (loczrama = 1, both TCMs
+ * enabled), which is why the linker script differs from the Main build.
+ */
+#define AM67_TCM_BASE           0x00000000U
+#define AM67_TCM_SIZE           (32U * 1024U)
+#define AM67_MSRAM_BASE         0x60000000U
+#define AM67_MSRAM_SIZE         (512U * 1024U)
+#define AM67_DDR_BASE           0x80000000U
+
+/*
+ * DDR carveout assigned to this core by the Linux device tree, must match
+ * the reserved-memory nodes used by the k3-r5 remoteproc driver. For the
+ * MCU core these are mcu_r5fss0_core0_memory_region@a1100000 (15M), 16M
+ * below the Main core's carveout so both cores can run at the same time.
+ */
+#define AM67_RSCTABLE_BASE      0xA1100000U
+#define AM67_TRACEBUF_BASE      0xA1110000U
+#define AM67_TRACEBUF_SIZE      (16U * 1024U)
+
+/*
+ * VIM interrupt controller (MCU_R5FSS0 VIC_CFG, in this core's own view).
+ */
+#define AM67_VIM_BASE           0x07FF0000U
+#define AM67_VIM_NUM_IRQS       512U
+
+/*
+ * MCU_TIMER0 used as the OS tick source, IRQ number from
+ * cslr_intr_mcu_r5fss0_core0.h.
+ *
+ * The device tree leaves this timer's clock mux at its reset default,
+ * unlike main_timer0 which is explicitly reparented, so the 25 MHz below
+ * is the expected HFOSC0 default rather than a verified value. A wrong
+ * parent shows up as a tick rate off by a clean integer ratio, not as a
+ * boot failure, so it is safe to confirm on hardware.
+ */
+#define AM67_TIMER0_BASE        0x04800000U
+#define AM67_TIMER0_CLK_HZ      25000000U
+#define AM67_TIMER0_IRQ         28U
+
+/*
+ * MAILBOX0 cluster 1 (MAILBOX0_REGS1), the A53 <-> MCU_R5F doorbell.
+ *
+ * This is the channel the Linux k3_r5_remoteproc driver uses to ask the R5F to
+ * shut down: `mboxes = <0x11 0x12>` on the r5f@79000000 node resolves to
+ * mailbox@29010000 / chan mbox-mcu-r5-0. Without a handler on this side,
+ * `remoteproc stop` blocks ~25 s and fails with -EBUSY
+ * ("k3_r5_rproc_stop: timeout waiting for rproc completion event"), which is
+ * why loading new firmware needed a full power cycle.
+ *
+ * FIFO direction is stated from LINUX's point of view in the device tree, so it
+ * inverts here: DT `ti,mbox-tx = <1 0 0>` means Linux transmits on FIFO 1, so
+ * the R5F RECEIVES on FIFO 1; DT `ti,mbox-rx = <0 0 0>` means the R5F
+ * TRANSMITS on FIFO 0. Getting this backwards yields a mailbox that never
+ * interrupts, which looks exactly like having no driver at all.
+ *
+ * The user index is not discoverable from the device tree -- Linux only
+ * declares its own (0). From the J722S TRM Table 4-138:
+ *   ..._CLUSTER_1_mailbox_cluster_pend_0 -> GICSS0_spi_109              (Linux, user 0)
+ *   ..._CLUSTER_1_mailbox_cluster_pend_2 -> MCU_R5FSS0_CORE0_cpu0_intr_241  (us, user 2)
+ *   ..._CLUSTER_1_mailbox_cluster_pend_3 -> WKUP_R5FSS0_CORE0_intr_241
+ * Cross-checked two ways: the DT parent interrupt <0 0x4d 4> is GIC SPI 77,
+ * and 77 + 32 = INTID 109 = the TRM's GICSS0_spi_109, which confirms
+ * pend_N <-> user N; and the TRM's MCU_TIMER0 -> cpu0_intr_28 matches
+ * AM67_TIMER0_IRQ above, which is hardware-verified, confirming that
+ * cpu0_intr_N is the VIM input number.
+ */
+#define AM67_MAILBOX_BASE       0x29010000U
+#define AM67_MAILBOX_IRQ        241U
+#define AM67_MAILBOX_USER       2U      /* our interrupt user index          */
+#define AM67_MAILBOX_RX_FIFO    1U      /* Linux writes here, we read it     */
+#define AM67_MAILBOX_TX_FIFO    0U      /* we write here, Linux reads it     */
+
+/*
+ * EPWM0 (eHRPWM), first PWM output on EHRPWM0_A -> Gemstone 40-pin header
+ * pin 29 (GPIO5 pad, muxed to EHRPWM0_A by the Linux DT overlay
+ * k3-am67a-t3-gem-o1-pwm-epwm0-gpio5.dtbo). The DT owns pinmux + the module
+ * clock/power; the firmware only drives EPWM registers.
+ *
+ * AM67_EPWM0_CLK_HZ is the EPWM counter input clock (SYSCLKOUT), i.e. the
+ * clock BEFORE the TBCTL HSPCLKDIV/CLKDIV prescale. It is the module "fck":
+ * confirmed 250 MHz on this board via /sys/kernel/debug/clk/clk_summary and
+ * the Linux pwm-tiehrpwm driver (it derives period/duty from clk_get_rate of
+ * "fck"). The separate epwm_tbclk gate must be enabled for the counter to
+ * run but is NOT a divider. Final confirmation pending scope measurement.
+ */
+#define AM67_EPWM0_BASE         0x23000000U
+#define AM67_EPWM0_CLK_HZ       250000000U   /* fck = SYSCLKOUT, pre-prescale. */
+
+/*
+ * EPWM1 (eHRPWM) second instance: EHRPWM1_A -> GPIO6 (pin 31), EHRPWM1_B ->
+ * GPIO13 (pin 33). Same IP and 250 MHz fck as EPWM0; A and B share the time
+ * base but have independent CMPA/CMPB compares.
+ *
+ * ECAP0/1/2 (eCAP in APWM mode) -> GPIO12 (pin 32) / GPIO16 (pin 36) /
+ * GPIO18 (pin 12). Separate IP from EHRPWM. The APWM counter (TSCTR) is 32-bit
+ * and clocked directly by the module fck, so no prescale is used.
+ * That fck is 125 MHz on this board -- HALF the EPWM fck (a different clock
+ * domain), verified via /sys/kernel/debug/clk/clk_summary
+ * (23100000/23110000/23120000.pwm fck = 125000000) and confirmed by scope
+ * (50 Hz with period = 2500000 ticks). All three ECAP instances share it.
+ *
+ * EHRPWM0_B -> GPIO14 (pin 8). Freed 2026-08-03: this pad was the UART1
+ * console TX until MAVLink moved to the shared-memory rings (DR-016) and the
+ * stock overlay k3-am67a-t3-gem-o1-pwm-epwm0-gpio5-gpio14.dtbo reconfigured
+ * main_uart1 to an RX-only pin group (pad 0x01AC, pin 10) while taking pad
+ * 0x01B0 for EHRPWM0_B. The four flight outputs are now EHRPWM0_A/B and
+ * EHRPWM1_A/B; the ECAP bases below are retained but no longer driven by
+ * AP_HAL_ChibiOS_K3::RCOutput.
+ */
+#define AM67_EPWM1_BASE         0x23010000U
+#define AM67_ECAP0_BASE         0x23100000U
+#define AM67_ECAP1_BASE         0x23110000U
+#define AM67_ECAP2_BASE         0x23120000U
+
+#if !defined(_FROM_ASM_)
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void boardInit(void);
+#ifdef __cplusplus
+}
+#endif
+#endif /* _FROM_ASM_ */
+
+#endif /* BOARD_H */

--- a/os/hal/boards/T3_GEM_O1/board.mk
+++ b/os/hal/boards/T3_GEM_O1/board.mk
@@ -1,0 +1,9 @@
+# List of all the board related files.
+BOARDSRC = $(CHIBIOS)/os/hal/boards/T3_GEM_O1/board.c
+
+# Required include directories.
+BOARDINC = $(CHIBIOS)/os/hal/boards/T3_GEM_O1
+
+# Shared variables.
+ALLCSRC += $(BOARDSRC)
+ALLINC  += $(BOARDINC)

--- a/os/xhal/ports/TI/AM67/am67_registry.h
+++ b/os/xhal/ports/TI/AM67/am67_registry.h
@@ -1,0 +1,110 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    TI/AM67/am67_registry.h
+ * @brief   AM67 capabilities registry.
+ * @details Describes what the SoC implements and where it lives, as seen
+ *          from an MCU-domain Cortex-R5F core. Board files select which of
+ *          these the firmware actually owns; the Linux host owns the rest.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef AM67_REGISTRY_H
+#define AM67_REGISTRY_H
+
+/*===========================================================================*/
+/* Platform capabilities.                                                    */
+/*===========================================================================*/
+
+/**
+ * @name    AM67 capabilities
+ * @{
+ */
+/* DMTIMER attributes.*/
+#define AM67_HAS_MCU_TIMER0                 TRUE
+#define AM67_MCU_TIMER0_BASE                0x04800000U
+#define AM67_MCU_TIMER0_IRQ                 28U
+
+/* McSPI attributes.*/
+#define AM67_HAS_MCU_MCSPI0                 TRUE
+#define AM67_MCU_MCSPI0_BASE                0x04B00000U
+#define AM67_MCU_MCSPI0_IRQ                 207U
+#define AM67_MCU_MCSPI0_CLOCK               48000000U
+
+/* I2C attributes.*/
+#define AM67_HAS_MCU_I2C0                   TRUE
+#define AM67_MCU_I2C0_BASE                  0x04900000U
+#define AM67_MCU_I2C0_IRQ                   197U
+
+/* UART attributes.*/
+#define AM67_HAS_MAIN_UART1                 TRUE
+#define AM67_MAIN_UART1_BASE                0x02810000U
+#define AM67_MAIN_UART1_IRQ                 211U
+
+/* EHRPWM attributes.*/
+#define AM67_HAS_EPWM0                      TRUE
+#define AM67_EPWM0_BASE                     0x23000000U
+#define AM67_HAS_EPWM1                      TRUE
+#define AM67_EPWM1_BASE                     0x23010000U
+#define AM67_EPWM_CHANNELS                  2U
+#define AM67_EPWM_CLOCK                     250000000U
+
+/* ECAP attributes.*/
+#define AM67_HAS_ECAP0                      TRUE
+#define AM67_ECAP0_BASE                     0x23100000U
+#define AM67_HAS_ECAP1                      TRUE
+#define AM67_ECAP1_BASE                     0x23110000U
+#define AM67_HAS_ECAP2                      TRUE
+#define AM67_ECAP2_BASE                     0x23120000U
+/* Measured on hardware, not the 250 MHz the eHRPWM sees (DR-002).*/
+#define AM67_ECAP_CLOCK                     125000000U
+
+/* RTI watchdog attributes.*/
+#define AM67_HAS_MCU_RTI0                   TRUE
+#define AM67_MCU_RTI0_BASE                  0x04880000U
+
+/* Mailbox attributes.*/
+#define AM67_HAS_MAILBOX0                   TRUE
+#define AM67_MAILBOX0_BASE                  0x29010000U
+#define AM67_MAILBOX0_IRQ                   241U
+/** @} */
+
+/*===========================================================================*/
+/* Platform memory map.                                                      */
+/*===========================================================================*/
+
+/**
+ * @name    Core-local and shared memories
+ * @note    Only one TCM is usable on an MCU-domain core: the device tree
+ *          sets @p ti,loczrama = <0>, putting the BTCM at address 0, and
+ *          @p ti,atcm-enable = <0> leaves the ATCM off. Address 0 is not
+ *          negotiable, the Cortex-R5 has no VBAR so the vectors, the
+ *          pre-MPU boot code and the banked mode stacks share this block.
+ * @{
+ */
+#define AM67_TCM_BASE                       0x00000000U
+#define AM67_TCM_SIZE                       (32U * 1024U)
+#define AM67_MSRAM_BASE                     0x60000000U
+#define AM67_MSRAM_SIZE                     (512U * 1024U)
+#define AM67_DDR_BASE                       0x80000000U
+/** @} */
+
+#endif /* AM67_REGISTRY_H */
+
+/** @} */

--- a/os/xhal/ports/TI/AM67/hal_lld.c
+++ b/os/xhal/ports/TI/AM67/hal_lld.c
@@ -1,0 +1,46 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    TI/AM67/hal_lld.c
+ * @brief   TI AM67 (J722S) R5F HAL subsystem low level driver source.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#include "hal.h"
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level HAL driver initialization.
+ * @details The interrupt controller is brought up here rather than from the
+ *          port because @p halInit() runs before @p chSysInit(): drivers
+ *          initialized later in @p halInit() register and enable their VIM
+ *          lines, and those settings must survive. @p vimInit() is one-shot,
+ *          so the port's own later call is a no-op.
+ *
+ * @notapi
+ */
+void hal_lld_init(void) {
+
+  vimInit();
+}
+
+/** @} */

--- a/os/xhal/ports/TI/AM67/hal_lld.h
+++ b/os/xhal/ports/TI/AM67/hal_lld.h
@@ -1,0 +1,86 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    TI/AM67/hal_lld.h
+ * @brief   TI AM67 (J722S) R5F HAL subsystem low level driver header.
+ * @details The R5F runs as a RemoteProc slave of the Linux host: clocks,
+ *          power domains and pin multiplexing are owned by the host, so
+ *          this layer only initializes what the R5F exclusively owns.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef HAL_LLD_H
+#define HAL_LLD_H
+
+#include "am67_registry.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Platform identification macros
+ * @{
+ */
+#define PLATFORM_NAME                       "TI AM67 (J722S) Cortex-R5F"
+/** @} */
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if !defined(AM67_MCUCONF)
+#error "Using a wrong mcuconf.h file, AM67_MCUCONF not defined"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Returns the frequency of a clock point in Hz.
+ * @note    Clock points are not implemented: the R5F does not own the clock
+ *          tree on this SoC, the Linux host does. Peripheral input
+ *          frequencies are constants in the registry instead.
+ */
+#define hal_lld_get_clock_point(clkpt)      0U
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void hal_lld_init(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/TI/AM67/platform.mk
+++ b/os/xhal/ports/TI/AM67/platform.mk
@@ -23,6 +23,7 @@ endif
 
 # Drivers compatible with the platform.
 include $(CHIBIOS)/os/xhal/ports/TI/LLD/DMTIMERv1/driver.mk
+include $(CHIBIOS)/os/xhal/ports/TI/LLD/UARTv1/driver.mk
 
 # Shared variables
 ALLCSRC += $(PLATFORMSRC)

--- a/os/xhal/ports/TI/AM67/platform.mk
+++ b/os/xhal/ports/TI/AM67/platform.mk
@@ -1,0 +1,29 @@
+# Required platform files.
+PLATFORMSRC := $(CHIBIOS)/os/xhal/ports/TI/AM67/hal_lld.c
+
+# Required include directories.
+PLATFORMINC := $(CHIBIOS)/os/xhal/ports/TI/AM67
+
+# Optional platform files.
+ifeq ($(USE_SMART_BUILD),yes)
+
+# Configuration files directory
+ifeq ($(HALCONFDIR),)
+  ifeq ($(CONFDIR),)
+    HALCONFDIR = .
+  else
+    HALCONFDIR := $(CONFDIR)
+  endif
+endif
+
+HALCONF := $(strip $(shell cat $(HALCONFDIR)/xhalconf.h | grep -E "\#define"))
+
+else
+endif
+
+# Drivers compatible with the platform.
+include $(CHIBIOS)/os/xhal/ports/TI/LLD/DMTIMERv1/driver.mk
+
+# Shared variables
+ALLCSRC += $(PLATFORMSRC)
+ALLINC  += $(PLATFORMINC)

--- a/os/xhal/ports/TI/LLD/DMTIMERv1/driver.mk
+++ b/os/xhal/ports/TI/LLD/DMTIMERv1/driver.mk
@@ -1,0 +1,3 @@
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/TI/LLD/DMTIMERv1/hal_st_lld.c
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/TI/LLD/DMTIMERv1

--- a/os/xhal/ports/TI/LLD/DMTIMERv1/hal_st_lld.c
+++ b/os/xhal/ports/TI/LLD/DMTIMERv1/hal_st_lld.c
@@ -1,0 +1,147 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    DMTIMERv1/hal_st_lld.c
+ * @brief   ST Driver subsystem low level driver source.
+ * @details The DMTIMER counts up from a preloaded value and interrupts on
+ *          overflow, auto-reloading for a periodic tick.
+ *
+ * @addtogroup ST
+ * @{
+ */
+
+#include "hal.h"
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+#define DMTIMER_IRQSTATUS                   0x28U
+#define DMTIMER_IRQSTATUS_SET               0x2CU
+#define DMTIMER_TCLR                        0x38U
+#define DMTIMER_TCRR                        0x3CU
+#define DMTIMER_TLDR                        0x40U
+
+#define DMTIMER_TCLR_ST                     (1U << 0)
+#define DMTIMER_TCLR_AR                     (1U << 1)
+#define DMTIMER_IRQ_OVF                     (1U << 1)
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+static inline volatile uint32_t *tmr_reg(uint32_t offset) {
+
+  return (volatile uint32_t *)(void *)(AM67_ST_TIMER_BASE + offset);
+}
+
+/**
+ * @brief   Acknowledges the overflow interrupt.
+ * @note    The line is level-sensitive at the VIM, so the write is read
+ *          back and repeated if the flag is still set: leaving it asserted
+ *          re-enters the handler forever.
+ */
+static void st_clear_irq(void) {
+
+  *tmr_reg(DMTIMER_IRQSTATUS) = DMTIMER_IRQ_OVF;
+
+  if ((*tmr_reg(DMTIMER_IRQSTATUS) & DMTIMER_IRQ_OVF) != 0U) {
+    *tmr_reg(DMTIMER_IRQSTATUS) = DMTIMER_IRQ_OVF;
+  }
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   System tick interrupt handler.
+ *
+ * @param[in] arg       handler argument, unused
+ * @return              The preemption-required flag.
+ *
+ * @notapi
+ */
+static bool st_irq_handler(void *arg) {
+  bool preemption_required;
+
+  (void)arg;
+
+  st_lld_serve_interrupt();
+
+  chSysLockFromISR();
+  preemption_required = chSchIsPreemptionRequired();
+  chSysUnlockFromISR();
+
+  return preemption_required;
+}
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level ST driver initialization.
+ *
+ * @notapi
+ */
+void st_lld_init(void) {
+  uint32_t reload;
+
+  /* Counter value producing CH_CFG_ST_FREQUENCY overflows per second.*/
+  reload = 0xFFFFFFFFU - (AM67_ST_TIMER_CLOCK / CH_CFG_ST_FREQUENCY) + 1U;
+
+  /* Stopped and quiet before it is reprogrammed, the core may have been
+     handed over by a boot stage that left the timer running.*/
+  *tmr_reg(DMTIMER_TCLR) = 0U;
+  st_clear_irq();
+
+  *tmr_reg(DMTIMER_TCRR) = reload;
+  *tmr_reg(DMTIMER_TLDR) = reload;
+  *tmr_reg(DMTIMER_IRQSTATUS_SET) = DMTIMER_IRQ_OVF;
+
+  vimSetHandler(AM67_ST_TIMER_IRQ, st_irq_handler, NULL);
+  vimSetPriority(AM67_ST_TIMER_IRQ, AM67_ST_IRQ_PRIORITY);
+  vimEnableInterrupt(AM67_ST_TIMER_IRQ);
+
+  /* Auto-reload mode, counting.*/
+  *tmr_reg(DMTIMER_TCLR) = DMTIMER_TCLR_ST | DMTIMER_TCLR_AR;
+}
+
+/**
+ * @brief   IRQ handling code.
+ *
+ * @notapi
+ */
+void st_lld_serve_interrupt(void) {
+
+  st_clear_irq();
+
+  chSysLockFromISR();
+  chSysTimerHandlerI();
+  chSysUnlockFromISR();
+}
+
+/** @} */

--- a/os/xhal/ports/TI/LLD/DMTIMERv1/hal_st_lld.h
+++ b/os/xhal/ports/TI/LLD/DMTIMERv1/hal_st_lld.h
@@ -1,0 +1,121 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    DMTIMERv1/hal_st_lld.h
+ * @brief   ST Driver subsystem low level driver header.
+ *
+ * @addtogroup ST
+ * @{
+ */
+
+#ifndef HAL_ST_LLD_H
+#define HAL_ST_LLD_H
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    Configuration options
+ * @{
+ */
+/**
+ * @brief   System tick timer instance base address.
+ */
+#if !defined(AM67_ST_TIMER_BASE) || defined(__DOXYGEN__)
+#define AM67_ST_TIMER_BASE                  AM67_MCU_TIMER0_BASE
+#endif
+
+/**
+ * @brief   System tick timer interrupt line.
+ */
+#if !defined(AM67_ST_TIMER_IRQ) || defined(__DOXYGEN__)
+#define AM67_ST_TIMER_IRQ                   AM67_MCU_TIMER0_IRQ
+#endif
+
+/**
+ * @brief   System tick timer input clock frequency.
+ * @note    Board-level, not SoC-level: the device tree leaves this timer's
+ *          clock mux at its reset default, so the board file states what
+ *          that default resolves to. A wrong value shows up as a tick rate
+ *          off by a clean integer ratio, not as a boot failure.
+ */
+#if !defined(AM67_ST_TIMER_CLOCK) || defined(__DOXYGEN__)
+#error "AM67_ST_TIMER_CLOCK not defined in board.h"
+#endif
+
+/**
+ * @brief   System tick timer interrupt priority.
+ * @note    Defaults to the most urgent level. The system tick must be able
+ *          to preempt every peripheral ISR: same-priority VIM lines cannot
+ *          preempt each other, so a peripheral handler that stays inside
+ *          its own drain loop would otherwise delay timekeeping for that
+ *          entire window.
+ */
+#if !defined(AM67_ST_IRQ_PRIORITY) || defined(__DOXYGEN__)
+#define AM67_ST_IRQ_PRIORITY                0U
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if CH_CFG_ST_TIMEDELTA > 0
+#error "the DMTIMERv1 ST driver does not implement tickless mode"
+#endif
+
+#if (AM67_ST_TIMER_CLOCK % CH_CFG_ST_FREQUENCY) != 0
+#error "the selected CH_CFG_ST_FREQUENCY is not exact for AM67_ST_TIMER_CLOCK"
+#endif
+
+#if (AM67_ST_TIMER_CLOCK / CH_CFG_ST_FREQUENCY) > 0xFFFFFFFFU
+#error "the selected CH_CFG_ST_FREQUENCY is too low for AM67_ST_TIMER_CLOCK"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void st_lld_init(void);
+  void st_lld_serve_interrupt(void);
+#ifdef __cplusplus
+}
+#endif
+
+/*===========================================================================*/
+/* Driver inline functions.                                                  */
+/*===========================================================================*/
+
+#endif /* HAL_ST_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/TI/LLD/UARTv1/driver.mk
+++ b/os/xhal/ports/TI/LLD/UARTv1/driver.mk
@@ -1,0 +1,9 @@
+ifeq ($(USE_SMART_BUILD),yes)
+ifneq ($(findstring HAL_USE_SIO TRUE,$(HALCONF)),)
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/TI/LLD/UARTv1/hal_sio_lld.c
+endif
+else
+PLATFORMSRC += $(CHIBIOS)/os/xhal/ports/TI/LLD/UARTv1/hal_sio_lld.c
+endif
+
+PLATFORMINC += $(CHIBIOS)/os/xhal/ports/TI/LLD/UARTv1

--- a/os/xhal/ports/TI/LLD/UARTv1/hal_sio_lld.c
+++ b/os/xhal/ports/TI/LLD/UARTv1/hal_sio_lld.c
@@ -1,0 +1,597 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    UARTv1/hal_sio_lld.c
+ * @brief   AM67 SIO subsystem low level driver source.
+ *
+ * @addtogroup HAL_SIO
+ * @{
+ */
+
+#include "hal.h"
+
+#if (HAL_USE_SIO == TRUE) || defined(__DOXYGEN__)
+
+/*===========================================================================*/
+/* Driver local definitions.                                                 */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver-private sticky bit for the character timeout condition.
+ * @note    Deliberately above the eight hardware LSR bits: the 16550 signals
+ *          a receiver gone quiet through the character timeout interrupt,
+ *          not through a status bit, so the handler records it alongside the
+ *          latched LSR bits.
+ */
+#define SIO_LSR_CTI                         (1U << 8)
+
+/**
+ * @brief   Error and status bits latched by the handler.
+ */
+#define SIO_LSR_STICKY                      (TI_UART_LSR_RX_ERRORS | SIO_LSR_CTI)
+
+/*===========================================================================*/
+/* Driver exported variables.                                                */
+/*===========================================================================*/
+
+#if (AM67_SIO_USE_UART1 == TRUE) || defined(__DOXYGEN__)
+/**
+ * @brief   SIOD1 driver identifier.
+ */
+SIODriver SIOD1;
+#endif
+
+/*===========================================================================*/
+/* Driver local variables and types.                                         */
+/*===========================================================================*/
+
+/**
+ * @brief   Driver default configuration.
+ */
+static const SIOConfig default_config = {
+  .baud                 = SIO_DEFAULT_BITRATE,
+  .lcr                  = TI_UART_LCR_8N1,
+  .fcr                  = TI_UART_FCR_FIFOEN | TI_UART_FCR_RXTRIGGER_8
+};
+
+/*===========================================================================*/
+/* Driver local functions.                                                   */
+/*===========================================================================*/
+
+/**
+ * @brief   Writes the IER register through the driver shadow.
+ * @note    IER and DLH share an address, selected by LCR.DLAB. Going
+ *          through the shadow keeps the driver from reading back whatever
+ *          the divisor latch happens to expose.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[in] ier       new IER value
+ */
+static void uart_set_ier(SIODriver *siop, uint32_t ier) {
+
+  siop->ier = ier;
+  siop->uart->IER_DLH = ier;
+}
+
+/**
+ * @brief   Latches the volatile part of the line status.
+ * @note    LSR clears its error bits on read, so any read that is not
+ *          recorded here loses them for good.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The raw LSR value.
+ */
+static uint32_t uart_latch_lsr(SIODriver *siop) {
+  uint32_t lsr;
+
+  lsr = siop->uart->LSR;
+  siop->lsr |= lsr & TI_UART_LSR_RX_ERRORS;
+
+  return lsr;
+}
+
+/**
+ * @brief   Translates latched status bits into SIO events.
+ *
+ * @param[in] lsr       latched status bits
+ * @return              The SIO events mask.
+ */
+static sioevents_t uart_lsr2evt(uint32_t lsr) {
+  sioevents_t evt = (sioevents_t)0;
+
+  if ((lsr & TI_UART_LSR_PE) != 0U) {
+    evt |= SIO_EV_PARITY_ERR;
+  }
+  if ((lsr & TI_UART_LSR_FE) != 0U) {
+    evt |= SIO_EV_FRAMING_ERR;
+  }
+  if ((lsr & TI_UART_LSR_OE) != 0U) {
+    evt |= SIO_EV_OVERRUN_ERR;
+  }
+  if ((lsr & TI_UART_LSR_BI) != 0U) {
+    evt |= SIO_EV_RX_BREAK;
+  }
+  if ((lsr & SIO_LSR_CTI) != 0U) {
+    evt |= SIO_EV_RX_IDLE;
+  }
+
+  return evt;
+}
+
+/**
+ * @brief   Common interrupt service routine.
+ *
+ * @param[in] arg       pointer to the @p SIODriver object
+ * @return              The preemption-required flag.
+ */
+static bool uart_irq_handler(void *arg) {
+  SIODriver *siop = (SIODriver *)arg;
+  bool preemption_required;
+
+  /* Called out of the lock: the __sio_wakeup_xxx() macros take the lock
+     themselves and the driver callback must not run while holding it.*/
+  sio_lld_serve_interrupt(siop);
+
+  chSysLockFromISR();
+  preemption_required = chSchIsPreemptionRequired();
+  chSysUnlockFromISR();
+
+  return preemption_required;
+}
+
+/*===========================================================================*/
+/* Driver interrupt handlers.                                                */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver exported functions.                                                */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level SIO driver initialization.
+ *
+ * @notapi
+ */
+void sio_lld_init(void) {
+
+#if AM67_SIO_USE_UART1 == TRUE
+  sioObjectInit(&SIOD1);
+  SIOD1.uart  = (TI_UART_TypeDef *)(void *)AM67_MAIN_UART1_BASE;
+  SIOD1.irq   = AM67_MAIN_UART1_IRQ;
+  SIOD1.clock = AM67_MAIN_UART1_CLOCK;
+  SIOD1.ier   = 0U;
+  SIOD1.lsr   = 0U;
+#endif
+}
+
+/**
+ * @brief   Configures and activates the SIO peripheral.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The operation status.
+ *
+ * @notapi
+ */
+msg_t sio_lld_start(SIODriver *siop) {
+  msg_t msg;
+
+  if (siop->state == HAL_DRV_STATE_STOP) {
+#if AM67_SIO_USE_UART1 == TRUE
+    if (&SIOD1 == siop) {
+      vimSetHandler(siop->irq, uart_irq_handler, (void *)siop);
+      vimSetPriority(siop->irq, AM67_SIO_UART1_IRQ_PRIORITY);
+      vimEnableInterrupt(siop->irq);
+    }
+#endif
+  }
+
+  /* Configures the peripheral.*/
+  msg = sio_lld_setcfg(siop, siop->config) == NULL ? HAL_RET_CONFIG_ERROR :
+                                                     HAL_RET_SUCCESS;
+
+  return msg;
+}
+
+/**
+ * @brief   Deactivates the SIO peripheral.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ *
+ * @notapi
+ */
+void sio_lld_stop(SIODriver *siop) {
+
+  if (siop->state == HAL_DRV_STATE_READY) {
+    uart_set_ier(siop, 0U);
+
+    /* The peripheral is inert with the mode disabled, which is also its
+       reset state, so a later start does not inherit half a setup.*/
+    siop->uart->MDR1 = TI_UART_MDR1_MODE_DISABLE;
+
+    vimDisableInterrupt(siop->irq);
+    vimSetHandler(siop->irq, NULL, NULL);
+  }
+}
+
+/**
+ * @brief   SIO configuration.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[in] config    pointer to the @p SIOConfig structure, @p NULL
+ *                      selects the default configuration
+ * @return              A pointer to the current configuration structure.
+ * @retval NULL         if the configuration is not valid.
+ *
+ * @notapi
+ */
+const SIOConfig *sio_lld_setcfg(SIODriver *siop, const SIOConfig *config) {
+  TI_UART_TypeDef *u = siop->uart;
+  uint32_t divisor;
+
+  if (config == NULL) {
+    config = &default_config;
+  }
+
+  /* The 16x oversampling divisor must be representable and non zero.*/
+  divisor = siop->clock / (16U * config->baud);
+  if ((divisor == 0U) || (divisor > 0xFFFFU)) {
+    return NULL;
+  }
+
+  /* Held disabled while it is reprogrammed, the divisor latch must not be
+     written with the transmitter live.*/
+  u->MDR1 = TI_UART_MDR1_MODE_DISABLE;
+  uart_set_ier(siop, 0U);
+
+  u->LCR = TI_UART_LCR_DLAB;
+  u->RBR_THR_DLL = divisor & 0xFFU;
+  u->IER_DLH = (divisor >> 8) & 0xFFU;
+  u->LCR = config->lcr;
+
+  /* The FIFO reset bits are self clearing, they are only meaningful in the
+     same write that enables the FIFOs.*/
+  u->IIR_FCR = config->fcr | TI_UART_FCR_RXRST | TI_UART_FCR_TXRST;
+
+  /* Discards anything the previous owner left in the receiver.*/
+  (void)uart_latch_lsr(siop);
+  siop->lsr = 0U;
+
+  /* Written last, the peripheral does nothing at all until the mode is
+     selected.*/
+  u->MDR1 = TI_UART_MDR1_MODE_UART16X;
+
+  return config;
+}
+
+/**
+ * @brief   Selects one of the pre-defined SIO configurations.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[in] cfgnum    driver configuration number
+ * @return              The configuration pointer.
+ * @retval NULL         if the configuration is not valid.
+ *
+ * @notapi
+ */
+const hal_sio_config_t *sio_lld_selcfg(SIODriver *siop,
+                                       unsigned cfgnum) {
+#if SIO_USE_CONFIGURATIONS == TRUE
+  extern const sio_configurations_t sio_configurations;
+
+  if (cfgnum >= sio_configurations.cfgsnum) {
+    return NULL;
+  }
+
+  return (const void *)sio_lld_setcfg(siop, &sio_configurations.cfgs[cfgnum]);
+#else
+
+  if (cfgnum > 0U) {
+    return NULL;
+  }
+
+  return (const void *)sio_lld_setcfg(siop, NULL);
+#endif
+}
+
+/**
+ * @brief   Enable flags change notification.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ *
+ * @notapi
+ */
+void sio_lld_update_enable_flags(SIODriver *siop) {
+  uint32_t ier = 0U;
+
+  /* The character timeout that carries the RX idle event is only reported
+     while the receiver interrupt is enabled, so both events map to it.*/
+  if ((siop->enabled & (SIO_EV_RX_NOTEMPTY | SIO_EV_RX_IDLE)) != 0U) {
+    ier |= TI_UART_IER_ERBFI;
+  }
+
+  /* The 16550 has no transmitter-empty interrupt, the handler tests TEMT
+     when the holding register goes empty, so both events map to ETBEI.*/
+  if ((siop->enabled & (SIO_EV_TX_NOTFULL | SIO_EV_TX_END)) != 0U) {
+    ier |= TI_UART_IER_ETBEI;
+  }
+
+  if ((siop->enabled & SIO_EV_ALL_ERRORS) != 0U) {
+    ier |= TI_UART_IER_ELSI;
+  }
+
+  uart_set_ier(siop, ier);
+}
+
+/**
+ * @brief   Get and clears SIO error event flags.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The pending event flags.
+ *
+ * @notapi
+ */
+sioevents_t sio_lld_get_and_clear_errors(SIODriver *siop) {
+  uint32_t lsr;
+
+  (void)uart_latch_lsr(siop);
+
+  lsr = siop->lsr & TI_UART_LSR_RX_ERRORS;
+  siop->lsr &= ~TI_UART_LSR_RX_ERRORS;
+
+  /* Errors acknowledged, the RX sources masked by the handler can be
+     armed again.*/
+  sio_lld_update_enable_flags(siop);
+
+  return uart_lsr2evt(lsr);
+}
+
+/**
+ * @brief   Get and clears SIO event flags.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[in] events    events to be returned and cleared
+ * @return              The pending event flags.
+ *
+ * @notapi
+ */
+sioevents_t sio_lld_get_and_clear_events(SIODriver *siop, sioevents_t events) {
+  sioevents_t pending;
+
+  pending = sio_lld_get_events(siop) & events;
+
+  /* Only the latched bits can be cleared, the live FIFO conditions clear
+     themselves when the FIFOs are drained or filled.*/
+  siop->lsr &= ~SIO_LSR_STICKY;
+
+  sio_lld_update_enable_flags(siop);
+
+  return pending;
+}
+
+/**
+ * @brief   Returns the pending SIO event flags.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The pending event flags.
+ *
+ * @notapi
+ */
+sioevents_t sio_lld_get_events(SIODriver *siop) {
+  sioevents_t evt;
+  uint32_t lsr;
+
+  lsr = uart_latch_lsr(siop);
+
+  evt = uart_lsr2evt(siop->lsr);
+
+  if ((lsr & TI_UART_LSR_DR) != 0U) {
+    evt |= SIO_EV_RX_NOTEMPTY;
+  }
+  if ((lsr & TI_UART_LSR_TEMT) != 0U) {
+    evt |= SIO_EV_TX_END;
+  }
+  if ((siop->uart->SSR & TI_UART_SSR_TXFIFOFULL) == 0U) {
+    evt |= SIO_EV_TX_NOTFULL;
+  }
+
+  return evt;
+}
+
+/**
+ * @brief   Reads data from the RX FIFO.
+ * @details The function is not blocking, it reads frames until the FIFO is
+ *          empty without waiting.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[out] buffer   pointer to the buffer for read frames
+ * @param[in] n         maximum number of frames to be read
+ * @return              The number of frames copied from the FIFO.
+ * @retval 0            if the RX FIFO is empty.
+ *
+ * @notapi
+ */
+size_t sio_lld_read(SIODriver *siop, uint8_t *buffer, size_t n) {
+  size_t rd = 0U;
+
+  while (rd < n) {
+    if (sio_lld_is_rx_empty(siop)) {
+      break;
+    }
+
+    *buffer++ = (uint8_t)siop->uart->RBR_THR_DLL;
+    rd++;
+  }
+
+  /* Re-arms what the handler masked, now that the FIFO has been drained.*/
+  if (sio_lld_is_rx_empty(siop)) {
+    sio_lld_update_enable_flags(siop);
+  }
+
+  return rd;
+}
+
+/**
+ * @brief   Writes data into the TX FIFO.
+ * @details The function is not blocking, it writes frames until there is
+ *          space available without waiting.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[in] buffer    pointer to the buffer for frames to be written
+ * @param[in] n         maximum number of frames to be written
+ * @return              The number of frames copied into the FIFO.
+ * @retval 0            if the TX FIFO is full.
+ *
+ * @notapi
+ */
+size_t sio_lld_write(SIODriver *siop, const uint8_t *buffer, size_t n) {
+  size_t wr = 0U;
+
+  while (wr < n) {
+    if (sio_lld_is_tx_full(siop)) {
+      break;
+    }
+
+    siop->uart->RBR_THR_DLL = (uint32_t)*buffer++;
+    wr++;
+  }
+
+  /* Re-arms the transmitter interrupt masked by the handler.*/
+  sio_lld_update_enable_flags(siop);
+
+  return wr;
+}
+
+/**
+ * @brief   Returns one frame from the RX FIFO.
+ * @note    Must be invoked with the RX FIFO known to be non empty.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The received frame.
+ *
+ * @notapi
+ */
+msg_t sio_lld_get(SIODriver *siop) {
+  msg_t msg;
+
+  msg = (msg_t)(siop->uart->RBR_THR_DLL & 0xFFU);
+
+  if (sio_lld_is_rx_empty(siop)) {
+    sio_lld_update_enable_flags(siop);
+  }
+
+  return msg;
+}
+
+/**
+ * @brief   Pushes one frame into the TX FIFO.
+ * @note    Must be invoked with the TX FIFO known not to be full.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[in] data      frame to be pushed
+ *
+ * @notapi
+ */
+void sio_lld_put(SIODriver *siop, uint_fast16_t data) {
+
+  siop->uart->RBR_THR_DLL = (uint32_t)data;
+
+  sio_lld_update_enable_flags(siop);
+}
+
+/**
+ * @brief   Control operation on a serial port.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @param[in] operation control operation code
+ * @param[in,out] arg   operation argument
+ * @return              The control operation status.
+ *
+ * @notapi
+ */
+msg_t sio_lld_control(SIODriver *siop, unsigned int operation, void *arg) {
+
+  (void)siop;
+  (void)operation;
+  (void)arg;
+
+  return HAL_RET_UNKNOWN_CTL;
+}
+
+/**
+ * @brief   Serves an UART interrupt.
+ * @details The interrupt identification register is read once per pass: on
+ *          a 16550 that read is what deasserts the reported condition, so
+ *          reading it twice loses an interrupt.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ *
+ * @notapi
+ */
+void sio_lld_serve_interrupt(SIODriver *siop) {
+  uint32_t iir, intid;
+
+  iir = siop->uart->IIR_FCR;
+  if ((iir & TI_UART_IIR_INTSTATUS) != 0U) {
+    /* Active low, nothing is pending.*/
+    return;
+  }
+
+  intid = iir & TI_UART_IIR_INTID_MASK;
+
+  /* The VIM line is level sensitive and none of these conditions clear
+     until the application moves data, so the serviced sources are masked
+     here and re-armed by the read/write paths. Without that the handler
+     re-enters until the application happens to drain the FIFO.*/
+  switch (intid) {
+  case TI_UART_IIR_INTID_RLS:
+    (void)uart_latch_lsr(siop);
+    uart_set_ier(siop, siop->ier & ~(TI_UART_IER_ERBFI | TI_UART_IER_ELSI));
+    __sio_wakeup_errors(siop);
+    break;
+
+  case TI_UART_IIR_INTID_CTI:
+    siop->lsr |= SIO_LSR_CTI;
+    uart_set_ier(siop, siop->ier & ~(TI_UART_IER_ERBFI | TI_UART_IER_ELSI));
+    __sio_wakeup_rxidle(siop);
+    __sio_wakeup_rx(siop);
+    break;
+
+  case TI_UART_IIR_INTID_RDA:
+    uart_set_ier(siop, siop->ier & ~(TI_UART_IER_ERBFI | TI_UART_IER_ELSI));
+    __sio_wakeup_rx(siop);
+    break;
+
+  case TI_UART_IIR_INTID_THRE:
+    uart_set_ier(siop, siop->ier & ~TI_UART_IER_ETBEI);
+    if ((siop->uart->LSR & TI_UART_LSR_TEMT) != 0U) {
+      __sio_wakeup_txend(siop);
+    }
+    __sio_wakeup_tx(siop);
+    break;
+
+  default:
+    break;
+  }
+
+  /* The callback is invoked out of the lock, per the XHAL callback
+     contract.*/
+  __sio_callback(siop);
+}
+
+#endif /* HAL_USE_SIO == TRUE */
+
+/** @} */

--- a/os/xhal/ports/TI/LLD/UARTv1/hal_sio_lld.h
+++ b/os/xhal/ports/TI/LLD/UARTv1/hal_sio_lld.h
@@ -1,0 +1,216 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    UARTv1/hal_sio_lld.h
+ * @brief   AM67 SIO subsystem low level driver header.
+ *
+ * @addtogroup HAL_SIO
+ * @{
+ */
+
+#ifndef HAL_SIO_LLD_H
+#define HAL_SIO_LLD_H
+
+#if (HAL_USE_SIO == TRUE) || defined(__DOXYGEN__)
+
+#include "ti_uart.h"
+
+/*===========================================================================*/
+/* Driver constants.                                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver pre-compile time settings.                                         */
+/*===========================================================================*/
+
+/**
+ * @name    AM67 configuration options
+ * @{
+ */
+/**
+ * @brief   SIO driver 1 enable switch.
+ * @details If set to @p TRUE the support for MAIN_UART1 is included.
+ * @note    The default is @p FALSE.
+ */
+#if !defined(AM67_SIO_USE_UART1) || defined(__DOXYGEN__)
+#define AM67_SIO_USE_UART1                  FALSE
+#endif
+
+/**
+ * @brief   MAIN_UART1 interrupt priority level setting.
+ */
+#if !defined(AM67_SIO_UART1_IRQ_PRIORITY) || defined(__DOXYGEN__)
+#define AM67_SIO_UART1_IRQ_PRIORITY         8U
+#endif
+/** @} */
+
+/*===========================================================================*/
+/* Derived constants and error checks.                                       */
+/*===========================================================================*/
+
+#if (AM67_SIO_USE_UART1 == TRUE) && (AM67_HAS_MAIN_UART1 == FALSE)
+#error "MAIN_UART1 not present in the selected device"
+#endif
+
+#if (AM67_SIO_USE_UART1 == FALSE)
+#error "SIO driver activated but no UART peripheral assigned"
+#endif
+
+#if !defined(AM67_MAIN_UART1_CLOCK)
+#error "AM67_MAIN_UART1_CLOCK not defined in board.h"
+#endif
+
+/*===========================================================================*/
+/* Driver data structures and types.                                         */
+/*===========================================================================*/
+
+/*===========================================================================*/
+/* Driver macros.                                                            */
+/*===========================================================================*/
+
+/**
+ * @brief   Low level fields of the SIO driver structure.
+ */
+#define sio_lld_driver_fields                                               \
+  /* Pointer to the UARTx registers block.*/                                \
+  TI_UART_TypeDef           *uart;                                          \
+  /* Interrupt line associated to the peripheral.*/                         \
+  uint32_t                  irq;                                            \
+  /* Functional clock frequency for the associated UART.*/                  \
+  uint32_t                  clock;                                          \
+  /* Shadow of the IER register, the peripheral overlays IER and DLH so a   \
+     read-modify-write is only safe while DLAB is known to be zero.*/       \
+  uint32_t                  ier;                                            \
+  /* Sticky line status bits captured by the handler, LSR clears on read    \
+     so the errors would otherwise be lost before the driver asks.*/        \
+  uint32_t                  lsr
+
+/**
+ * @brief   Low level fields of the SIO configuration structure.
+ */
+#define sio_lld_config_fields                                               \
+  /* Desired baud rate.*/                                                   \
+  uint32_t                  baud;                                           \
+  /* UART LCR register initialization data.*/                               \
+  uint32_t                  lcr;                                            \
+  /* UART FCR register initialization data.*/                               \
+  uint32_t                  fcr
+
+/**
+ * @brief   Determines the state of the RX FIFO.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The RX FIFO state.
+ * @retval false        if RX FIFO is not empty
+ * @retval true         if RX FIFO is empty
+ *
+ * @notapi
+ */
+#define sio_lld_is_rx_empty(siop)                                           \
+  (bool)(((siop)->uart->LSR & TI_UART_LSR_DR) == 0U)
+
+/**
+ * @brief   Determines the activity state of the receiver.
+ * @note    A 16550 has no line-idle status bit. The closest honest answer
+ *          is "nothing is waiting to be read"; the RX idle *event* comes
+ *          from the character timeout interrupt instead.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The RX activity state.
+ * @retval false        if RX is in active state.
+ * @retval true         if RX is in idle state.
+ *
+ * @notapi
+ */
+#define sio_lld_is_rx_idle(siop)                                            \
+  (bool)(((siop)->uart->LSR & TI_UART_LSR_DR) == 0U)
+
+/**
+ * @brief   Determines if RX has pending error events to be read and cleared.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The RX error events.
+ * @retval false        if RX has no pending events
+ * @retval true         if RX has pending events
+ *
+ * @notapi
+ */
+#define sio_lld_has_rx_errors(siop)                                         \
+  (bool)(((siop)->lsr & TI_UART_LSR_RX_ERRORS) != 0U)
+
+/**
+ * @brief   Determines the state of the TX FIFO.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The TX FIFO state.
+ * @retval false        if TX FIFO is not full
+ * @retval true         if TX FIFO is full
+ *
+ * @notapi
+ */
+#define sio_lld_is_tx_full(siop)                                            \
+  (bool)(((siop)->uart->SSR & TI_UART_SSR_TXFIFOFULL) != 0U)
+
+/**
+ * @brief   Determines the transmission state.
+ *
+ * @param[in] siop      pointer to the @p SIODriver object
+ * @return              The TX state.
+ * @retval false        if transmission is idle
+ * @retval true         if transmission is ongoing
+ *
+ * @notapi
+ */
+#define sio_lld_is_tx_ongoing(siop)                                         \
+  (bool)(((siop)->uart->LSR & TI_UART_LSR_TEMT) == 0U)
+
+/*===========================================================================*/
+/* External declarations.                                                    */
+/*===========================================================================*/
+
+#if (AM67_SIO_USE_UART1 == TRUE) && !defined(__DOXYGEN__)
+extern SIODriver SIOD1;
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void sio_lld_init(void);
+  msg_t sio_lld_start(SIODriver *siop);
+  void sio_lld_stop(SIODriver *siop);
+  const SIOConfig *sio_lld_setcfg(SIODriver *siop, const SIOConfig *config);
+  const hal_sio_config_t *sio_lld_selcfg(SIODriver *siop,
+                                         unsigned cfgnum);
+  void sio_lld_update_enable_flags(SIODriver *siop);
+  sioevents_t sio_lld_get_and_clear_errors(SIODriver *siop);
+  sioevents_t sio_lld_get_and_clear_events(SIODriver *siop, sioevents_t events);
+  sioevents_t sio_lld_get_events(SIODriver *siop);
+  size_t sio_lld_read(SIODriver *siop, uint8_t *buffer, size_t n);
+  size_t sio_lld_write(SIODriver *siop, const uint8_t *buffer, size_t n);
+  msg_t sio_lld_get(SIODriver *siop);
+  void sio_lld_put(SIODriver *siop, uint_fast16_t data);
+  msg_t sio_lld_control(SIODriver *siop, unsigned int operation, void *arg);
+  void sio_lld_serve_interrupt(SIODriver *siop);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_USE_SIO == TRUE */
+
+#endif /* HAL_SIO_LLD_H */
+
+/** @} */

--- a/os/xhal/ports/TI/LLD/UARTv1/ti_uart.h
+++ b/os/xhal/ports/TI/LLD/UARTv1/ti_uart.h
@@ -102,6 +102,15 @@ typedef struct {
 /** @} */
 
 /**
+ * @name    MCR bits
+ * @{
+ */
+#define TI_UART_MCR_DTR                     (1U << 0)
+#define TI_UART_MCR_RTS                     (1U << 1)
+#define TI_UART_MCR_LPBK                    (1U << 4)
+/** @} */
+
+/**
  * @name    LSR bits
  * @{
  */

--- a/os/xhal/ports/TI/LLD/UARTv1/ti_uart.h
+++ b/os/xhal/ports/TI/LLD/UARTv1/ti_uart.h
@@ -1,0 +1,146 @@
+/*
+    ChibiOS - Copyright (C) 2006-2026 Giovanni Di Sirio.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+/**
+ * @file    UARTv1/ti_uart.h
+ * @brief   TI UART registers layout header.
+ * @details 16550-compatible with TI extensions. All registers are 32 bits
+ *          wide at stride 4 and must be accessed with full 32-bit reads and
+ *          writes, a K3 interconnect requirement.
+ *
+ * @addtogroup HAL
+ * @{
+ */
+
+#ifndef TI_UART_H
+#define TI_UART_H
+
+/**
+ * @brief   TI UART registers block.
+ */
+typedef struct {
+  volatile uint32_t     RBR_THR_DLL;
+  volatile uint32_t     IER_DLH;
+  volatile uint32_t     IIR_FCR;
+  volatile uint32_t     LCR;
+  volatile uint32_t     MCR;
+  volatile uint32_t     LSR;
+  volatile uint32_t     MSR;
+  volatile uint32_t     SCR;
+  volatile uint32_t     MDR1;
+  volatile uint32_t     resvd1[8];
+  volatile uint32_t     SSR;
+  volatile uint32_t     resvd2[3];
+  volatile uint32_t     SYSC;
+  volatile uint32_t     SYSS;
+} TI_UART_TypeDef;
+
+/**
+ * @name    IER bits (DLAB = 0)
+ * @{
+ */
+#define TI_UART_IER_ERBFI                   (1U << 0)
+#define TI_UART_IER_ETBEI                   (1U << 1)
+#define TI_UART_IER_ELSI                    (1U << 2)
+#define TI_UART_IER_EDSSI                   (1U << 3)
+/** @} */
+
+/**
+ * @name    IIR bits (read)
+ * @{
+ */
+#define TI_UART_IIR_INTSTATUS               (1U << 0)
+#define TI_UART_IIR_INTID_POS               1U
+#define TI_UART_IIR_INTID_MASK              (7U << TI_UART_IIR_INTID_POS)
+#define TI_UART_IIR_INTID_MSI               (0U << TI_UART_IIR_INTID_POS)
+#define TI_UART_IIR_INTID_THRE              (1U << TI_UART_IIR_INTID_POS)
+#define TI_UART_IIR_INTID_RDA               (2U << TI_UART_IIR_INTID_POS)
+#define TI_UART_IIR_INTID_RLS               (3U << TI_UART_IIR_INTID_POS)
+#define TI_UART_IIR_INTID_CTI               (6U << TI_UART_IIR_INTID_POS)
+/** @} */
+
+/**
+ * @name    FCR bits (write)
+ * @{
+ */
+#define TI_UART_FCR_FIFOEN                  (1U << 0)
+#define TI_UART_FCR_RXRST                   (1U << 1)
+#define TI_UART_FCR_TXRST                   (1U << 2)
+#define TI_UART_FCR_RXTRIGGER_1             (0U << 6)
+#define TI_UART_FCR_RXTRIGGER_4             (1U << 6)
+#define TI_UART_FCR_RXTRIGGER_8             (2U << 6)
+#define TI_UART_FCR_RXTRIGGER_14            (3U << 6)
+/** @} */
+
+/**
+ * @name    LCR bits
+ * @{
+ */
+#define TI_UART_LCR_WLS_5BIT                0U
+#define TI_UART_LCR_WLS_6BIT                1U
+#define TI_UART_LCR_WLS_7BIT                2U
+#define TI_UART_LCR_WLS_8BIT                3U
+#define TI_UART_LCR_STB                     (1U << 2)
+#define TI_UART_LCR_PEN                     (1U << 3)
+#define TI_UART_LCR_EPS                     (1U << 4)
+#define TI_UART_LCR_BRK                     (1U << 6)
+#define TI_UART_LCR_DLAB                    (1U << 7)
+#define TI_UART_LCR_8N1                     TI_UART_LCR_WLS_8BIT
+/** @} */
+
+/**
+ * @name    LSR bits
+ * @{
+ */
+#define TI_UART_LSR_DR                      (1U << 0)
+#define TI_UART_LSR_OE                      (1U << 1)
+#define TI_UART_LSR_PE                      (1U << 2)
+#define TI_UART_LSR_FE                      (1U << 3)
+#define TI_UART_LSR_BI                      (1U << 4)
+#define TI_UART_LSR_THRE                    (1U << 5)
+#define TI_UART_LSR_TEMT                    (1U << 6)
+#define TI_UART_LSR_RXFE                    (1U << 7)
+#define TI_UART_LSR_RX_ERRORS               (TI_UART_LSR_OE | TI_UART_LSR_PE | \
+                                             TI_UART_LSR_FE | TI_UART_LSR_BI)
+/** @} */
+
+/**
+ * @name    SSR bits (TI extension)
+ * @{
+ */
+#define TI_UART_SSR_TXFIFOFULL              (1U << 0)
+/** @} */
+
+/**
+ * @name    MDR1 bits (TI extension)
+ * @note    The UART is inert until MDR1 selects an operating mode, whatever
+ *          the rest of the configuration says. Written last on start and
+ *          first on stop.
+ * @{
+ */
+#define TI_UART_MDR1_MODE_MASK              7U
+#define TI_UART_MDR1_MODE_UART16X           0U
+#define TI_UART_MDR1_MODE_DISABLE           7U
+/** @} */
+
+/**
+ * @brief   TX FIFO depth.
+ */
+#define TI_UART_TX_FIFO_DEPTH               64U
+
+#endif /* TI_UART_H */
+
+/** @} */


### PR DESCRIPTION
## Summary

Adds the foundation of a TI AM67 (J722S) XHAL port for the SoC's Cortex-R5F, plus the
board and a demo that exercises it. This is the first TI port in XHAL; it follows the
layout the RP port established — reusable IP blocks under
`os/xhal/ports/TI/LLD/<IPvN>/`, family glue under `os/xhal/ports/TI/AM67/`.

What lands here:

- **ARMv7-R AM67 sub-port** (`os/common/ports/ARMv7-R/platforms/am67/`) on the port's
  existing `port_platform_init()` hook, so VIM (Vectored Interrupt Manager) setup and
  `__port_irq_dispatch()` live in the sub-port rather than in the HAL.
- **XHAL platform** (`os/xhal/ports/TI/AM67/`): `hal_lld`, the instance registry and
  `platform.mk`.
- **DMTIMERv1 ST driver**, the system tick.
- **UARTv1 SIO driver**, the console path.
- **Board `T3_GEM_O1`** and the demo `RT-XHAL-T3-GEM-O1`, a heartbeat
  thread plus a console echo loop over `SIOD1`.

Three UART details shape the driver, since the AM67 UARTs are 16550-compatible with TI
extensions. `IER` shares an address with the divisor latch high byte selected by
`LCR.DLAB`, so the driver keeps a shadow instead of reading the register back. `LSR`
clears its error bits on read, so every read goes through a helper that latches them
for later reporting. And the 16550 has no line-idle status bit, so the RX idle event
is derived from the character timeout interrupt and recorded in a driver-private
sticky bit above the eight hardware `LSR` bits. The VIM line is level sensitive and no
FIFO condition clears until the application moves data, so the handler masks the
sources it serviced and the read/write paths re-arm them; without that the handler
re-enters until the application happens to drain the FIFO. `MDR1` is written last on
start and first on stop, because the peripheral is inert until the mode is selected.

The board file carries the peripheral input clocks the XHAL drivers ask for. They are
board-level rather than SoC-level because the device tree owns the clock muxes, so the
same peripheral on another carrier can be parented differently. The eHRPWM and eCAP
counter clocks are not among them: those are owned by `am67_registry.h`.

The demo's linker script gives code and data separate memory regions in both TCM and
DDR, so the image links as read-execute and read-write segments rather than one RWX
`PT_LOAD`. The MPU covers DDR with a single region and the split stays inside the same
remoteproc carveout, so nothing depends on the boundary.

## Related

- Issue(s): none
- Notes for reviewers: stacked on the AM67R5F startup device PR and should be merged
  after it. All files added here are new; no existing port, driver or demo is
  modified.

## Target Branch Check

- [x] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [x] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [x] Style check passed on changed `.c`/`.h` files — `tools/style/stylecheck.py` on
      all 19 changed `.c`/`.h` files: no findings
- [x] Build check passed (POSIX simulator compile and relevant ARM target compile) —
      `RT-Posix-Simulator` links, `test/rt-ports/testbuild` ARMv7-M target builds, and
      `RT-XHAL-GEMSTONE-O1-R5F` builds warning-free at text 11544 B with
      `arm-none-eabi-gcc 13.2.1`

## Testing

- [x] Test run successfully locally
- Any other tests run on a device? Yes, on a T3 Gemstone O1 (AM67A/J722S) R5F:
  - The demo ran with the heartbeat printing iterations 0 through 96 exactly 1000 ms
    apart across 96 s with zero drift, and later for 157 s unbroken with a clean fault
    block. That exercises ARMCR5 startup, the ARMv7-R AM67 sub-port and its
    `__port_irq_dispatch()`, the DMTIMER tick rate (confirming `AM67_ST_TIMER_CLOCK`
    = 25 MHz), XHAL core with `drvStart()`, and the scheduler.
  - The UART was verified separately, because a running heartbeat does not prove the
    UART transmits: the thread blocks until the TX FIFO accepts every byte, but a dead
    peripheral can leave `SSR.TXFIFOFULL` reading 0 forever and the driver then writes
    into a void without stalling. The UART's own internal loopback (`MCR.LPBK`) was
    used instead: wrote 4 bytes, read back 4, `'PING'`, `LSR = 0x60` (`THRE|TEMT`, no
    error bits). That covers TX, RX, both FIFOs and the driver's read and write paths.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [x] If API/ABI changed, rationale and migration notes are provided — not applicable
- [x] Risks/limitations are documented below

Everything added here is new files under new paths, so the only contact with existing
code is the ARMv7-R platforms hook, used as designed.

Bytes on the wire and the RX interrupt path are not proven. The loopback test is
conclusive for the driver's own paths but its reads were polled, and it does not put a
signal on a pin. A cable test is not possible on this board as configured: the console
TX pad is assigned to EHRPWM0 channel B by the device tree overlay, so no UART pin is
exposed. `MCR.LPBK` is retained in `ti_uart.h` because it is the cable-free way to
retest this driver.