### PR TITLE
SDC: MMC/eMMC cards expect RCA to be assigned by host

### DIFF
--- a/os/hal/src/hal_sdc.c
+++ b/os/hal/src/hal_sdc.c
@@ -711,10 +711,20 @@ bool sdcConnect(SDCDriver *sdcp) {
     goto failed;
   }
 
-  /* Asks for the RCA.*/
-  if (sdc_lld_send_cmd_short_crc(sdcp, MMCSD_CMD_SEND_RELATIVE_ADDR,
-                                 0, &sdcp->rca)) {
-    goto failed;
+  if ((sdcp->cardmode &  SDC_MODE_CARDTYPE_MASK) == SDC_MODE_CARDTYPE_MMC) {
+    /* Set RCA.*/
+    /* MMC card expects its address in high 16 bits of argument */
+    sdcp->rca = 0x0002 << 16;
+    if (sdc_lld_send_cmd_short_crc(sdcp, MMCSD_CMD_SET_RELATIVE_ADDR,
+                                   sdcp->rca, resp)) {
+      goto failed;
+    }
+  } else {
+    /* Asks for the RCA.*/
+    if (sdc_lld_send_cmd_short_crc(sdcp, MMCSD_CMD_SEND_RELATIVE_ADDR,
+                                   0, &sdcp->rca)) {
+      goto failed;
+    }
   }
 
   /* Reads CSD.*/


### PR DESCRIPTION
## Summary

eMMC (and modern MMC card, but not tested) expect host to set Relative Card Address using CMD3. While SD card randomly generates RCA address and provides it to host with CMD3 reply.

## Related

- Issue(s):
- Notes for reviewers:

## Target Branch Check

<!-- put a x instead of the space in the [ ] to check the box [x] -->

- [ ] This PR targets `master` — all changes land on `master` first (upstream-first policy);
      `stable-*` branches only receive maintainer-selected backports of commits already
      merged on `master`

## Scope

- [x] Change is focused and does not bundle unrelated work
- [ ] I reviewed impact on other ports/configurations where relevant

## Mechanical Checks

- [ ] Style check passed on changed `.c`/`.h` files
- [ ] Build check passed (POSIX simulator compile and relevant ARM target compile)

## Testing

- [ ] Test run successfully locally
- [x] Tested on custom STM32F767 device with KLMAG1JETD-B041 eMMC chip.

## Compatibility and Risk

- [x] No intentional public API/ABI break
- [ ] If API/ABI changed, rationale and migration notes are provided
- [ ] Risks/limitations are documented below
