### PR TITLE
FTL codegen libraries: update to the current code-first syntax

### DIFF
--- a/tools/ftl/libs/libcclasses.ftlc
+++ b/tools/ftl/libs/libcclasses.ftlc
@@ -32,7 +32,7 @@ assign ifscache={}
   */
 macro ResetState()
   assign generated = false
-endmacro
+end
 
 /*
   -- Loads an XML file into the XML cache.
@@ -46,12 +46,12 @@ function LoadXML(xmlname="")
       attempt
         return pp.loadData("xml", path[0]?ensure_ends_with("/") + xmlname)
       recover
-      endattempt
-    endlist
-  endattempt
+      end
+    end
+  end
   pp.dropOutputFile()
   stop ">>>> Importing '" + xmlname + "' failed!"
-endfunction
+end
 
 /*
   -- Getting references of all module public classes/interfaces.
@@ -59,10 +59,10 @@ endfunction
 macro ImportModulePublicClasses(node=[])
   list node.public.types.interface as interface
     assign ifscache = ifscache + {GetNodeName(interface):interface}
-  endlist
+  end
   list node.public.types.class as class
     assign classescache = classescache + {GetNodeName(class):class}
-  endlist
+  end
   list node.imports.import as import
     local xmlname = import?trim
     if xmlcache[xmlname]??
@@ -71,9 +71,9 @@ macro ImportModulePublicClasses(node=[])
       local xmldoc = LoadXML(xmlname)
       ImportModulePublicClasses(node=xmldoc.module)
       assign xmlcache = xmlcache + {xmlname:xmldoc}
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- Getting references of all module private classes/interfaces.
@@ -81,11 +81,11 @@ endmacro
 macro ImportModulePrivateClasses(node=[])
   list node.public.types.interface as interface
     assign ifscache = ifscache + {GetNodeName(interface):interface}
-  endlist
+  end
   list node.public.types.class as class
     assign classescache = classescache + {GetNodeName(class):class}
-  endlist
-endmacro
+  end
+end
 
 macro InitModule(node=[])
   ccode.ResetState()
@@ -93,35 +93,35 @@ macro InitModule(node=[])
   ImportModulePrivateClasses(node=node)
   ImportModulePublicClasses(node=node)
   /* ${xmlcache?keys?join(", ")} - ${classescache?keys?join(", ")} - ${ifscache?keys?join(", ")} */
-endmacro
+end
 
 /*
   -- Returns the name attribute from an XML node.
   */
 function GetNodeName(node=[], default="no-name")
   return (node.@name[0]!default)?trim
-endfunction
+end
 
 /*
   -- Returns the namespace attribute from an XML node.
   */
 function GetNodeNamespace(node=[], default="no-namespace")
   return (node.@namespace[0]!default)?trim
-endfunction
+end
 
 /*
   -- Returns the ancestorname attribute from an XML node.
   */
 function GetNodeAncestorName(node=[], default="")
   return (node.@ancestorname[0]!default)?trim
-endfunction
+end
 
 /*
   -- Returns the descr attribute from an XML node.
   */
 function GetNodeDescription(node=[], default="no-descr")
   return (node.@descr[0]!default)?trim
-endfunction
+end
 
 /*
   -- Returns the check (conditional compilation) attribute from an XML node,
@@ -129,7 +129,7 @@ endfunction
   */
 function GetNodeCheck(node=[], default="")
   return (node.@check[0]!default)?trim
-endfunction
+end
 
 /*
   -- Returns the interface C type from an XML node.
@@ -141,9 +141,9 @@ function GetInterfaceCType(node=[], default="")
     local ifctype = ifname + interface_suffix
   else
     local ifctype = default
-  endif
+  end
   return ifctype
-endfunction
+end
 
 /*
   -- Returns the interface ancestor C type from an XML node.
@@ -155,9 +155,9 @@ function GetInterfaceAncestorCType(node=[], default="")
     local ancestorctype = ancestorname + interface_suffix
   else
     local ancestorctype = default
-  endif
+  end
   return ancestorctype
-endfunction
+end
 
 /*
   -- Returns the class C type from an XML node.
@@ -169,9 +169,9 @@ function GetClassCType(node=[], default="")
     local classctype = classname + class_suffix
   else
     local classctype = default
-  endif
+  end
   return classctype
-endfunction
+end
 
 /*
   -- Returns the class ancestor C type from an XML node.
@@ -183,9 +183,9 @@ function GetClassAncestorCType(node=[], default="")
     local ancestorctype = ancestorname + class_suffix
   else
     local ancestorctype = default
-  endif
+  end
   return ancestorctype
-endfunction
+end
 
 /*
   -- Returns the class type from an XML node.
@@ -194,7 +194,7 @@ function GetClassType(node=[], default="no-type")
   local class = node
   local classtype = (class.@type[0]!default)?trim
   return classtype
-endfunction
+end
 
 /*
   -- Returns the method short name from an XML node.
@@ -204,9 +204,9 @@ function GetMethodShortName(node=[], default="")
   local methodsname = (method.@shortname[0]!default)?trim
     if methodsname?length == 0
       local methodsname = GetNodeName(method, default)?lower_case
-    endif
+    end
   return methodsname
-endfunction
+end
 
 /*
   -- Returns the method return C type from an XML node.
@@ -215,14 +215,14 @@ function GetMethodCType(node=[], default="void")
   local method = node
   local methodctype = (method.@ctype[0]!default)?trim
   return methodctype
-endfunction
+end
 
 /*
   -- Returns the method short name from an XML node.
   */
 function GetObjinitCallsuper(node=[], default="true")
   return (node.@callsuper[0]!default)?trim
-endfunction
+end
 
 /*
   -- Get class by name.
@@ -230,9 +230,9 @@ endfunction
 function GetClassByName(classname="")
   if classescache[classname]??
     return classescache[classname]
-  endif
+  end
   stop ">>>> Unknown class '" + classname + "'"
-endfunction
+end
 
 /*
   -- Get interface by name.
@@ -240,9 +240,9 @@ endfunction
 function GetInterfaceByName(ifname="")
   if ifscache[ifname]??
     return ifscache[ifname]
-  endif
+  end
   stop ">>>> Unknown interface '" + ifname + "'"
-endfunction
+end
 
 /*
   -- Returns the ancestor of the specified class.
@@ -251,9 +251,9 @@ function GetAncestorClass(class=[])
   local ancestorname = GetNodeAncestorName(class)
   if classescache[ancestorname]??
     return classescache[ancestorname]
-  endif
+  end
   stop ">>>> Unknown class '" + ancestorname + "'"
-endfunction
+end
 
 /*
   -- Returns a sequence of class ancestors classes from an XML node.
@@ -262,13 +262,13 @@ function GetClassAncestorsSequence(class=[])
   local ancestorname = GetNodeAncestorName(class)
   if ancestorname?length == 0
     return []
-  endif
+  end
   if classescache[ancestorname]??
     local ancestorclass = classescache[ancestorname]
     return GetClassAncestorsSequence(ancestorclass) + [ancestorclass]
-  endif
+  end
   stop ">>>> Unknown class '" + ancestorname + "'"
-endfunction
+end
 
 /*
   -- Returns a sequence of class virtual methods, including those from
@@ -280,10 +280,10 @@ function GetClassVirtualMethodsSequence(node=[])
   list classes as class
     list class.methods.virtual.method as method
       local methods = methods + method
-    endlist
-  endlist
+    end
+  end
   return methods
-endfunction
+end
 
 /*
   -- Returns a sequence of interface ancestors interfaces from an XML node.
@@ -292,13 +292,13 @@ function GetInterfaceAncestorsSequence(if=[])
   local ancestorname = GetNodeAncestorName(if)
   if ancestorname?length == 0
     return []
-  endif
+  end
   if ifscache[ancestorname]??
     local ancestorif = ifscache[ancestorname]
     return GetInterfaceAncestorsSequence(ancestorif) + [ancestorif]
-  endif
+  end
   stop ">>>> Unknown interface '" + ancestorname + "'"
-endfunction
+end
 
 /*
   -- Returns a sequence of interface methods, including those from
@@ -310,10 +310,10 @@ function GetInterfaceMethodsSequence(node=[])
   list ifs as if
     list if.methods.method as method
       local methods = methods + method
-    endlist
-  endlist
+    end
+  end
   return methods
-endfunction
+end
 
 /*
   -- Returns a sequence of class ancestors CTypes.
@@ -322,9 +322,9 @@ function GetClassAncestorsCTypes(ancestors=[])
   local names = []
   list ancestors as ancestor
     local names = names + [GetClassCType(ancestor)]
-  endlist
+  end
   return names
-endfunction
+end
 
 /*
   -- Returns a sequence of interface ancestors CTypes.
@@ -333,9 +333,9 @@ function GetInterfaceAncestorsCTypes(ancestors=[])
   local names = []
   list ancestors as ancestor
     local names = names + [GetInterfaceCType(ancestor)]
-  endlist
+  end
   return names
-endfunction
+end
 
 /*
   -- Returns the closest method implementation name searching in the specified
@@ -350,12 +350,12 @@ function GetMethodNearestImplementation(classes=[], method=[])
          each class so picking the current class one. */
     if shortname == "dispose"
       return "__" + classnamespace + "_" + shortname + "_impl"
-    endif
+    end
     /* First checking among the current class overrides.*/
     local m = class["methods/override/method[@shortname='" + shortname + "']"]
     if m[0]??
       return "__" + classnamespace + "_" + shortname + "_impl"
-    endif
+    end
     /* Checking if we reached the class where the method was declared.*/
     local m = class["methods/virtual/method[@shortname='" + shortname + "']"]
     if m[0]??
@@ -366,11 +366,11 @@ function GetMethodNearestImplementation(classes=[], method=[])
         return "__" + classnamespace + "_" + shortname + "_impl"
       else
         return "NULL /* Method not found.*/"
-      endif
-    endif
-  endlist
+      end
+    end
+  end
   return "NULL"
-endfunction
+end
 
 /*
   -- Returns the class in the sequence of ancestors owning the specified
@@ -382,10 +382,10 @@ function GetVirtualMethodOwnerClass(ancestors=[], shortname="")
     local m = ancestor["methods/virtual/method[@shortname='" + shortname + "']"]
     if m[0]??
       return [ancestor, m]
-    endif
-  endlist
+    end
+  end
   stop ">>>> Undefined method '" + shortname + "'"
-endfunction
+end
 
 /*
   -- This macro generates a class wrapper from an XML node.
@@ -402,12 +402,12 @@ macro GenerateClass(node=[])
   if classcheck?length > 0
     emit "#if (${classcheck}) || defined (__DOXYGEN__)\n"
     emit "\n"
-  endif
+  end
   emit "/**\n"
   doxygen.EmitTagVerbatim(indent="", tag="class", text=classctype)
   if ancestorname?length > 0
     doxygen.EmitTagVerbatim(indent="", tag="extends", text=GetClassAncestorCType(class, ""))
-  endif
+  end
   GenerateClassImplementsTags(class.implements)
   emit " *\n"
   doxygen.EmitBriefFromNode(node=class)
@@ -433,7 +433,7 @@ macro GenerateClass(node=[])
     ccode.Indent(1)
     emit "/* From ${GetClassCType(ancestor)}.*/\n"
     GenerateVMTPointers(ancestor.methods.virtual)
-  endlist
+  end
   ccode.Indent(1)
   emit "/* From ${classctype}.*/\n"
   GenerateVMTPointers(class.methods.virtual)
@@ -456,7 +456,7 @@ macro GenerateClass(node=[])
       indent = ccode.indentation,
       fields = ancestor.fields
     )
-  endlist
+  end
   GenerateClassInterfaceFields(node = class.implements)
   ccode.GenerateStructureFieldsFromNode(
     indent = ccode.indentation,
@@ -467,8 +467,8 @@ macro GenerateClass(node=[])
   if classcheck?length > 0
     emit "\n"
     emit "#endif /* ${classcheck} */\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates an interface wrapper from an XML node.
@@ -485,7 +485,7 @@ macro GenerateInterface(node=[])
   emit " * @interface   ${ifctype}\n"
   if ancestorname?length > 0
     doxygen.EmitTagVerbatim(indent="", tag="extends", text=GetInterfaceAncestorCType(if, ""))
-  endif
+  end
   emit " *\n"
   doxygen.EmitBriefFromNode(node=if)
   doxygen.EmitDetailsFromNode(node=if)
@@ -513,7 +513,7 @@ macro GenerateInterface(node=[])
     ccode.Indent(1)
     emit "/* From ${GetInterfaceCType(ancestor)}.*/\n"
     GenerateVMTPointers(ancestor.methods)
-  endlist
+  end
   ccode.Indent(1)
   emit "/* From ${ifctype}.*/\n"
   GenerateVMTPointers(if.methods)
@@ -532,7 +532,7 @@ macro GenerateInterface(node=[])
   emit ccode.MakeVariableDeclaration(ccode.indentation, "vmt", vmtctype) + "\n"
   emit "};\n"
   emit "/** @} */\n"
-endmacro
+end
 
 /*
   -- Generates implementation functions for constructor, destructor,
@@ -598,15 +598,15 @@ macro GenerateClassImplementations(node=[], modifiers=[])
         params      = ["self", "vmt"]
       )
       emit "\n"
-    endif
-  endif
+    end
+  end
   if class.implements.*?size > 0
     GenerateClassInterfacesInit(
       node           = class.implements,
       classctype     = classctype,
       classnamespace = classnamespace
     )
-  endif
+  end
   if ((class.methods.objinit[0].implementation[0])?? &&
        (class.methods.objinit[0].implementation[0]?trim?length > 0))
     ccode.Indent(1)
@@ -618,7 +618,7 @@ macro GenerateClassImplementations(node=[], modifiers=[])
   else
     ccode.Indent(1)
     emit "/* No initialization code.*/\n"
-  endif
+  end
   emit "\n"
   ccode.Indent(1)
   emit "return self;\n"
@@ -659,7 +659,7 @@ macro GenerateClassImplementations(node=[], modifiers=[])
     emit "/* No finalization code.*/\n"
     ccode.Indent(1)
     emit "(void)self;\n"
-  endif
+  end
   if ancestorname?length > 0
     local ancestor = GetAncestorClass(class)
     emit "\n"
@@ -667,7 +667,7 @@ macro GenerateClassImplementations(node=[], modifiers=[])
     emit "/* Finalization of the ancestors-defined parts.*/\n"
     ccode.Indent(1)
     emit "__${GetNodeNamespace(ancestor)}_dispose_impl(self);\n"
-  endif
+  end
   emit "}\n"
   /* Scanning for al method overrides defined in the current class then
        checking in which class the virtual method is defined.*/
@@ -708,7 +708,7 @@ macro GenerateClassImplementations(node=[], modifiers=[])
       ccode  = methodimpl
     )
     emit "}\n"
-  endlist
+  end
   /* Scanning for all virtual methods defined in the current class.*/
   list class.methods.virtual.method as method
     local methodname     = GetNodeName(method)
@@ -744,11 +744,11 @@ macro GenerateClassImplementations(node=[], modifiers=[])
         ccode  = methodimpl
       )
       emit "}\n"
-    endif
-  endlist
+    end
+  end
   emit "/** @} */\n"
   emit "\n"
-endmacro
+end
 
 /*
   -- This macro generates regular methods from an XML node.
@@ -771,10 +771,10 @@ macro GenerateMethods(node=[], classctype="no-ctype", modifiers=[], nodoc=false)
           extratext="Pointer to a @p " + classctype + " instance.",
           memberof=""
         )
-      endif
+      end
       if modifiers?seq_contains("static") && modifiers?seq_contains("inline")
         emit "CC_FORCE_INLINE\n"
-      endif
+      end
       ccode.GeneratePrototypeFromNode(
         modifiers = modifiers,
         params    = ["void *ip"],
@@ -789,7 +789,7 @@ macro GenerateMethods(node=[], classctype="no-ctype", modifiers=[], nodoc=false)
       emit "}\n"
       if this?has_next
         emit "\n"
-      endif
+      end
     elseif this?node_name == "condition"
       local condition = this
       local condcheck = (condition.@check[0]!"1")?trim
@@ -803,7 +803,7 @@ macro GenerateMethods(node=[], classctype="no-ctype", modifiers=[], nodoc=false)
       emit "#endif /* ${condcheck} */\n"
       if this?has_next
         emit "\n"
-      endif
+      end
     elseif this?node_name == "elseif"
       local nodoc = true
       local condcheck = (this.@check[0]!"")?trim
@@ -812,10 +812,10 @@ macro GenerateMethods(node=[], classctype="no-ctype", modifiers=[], nodoc=false)
         emit "\n"
       else
         emit "#elif ${condcheck}\n"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end
 
 /*
   -- This macro generates regular methods from an XML node.
@@ -835,8 +835,8 @@ macro GenerateClassRegularMethods(node=[], modifiers=[])
     )
     emit "/** @} */\n"
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates inline methods from an XML node.
@@ -848,7 +848,7 @@ macro GenerateClassInlineMethods(node=[])
     local classcheck = GetNodeCheck(class)
     if classcheck?length > 0
       emit "#if (${classcheck}) || defined (__DOXYGEN__)\n"
-    endif
+    end
     emit "/**\n"
     doxygen.EmitTagVerbatim("", "name", "Inline methods of " + classctype)
     emit " * @{\n"
@@ -861,10 +861,10 @@ macro GenerateClassInlineMethods(node=[])
     emit "/** @} */\n"
     if classcheck?length > 0
       emit "#endif /* ${classcheck} */\n"
-    endif
+    end
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates virtual methods as inline functions
@@ -903,16 +903,16 @@ macro GenerateVirtualMethods(methods=[], ctype="no-ctype", namespace="no-namespa
         ccode.GenerateFunctionCall(ccode.indentation, "", callname, callparams)
       else
         ccode.GenerateFunctionCall(ccode.indentation, "return ", callname, callparams)
-      endif
+      end
       emit "}\n"
       if method?has_next
         emit "\n"
-      endif
-    endlist
+      end
+    end
     emit "/** @} */\n"
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates class virtual methods as inline functions
@@ -926,7 +926,7 @@ macro GenerateClassVirtualMethods(node=[])
     local classcheck = GetNodeCheck(class)
     if classcheck?length > 0
       emit "#if (${classcheck}) || defined (__DOXYGEN__)\n"
-    endif
+    end
     GenerateVirtualMethods(
       methods   = class.methods.virtual,
       ctype     = classctype,
@@ -935,9 +935,9 @@ macro GenerateClassVirtualMethods(node=[])
     if classcheck?length > 0
       emit "#endif /* ${classcheck} */\n"
       emit "\n"
-    endif
-  endif
-endmacro
+    end
+  end
+end
 
 /*
   -- Generates extern prototypes for constructor, destructor, overidden
@@ -986,7 +986,7 @@ macro GenerateClassPrototypes(node=[])
       node      = ancestormethod
     )
     emit ";\n"
-  endlist
+  end
   /* Scanning for all virtual methods defined in the current class.*/
   list class.methods.virtual.method as method
     local methodname     = GetNodeName(method)
@@ -1002,9 +1002,9 @@ macro GenerateClassPrototypes(node=[])
         node      = method
       )
       emit ";\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates regular method prototypes from an XML node.
@@ -1029,9 +1029,9 @@ macro GenerateClassRegularMethodsPrototypes(node=[])
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
       GenerateClassRegularMethodsPrototypes(node=condition)
       emit "#endif /* ${condcheck} */\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates regular method prototypes from a class XML node.
@@ -1041,15 +1041,15 @@ macro GenerateClassMethodsPrototypes(class=[])
     local classcheck = GetNodeCheck(class)
     if classcheck?length > 0
       emit "#if (${classcheck}) || defined (__DOXYGEN__)\n"
-    endif
+    end
     ccode.Indent(1)
     emit "/* Methods of ${classctype}.*/\n"
     GenerateClassPrototypes(node=class)
     GenerateClassRegularMethodsPrototypes(node=class.methods.regular)
     if classcheck?length > 0
       emit "#endif /* ${classcheck} */\n"
-    endif
-endmacro
+    end
+end
 
 /*
   -- This macro generates virtual methods pointers from a sequence of XML nodes.
@@ -1062,8 +1062,8 @@ macro GenerateVMTPointers(methods=[], ipctype="void *")
                     ccode.MakeProtoParamsSequence([ipctype + "ip"], method)?join(", ") +
                     ");")
     emit funcptr + "\n"
-  endlist
-endmacro
+  end
+end
 
 /*
   -- This macro generates a class VMT structure from an XML node.
@@ -1082,7 +1082,7 @@ macro GenerateClassVMT(node=[], modifiers=[])
     emit " */\n"
     if modifiers?size > 0
       emit modifiers?join(" ") + " "
-    endif
+    end
     emit "const struct ${classname}_vmt __${classname}_vmt = {\n"
     local classes = GetClassAncestorsSequence(node) + [node]
     local methods = GetClassVirtualMethodsSequence(node)
@@ -1095,12 +1095,12 @@ macro GenerateClassVMT(node=[], modifiers=[])
         emit s + "," + "\n"
       else
         emit s + "\n"
-      endif
-    endlist
+      end
+    end
     emit "};\n"
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates class method implementations from an XML node.
@@ -1133,13 +1133,13 @@ macro GenerateClassInterfacesInit(node=[], classctype="no-ctype", classnamespace
                       methodshortname + "_impl")
         else
           local s = s + "NULL /* Missing implementation.*/"
-        endif
+        end
         if method?has_next
           emit s + "," + "\n"
         else
           emit s + "\n"
-        endif
-      endlist
+        end
+      end
       ccode.Indent(2)
       emit "};\n"
       ccode.Indent(2)
@@ -1148,7 +1148,7 @@ macro GenerateClassInterfacesInit(node=[], classctype="no-ctype", classnamespace
       emit "}\n"
       if node?node_name != "condition"
         emit "\n"
-      endif
+      end
     elseif this?node_name == "condition"
       local condcheck = (this.@check[0]!"1")?trim
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
@@ -1159,9 +1159,9 @@ macro GenerateClassInterfacesInit(node=[], classctype="no-ctype", classnamespace
       )
       emit "#endif /* ${condcheck} */\n"
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates class interface fields from an XML node.
@@ -1188,9 +1188,9 @@ macro GenerateClassInterfaceFields(node=[])
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
       GenerateClassInterfaceFields(this)
       emit "#endif /* ${condcheck} */\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a Doxygen list of implemented interfaces from an XML node.
@@ -1204,9 +1204,9 @@ macro GenerateClassImplementsTags(node=[])
       doxygen.EmitTagVerbatim(indent="", tag="implements", text=refctype)
     elseif this?node_name == "condition"
       GenerateClassImplementsTags(this)
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates private constructor and destructor from an XML node.
@@ -1222,7 +1222,7 @@ macro GenerateClassPrivateConstructor(node=[])
     local classcheck = GetNodeCheck(node)
     if classcheck?length > 0
       emit "#if (${classcheck}) || defined (__DOXYGEN__)\n"
-    endif
+    end
     emit "/**\n"
     doxygen.EmitTagVerbatim("", "name", "Default constructor of " + classctype)
     emit " * @{\n"
@@ -1261,10 +1261,10 @@ macro GenerateClassPrivateConstructor(node=[])
     emit "/** @} */\n"
     if classcheck?length > 0
       emit "#endif /* ${classcheck} */\n"
-    endif
+    end
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates public constructor and destructor from an XML node.
@@ -1280,7 +1280,7 @@ macro GenerateClassPublicConstructor(node=[])
     local classcheck = GetNodeCheck(node)
     if classcheck?length > 0
       emit "#if (${classcheck}) || defined (__DOXYGEN__)\n"
-    endif
+    end
     emit "/**\n"
     doxygen.EmitTagVerbatim("", "name", "Default constructor of " + classctype)
     emit " * @{\n"
@@ -1322,10 +1322,10 @@ macro GenerateClassPublicConstructor(node=[])
     emit "/** @} */\n"
     if classcheck?length > 0
       emit "#endif /* ${classcheck} */\n"
-    endif
+    end
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates interface virtual methods as inline functions
@@ -1339,7 +1339,7 @@ macro GenerateInterfaceVirtualMethods(if=[])
     ctype     = ifctype,
     namespace = ifnamespace
   )
-endmacro
+end
 
 /*
   -- This macro generates a class wrapper from an XML node.
@@ -1356,7 +1356,7 @@ macro GenerateInterfaceWrapper(node=[])
   emit " * @interface   ${ifctype}\n"
   if ancestorctype?length > 0
     emit " * @extends     ${ancestorctype}\n"
-  endif
+  end
   emit " *\n"
   doxygen.EmitBriefFromNode(node=if)
   doxygen.EmitDetailsFromNode(node=if)
@@ -1387,7 +1387,7 @@ macro GenerateInterfaceWrapper(node=[])
     GenerateVMTPointers(methods=if.methods)
     emit "};\n"
     emit "\n"
-  endif
+  end
   emit "/**\n"
   doxygen.EmitBrief("", "Interface @p " + ifctype + " methods.")
   emit " */\n"
@@ -1396,7 +1396,7 @@ macro GenerateInterfaceWrapper(node=[])
   if ancestorname?length > 0
     emit ((ccode.indentation + "__" + ancestorname +
                        "_methods")?right_pad(ccode.backslash_align) + "\\" + "\n")
-  endif
+  end
   if if.methods.method?size > 0
     ccode.GenerateVariableDeclaration(
       indent=ccode.indentation,
@@ -1410,7 +1410,7 @@ macro GenerateInterfaceWrapper(node=[])
     emit (ccode.indentation + "   the implementing class structure.*/")?right_pad(ccode.backslash_align) + "\\" + "\n"
     emit (ccode.indentation + "size_t instance_offset;") + "\n"
     emit "\n"
-  endif
+  end
   emit "/**\n"
   doxygen.EmitBrief("", "Interface @p " + ifctype + " VMT initializer.")
   emit " *\n"
@@ -1423,12 +1423,12 @@ macro GenerateInterfaceWrapper(node=[])
     local s = "  __" + ancestorname + "_vmt_init(ns, off)"
     if node.methods?size > 0
       local s = (s + " ")?right_pad(76) + "\\"
-    endif
+    end
     emit s + "\n"
     GenerateVMTInitializers(methods=node.methods, namespace=ifnamespace)
   else
     emit (ccode.indentation + ".instance_offset")?right_pad(ccode.initializers_align) + "= off," + "\n"
-  endif
+  end
   emit "\n"
   emit "/**\n"
   doxygen.EmitBrief("", "Interface @p " + ifctype + " virtual methods table.")
@@ -1450,7 +1450,7 @@ macro GenerateInterfaceWrapper(node=[])
   emit ccode.MakeVariableDeclaration(ccode.indentation, "vmt", vmtctype) + "\n"
   emit "};\n"
   emit "/** @} */\n"
-endmacro
+end
 
 macro GenerateInterfacesImplementations(node=[],
                                         classnamespace="no-namespace",
@@ -1466,7 +1466,7 @@ macro GenerateInterfacesImplementations(node=[],
         local foundmethods = ifmethods?filter(m -> GetMethodShortName(m) == methodsname)
         if !foundmethods[0]??
           stop ">>>> Method '" + methodsname + "' not found."
-        endif
+        end
         local method     = foundmethods[0]
         local methodname = GetNodeName(method)
         emit "/**\n"
@@ -1498,8 +1498,8 @@ macro GenerateInterfacesImplementations(node=[],
         emit "}\n"
         if methodref?has_next
           emit "\n"
-        endif
-      endlist
+        end
+      end
     elseif this?node_name == "condition"
       local condcheck = (this.@check[0]!"1")?trim
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
@@ -1509,15 +1509,15 @@ macro GenerateInterfacesImplementations(node=[],
         classctype     = classctype
       )
       emit "#endif /* ${condcheck} */\n"
-    endif
+    end
     if this?has_next
       emit "\n"
     elseif ((this?parent?node_name != "condition") &&
              (this?parent?node_name != "implements"))
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a class interfaces implementatios from an XML node.
@@ -1537,8 +1537,8 @@ macro GenerateClassInterfacesImplementations(node=[], private=false)
     )
     emit "/** @} */\n"
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates the class code from an XML node.
@@ -1548,7 +1548,7 @@ macro GenerateClassCode(class=[], modifiers=[])
   if classcheck?length > 0
     emit "#if (${classcheck}) || defined (__DOXYGEN__)\n"
     emit "\n"
-  endif
+  end
   GenerateClassInterfacesImplementations(node=class)
   GenerateClassImplementations(node=class, modifiers=modifiers)
   GenerateClassVMT(node=class, modifiers=modifiers)
@@ -1556,5 +1556,5 @@ macro GenerateClassCode(class=[], modifiers=[])
   if classcheck?length > 0
     emit "#endif /* ${classcheck} */\n"
     emit "\n"
-  endif
-endmacro
+  end
+end

--- a/tools/ftl/libs/libccode.ftlc
+++ b/tools/ftl/libs/libccode.ftlc
@@ -37,7 +37,7 @@ assign boundary = 80
   */
 macro ResetState()
   assign generated = false
-endmacro
+end
 
 /*
   -- Returns the function/macro name from an XML node.
@@ -45,7 +45,7 @@ endmacro
 function GetName(node=[], default="no-name")
   local name = (node.@name[0]!default)?trim
   return name
-endfunction
+end
 
 /*
   -- Returns the function return C type from an XML node.
@@ -54,9 +54,9 @@ function GetCType(node=[], default="void")
   local ctype = (node.@ctype[0]!default)?trim
   if ctype?length == 0
     local ctype = default
-  endif
+  end
   return ctype
-endfunction
+end
 
 /*
   -- Returns the function/macro implementation from an XML node.
@@ -64,7 +64,7 @@ endfunction
 function GetImplementation(node=[], default="")
   local impl = node.implementation[0]!default
   return impl
-endfunction
+end
 
 /*
   -- This function generates a variable or field declaration in a string.
@@ -79,17 +79,17 @@ function MakeVariableDeclaration(indent="", name="no-name", ctype="no-ctype")
       local fstring = fstring?replace("$N", name)
     else
       local fstring = fstring + name
-    endif
+    end
   else
     local fstring = indent + ctype
     if fstring?contains("$N")
       local fstring = fstring?replace("$N", name)
     else
       local fstring = (fstring + " ")?right_pad(fields_align) + name
-    endif
-  endif
+    end
+  end
   return fstring + ";"
-endfunction
+end
 
 /*
   -- Creates a sequence containing function parameters taken from an XML node.
@@ -106,15 +106,15 @@ function MakeProtoParamsSequence(params=[], node=[])
         local pstring = ctype + "" + name
       else
         local pstring = ctype + " " + name
-      endif
-    endif
+      end
+    end
     local params = params + [pstring]
-  endlist
+  end
   if params?size == 0
     local params = ["void"]
-  endif
+  end
   return params
-endfunction
+end
 
 /*
   -- Creates a sequence containing parameters names taken from an XML node.
@@ -123,9 +123,9 @@ function MakeCallParamsSequence(params=[], node=[])
   list node.param as param
     local name  = (param.@name[0]!"no-name")?trim
     local params = params + [name]
-  endlist
+  end
   return params
-endfunction
+end
 
 /*
   -- Emits the specified indentation as spaces.
@@ -133,8 +133,8 @@ endfunction
 macro Indent(n=0)
   list 1..n as i
     emit indentation
-  endlist
-endmacro
+  end
+end
 
 /*
   -- Emits a C function body code reformatting the indentation using the
@@ -150,13 +150,13 @@ macro GenerateIndentedCCode(indent=indentation, ccode="")
           emit s + "\n"
         else
           emit indent + s + "\n"
-        endif
+        end
       else
         emit "\n"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end
 
 /*
   -- This macro generates a variable or field.
@@ -166,7 +166,7 @@ endmacro
 macro GenerateVariableDeclaration(indent="", name="no-name", ctype="no-ctype")
   local fstring = MakeVariableDeclaration(indent, name, ctype)
   emit fstring
-endmacro
+end
 
 /*
   -- This macro generates a function prototype from an XML node.
@@ -178,10 +178,10 @@ macro GeneratePrototype(indent="", name="no-name", ctype="no-ctype",
     local l1 = ctype + name + "("
   else
     local l1 = ctype + " " + name + "("
-  endif
+  end
   if modifiers?size > 0
     local l1 = modifiers?join(" ") + " " + l1
-  endif
+  end
   local l1 = indent + l1
   local ln = ""?right_pad(l1?length)
   list params as param
@@ -193,11 +193,11 @@ macro GeneratePrototype(indent="", name="no-name", ctype="no-ctype",
         local line = ln + param
       else
         local line = line + ", " + param
-      endif
-    endif
-  endlist
+      end
+    end
+  end
   emit line + ")"
-endmacro
+end
 
 /*
   -- This macro generates a function prototype from an XML node.
@@ -207,10 +207,10 @@ macro GeneratePrototypeFromNode(indent="", name="", ctype="",
                                 modifiers=[], params=[], node=[])
   if name?length == 0
     local name = GetName(node)
-  endif
+  end
   if ctype?length == 0
     local ctype = GetCType(node)
-  endif
+  end
   local params = MakeProtoParamsSequence(params, node)
   GeneratePrototype(
     indent    = indent,
@@ -219,7 +219,7 @@ macro GeneratePrototypeFromNode(indent="", name="", ctype="",
     modifiers = modifiers,
     params    = params
   )
-endmacro
+end
 
 /*
   -- This macro generates a function call.
@@ -227,12 +227,12 @@ endmacro
 macro GenerateFunctionCall(indent="", destination="", name="", params=[])
   if name?length == 0
     local name = "no-name"
-  endif
+  end
   if destination?trim?length > 0
     local l1 = indent + destination?trim + " " + name + "("
   else
     local l1 = indent + destination?trim + name + "("
-  endif
+  end
   local ln = ""?right_pad(l1?length)
   local line = l1
   list params as param
@@ -244,11 +244,11 @@ macro GenerateFunctionCall(indent="", destination="", name="", params=[])
         local line = ln + param
       else
         local line = line + ", " + param
-      endif
-    endif
-  endlist
+      end
+    end
+  end
   emit line + ");" + "\n"
-endmacro
+end
 
 /*
   -- Generates inclusions from an XML node.
@@ -261,7 +261,7 @@ macro GenerateInclusionsFromNode(node=[])
         emit "#include <${this[0]}>\n"
       else
         emit "#include \"${this[0]}\"\n"
-      endif
+      end
     elseif this?node_name == "condition"
       local condcheck = (this.@check[0]!"1")?trim
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
@@ -273,10 +273,10 @@ macro GenerateInclusionsFromNode(node=[])
         emit "#else\n"
       else
         emit "#elif ${condcheck}\n"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end
 
 /*
   -- Generates a single line definition macro from an XML node.
@@ -290,9 +290,9 @@ macro GenerateDefineFromNode(node=[])
     local s = ("#define " + name +  "(" + params?join(", ") + ") ")?right_pad(define_value_align) + value
   else
     local s = ("#define " + name +  " ")?right_pad(define_value_align) + value
-  endif
+  end
   emit s + "\n"
-endmacro
+end
 
 /*
   -- Generates all single line definitions from an XML node.
@@ -305,19 +305,19 @@ macro GenerateDefinesFromNode(node=[])
         GenerateDefineFromNode(this)
         if this?has_next || node?node_name?starts_with("definitions")
           emit "\n"
-        endif
+        end
       else
         GenerateDefineFromNode(this)
         if node?node_name?starts_with("definitions")
           emit "\n"
-        endif
-      endif
+        end
+      end
     elseif this?node_name == "verbatim"
       local ccode = (this[0]!"")?trim
       GenerateIndentedCCode("", ccode)
       if node?node_name?starts_with("definitions")
         emit "\n"
-      endif
+      end
     elseif this?node_name == "group"
       local groupdescription = (this.@description[0]!"no-description")?trim
       emit "/**\n"
@@ -328,7 +328,7 @@ macro GenerateDefinesFromNode(node=[])
       emit "/** @} */\n"
       if (node?node_name != "group") && (node?node_name != "condition")
         emit "\n"
-      endif
+      end
     elseif this?node_name == "condition"
       local condcheck = (this.@check[0]!"1")?trim
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
@@ -336,10 +336,10 @@ macro GenerateDefinesFromNode(node=[])
       emit "#endif /* ${condcheck} */\n"
       if (node?node_name != "group") && (node?node_name != "condition")
         emit "\n"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end
 
 /*
   -- Generates a conmfiguration definition from an XML node.
@@ -353,7 +353,7 @@ macro GenerateConfigFromNode(node=[])
   emit "#if !defined(${name}) || defined(__DOXYGEN__)\n"
   emit s + "\n"
   emit "#endif\n"
-endmacro
+end
 
 /*
   -- Generates all configurations from an XML node.
@@ -370,12 +370,12 @@ macro GenerateConfigsFromNode(node=[])
       GenerateConfigFromNode(node=config)
       if !config?is_last
         emit "\n"
-      endif
-    endlist
+      end
+    end
     emit "/** @} */\n"
     emit "\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- Generates all configuration checks from an XML node.
@@ -396,20 +396,20 @@ macro GenerateConfigAssertsFromNode(node=[])
             emit "#error \"${message}\"\n"
           else
             emit "#error \"invalid ${name} value\"\n"
-          endif
+          end
           emit "#endif\n"
           emit "\n"
-        endlist
-      endif
+        end
+      end
     elseif this?node_name == "verbatim"
       local ccode = (this[0]!"")?trim
       if ccode?length > 0
         GenerateIndentedCCode("", ccode)
         emit "\n"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end
 
 /*
   -- Generates a multi-line C macro from an XML node.
@@ -433,10 +433,10 @@ macro GenerateMacroFromNode(indent=indentation, node=[])
         emit (indent + s + "") + "\n"
       else
         emit (indent + s + "")?right_pad(backslash_align) + "\\" + "\n"
-      endif
-    endlist
-  endif
-endmacro
+      end
+    end
+  end
+end
 
 /*
   -- Generates all macros from an XML node.
@@ -446,14 +446,14 @@ macro GenerateMacrosFromNode(indent=indentation, node=[])
     if this?node_name == "macro"
       if this.brief[0]?? && !this?is_first
         emit "\n"
-      endif
+      end
       doxygen.EmitFullCommentFromNode("", this)
       GenerateMacroFromNode(node=this)
     elseif this?node_name == "group"
       local groupdescription = (this.@description[0]!"no-description")?trim
       if !this?is_first
         emit "\n"
-      endif
+      end
       emit "/**\n"
       emit " * @name    ${groupdescription}\n"
       emit " * @{\n"
@@ -464,7 +464,7 @@ macro GenerateMacrosFromNode(indent=indentation, node=[])
       local condcheck = (this.@check[0]!"1")?trim
       if !this?is_first
         emit "\n"
-      endif
+      end
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
       GenerateMacrosFromNode(node=this)
       emit "#endif /* ${condcheck} */\n"
@@ -472,18 +472,18 @@ macro GenerateMacrosFromNode(indent=indentation, node=[])
       local condcheck = (this.@check[0]!"")?trim
       if !this?is_first
         emit "\n"
-      endif
+      end
       if condcheck?length == 0
         emit "#else\n"
       else
         emit "#elif ${condcheck}\n"
-      endif
-    endif
+      end
+    end
     if this?is_last && (node?node_name?starts_with("macros"))
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a simple type definition from an XML node.
@@ -499,13 +499,13 @@ macro GenerateTypedefFromNode(indent="", node=[])
       emit "${indent}typedef ${basectype};\n"
     else
       emit "${indent}typedef ${basectype} ${typename};\n"
-    endif
+    end
   elseif typedef.structtype[0]??
   elseif typedef.enumtype[0]??
   elseif typedef.functype[0]??
   else
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a struct definition from an XML node.
@@ -514,11 +514,11 @@ macro GenerateStructFromNode(indent="", node=[], default="###no-name###")
   local structname = GetName(node, default)
   if structname?length > 0
     local structname = structname + " "
-  endif
+  end
   emit "${indent}struct ${structname}{\n"
   ccode.GenerateStructureFieldsFromNode(indent+indentation, node.fields)
   emit "${indent}};\n"
-endmacro
+end
 
 /*
   -- This macro generates a union definition from an XML node.
@@ -527,11 +527,11 @@ macro GenerateUnionFromNode(indent="", node=[], default="###no-name###")
   local unionname = GetName(node, default)
   if unionname?length > 0
     local unionname = unionname + " "
-  endif
+  end
   emit "${indent}union ${unionname}{\n"
   ccode.GenerateStructureFieldsFromNode(indent+indentation, node.fields)
   emit "${indent}};\n"
-endmacro
+end
 
 /*
   -- Generates type definitions from an XML node.
@@ -559,12 +559,12 @@ macro GenerateTypesFromNode(indent="", node=[])
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
       GenerateTypesFromNode("", this)
       emit "#endif /* ${condcheck} */\n"
-    endif
+    end
     if this?has_next || (node?node_name != "condition")
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a variable definition from an XML node.
@@ -578,10 +578,10 @@ macro GenerateVariableFromNode(indent="", node=[], static=false)
     local varstring = indent + "static " + varstring
   else
     local varstring = indent + varstring
-  endif
+  end
   doxygen.EmitFullCommentFromNode(indent, node)
   emit varstring + "\n"
-endmacro
+end
 
 /*
   -- Generates variable definitions from an XML node.
@@ -599,12 +599,12 @@ macro GenerateVariablesFromNode(indent="", node=[], static=false)
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
       GenerateVariablesFromNode(indent, this, static)
       emit "#endif /* ${condcheck} */\n"
-    endif
+    end
     if this?has_next || (node?node_name != "condition")
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a variable extern definition from an XML node.
@@ -615,7 +615,7 @@ macro GenerateVariableExternFromNode(indent="", node=[])
   local varctype  = GetCType(node)
   local varstring = MakeVariableDeclaration(indent+"extern ", varname, varctype)
   emit varstring + "\n"
-endmacro
+end
 
 /*
   -- Generates variable extern definitions from an XML node.
@@ -630,12 +630,12 @@ macro GenerateVariablesExternFromNode(indent="", node=[])
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
       GenerateVariablesExternFromNode(indent, this)
       emit "#endif /* ${condcheck} */\n"
-    endif
+    end
     if this?is_last && (node?node_name != "condition")
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates structure fields from an XML node.
@@ -658,9 +658,9 @@ macro GenerateStructureFieldsFromNode(indent="", fields=[])
     elseif node?node_name == "verbatim"
       local ccode = (node[0]!"")?trim
       GenerateIndentedCCode(indent, ccode)
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- Generates a function from an XML node.
@@ -671,7 +671,7 @@ macro GenerateFunctionFromNode(modifiers=[], node=[])
   emit " {\n"
   GenerateIndentedCCode(indent=indentation, ccode=funcimpl)
   emit "}\n"
-endmacro
+end
 
 /*
   -- Generates all functions from an XML node.
@@ -682,14 +682,14 @@ macro GenerateFunctionsFromNode(modifiers=[], node=[])
       assign generated = true
       if !this?is_first
         emit "\n"
-      endif
+      end
       doxygen.EmitFullCommentFromNode("", this)
       GenerateFunctionFromNode(modifiers=modifiers, node=this)
     elseif this?node_name == "group"
       local groupdescription = (this.@description[0]!"no-description")?trim
       if !this?is_first
         emit "\n"
-      endif
+      end
       emit "/**\n"
       emit " * @name    ${groupdescription}\n"
       emit " * @{\n"
@@ -699,14 +699,14 @@ macro GenerateFunctionsFromNode(modifiers=[], node=[])
     elseif this?node_name == "verbatim"
       if !this?is_first
         emit "\n"
-      endif
+      end
       local ccode = (this[0]!"")?trim
       GenerateIndentedCCode("", ccode)
     elseif this?node_name == "condition"
       local condcheck = (this.@check[0]!"1")?trim
       if !this?is_first
         emit "\n"
-      endif
+      end
       emit "#if (${condcheck}) || defined (__DOXYGEN__)\n"
       GenerateFunctionsFromNode(modifiers=modifiers, node=this)
       emit "#endif /* ${condcheck} */\n"
@@ -714,18 +714,18 @@ macro GenerateFunctionsFromNode(modifiers=[], node=[])
       local condcheck = (this.@check[0]!"")?trim
       if !this?is_first
         emit "\n"
-      endif
+      end
       if condcheck?length == 0
         emit "#else\n"
       else
         emit "#elif ${condcheck}\n"
-      endif
-    endif
+      end
+    end
     if this?is_last && (node?node_name?starts_with("functions"))
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- Generates all function prototypes from an XML node.
@@ -749,7 +749,7 @@ macro GenerateFunctionPrototypesFromNode(indent=indentation, modifiers=[], node=
         emit "#else\n"
       else
         emit "#elif ${condcheck}\n"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end

--- a/tools/ftl/libs/libclocks.ftlc
+++ b/tools/ftl/libs/libclocks.ftlc
@@ -18,19 +18,19 @@
 
 import "/@lib/libpp.ftlc" as ppcode
 
-prename = doc1.clocktree.settings.prefixes.@clock_points[0]?string
-premacro = doc1.clocktree.settings.prefixes.@macros[0]?string
-precfg = doc1.clocktree.settings.prefixes.@cfgs[0]?string
-postclocks = doc1.clocktree.settings.suffixes.@frequency[0]?string
-postclock = (doc1.clocktree.settings.suffixes.@clock[0]!"_CLOCK")?string
-postnominal = (doc1.clocktree.settings.suffixes.@nominal[0]!"_SOURCE_FREQ")?string
-postvalues = doc1.clocktree.settings.suffixes.@values[0]?string
-postbits = doc1.clocktree.settings.suffixes.@bits[0]?string
-postchoices = doc1.clocktree.settings.suffixes.@selector[0]?string
-postenable = doc1.clocktree.settings.suffixes.@enable[0]?string
-postenabled = doc1.clocktree.settings.suffixes.@enabled[0]?string
-postmin = "_MIN"
-postmax = "_MAX"
+assign prename = doc1.clocktree.settings.prefixes.@clock_points[0]?string
+assign premacro = doc1.clocktree.settings.prefixes.@macros[0]?string
+assign precfg = doc1.clocktree.settings.prefixes.@cfgs[0]?string
+assign postclocks = doc1.clocktree.settings.suffixes.@frequency[0]?string
+assign postclock = (doc1.clocktree.settings.suffixes.@clock[0]!"_CLOCK")?string
+assign postnominal = (doc1.clocktree.settings.suffixes.@nominal[0]!"_SOURCE_FREQ")?string
+assign postvalues = doc1.clocktree.settings.suffixes.@values[0]?string
+assign postbits = doc1.clocktree.settings.suffixes.@bits[0]?string
+assign postchoices = doc1.clocktree.settings.suffixes.@selector[0]?string
+assign postenable = doc1.clocktree.settings.suffixes.@enable[0]?string
+assign postenabled = doc1.clocktree.settings.suffixes.@enabled[0]?string
+assign postmin = "_MIN"
+assign postmax = "_MAX"
 
 /* Configures the preprocessor emitter used by this library.*/
 macro ConfigurePreprocessor(
@@ -45,7 +45,7 @@ macro ConfigurePreprocessor(
     backslashColumn=backslashColumn,
     splitColumn=splitColumn)
   ppcode.ResetPP()
-endmacro
+end
 
 /* Validates uniqueness of bit targets in a parsed bits list.*/
 function ValidateBitTargets(bits, context)
@@ -54,12 +54,12 @@ function ValidateBitTargets(bits, context)
     local target = bit["target"]
     if targets?seq_contains(target)
       stop ">>>> Duplicate bits target '" + target + "' in " + context
-    endif
+    end
     local targets = targets + [target]
-  endlist
+  end
 
   return bits
-endfunction
+end
 
 /* Parses value bits elements.*/
 function ParseValueBits(node, context)
@@ -70,12 +70,12 @@ function ParseValueBits(node, context)
       local masks = []
     else
       local masks = [mask]
-    endif
+    end
     local bits = bits + [{"target":(bit.@target[0]!"")?string, "value":bit.@value[0]?string, "masks":masks}]
-  endlist
+  end
 
   return ValidateBitTargets(bits, context)
-endfunction
+end
 
 /* Checks that two bit groups do not reuse the same mask on one target.*/
 function CheckBitMaskOverlap(inherited, localbits)
@@ -83,12 +83,12 @@ function CheckBitMaskOverlap(inherited, localbits)
     list localbits["masks"] as localmask
       if inheritedmask == localmask
         return inheritedmask
-      endif
-    endlist
-  endlist
+      end
+    end
+  end
 
   return ""
-endfunction
+end
 
 /* Combines inherited and local value bits expressions by target.*/
 function MergeValueBits(inherited, localbits, context)
@@ -98,25 +98,25 @@ function MergeValueBits(inherited, localbits, context)
     if localbit?size > 0
       if bit["masks"]?size == 0 || localbit["masks"]?size == 0
         stop ">>>> Missing bits mask for merged target '" + bit["target"] + "' in " + context
-      endif
+      end
       local overlap = CheckBitMaskOverlap(bit, localbit)
       if overlap != ""
         stop ">>>> Overlapping bits mask '" + overlap + "' for target '" + bit["target"] + "' in " + context
-      endif
+      end
       local merged = merged + [{"target":bit["target"], "value":"(" + bit["value"] + " | " + localbit["value"] + ")", "masks":bit["masks"] + localbit["masks"]}]
     else
       local merged = merged + [bit]
-    endif
-  endlist
+    end
+  end
 
   list localbits as bit
     if !HasValueBitsTarget(inherited, bit["target"])
       local merged = merged + [bit]
-    endif
-  endlist
+    end
+  end
 
   return merged
-endfunction
+end
 
 /* Parses enable-state bits elements.*/
 function ParseBoolBits(node, context)
@@ -127,31 +127,31 @@ function ParseBoolBits(node, context)
       local masks = []
     else
       local masks = [mask]
-    endif
+    end
     local bits = bits + [{"target":(bit.@target[0]!"")?string, "enabled":bit.@enabled[0]?string, "disabled":bit.@disabled[0]?string, "masks":masks}]
-  endlist
+  end
 
   return ValidateBitTargets(bits, context)
-endfunction
+end
 
 /* Returns the string value of a single untargeted bits element.*/
 function GetBitsValue(node)
   local bits = ParseValueBits(node, "selection")
   if bits?size == 1 && bits[0]["target"] == ""
     return bits[0]["value"]
-  endif
+  end
 
   if bits?size == 0
     stop ">>>> Missing bits element"
-  endif
+  end
 
   stop ">>>> Selection bits must use one untargeted bits element"
-endfunction
+end
 
 /* Builds a generated selector macro name from a field name and selector label.*/
 function GetGeneratedSelectorMacro(field, label)
   return field + "_" + label
-endfunction
+end
 
 /* Builds one preprocessor expression from nested conditional terms.*/
 function BuildAndExpression(terms)
@@ -162,46 +162,46 @@ function BuildAndExpression(terms)
       local expression = formatted
     else
       local expression = expression + " && " + formatted
-    endif
-  endlist
+    end
+  end
 
   return expression
-endfunction
+end
 
 /* Splits an expression containing top-level && operators.*/
 function SplitAndCondition(expression)
   local terms = []
   list expression?split("&&") as term
     local terms = terms + [term?trim]
-  endlist
+  end
 
   return terms
-endfunction
+end
 
 /* Splits an expression containing top-level || operators.*/
 function SplitOrCondition(expression)
   local terms = []
   list expression?split("||") as term
     local terms = terms + [term?trim]
-  endlist
+  end
 
   return terms
-endfunction
+end
 
 /* Removes one external pair from XML-authored OR groups when present.*/
 function NormalizeOrCondition(expression)
   local text = expression?trim
   if text?starts_with("((") && text?ends_with("))")
     return text?remove_beginning("(")?remove_ending(")")
-  endif
+  end
 
   return text
-endfunction
+end
 
 /* Builds a generated variant macro name.*/
 function GetVariantMacroName(name)
   return premacro + "CLOCKTREE_VARIANT_" + name
-endfunction
+end
 
 /* Parses variant declarations.*/
 function ParseVariants()
@@ -215,25 +215,25 @@ function ParseVariants()
 
       if names?seq_contains(name)
         stop ">>>> Duplicate clock tree variant '" + name + "'"
-      endif
+      end
       local names = names + [name]
       local variants = variants + [{"name":name, "macro":GetVariantMacroName(name), "condition":condition}]
-    endlist
-  endif
+    end
+  end
 
   return variants
-endfunction
+end
 
 /* Returns a variant declaration by name.*/
 function GetVariantDeclaration(variants, name)
   list variants as variant
     if variant["name"] == name
       return variant
-    endif
-  endlist
+    end
+  end
 
   return {}
-endfunction
+end
 
 /* Parses an optional variants attribute.*/
 function ParseVariantRefs(node, variants, context)
@@ -242,46 +242,46 @@ function ParseVariantRefs(node, variants, context)
 
   if text == ""
     return refs
-  endif
+  end
 
   list text?replace(",", " ")?word_list as name
     if refs?seq_contains(name)
       stop ">>>> Duplicate variant '" + name + "' in " + context
-    endif
+    end
     if GetVariantDeclaration(variants, name)?size == 0
       stop ">>>> Unknown variant '" + name + "' in " + context
-    endif
+    end
     local refs = refs + [name]
-  endlist
+  end
 
   return refs
-endfunction
+end
 
 /* Builds the active-variant expression for a variant reference list.*/
 function BuildVariantCondition(refs)
   if refs?size == 0
     return "TRUE"
-  endif
+  end
 
   local terms = []
   list refs as ref
     local terms = terms + [GetVariantMacroName(ref) + " == TRUE"]
-  endlist
+  end
 
   return BuildOrExpression(terms)
-endfunction
+end
 
 /* Parses variant metadata for one XML element.*/
 function ParseVariantMetadata(node, variants, context)
   local refs = ParseVariantRefs(node, variants, context)
 
   return {"variants":refs, "variant_condition":BuildVariantCondition(refs)}
-endfunction
+end
 
 /* Returns true if a parsed element is variant-specific.*/
 function IsVariantSpecific(item)
   return (item["variant_condition"]!"TRUE") != "TRUE"
-endfunction
+end
 
 /* Parses a recursive conditional value select into flat conditional cases.*/
 function ParseConditionalValueSelect(select, conditions, bits, context)
@@ -294,21 +294,21 @@ function ParseConditionalValueSelect(select, conditions, bits, context)
 
     if hasvalue && hasselect
       stop ">>>> Conditional branch in " + context + " cannot specify both value and select"
-    endif
+    end
     if !hasvalue && !hasselect
       stop ">>>> Conditional branch in " + context + " must specify value or select"
-    endif
+    end
 
     if hasselect
       local cases = cases + ParseConditionalValueSelect(when.select[0], branchconditions, branchbits, context)
     else
       local cases = cases + [{"when":BuildAndExpression(branchconditions), "value":when.@value[0]?string, "bits":branchbits}]
-    endif
-  endlist
+    end
+  end
 
   if !select.otherwise[0]??
     stop ">>>> Conditional select in " + context + " requires otherwise"
-  endif
+  end
 
   local otherwise = select.otherwise[0]
   local branchbits = MergeValueBits(bits, ParseValueBits(otherwise, context + " conditional otherwise"), context + " conditional otherwise")
@@ -317,36 +317,36 @@ function ParseConditionalValueSelect(select, conditions, bits, context)
 
   if hasvalue && hasselect
     stop ">>>> Conditional otherwise in " + context + " cannot specify both value and select"
-  endif
+  end
   if !hasvalue && !hasselect
     stop ">>>> Conditional otherwise in " + context + " must specify value or select"
-  endif
+  end
 
   if hasselect
     local cases = cases + ParseConditionalValueSelect(otherwise.select[0], conditions, branchbits, context)
   else
     local cases = cases + [{"when":BuildAndExpression(conditions), "value":otherwise.@value[0]?string, "bits":branchbits}]
-  endif
+  end
 
   return cases
-endfunction
+end
 
 /* Parses conditional source frequency cases.*/
 function ParseFrequencyCases(source, point)
   if source.frequencies[0].select[0]??
     return ParseConditionalValueSelect(source.frequencies[0].select[0], [], [], "frequency table for clock point '" + point + "'")
-  endif
+  end
 
   local cases = []
   list source.frequencies[0]["case"] as casefreq
     local cases = cases + [{"when":casefreq.@when[0]?string, "value":casefreq.@value[0]?string, "bits":ParseValueBits(casefreq, "frequency case for clock point '" + point + "'")}]
-  endlist
+  end
 
   local default = source.frequencies[0]["default"][0]
   local cases = cases + [{"when":"", "value":default.@value[0]?string, "bits":ParseValueBits(default, "default frequency for clock point '" + point + "'")}]
 
   return cases
-endfunction
+end
 
 /* Parses divider/multiplier value selection subtrees.*/
 function ParseScaler(scaler)
@@ -374,22 +374,22 @@ function ParseScaler(scaler)
       if choice.bits[0]??
         if encoding != ""
           stop ">>>> Choice '" + item + "' mixes explicit bits and selector encoding"
-        endif
+        end
         local bits = GetBitsValue(choice)
       else
         if field == "" || offset == "" || encoding == ""
           stop ">>>> Missing selector encoding for choice '" + item + "'"
-        endif
+        end
         local bits = GetGeneratedSelectorMacro(field, item)
         local selectors = selectors + [{"kind":"encoded", "field":field, "macro":bits, "encoding":encoding, "offset":offset}]
-      endif
+      end
       local choices = choices + [{"item":item, "value":value, "bits":bits}]
-    endlist
+    end
     local data = {"choices":choices, "default":default, "field":field, "offset":offset, "selectors":selectors}
-  endif
+  end
 
   return {"kind":kind, "data":data}
-endfunction
+end
 
 /* Returns the default configuration value for a scaler.*/
 function GetScalerDefault(point)
@@ -404,65 +404,65 @@ function GetScalerDefault(point)
     local default = data["choices"][0]["value"]!""
   else
     local default = ""
-  endif
+  end
 
   if default == ""
     stop ">>>> Missing default value for clock point '" + point["name"] + "'"
-  endif
+  end
 
   return default
-endfunction
+end
 
 /* Returns the enable condition macro for a clock point.*/
 function GetEnableMacro(point)
   if point["enable"] == "manual" || point["enable"] == "auto" || point["enable"] == "never" || point["enable"] == "always"
     return premacro + point["name"] + postenabled
-  endif
+  end
 
   stop ">>>> Unknown enable mode '" + point["enable"] + "' for clock point '" + point["name"] + "'"
-endfunction
+end
 
 /* Parses optional clock frequency limits.*/
 function ParseClockLimits(clock)
   if clock.limits[0]??
     return {"ref":clock.limits[0].@ref[0]?string}
-  endif
+  end
 
   return {}
-endfunction
+end
 
 /* Returns a limit declaration by name.*/
 function GetLimitDeclaration(limits, name)
   list limits as limit
     if limit["name"] == name
       return limit
-    endif
-  endlist
+    end
+  end
 
   return {}
-endfunction
+end
 
 /* Returns a state value set by state name.*/
 function GetStateValues(values, state)
   list values as value
     if value["state"] == state
       return value
-    endif
-  endlist
+    end
+  end
 
   return {}
-endfunction
+end
 
 /* Returns a limit value by limit name.*/
 function GetLimitValue(values, name)
   list values as value
     if value["name"] == name
       return value
-    endif
-  endlist
+    end
+  end
 
   return {}
-endfunction
+end
 
 /* Parses selectable frequency limit definitions.*/
 function ParseLimitModel()
@@ -472,11 +472,11 @@ function ParseLimitModel()
 
   if !hasstates && !haslimitset && !haslimitvalues
     return {"states":[], "limits":[], "values":[]}
-  endif
+  end
 
   if !hasstates || !haslimitset || !haslimitvalues
     stop ">>>> Incomplete clock limit model"
-  endif
+  end
 
   local statenames = []
   local states = []
@@ -484,10 +484,10 @@ function ParseLimitModel()
     local name = state.@name[0]?string
     if statenames?seq_contains(name)
       stop ">>>> Duplicate clock limit state '" + name + "'"
-    endif
+    end
     local statenames = statenames + [name]
     local states = states + [{"name":name, "when":state.@when[0]?string}]
-  endlist
+  end
 
   local limitnames = []
   local limits = []
@@ -495,10 +495,10 @@ function ParseLimitModel()
     local name = limit.@name[0]?string
     if limitnames?seq_contains(name)
       stop ">>>> Duplicate clock limit '" + name + "'"
-    endif
+    end
     local limitnames = limitnames + [name]
     local limits = limits + [{"name":name, "min":limit.@min[0]?string, "max":limit.@max[0]?string}]
-  endlist
+  end
 
   local valueStates = []
   local values = []
@@ -506,10 +506,10 @@ function ParseLimitModel()
     local statename = statevalues.@state[0]?string
     if !statenames?seq_contains(statename)
       stop ">>>> Unknown clock limit state '" + statename + "'"
-    endif
+    end
     if valueStates?seq_contains(statename)
       stop ">>>> Duplicate values for clock limit state '" + statename + "'"
-    endif
+    end
     local valueStates = valueStates + [statename]
 
     local valuenames = []
@@ -518,72 +518,72 @@ function ParseLimitModel()
       local name = limit.@name[0]?string
       if !limitnames?seq_contains(name)
         stop ">>>> Unknown clock limit '" + name + "' in state '" + statename + "'"
-      endif
+      end
       if valuenames?seq_contains(name)
         stop ">>>> Duplicate clock limit value '" + name + "' in state '" + statename + "'"
-      endif
+      end
       local valuenames = valuenames + [name]
       local variants = []
       if limit["case"][0]?? || limit["default"][0]??
         if limit.@min[0]?? || limit.@max[0]??
           stop ">>>> Direct and conditional values cannot be mixed for clock limit '" + name + "' in state '" + statename + "'"
-        endif
+        end
         if !limit["default"][0]??
           stop ">>>> Missing default value for clock limit '" + name + "' in state '" + statename + "'"
-        endif
+        end
         list limit["case"] as casevalue
           local variants = variants + [{"when":casevalue.@when[0]?string, "min":(casevalue.@min[0]!"")?string, "max":(casevalue.@max[0]!"")?string}]
-        endlist
+        end
         local defaultvalue = limit["default"][0]
         local variants = variants + [{"when":"", "min":(defaultvalue.@min[0]!"")?string, "max":(defaultvalue.@max[0]!"")?string}]
       else
         local variants = variants + [{"when":"", "min":(limit.@min[0]!"")?string, "max":(limit.@max[0]!"")?string}]
-      endif
+      end
       local limitvalues = limitvalues + [{"name":name, "variants":variants}]
-    endlist
+    end
 
     local values = values + [{"state":statename, "limits":limitvalues}]
-  endlist
+  end
 
   list states as state
     local statevalues = GetStateValues(values, state["name"])
     if statevalues?size == 0
       stop ">>>> Missing clock limit values for state '" + state["name"] + "'"
-    endif
+    end
 
     list limits as limit
       local limitvalue = GetLimitValue(statevalues["limits"], limit["name"])
       if limitvalue?size == 0
         stop ">>>> Missing clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-      endif
+      end
       if limitvalue["variants"]?size == 0
         stop ">>>> Missing value variants for clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-      endif
+      end
       if limitvalue["variants"]?last["when"] != ""
         stop ">>>> Missing default value for clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-      endif
+      end
       list limitvalue["variants"] as variant
         if variant["when"] == "" && !variant?is_last
           stop ">>>> Default value must be last for clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-        endif
+        end
         if limit["min"] == "yes" && variant["min"] == ""
           stop ">>>> Missing minimum value for clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-        endif
+        end
         if limit["min"] == "no" && variant["min"] != ""
           stop ">>>> Unexpected minimum value for clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-        endif
+        end
         if limit["max"] == "yes" && variant["max"] == ""
           stop ">>>> Missing maximum value for clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-        endif
+        end
         if limit["max"] == "no" && variant["max"] != ""
           stop ">>>> Unexpected maximum value for clock limit '" + limit["name"] + "' in state '" + state["name"] + "'"
-        endif
-      endlist
-    endlist
-  endlist
+        end
+      end
+    end
+  end
 
   return {"states":states, "limits":limits, "values":values}
-endfunction
+end
 
 /* Parses arbitrary support definitions and structured enumerations.*/
 function ParseDefinitions(variants)
@@ -603,21 +603,21 @@ function ParseDefinitions(variants)
 
       if itemnames?seq_contains(itemname)
         stop ">>>> Duplicate item '" + itemname + "' in enumeration '" + enumname + "'"
-      endif
+      end
       local itemnames = itemnames + [itemname]
 
       if names?seq_contains(name)
         stop ">>>> Duplicate definition '" + name + "'"
-      endif
+      end
       local names = names + [name]
 
       if field != ""
         local value = "((" + value + ") << " + field + ")"
-      endif
+      end
 
       local definitions = definitions + [{"name":name, "value":value, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}]
-    endlist
-  endlist
+    end
+  end
 
   list doc1.clocktree.settings.definitions.define as define
     local name = define.@name[0]?string
@@ -626,14 +626,14 @@ function ParseDefinitions(variants)
 
     if names?seq_contains(name)
       stop ">>>> Duplicate definition '" + name + "'"
-    endif
+    end
     local names = names + [name]
 
     local definitions = definitions + [{"name":name, "value":value, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}]
-  endlist
+  end
 
   return definitions
-endfunction
+end
 
 /* Parses the generic configuration settings.*/
 function ParseConfigurations(variants)
@@ -655,65 +655,65 @@ function ParseConfigurations(variants)
 
     if names?seq_contains(name)
       stop ">>>> Duplicate configuration '" + name + "'"
-    endif
+    end
     local names = names + [name]
 
     if role != ""
       if roles?seq_contains(role)
         stop ">>>> Duplicate configuration role '" + role + "'"
-      endif
+      end
       local roles = roles + [role]
-    endif
+    end
 
     if type == "bool"
       if default != "TRUE" && default != "FALSE"
         stop ">>>> Invalid default value for boolean configuration '" + name + "'"
-      endif
+      end
       if minval != "" || maxval != "" || values != ""
         stop ">>>> Invalid constraints for boolean configuration '" + name + "'"
-      endif
+      end
     elseif type == "value"
       if values != ""
         stop ">>>> Invalid value list for numeric configuration '" + name + "'"
-      endif
+      end
     elseif type == "set"
       if values == ""
         stop ">>>> Missing value list for set configuration '" + name + "'"
-      endif
+      end
       if minval != "" || maxval != ""
         stop ">>>> Invalid range constraints for set configuration '" + name + "'"
-      endif
+      end
       if !values?replace(",", " ")?word_list?seq_contains(default)
         stop ">>>> Invalid default value for set configuration '" + name + "'"
-      endif
+      end
     elseif type == "raw"
       if minval != "" || maxval != "" || values != ""
         stop ">>>> Invalid constraints for raw configuration '" + name + "'"
-      endif
+      end
     else
       stop ">>>> Unknown configuration type '" + type + "' for configuration '" + name + "'"
-    endif
+    end
 
     local configs = configs + [{"name":name, "type":type, "default":default, "role":role, "min":minval, "max":maxval, "values":values, "description":description, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}]
-  endlist
+  end
 
   return configs
-endfunction
+end
 
 /* Returns a generated derived configuration macro name.*/
 function GetDerivedConfigMacro(name)
   return premacro + "DCFG_" + name
-endfunction
+end
 
 /* Parses derived configuration settings.*/
 function ParseDerivedConfigurations(definitions, configs, variants)
   local names = []
   list definitions as definition
     local names = names + [definition["name"]]
-  endlist
+  end
   list configs as config
     local names = names + [config["name"]]
-  endlist
+  end
 
   local dconfigs = []
   if doc1.clocktree.settings["derived-configs"][0]??
@@ -726,19 +726,19 @@ function ParseDerivedConfigurations(definitions, configs, variants)
 
       if names?seq_contains(name)
         stop ">>>> Duplicate derived configuration '" + name + "'"
-      endif
+      end
       local names = names + [name]
 
       if type != "expression"
         stop ">>>> Unknown derived configuration type '" + type + "' for configuration '" + name + "'"
-      endif
+      end
 
       local dconfigs = dconfigs + [{"name":name, "type":type, "value":value, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}]
-    endlist
-  endif
+    end
+  end
 
   return dconfigs
-endfunction
+end
 
 /* Parses cross-configuration assertions.*/
 function ParseConfigurationAssertions(variants)
@@ -754,15 +754,15 @@ function ParseConfigurationAssertions(variants)
 
       if names?seq_contains(name)
         stop ">>>> Duplicate configuration assertion '" + name + "'"
-      endif
+      end
       local names = names + [name]
 
       local asserts = asserts + [{"name":name, "condition":condition, "message":message, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}]
-    endlist
-  endif
+    end
+  end
 
   return asserts
-endfunction
+end
 
 /* Parses terminal clock sinks.*/
 function ParseSinks(clocknames, variants)
@@ -779,25 +779,25 @@ function ParseSinks(clocknames, variants)
         local description = sink.description[0]?string?word_list?join(" ")
       else
         local description = "no description"
-      endif
+      end
       local limits = ParseClockLimits(sink)
       local variantdata = ParseVariantMetadata(sink, variants, "clock sink '" + name + "'")
 
       if names?seq_contains(name)
         stop ">>>> Duplicate clock sink '" + name + "'"
-      endif
+      end
       local names = names + [name]
 
       if clocknames?seq_contains(input) == false
         stop ">>>> Unknown clock point '" + input + "' referenced by sink '" + name + "'"
-      endif
+      end
 
       local sinks = sinks + [{"name":name, "input":input, "condition":condition, "implicit_mode":implicitmode, "description":description, "limits":limits, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}]
-    endlist
-  endif
+    end
+  end
 
   return sinks
-endfunction
+end
 
 /* Parses one source or clock point.*/
 function ParseClockPoint(clock, sourceonly, variants)
@@ -812,15 +812,15 @@ function ParseClockPoint(clock, sourceonly, variants)
     local clockdescr = clock.description[0]?string?word_list?join(" ")
   else
     local clockdescr = "no description"
-  endif
+  end
   if clockdefault != "" && clockenable != "manual"
     stop ">>>> Enable default specified for non-manual clock point '" + clockname + "'"
-  endif
+  end
   local clockbits = ParseBoolBits(clock, "clock point '" + clockname + "'")
   local clocklimits = ParseClockLimits(clock)
   if clockenable == "manual" && clockbits?size == 0
     stop ">>>> Missing enable bits for manually enabled clock point '" + clockname + "'"
-  endif
+  end
 
   /* Determining the type of the clock point by looking at the child element.*/
   if sourceonly || clock.derived[0]??
@@ -830,29 +830,29 @@ function ParseClockPoint(clock, sourceonly, variants)
     else
       local node = clock.derived[0]
       local kind = "Derived"
-    endif
+    end
 
     local hasfrequency = node.@frequency[0]??
     local hasfrequencies = node.frequencies[0]??
     if hasfrequency && hasfrequencies
       stop ">>>> " + kind + " clock point '" + clockname + "' mixes fixed and conditional frequencies"
-    endif
+    end
     if !hasfrequency && !hasfrequencies
       stop ">>>> " + kind + " clock point '" + clockname + "' has no frequency definition"
-    endif
+    end
     local clockinput = (node.@input[0]!"")?string
     if sourceonly && clockinput != ""
       stop ">>>> Source clock point '" + clockname + "' cannot use an input clock"
-    endif
+    end
     if hasfrequencies
       if clockinput != ""
         stop ">>>> Conditional frequency " + kind?lower_case + " clock point '" + clockname + "' cannot use an input clock"
-      endif
+      end
       return {"type":"source", "subtype":"frequencies", "sourceonly":sourceonly, "description":clockdescr, "name":clockname, "enable":clockenable, "enable_default":clockdefault, "dynamic":clockdynamic, "private":clockprivate, "bits":clockbits, "limits":clocklimits, "frequencies":ParseFrequencyCases(node, clockname), "input":"", "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}
     else
       local clockfreq = node.@frequency[0]?string
       return {"type":"source", "subtype":"fixed", "sourceonly":sourceonly, "description":clockdescr, "name":clockname, "enable":clockenable, "enable_default":clockdefault, "dynamic":clockdynamic, "private":clockprivate, "bits":clockbits, "limits":clocklimits, "frequency":clockfreq, "input":clockinput, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}
-    endif
+    end
 
   elseif clock.mux[0]??
     /* It is a muxed clock.*/
@@ -873,33 +873,33 @@ function ParseClockPoint(clock, sourceonly, variants)
       if inputencoding != ""
         if muxfield == "" || muxoffset == ""
           stop ">>>> Missing selector encoding for input '" + inputpoint + "' in clock mux '" + clockname + "'"
-        endif
+        end
         local inputvalue = GetGeneratedSelectorMacro(muxfield, inputlabel)
         local muxselectors = muxselectors + [{"kind":"encoded", "field":muxfield, "macro":inputvalue, "encoding":inputencoding, "offset":muxoffset}]
         if input.bits[0]??
           local inputbits = "(" + inputvalue + " | " + GetBitsValue(input) + ")"
         else
           local inputbits = inputvalue
-        endif
+        end
       elseif input.bits[0]??
         local inputvalue = GetBitsValue(input)
         local inputbits = inputvalue
       else
         stop ">>>> Missing selector encoding for input '" + inputpoint + "' in clock mux '" + clockname + "'"
-      endif
+      end
       if muxvalues?seq_contains(inputvalue)
         stop ">>>> Duplicate selector value '" + inputvalue + "' in clock mux '" + clockname + "'"
-      endif
+      end
       local muxvalues = muxvalues + [inputvalue]
       if inputdefault == "yes"
         local muxdefault = inputvalue
-      endif
+      end
       local muxinputs = muxinputs + [{"point":inputpoint, "value":inputvalue, "bits":inputbits, "default":inputdefault}]
       local muxbranches = muxbranches + [{"type":"input", "point":inputpoint, "value":inputvalue, "bits":inputbits, "default":inputdefault, "condition":""}]
-    endlist
+    end
     if muxinputs?size == 0
       stop ">>>> Missing input for clock mux '" + clockname + "'"
-    endif
+    end
     list clock.mux.inactive as inactive
       local hasinactivevalue = inactive.@value[0]??
       local inactivelabel = (inactive.@label[0]!"")?string
@@ -910,15 +910,15 @@ function ParseClockPoint(clock, sourceonly, variants)
         local inactivevalue = inactive.@value[0]?string
       else
         stop ">>>> Missing selector value for inactive branch in clock mux '" + clockname + "'"
-      endif
+      end
       local inactivebits = (inactive.@bits[0]!"0U")?string
       local inactivecondition = inactive.@when[0]?string
       if muxvalues?seq_contains(inactivevalue)
         stop ">>>> Duplicate selector value '" + inactivevalue + "' in clock mux '" + clockname + "'"
-      endif
+      end
       local muxvalues = muxvalues + [inactivevalue]
       local muxbranches = muxbranches + [{"type":"inactive", "point":"", "value":inactivevalue, "bits":inactivebits, "default":"no", "condition":inactivecondition}]
-    endlist
+    end
     return {"type":"mux", "name":clockname, "muxname":muxname, "field":muxfield, "setting":muxsetting, "inputs":muxinputs, "branches":muxbranches, "selectors":muxselectors, "default":muxdefault, "description":clockdescr, "enable":clockenable, "enable_default":clockdefault, "dynamic":clockdynamic, "private":clockprivate, "bits":clockbits, "limits":clocklimits, "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}
 
   elseif clock.divider[0]??
@@ -936,29 +936,29 @@ function ParseClockPoint(clock, sourceonly, variants)
     local mulsetting = (clock.multiplier[0].@setting[0]!"")?string
     local mulparsed = ParseScaler(clock.multiplier[0])
     return {"type":"multiplier", "description":clockdescr, "name":clockname, "enable":clockenable, "enable_default":clockdefault, "dynamic":clockdynamic, "private":clockprivate, "bits":clockbits, "limits":clocklimits, "mulname":mulname, "input":mulinput, "setting":mulsetting, "kind":mulparsed["kind"], "data":mulparsed["data"], "variants":variantdata["variants"], "variant_condition":variantdata["variant_condition"]}
-  endif
+  end
 
   stop ">>>> Unknown clock point type for '" + clockname + "'"
-endfunction
+end
 
 /* Returns true if a point frequency expression is not valid in generated _FREQ macros.*/
 function HasRuntimeFrequencyExpression(point)
   if point["type"] != "source"
     return false
-  endif
+  end
 
   if point["subtype"] == "frequencies"
     list point["frequencies"] as frequency
       if frequency["value"]?contains("hal_lld_get_clock_point(")
         return true
-      endif
-    endlist
+      end
+    end
   elseif point["frequency"]?contains("hal_lld_get_clock_point(")
     return true
-  endif
+  end
 
   return false
-endfunction
+end
 
 /* Initializes the parsed clock tree data model.*/
 function Initialize()
@@ -983,8 +983,8 @@ function Initialize()
       local clocknames = clocknames + [clockname]
       local points = points + [clockpoint]
       local clocks = clocks + [clockpoint]
-    endlist
-  endif
+    end
+  end
 
   /* Scanning clock points, gathering data.*/
   list doc1.clocktree.clocks.clock as clock
@@ -999,9 +999,9 @@ function Initialize()
       local dividers = dividers + [clockpoint]
     elseif clockpoint["type"] == "multiplier"
       local multipliers = multipliers + [clockpoint]
-    endif
+    end
     local clocks = clocks + [clockpoint]
-  endlist
+  end
 
   /* Validating references.*/
   list muxes as mux
@@ -1009,40 +1009,40 @@ function Initialize()
       local inputpoint = input["point"]
       if clocknames?seq_contains(inputpoint) == false
         stop ">>>> Unknown clock point '" + inputpoint + "' referenced by mux '" + mux["name"] + "'"
-      endif
-    endlist
-  endlist
+      end
+    end
+  end
   list clocks as clock
     if clock["type"] == "source"
       local inputpoint = clock["input"]
       if inputpoint != "" && clocknames?seq_contains(inputpoint) == false
         stop ">>>> Unknown clock point '" + inputpoint + "' referenced by source '" + clock["name"] + "'"
-      endif
-    endif
-  endlist
+      end
+    end
+  end
   list dividers as div
     local inputpoint = div["input"]
     if clocknames?seq_contains(inputpoint) == false
       stop ">>>> Unknown clock point '" + inputpoint + "' referenced by divider '" + div["name"] + "'"
-    endif
-  endlist
+    end
+  end
   list multipliers as mul
     local inputpoint = mul["input"]
     if clocknames?seq_contains(inputpoint) == false
       stop ">>>> Unknown clock point '" + inputpoint + "' referenced by multiplier '" + mul["name"] + "'"
-    endif
-  endlist
+    end
+  end
   list clocks as clock
     if HasRuntimeFrequencyExpression(clock)
       stop ">>>> Clock point '" + clock["name"] + "' uses a runtime function call in a _FREQ expression"
-    endif
+    end
     if clock["limits"]?size > 0
       local limit = GetLimitDeclaration(limitmodel["limits"], clock["limits"]["ref"])
       if limit?size == 0
         stop ">>>> Unknown clock limit '" + clock["limits"]["ref"] + "' referenced by clock point '" + clock["name"] + "'"
-      endif
-    endif
-  endlist
+      end
+    end
+  end
 
   local sinks = ParseSinks(clocknames, variants)
   list sinks as sink
@@ -1050,25 +1050,25 @@ function Initialize()
       local limit = GetLimitDeclaration(limitmodel["limits"], sink["limits"]["ref"])
       if limit?size == 0
         stop ">>>> Unknown clock limit '" + sink["limits"]["ref"] + "' referenced by clock sink '" + sink["name"] + "'"
-      endif
-    endif
+      end
+    end
     if sink["implicit_mode"]
       local config = BuildSinkClockModeConfig(sink)
       list configs as existing
         if existing["name"] == config["name"]
           stop ">>>> Duplicate implicit clock mode configuration '" + config["name"] + "' for clock sink '" + sink["name"] + "'"
-        endif
-      endlist
+        end
+      end
       local configs = configs + [config]
       local asserts = asserts + [BuildSinkClockModeAssert(sink)]
-    endif
-  endlist
+    end
+  end
 
   return {"variants":variants, "definitions":definitions, "configs":configs, "derived_configs":dconfigs, "asserts":asserts, "limits":limitmodel, "clocknames":clocknames, "clocks":clocks, "points":points, "muxes":muxes, "dividers":dividers, "multipliers":multipliers, "sinks":sinks}
-endfunction
+end
 
 /* Static data parsed at startup.*/
-model = Initialize()
+assign model = Initialize()
 
 /* Emits clock tree variant selection macros and consistency checks.*/
 macro EmitVariantSelection()
@@ -1088,13 +1088,13 @@ macro EmitVariantSelection()
       ppcode.EmitPPEndif()
       sep
         emit "\e"
-      endsep
-    endlist
+      end
+    end
 
     local none = []
     list model["variants"] as variant
       local none = none + [variant["macro"] + " == FALSE"]
-    endlist
+    end
     emit "\e"
     ppcode.EmitPPAssert(
       expression="!(" + BuildAndExpression(none) + ")",
@@ -1109,14 +1109,14 @@ macro EmitVariantSelection()
             expression="!((" + left["macro"] + " == TRUE) && (" + right["macro"] + " == TRUE))",
             message="\"multiple clock tree variants selected\"",
             requires=["TRUE"])
-        endif
-      endlist
-    endlist
+        end
+      end
+    end
     emit """
 /** @} */
 """
-  endif
-endmacro
+  end
+end
 
 /* Emits a variant guard start for one parsed item.*/
 macro EmitVariantGuardStart(item, doxygen=true)
@@ -1125,21 +1125,21 @@ macro EmitVariantGuardStart(item, doxygen=true)
       ppcode.EmitPPIf(expression="(" + item["variant_condition"] + ") || defined(__DOXYGEN__)")
     else
       ppcode.EmitPPIf(expression=item["variant_condition"])
-    endif
-  endif
-endmacro
+    end
+  end
+end
 
 /* Emits a variant guard end for one parsed item.*/
 macro EmitVariantGuardEnd(item)
   if IsVariantSpecific(item)
     ppcode.EmitPPEndif()
-  endif
-endmacro
+  end
+end
 
 /* Returns true if a dynamic clock point is part of the public runtime API.*/
 function IsPublicDynamicPoint(point)
   return point["dynamic"] == "yes" && (point["private"]!"false") != "true"
-endfunction
+end
 
 /* Returns the clock points belonging to the public dynamic set.*/
 function GetDynamicPoints()
@@ -1147,22 +1147,22 @@ function GetDynamicPoints()
   list model["clocks"] as point
     if IsPublicDynamicPoint(point)
       local points = points + [point]
-    endif
-  endlist
+    end
+  end
 
   return points
-endfunction
+end
 
 /* Returns the configuration assigned to a semantic role.*/
 function GetConfigByRole(role)
   list model["configs"] as config
     if config["role"] == role
       return config
-    endif
-  endlist
+    end
+  end
 
   stop ">>>> Missing configuration with role '" + role + "'"
-endfunction
+end
 
 /* Emits dynamic clock point indexes and names.*/
 macro EmitClockPointConstants()
@@ -1175,7 +1175,7 @@ macro EmitClockPointConstants()
 ${("#define " + prename + point["name"])?right_pad(32) + index + "U"}
 """
       local index = index + 1
-    endlist
+    end
     emit """
 ${("#define " + prename + "ARRAY_SIZE")?right_pad(32) + points?size + "U"}
 
@@ -1186,43 +1186,43 @@ ${("#define " + prename + "ARRAY_SIZE")?right_pad(32) + points?size + "U"}
       local name = "\"" + point["name"] + "\""
       if !point?is_last
         local name = name + ","
-      endif
+      end
       emit """
 ${("    " + name)?right_pad(76)}\
 """
-    endlist
+    end
     emit """
   }
 """
-  endif
-endmacro
+  end
+end
 
 /* Returns true if any mux has generated selector constants.*/
 function HasGeneratedMuxSelectors()
   list model["muxes"] as mux
     if mux["selectors"]?size > 0
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Returns true if any scaler has generated selector constants.*/
 function HasGeneratedScalerSelectors()
   list model["dividers"] as divider
     if divider["data"]["selectors"]?size > 0
       return true
-    endif
-  endlist
+    end
+  end
   list model["multipliers"] as multiplier
     if multiplier["data"]["selectors"]?size > 0
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Emits arbitrary support definitions from the XML settings section.*/
 macro EmitDefinitions()
@@ -1237,27 +1237,27 @@ macro EmitDefinitions()
     if HasImplicitSinkModes()
       if !IsGeneratedDefinition(GetSinkClockModeDisabledValue())
         ppcode.EmitPPDefine(name=GetSinkClockModeDisabledValue(), value="0U")
-      endif
+      end
       if !IsGeneratedDefinition(GetSinkClockModeAutoValue())
         ppcode.EmitPPDefine(name=GetSinkClockModeAutoValue(), value="1U")
-      endif
+      end
       if !IsGeneratedDefinition(GetSinkClockModeEnabledValue())
         ppcode.EmitPPDefine(name=GetSinkClockModeEnabledValue(), value="2U")
-      endif
+      end
       if model["definitions"]?size > 0
         emit "\e"
-      endif
-    endif
+      end
+    end
     list model["definitions"] as definition
       EmitVariantGuardStart(item=definition)
       ppcode.EmitPPDefine(name=definition["name"], value=definition["value"])
       EmitVariantGuardEnd(item=definition)
-    endlist
+    end
     emit """
 /** @} */
 """
-  endif
-endmacro
+  end
+end
 
 /* Emits generated selector constants for one group of fields.*/
 macro EmitGeneratedSelectors(selectors)
@@ -1266,9 +1266,9 @@ macro EmitGeneratedSelectors(selectors)
       ppcode.EmitPPDefine(name=selector["macro"], value="((" + selector["encoding"] + ") << " + selector["offset"] + ")")
     else
       ppcode.EmitPPDefine(name=selector["macro"], value=selector["value"])
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /* Emits generated mux selector constants.*/
 macro EmitMuxSelectorConstants()
@@ -1287,14 +1287,14 @@ macro EmitMuxSelectorConstants()
         EmitVariantGuardEnd(item=mux)
         sep
           emit "\e"
-        endsep
-      endif
-    endlist
+        end
+      end
+    end
     emit """
 /** @} */
 """
-  endif
-endmacro
+  end
+end
 
 /* Emits generated scaler selector constants.*/
 macro EmitScalerSelectorConstants()
@@ -1313,9 +1313,9 @@ macro EmitScalerSelectorConstants()
         EmitVariantGuardEnd(item=divider)
         sep
           emit "\e"
-        endsep
-      endif
-    endlist
+        end
+      end
+    end
     list model["multipliers"] as multiplier
       if multiplier["data"]["selectors"]?size > 0
         EmitVariantGuardStart(item=multiplier)
@@ -1323,14 +1323,14 @@ macro EmitScalerSelectorConstants()
         EmitVariantGuardEnd(item=multiplier)
         sep
           emit "\e"
-        endsep
-      endif
-    endlist
+        end
+      end
+    end
     emit """
 /** @} */
 """
-  endif
-endmacro
+  end
+end
 
 /* Emits the static clock point getter for non-dynamic mode.*/
 macro EmitStaticClockPointGetter()
@@ -1360,52 +1360,52 @@ macro EmitStaticClockPointGetter()
         local prefix = "  ("
       else
         local prefix = "   "
-      endif
+      end
       local line = (prefix + "(clkpt) == " + clkmacro)?right_pad(30) + " ? " + freqmacro?right_pad(24) + " :"
       ppcode.EmitPPLogicalLine(text=line, continued=true)
-    endlist
+    end
     emit """
    0U)
 #endif
 """
-  endif
-endmacro
+  end
+end
 
 /* Returns a clock point by name.*/
 function GetClockPoint(name)
   list model["clocks"] as point
     if point["name"] == name
       return point
-    endif
-  endlist
+    end
+  end
 
   stop ">>>> Unknown clock point '" + name + "'"
-endfunction
+end
 
 /* Returns a generated clock point frequency macro name.*/
 function GetClockFrequencyMacro(name)
   return premacro + name + postclocks
-endfunction
+end
 
 /* Returns a generated nominal source frequency macro name.*/
 function GetClockNominalFrequencyMacro(name)
   return premacro + name + postnominal
-endfunction
+end
 
 /* Returns a generated current clock point macro name.*/
 function GetClockCurrentMacro(name)
   return premacro + name + postclock
-endfunction
+end
 
 /* Returns a generated dynamic clock point index macro name.*/
 function GetClockIndexMacro(name)
   return prename + name
-endfunction
+end
 
 /* Returns the default/static frequency expression for a clock point.*/
 function GetDefaultFrequencyExpression(name)
   return GetClockFrequencyMacro(name)
-endfunction
+end
 
 /* Returns the runtime frequency expression for a clock point reference.*/
 function GetRuntimeFrequencyExpression(name)
@@ -1413,92 +1413,92 @@ function GetRuntimeFrequencyExpression(name)
 
   if IsPublicDynamicPoint(point)
     return "hal_lld_get_clock_point(" + GetClockIndexMacro(name) + ")"
-  endif
+  end
 
   return GetClockCurrentMacro(name)
-endfunction
+end
 
 /* Returns the selector/configuration macro used by a mux clock point.*/
 function GetMuxSettingMacro(point)
   if (point["setting"]!"") != ""
     return point["setting"]
-  endif
+  end
 
   return precfg + point["name"] + postchoices
-endfunction
+end
 
 /* Returns the selector/configuration macro used by a scaler clock point.*/
 function GetScalerSettingMacro(point)
   if (point["setting"]!"") != ""
     return point["setting"]
-  endif
+  end
 
   return precfg + point["name"] + postvalues
-endfunction
+end
 
 /* Returns the generated demand macro for a clock sink.*/
 function GetSinkDemandMacro(sink)
   return premacro + sink["name"] + "_DEMANDED"
-endfunction
+end
 
 /* Returns true if a condition references a generated enable macro.*/
 function ReferencesGeneratedEnableMacro(condition)
   list model["clocks"] as point
     if condition?matches(".*\\b" + GetEnableMacro(point) + "\\b.*")
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Returns true if a condition contains the defined operator.*/
 function ContainsDefinedOperator(condition)
   return condition?matches(".*\\bdefined\\s*\\(.*")
-endfunction
+end
 
 /* Returns the generated clock mode setting macro for an implicit sink.*/
 function GetSinkClockModeMacro(sink)
   return precfg + sink["name"] + "_CLOCK_MODE"
-endfunction
+end
 
 /* Returns the external requirement atom for an implicit sink.*/
 function GetSinkClockRequiredMacro(sink)
   return premacro + sink["name"] + "_CLOCK_REQUIRED"
-endfunction
+end
 
 /* Returns the generated disabled mode value for implicit sinks.*/
 function GetSinkClockModeDisabledValue()
   return premacro + "CLOCK_DISABLED"
-endfunction
+end
 
 /* Returns the generated auto mode value for implicit sinks.*/
 function GetSinkClockModeAutoValue()
   return premacro + "CLOCK_AUTO"
-endfunction
+end
 
 /* Returns the generated enabled mode value for implicit sinks.*/
 function GetSinkClockModeEnabledValue()
   return premacro + "CLOCK_ENABLED"
-endfunction
+end
 
 /* Returns true if a macro is one of the generated sink mode values.*/
 function IsGeneratedSinkModeValue(name)
   return (name == GetSinkClockModeDisabledValue() ||
           name == GetSinkClockModeAutoValue() ||
           name == GetSinkClockModeEnabledValue())
-endfunction
+end
 
 /* Returns true if there are implicit-mode sinks.*/
 function HasImplicitSinkModes()
   list model["sinks"] as sink
     if sink["implicit_mode"]
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Returns the generated demand condition for an implicit sink.*/
 function GetImplicitSinkDemandCondition(sink)
@@ -1508,7 +1508,7 @@ function GetImplicitSinkDemandCondition(sink)
   return ("(" + modemacro + " == " + GetSinkClockModeEnabledValue() + ") || " +
           "((" + modemacro + " == " + GetSinkClockModeAutoValue() + ") && " +
           "defined(" + requiredmacro + "))")
-endfunction
+end
 
 /* Builds the implicit clock mode configuration for one sink.*/
 function BuildSinkClockModeConfig(sink)
@@ -1516,7 +1516,7 @@ function BuildSinkClockModeConfig(sink)
   local values = GetSinkClockModeDisabledValue() + " " + GetSinkClockModeAutoValue() + " " + GetSinkClockModeEnabledValue()
 
   return {"name":GetSinkClockModeMacro(sink), "type":"set", "default":GetSinkClockModeAutoValue(), "role":"", "min":"", "max":"", "values":values, "description":description, "variants":sink["variants"], "variant_condition":sink["variant_condition"]}
-endfunction
+end
 
 /* Builds the disabled-vs-required assertion for one implicit sink.*/
 function BuildSinkClockModeAssert(sink)
@@ -1526,11 +1526,11 @@ function BuildSinkClockModeAssert(sink)
                      "!defined(" + requiredmacro + ")")
 
   return {"name":sink["name"] + "_CLOCK_NOT_DISABLED", "condition":condition, "message":sink["name"] + " clock disabled but " + sink["name"] + " clock is required", "variants":sink["variants"], "variant_condition":sink["variant_condition"]}
-endfunction
+end
 
 /* Current clock point values are emitted together with their _FREQ macros.*/
 macro EmitCurrentClockDefinitions()
-endmacro
+end
 
 /* Returns the downstream demand conditions for a clock point.*/
 function GetDemandConditions(point)
@@ -1539,32 +1539,32 @@ function GetDemandConditions(point)
     if sink["input"] == point["name"]
       local demandmacro = GetSinkDemandMacro(sink)
       local conditions = conditions + [{"demander":sink["name"], "terms":[demandmacro + " == TRUE"], "requires":["TRUE"]}]
-    endif
-  endlist
+    end
+  end
   list model["clocks"] as downstream
     if downstream["type"] == "source"
       if downstream["input"] == point["name"]
         local enmacro = GetEnableMacro(downstream)
         local conditions = conditions + [{"demander":downstream["name"], "terms":[enmacro + " == TRUE"], "requires":[enmacro, "TRUE"]}]
-      endif
+      end
     elseif downstream["type"] == "mux"
       local enmacro = GetEnableMacro(downstream)
       local selmacro = GetMuxSettingMacro(downstream)
       list downstream["inputs"] as input
         if input["point"] == point["name"]
           local conditions = conditions + [{"demander":downstream["name"], "terms":[enmacro + " == TRUE", selmacro + " == " + input["value"]], "requires":AddExternalMacroRequirements(["TRUE"], [input["value"]])}]
-        endif
-      endlist
+        end
+      end
     elseif downstream["type"] == "divider" || downstream["type"] == "multiplier"
       if downstream["input"] == point["name"]
         local enmacro = GetEnableMacro(downstream)
         local conditions = conditions + [{"demander":downstream["name"], "terms":[enmacro + " == TRUE"], "requires":[enmacro, "TRUE"]}]
-      endif
-    endif
-  endlist
+      end
+    end
+  end
 
   return conditions
-endfunction
+end
 
 /* Returns the mux bits corresponding to a disabled source, if declared.*/
 function GetMuxDisabledBits(point)
@@ -1574,18 +1574,18 @@ function GetMuxDisabledBits(point)
   list point["inputs"] as input
     if input["point"] == "NONE"
       local disabledinputbits = input["bits"]
-    endif
-  endlist
+    end
+  end
 
   if disabledbits != "" && disabledinputbits != ""
     return "(" + disabledbits + " | " + disabledinputbits + ")"
-  endif
+  end
   if disabledbits != ""
     return disabledbits
-  endif
+  end
 
   return disabledinputbits
-endfunction
+end
 
 /* Emits generic configuration settings.*/
 macro EmitGenericConfigurations()
@@ -1600,9 +1600,9 @@ macro EmitGenericConfigurations()
     EmitVariantGuardEnd(item=config)
     sep
       emit "\e"
-    endsep
-  endlist
-endmacro
+    end
+  end
+end
 
 /* Emits derived configuration macros.*/
 macro EmitDerivedConfigurationMacros()
@@ -1618,10 +1618,10 @@ macro EmitDerivedConfigurationMacros()
       EmitVariantGuardEnd(item=config)
       sep
         emit "\e"
-      endsep
-    endlist
-  endif
-endmacro
+      end
+    end
+  end
+end
 
 /* Emits clock point configuration settings in XML order.*/
 macro EmitConfigurations()
@@ -1629,18 +1629,18 @@ macro EmitConfigurations()
   list model["clocks"] as point
     if point["enable"] == "manual"
       local configs = configs + [{"type":"enable", "point":point}]
-    endif
+    end
     if point["type"] == "mux" && (point["setting"]!"") == ""
       local configs = configs + [{"type":"mux", "point":point}]
     elseif (point["type"] == "divider" || point["type"] == "multiplier") && (point["setting"]!"") == ""
       local configs = configs + [{"type":"value", "point":point}]
-    endif
-  endlist
+    end
+  end
 
   EmitGenericConfigurations()
   if model["configs"]?size > 0 && configs?size > 0
     emit "\e"
-  endif
+  end
 
   list configs as config
     local point = config["point"]
@@ -1653,23 +1653,23 @@ macro EmitConfigurations()
         local default = point["enable_default"]
       else
         local default = "FALSE"
-      endif
+      end
     elseif config["type"] == "mux"
       local name = GetMuxSettingMacro(point)
       local brief = "Selects the " + point["name"] + " clock source."
       local notes = " * @note    Allowed sources:\n"
       list point["inputs"] as input
         local notes = notes + " *          - " + input["point"] + ".\n"
-      endlist
+      end
       list point["branches"] as branch
         if branch["type"] == "inactive"
           local notes = notes + " *          - inactive selection " + branch["value"] + ".\n"
-        endif
-      endlist
+        end
+      end
       local default = point["default"]
       if default == ""
         stop ">>>> Missing default input for clock mux '" + point["name"] + "'"
-      endif
+      end
     else
       local name = GetScalerSettingMacro(point)
       local notes = ""
@@ -1677,16 +1677,16 @@ macro EmitConfigurations()
         local brief = "Configures the " + point["name"] + " clock divider value."
       else
         local brief = "Configures the " + point["name"] + " clock multiplier value."
-      endif
+      end
       local default = GetScalerDefault(point)
-    endif
+    end
     emit """
 /**
  * @brief   ${brief}
 """
     if notes != ""
       emit notes
-    endif
+    end
     emit """
  */
 """
@@ -1694,79 +1694,79 @@ macro EmitConfigurations()
     EmitVariantGuardEnd(item=point)
     sep
       emit "\e"
-    endsep
-  endlist
-endmacro
+    end
+  end
+end
 
 /* Returns true if a generic configuration has emitted checks.*/
 function HasGenericConfigCheck(config)
   if config["type"] == "bool" || config["type"] == "set"
     return true
-  endif
+  end
 
   if config["type"] == "value"
     if config["min"] != "" || config["max"] != ""
       return true
-    endif
-  endif
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Returns true if generic configuration checks are emitted.*/
 function HasGenericConfigChecks()
   if model["asserts"]?size > 0
     return true
-  endif
+  end
 
   list model["configs"] as config
     if HasGenericConfigCheck(config)
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Emits one cross-configuration assertion.*/
 macro EmitOneConfigAssertion(assertion)
   ppcode.EmitPPAssert(
     expression=assertion["condition"],
     message="\"" + assertion["message"] + "\"")
-endmacro
+end
 
 /* Formats one preprocessor condition term.*/
 function FormatConditionTerm(term)
   local text = term?trim
   if text?starts_with("defined(") || text?starts_with("!defined(")
     return text
-  endif
+  end
   if text?starts_with("(") && text?ends_with(")")
     return text
-  endif
+  end
 
   return "(" + text + ")"
-endfunction
+end
 
 /* Adds one explicitly referenced external macro to a requirements list.*/
 function GetDefinedMacroName(name)
   if name?contains("(")
     return name?keep_before("(")
-  endif
+  end
 
   return name
-endfunction
+end
 
 /* Returns true if a macro is generated as an XML support definition.*/
 function IsGeneratedDefinition(name)
   list model["definitions"] as definition
     if GetDefinedMacroName(definition["name"]) == name
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Returns true if a macro is generated as a selector constant.*/
 function IsGeneratedSelector(name)
@@ -1774,52 +1774,52 @@ function IsGeneratedSelector(name)
     list mux["selectors"] as selector
       if selector["macro"] == name
         return true
-      endif
-    endlist
-  endlist
+      end
+    end
+  end
 
   list model["dividers"] as divider
     list divider["data"]["selectors"] as selector
       if selector["macro"] == name
         return true
-      endif
-    endlist
-  endlist
+      end
+    end
+  end
 
   list model["multipliers"] as multiplier
     list multiplier["data"]["selectors"] as selector
       if selector["macro"] == name
         return true
-      endif
-    endlist
-  endlist
+      end
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Returns true if a macro is generated by the clock tree header itself.*/
 function IsGeneratedMacro(name)
   return IsGeneratedDefinition(name) || IsGeneratedSelector(name) || (HasImplicitSinkModes() && IsGeneratedSinkModeValue(name))
-endfunction
+end
 
 /* Adds one explicitly referenced external macro to a requirements list.*/
 function AddExternalMacroRequirement(requires, ref)
   local text = ref?trim
   if text?matches("^[A-Za-z_][A-Za-z0-9_]*$") && text != "__DOXYGEN__" && !IsGeneratedMacro(text) && !requires?seq_contains(text)
     return requires + [text]
-  endif
+  end
 
   return requires
-endfunction
+end
 
 /* Adds explicitly referenced external macros to a requirements list.*/
 function AddExternalMacroRequirements(requires, refs)
   list refs as ref
     local requires = AddExternalMacroRequirement(requires, ref)
-  endlist
+  end
 
   return requires
-endfunction
+end
 
 /* Builds one OR expression from terms.*/
 function BuildOrExpression(terms)
@@ -1830,11 +1830,11 @@ function BuildOrExpression(terms)
       local expression = formatted
     else
       local expression = expression + " || " + formatted
-    endif
-  endlist
+    end
+  end
 
   return expression
-endfunction
+end
 
 /* Emits a preprocessor condition using && between all terms.*/
 macro EmitAndCondition(keyword, terms)
@@ -1843,15 +1843,15 @@ macro EmitAndCondition(keyword, terms)
       local line = keyword + " " + FormatConditionTerm(term)
     else
       local line = "    " + FormatConditionTerm(term)
-    endif
+    end
     if !term?is_last
       local line = line + " && \\"
-    endif
+    end
     emit """
 ${line}
 """
-  endlist
-endmacro
+  end
+end
 
 /* Emits a preprocessor condition using || between checks, then a doxygen guard.*/
 macro EmitDoxygenGuardedOrCondition(checks)
@@ -1863,21 +1863,21 @@ macro EmitDoxygenGuardedOrCondition(checks)
         local line = "#if (" + FormatConditionTerm(check)
       else
         local line = "     " + FormatConditionTerm(check)
-      endif
+      end
       if check?is_last
         local line = line + ") && \\"
       else
         local line = line + " || \\"
-      endif
+      end
       emit """
 ${line}
 """
-    endlist
+    end
     emit """
     !defined(__DOXYGEN__)
 """
-  endif
-endmacro
+  end
+end
 
 /* Emits a state selection condition, optionally with a doxygen alternative.*/
 macro EmitStateCondition(keyword, expression, doxygen)
@@ -1891,17 +1891,17 @@ macro EmitStateCondition(keyword, expression, doxygen)
           local line = "      " + FormatConditionTerm(term)
         else
           local line = "     " + FormatConditionTerm(term)
-        endif
-      endif
+        end
+      end
       if term?is_last
         local line = line + ") || \\"
       else
         local line = line + " && \\"
-      endif
+      end
       emit """
 ${line}
 """
-    endlist
+    end
     emit """
     defined(__DOXYGEN__)
 """
@@ -1911,7 +1911,7 @@ ${line}
       local operator = " || "
     else
       local operator = " && "
-    endif
+    end
     list terms as term
       if term?is_first
         local line = keyword + " " + FormatConditionTerm(term)
@@ -1920,17 +1920,17 @@ ${line}
           local line = "      " + FormatConditionTerm(term)
         else
           local line = "    " + FormatConditionTerm(term)
-        endif
-      endif
+        end
+      end
       if !term?is_last
         local line = line + operator + "\\"
-      endif
+      end
       emit """
 ${line}
 """
-    endlist
-  endif
-endmacro
+    end
+  end
+end
 
 /* Emits checks for one generic configuration setting.*/
 macro EmitOneGenericConfigChecks(config)
@@ -1947,30 +1947,30 @@ macro EmitOneGenericConfigChecks(config)
     if config["min"] != ""
       local checks = checks + [name + " >= " + config["min"]]
       local requires = AddExternalMacroRequirement(requires, config["min"])
-    endif
+    end
     if config["max"] != ""
       local checks = checks + [name + " <= " + config["max"]]
       local requires = AddExternalMacroRequirement(requires, config["max"])
-    endif
+    end
     if checks?size > 0
       ppcode.EmitPPAssert(
         expression=BuildAndExpression(checks),
         message="\"invalid " + name + " value specified\"",
         requires=requires)
-    endif
+    end
   elseif config["type"] == "set"
     local checks = []
     local requires = []
     list config["values"]?replace(",", " ")?word_list as value
       local checks = checks + [name + " == " + value]
       local requires = AddExternalMacroRequirement(requires, value)
-    endlist
+    end
     ppcode.EmitPPAssert(
       expression=BuildOrExpression(checks),
       message="\"invalid " + name + " value specified\"",
       requires=requires)
-  endif
-endmacro
+  end
+end
 
 /* Emits checks for generic configuration settings.*/
 macro EmitGenericConfigChecks()
@@ -1985,25 +1985,25 @@ macro EmitGenericConfigChecks()
       if HasGenericConfigCheck(config)
         if emitted
           emit "\e"
-        endif
+        end
         EmitVariantGuardStart(item=config, doxygen=false)
         EmitOneGenericConfigChecks(config=config)
         EmitVariantGuardEnd(item=config)
         local emitted = true
-      endif
-    endlist
+      end
+    end
 
     list model["asserts"] as assertion
       if emitted
         emit "\e"
-      endif
+      end
       EmitVariantGuardStart(item=assertion, doxygen=false)
       EmitOneConfigAssertion(assertion=assertion)
       EmitVariantGuardEnd(item=assertion)
       local emitted = true
-    endlist
-  endif
-endmacro
+    end
+  end
+end
 
 /* Returns a generated limit macro name.*/
 function GetLimitMacro(limit, kind)
@@ -2011,10 +2011,10 @@ function GetLimitMacro(limit, kind)
     return premacro + limit["name"] + postmin
   elseif kind == "max"
     return premacro + limit["name"] + postmax
-  endif
+  end
 
   stop ">>>> Unknown clock limit kind '" + kind + "'"
-endfunction
+end
 
 /* Returns a generated state-specific limit macro name.*/
 function GetStateLimitMacro(state, limit, kind)
@@ -2022,27 +2022,27 @@ function GetStateLimitMacro(state, limit, kind)
     return premacro + state["name"]?upper_case + "_" + limit["name"] + postmin
   elseif kind == "max"
     return premacro + state["name"]?upper_case + "_" + limit["name"] + postmax
-  endif
+  end
 
   stop ">>>> Unknown clock limit kind '" + kind + "'"
-endfunction
+end
 
 /* Emits one state-specific clock limit value macro.*/
 macro EmitOneStateLimitValueMacro(state, limit, variant, kind)
   local macroname = GetStateLimitMacro(state, limit, kind)
 
   ppcode.EmitPPDefine(name=macroname, value=variant[kind])
-endmacro
+end
 
 /* Emits state-specific clock limit value macros for one variant.*/
 macro EmitStateLimitValueMacros(state, limit, variant)
   if limit["min"] == "yes"
     EmitOneStateLimitValueMacro(state=state, limit=limit, variant=variant, kind="min")
-  endif
+  end
   if limit["max"] == "yes"
     EmitOneStateLimitValueMacro(state=state, limit=limit, variant=variant, kind="max")
-  endif
-endmacro
+  end
+end
 
 /* Emits one state-specific clock limit value, optionally conditionally.*/
 macro EmitStateLimitValue(state, statevalues, limit)
@@ -2061,14 +2061,14 @@ macro EmitStateLimitValue(state, statevalues, limit)
         emit """
 #else
 """
-      endif
+      end
       EmitStateLimitValueMacros(state=state, limit=limit, variant=variant)
-    endlist
+    end
     emit """
 #endif
 """
-  endif
-endmacro
+  end
+end
 
 /* Emits grouped state-specific clock limit values.*/
 macro EmitStateLimitDefinitions()
@@ -2076,7 +2076,7 @@ macro EmitStateLimitDefinitions()
     local statevalues = GetStateValues(model["limits"]["values"], state["name"])
     if !state?is_first
       emit "\e"
-    endif
+    end
     emit """
 /**
  * @name    Frequency limits for ${state["name"]} state
@@ -2085,12 +2085,12 @@ macro EmitStateLimitDefinitions()
 """
     list model["limits"]["limits"] as limit
       EmitStateLimitValue(state=state, statevalues=statevalues, limit=limit)
-    endlist
+    end
     emit """
 /** @} */
 """
-  endlist
-endmacro
+  end
+end
 
 /* Emits one final clock limit selection.*/
 macro EmitOneLimitSelection(state, limit, kind)
@@ -2098,7 +2098,7 @@ macro EmitOneLimitSelection(state, limit, kind)
   local statemacro = GetStateLimitMacro(state, limit, kind)
 
   ppcode.EmitPPDefine(name=macroname, value=statemacro)
-endmacro
+end
 
 /* Emits final clock limit selections.*/
 macro EmitLimitSelections()
@@ -2113,21 +2113,21 @@ macro EmitLimitSelections()
         EmitStateCondition(keyword="#if", expression=state["when"], doxygen=true)
       else
         EmitStateCondition(keyword="#elif", expression=state["when"], doxygen=false)
-      endif
+      end
       list model["limits"]["limits"] as limit
         if limit["min"] == "yes"
           EmitOneLimitSelection(state=state, limit=limit, kind="min")
-        endif
+        end
         if limit["max"] == "yes"
           EmitOneLimitSelection(state=state, limit=limit, kind="max")
-        endif
-      endlist
-    endlist
+        end
+      end
+    end
     ppcode.EmitPPElseAt(level=0)
     ppcode.EmitPPErrorAt(message="\"unable to select clock frequency limits\"", level=1)
     ppcode.EmitPPEndifAt(level=0)
-  endif
-endmacro
+  end
+end
 
 /* Emits generated clock limit definitions.*/
 macro EmitLimitDefinitions()
@@ -2135,8 +2135,8 @@ macro EmitLimitDefinitions()
     EmitStateLimitDefinitions()
     emit "\e"
     EmitLimitSelections()
-  endif
-endmacro
+  end
+end
 
 /* Emits enable-state definitions for all clock points.*/
 macro EmitEnableExpression(name, expression, conditions)
@@ -2146,25 +2146,25 @@ macro EmitEnableExpression(name, expression, conditions)
       local terms = []
       list condition["terms"] as term
         local terms = terms + [FormatConditionTerm(term)]
-      endlist
+      end
       if terms?size > 1
         local conditionexpressions = conditionexpressions + ["(" + terms?join(" && ") + ")"]
       else
         local conditionexpressions = conditionexpressions + [terms[0]]
-      endif
-    endlist
+      end
+    end
     local expression = "(" + conditionexpressions?join(" || ") + ")"
     ppcode.EmitPPDefine(name=name, value=expression)
   else
     ppcode.EmitPPDefine(name=name, value=expression)
-  endif
-endmacro
+  end
+end
 
 /* Emits a sink demand expression that depends on a generated enable state.*/
 macro EmitDeferredSinkDemandDefinition(sink, demandmacro, condition)
   if ContainsDefinedOperator(condition)
     stop ">>>> Clock sink '" + sink["name"] + "' condition cannot combine defined() with a generated enable macro"
-  endif
+  end
 
   ppcode.EmitPPIf(expression="defined(__DOXYGEN__)")
   ppcode.EmitPPDefine(name=demandmacro, value="TRUE")
@@ -2172,14 +2172,14 @@ macro EmitDeferredSinkDemandDefinition(sink, demandmacro, condition)
     ppcode.EmitPPElif(expression=sink["variant_condition"])
   else
     ppcode.EmitPPElse()
-  endif
+  end
   ppcode.EmitPPDefine(name=demandmacro, value="(" + condition + ")")
   if IsVariantSpecific(sink)
     ppcode.EmitPPElse()
     ppcode.EmitPPDefine(name=demandmacro, value="FALSE")
-  endif
+  end
   ppcode.EmitPPEndif()
-endmacro
+end
 
 /* Emits generated sink demand states without embedding defined() in macros.*/
 macro EmitSinkDemandDefinitions()
@@ -2196,7 +2196,7 @@ macro EmitSinkDemandDefinitions()
         local condition = GetImplicitSinkDemandCondition(sink)
       else
         local condition = sink["condition"]
-      endif
+      end
       emit """
 /**
  * @brief   ${sink["name"]} sink demand state.
@@ -2216,41 +2216,41 @@ macro EmitSinkDemandDefinitions()
           ppcode.EmitPPEndif()
         else
           ppcode.EmitPPDefine(name=demandmacro, value="TRUE")
-        endif
+        end
       elseif !sink["implicit_mode"] && !condition?contains("defined(")
         /* Keep generated-clock dependencies deferred until macro expansion.*/
         if IsVariantSpecific(sink)
           local condition = "((" + sink["variant_condition"] + ") && (" + condition + "))"
-        endif
+        end
         ppcode.EmitPPDefine(name=demandmacro, value="(" + condition + ")")
       else
         if IsVariantSpecific(sink)
           ppcode.EmitPPIf(expression="((" + sink["variant_condition"] + ") && (" + condition + ")) || defined(__DOXYGEN__)")
         else
           ppcode.EmitPPIf(expression="(" + condition + ") || defined(__DOXYGEN__)")
-        endif
+        end
         ppcode.EmitPPDefine(name=demandmacro, value="TRUE")
         ppcode.EmitPPElse()
         ppcode.EmitPPDefine(name=demandmacro, value="FALSE")
         ppcode.EmitPPEndif()
-      endif
+      end
       sep
         emit "\e"
-      endsep
-    endlist
+      end
+    end
     emit """
 /** @} */
 """
-  endif
-endmacro
+  end
+end
 
 macro EmitEnableDefinitions()
   local enabledpoints = []
   list model["clocks"] as point
     if point["enable"] == "manual" || point["enable"] == "auto" || point["enable"] == "never" || point["enable"] == "always"
       local enabledpoints = enabledpoints + [point]
-    endif
-  endlist
+    end
+  end
 
   list enabledpoints as point
     local enmacro = GetEnableMacro(point)
@@ -2264,15 +2264,15 @@ macro EmitEnableDefinitions()
           local expression = "((" + conditions[0]["terms"][0] + "))"
         else
           local expression = ""
-        endif
+        end
       else
         local expression = "TRUE"
-      endif
+      end
     elseif point["enable"] == "always"
       local expression = "TRUE"
     else
       local expression = "FALSE"
-    endif
+    end
     emit """
 /**
  * @brief   ${point["name"]} clock derived enable state.
@@ -2280,32 +2280,32 @@ macro EmitEnableDefinitions()
 """
     if IsVariantSpecific(point)
       EmitVariantGuardStart(item=point)
-    endif
+    end
     EmitEnableExpression(name=enmacro, expression=expression, conditions=conditions)
     if IsVariantSpecific(point)
       ppcode.EmitPPElse()
       ppcode.EmitPPDefine(name=enmacro, value="FALSE")
       ppcode.EmitPPEndif()
-    endif
+    end
     sep
       emit "\e"
-    endsep
-  endlist
-endmacro
+    end
+  end
+end
 
 /* Returns the register bits macro for a clock point and target.*/
 function GetBitsMacro(point, target)
   if target == ""
     return premacro + point["name"] + postbits
-  endif
+  end
 
   return premacro + target + "_" + point["name"] + postbits
-endfunction
+end
 
 /* Returns indentation for nested preprocessor directives.*/
 function GetPpIndent(level)
   return ppcode.GetPPIndentAt(level)
-endfunction
+end
 
 /* Returns unique bit targets from enable and value bits.*/
 function GetBitTargets(pointbits, valuebits)
@@ -2313,64 +2313,64 @@ function GetBitTargets(pointbits, valuebits)
   list pointbits as bit
     if !targets?seq_contains(bit["target"])
       local targets = targets + [bit["target"]]
-    endif
-  endlist
+    end
+  end
   list valuebits as bit
     if !targets?seq_contains(bit["target"])
       local targets = targets + [bit["target"]]
-    endif
-  endlist
+    end
+  end
 
   if targets?size == 0
     local targets = [""]
-  endif
+  end
 
   return targets
-endfunction
+end
 
 /* Returns the value bits expression for one target.*/
 function GetValueBitsExpression(valuebits, target)
   list valuebits as bit
     if bit["target"] == target
       return bit["value"]
-    endif
-  endlist
+    end
+  end
 
   return ""
-endfunction
+end
 
 /* Returns the value bits object for one target.*/
 function GetValueBits(valuebits, target)
   list valuebits as bit
     if bit["target"] == target
       return bit
-    endif
-  endlist
+    end
+  end
 
   return {}
-endfunction
+end
 
 /* Returns true if value bits contain one target.*/
 function HasValueBitsTarget(valuebits, target)
   list valuebits as bit
     if bit["target"] == target
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Returns the enable-state bits expression for one target and state.*/
 function GetBoolBitsExpression(pointbits, target, state)
   list pointbits as bit
     if bit["target"] == target
       return bit[state]
-    endif
-  endlist
+    end
+  end
 
   return ""
-endfunction
+end
 
 /* Emits one targeted bits definition, optionally combined with enable-state bits.*/
 macro EmitTargetBitsDefinitionAt(point, bits, target, indent)
@@ -2385,7 +2385,7 @@ macro EmitTargetBitsDefinitionAt(point, bits, target, indent)
       local disabledbits = disabledbits
     else
       local enabledbits = "(" + enabledbits + " | " + bits + ")"
-    endif
+    end
 
     if point["enable"] == "always" || enabledbits == disabledbits
       ppcode.EmitPPDefineAt(name=bitsmacro, value=enabledbits, level=indent)
@@ -2397,11 +2397,11 @@ macro EmitTargetBitsDefinitionAt(point, bits, target, indent)
       ppcode.EmitPPElseAt(level=indent)
       ppcode.EmitPPDefineAt(name=bitsmacro, value=disabledbits, level=indent + 1)
       ppcode.EmitPPEndifAt(level=indent)
-    endif
+    end
   else
     if bits == ""
       local bits = "0U"
-    endif
+    end
 
     if point["enable"] == "always"
       ppcode.EmitPPDefineAt(name=bitsmacro, value=bits, level=indent)
@@ -2413,19 +2413,19 @@ macro EmitTargetBitsDefinitionAt(point, bits, target, indent)
       ppcode.EmitPPElseAt(level=indent)
       ppcode.EmitPPDefineAt(name=bitsmacro, value="0U", level=indent + 1)
       ppcode.EmitPPEndifAt(level=indent)
-    endif
-  endif
-endmacro
+    end
+  end
+end
 
 /* Emits one targeted bits definition without extra indentation.*/
 macro EmitTargetBitsDefinition(point, bits, target)
   EmitTargetBitsDefinitionAt(point=point, bits=bits, target=target, indent=0)
-endmacro
+end
 
 /* Emits one untargeted bits definition, preserving legacy call sites.*/
 macro EmitBitsDefinition(point, bits)
   EmitTargetBitsDefinition(point=point, bits=bits, target="")
-endmacro
+end
 
 /* Emits bits definitions for all targets used by a clock point/value pair.*/
 macro EmitBitsDefinitionsAt(point, valuebits, indent)
@@ -2435,19 +2435,19 @@ macro EmitBitsDefinitionsAt(point, valuebits, indent)
     EmitTargetBitsDefinitionAt(point=point, bits=bits, target=target, indent=indent)
     sep
       emit "\e"
-    endsep
-  endlist
-endmacro
+    end
+  end
+end
 
 /* Emits bits definitions without extra indentation.*/
 macro EmitBitsDefinitions(point, valuebits)
   EmitBitsDefinitionsAt(point=point, valuebits=valuebits, indent=0)
-endmacro
+end
 
 /* Emits one dynamic current clock definition for a clock point.*/
 macro EmitDynamicCurrentClockDefinition(point)
   ppcode.EmitPPDefine(name=GetClockCurrentMacro(point["name"]), value=GetRuntimeFrequencyExpression(point["name"]))
-endmacro
+end
 
 /* Emits one frequency definition and, for non-dynamic points, its current value.*/
 macro EmitFrequencyAndCurrentAt(point, frequency, current, indent)
@@ -2455,8 +2455,8 @@ macro EmitFrequencyAndCurrentAt(point, frequency, current, indent)
   ppcode.EmitPPDefineAt(name=freqmacro, value=frequency, level=indent)
   if !IsPublicDynamicPoint(point)
     ppcode.EmitPPDefineAt(name=GetClockCurrentMacro(point["name"]), value=current, level=indent)
-  endif
-endmacro
+  end
+end
 
 /* Emits one frequency definition, optionally conditional on enable state.*/
 macro EmitFrequencyDefinition(point, frequency, current)
@@ -2470,7 +2470,7 @@ macro EmitFrequencyDefinition(point, frequency, current)
       EmitDynamicCurrentClockDefinition(point=point)
     else
       ppcode.EmitPPDefine(name=clockmacro, value=current)
-    endif
+    end
   elseif point["enable"] == "never" || frequency == "0U"
     ppcode.EmitPPDefine(name=freqmacro, value="0U")
     ppcode.EmitPPDefine(name=clockmacro, value="0U")
@@ -2479,33 +2479,33 @@ macro EmitFrequencyDefinition(point, frequency, current)
     ppcode.EmitPPDefine(name=freqmacro, value=frequency)
     if !IsPublicDynamicPoint(point)
       ppcode.EmitPPDefine(name=clockmacro, value=current)
-    endif
+    end
     ppcode.EmitPPElse()
     ppcode.EmitPPDefine(name=freqmacro, value="0U")
     if !IsPublicDynamicPoint(point)
       ppcode.EmitPPDefine(name=clockmacro, value="0U")
-    endif
+    end
     ppcode.EmitPPEndif()
     if IsPublicDynamicPoint(point)
       EmitDynamicCurrentClockDefinition(point=point)
-    endif
-  endif
-endmacro
+    end
+  end
+end
 
 /* Emits configuration value checks for one clock point.*/
 function HasClockChecks(point)
   if point["enable"] == "manual"
     return true
-  endif
+  end
 
   if point["type"] == "divider" || point["type"] == "multiplier"
     if point["kind"] == "value" || point["kind"] == "set"
       return true
-    endif
-  endif
+    end
+  end
 
   return false
-endfunction
+end
 
 macro EmitClockChecks(point)
   if point["enable"] == "manual"
@@ -2514,7 +2514,7 @@ macro EmitClockChecks(point)
       expression="(" + enmacro + " == TRUE) || (" + enmacro + " == FALSE)",
       message="\"invalid " + enmacro + " value specified\"",
       requires=AddExternalMacroRequirements([], ["TRUE", "FALSE"]))
-  endif
+  end
 
   if point["type"] == "divider" || point["type"] == "multiplier"
     local valmacro = GetScalerSettingMacro(point)
@@ -2526,63 +2526,63 @@ macro EmitClockChecks(point)
       if minval != ""
         local checks = checks + [valmacro + " >= " + minval]
         local requires = AddExternalMacroRequirement(requires, minval)
-      endif
+      end
       if maxval != ""
         local checks = checks + [valmacro + " <= " + maxval]
         local requires = AddExternalMacroRequirement(requires, maxval)
-      endif
+      end
     elseif point["kind"] == "set"
       list point["data"]["values"]?replace(",", " ")?word_list as value
         local checks = checks + [valmacro + " == " + value]
         local requires = AddExternalMacroRequirement(requires, value)
-      endlist
-    endif
+      end
+    end
     if checks?size > 0
       if point["kind"] == "set"
         local expression = BuildOrExpression(checks)
       else
         local expression = BuildAndExpression(checks)
-      endif
+      end
       ppcode.EmitPPAssert(
         expression=expression,
         message="\"invalid " + valmacro + " value specified\"",
         requires=requires)
-    endif
-  endif
-endmacro
+    end
+  end
+end
 
 /* Returns the nominal source frequency expression for a source-style point.*/
 function GetNominalFrequencyExpression(point)
   if point["type"] != "source" || !(point["sourceonly"]!false)
     return ""
-  endif
+  end
 
   if point["subtype"] == "frequencies"
     list point["frequencies"] as frequency
       if frequency["when"] == ""
         return frequency["value"]
-      endif
-    endlist
+      end
+    end
 
     stop ">>>> Missing default nominal frequency for clock point '" + point["name"] + "'"
-  endif
+  end
 
   return point["frequency"]
-endfunction
+end
 
 /* Returns true if a point represents an explicit no-clock input.*/
 function IsNoClockPoint(name)
   if name == "NONE"
     return true
-  endif
+  end
 
   local point = GetClockPoint(name)
   if point["type"] == "source" && point["subtype"] == "fixed" && point["frequency"]?trim == "0U"
     return true
-  endif
+  end
 
   return false
-endfunction
+end
 
 /* Emits the nominal source frequency for one source-style point.*/
 macro EmitNominalFrequency(point)
@@ -2594,13 +2594,13 @@ macro EmitNominalFrequency(point)
  */
 """
     ppcode.EmitPPDefine(name=GetClockNominalFrequencyMacro(point["name"]), value=frequency)
-  endif
-endmacro
+  end
+end
 
 /* Returns true if a clock point has frequency checks.*/
 function HasClockFrequencyChecks(point)
   return point["limits"]?size > 0
-endfunction
+end
 
 /* Returns the Doxygen brief for one generated clock point block.*/
 function GetClockPointBrief(point)
@@ -2609,13 +2609,13 @@ function GetClockPointBrief(point)
 
   if lower?ends_with("clock point")
     return description?cap_first + "."
-  endif
+  end
   if lower?ends_with("clock")
     return description?cap_first + " point."
-  endif
+  end
 
   return description?cap_first + " clock point."
-endfunction
+end
 
 /* Emits frequency range checks for one clock point.*/
 macro EmitClockFrequencyChecks(point)
@@ -2627,12 +2627,12 @@ macro EmitClockFrequencyChecks(point)
       local minval = GetLimitMacro(limit, "min")
     else
       local minval = ""
-    endif
+    end
     if limit["max"] == "yes"
       local maxval = GetLimitMacro(limit, "max")
     else
       local maxval = ""
-    endif
+    end
 
     if point["type"] == "mux"
       local selmacro = GetMuxSettingMacro(point)
@@ -2643,7 +2643,7 @@ macro EmitClockFrequencyChecks(point)
           if !IsNoClockPoint(input["point"])
             if emitted
               emit "\e"
-            endif
+            end
             local inputfreq = GetDefaultFrequencyExpression(input["point"])
             local active = BuildAndExpression([enmacro + " == TRUE", selmacro + " == " + input["value"]])
             local requires = AddExternalMacroRequirements(["TRUE"], [input["value"]])
@@ -2652,13 +2652,13 @@ macro EmitClockFrequencyChecks(point)
               message="\"" + freqmacro + " below minimum frequency\"",
               requires=requires)
             local emitted = true
-          endif
-        endlist
-      endif
+          end
+        end
+      end
 
       if minval != "" && maxval != "" && emitted
         emit "\e"
-      endif
+      end
 
       if maxval != ""
         local maxemitted = false
@@ -2666,7 +2666,7 @@ macro EmitClockFrequencyChecks(point)
           if !IsNoClockPoint(input["point"])
             if maxemitted
               emit "\e"
-            endif
+            end
             local inputfreq = GetDefaultFrequencyExpression(input["point"])
             local active = BuildAndExpression([enmacro + " == TRUE", selmacro + " == " + input["value"]])
             local requires = AddExternalMacroRequirements(["TRUE"], [input["value"]])
@@ -2675,46 +2675,46 @@ macro EmitClockFrequencyChecks(point)
               message="\"" + freqmacro + " above maximum frequency\"",
               requires=requires)
             local maxemitted = true
-          endif
-        endlist
-      endif
+          end
+        end
+      end
     else
       if minval != ""
         ppcode.EmitPPAssert(
           expression="(" + enmacro + " != TRUE) || (" + freqmacro + " >= " + minval + ")",
           message="\"" + freqmacro + " below minimum frequency\"",
           requires=["TRUE"])
-      endif
+      end
 
       if minval != "" && maxval != ""
         emit "\e"
-      endif
+      end
 
       if maxval != ""
         ppcode.EmitPPAssert(
           expression="(" + enmacro + " != TRUE) || (" + freqmacro + " <= " + maxval + ")",
           message="\"" + freqmacro + " above maximum frequency\"",
           requires=["TRUE"])
-      endif
-    endif
-  endif
-endmacro
+      end
+    end
+  end
+end
 
 /* Returns true if a sink has frequency checks.*/
 function HasSinkFrequencyChecks(sink)
   return sink["limits"]?size > 0
-endfunction
+end
 
 /* Returns true if any sink has frequency checks.*/
 function HasAnySinkFrequencyChecks()
   list model["sinks"] as sink
     if HasSinkFrequencyChecks(sink)
       return true
-    endif
-  endlist
+    end
+  end
 
   return false
-endfunction
+end
 
 /* Emits frequency range checks for one sink.*/
 macro EmitOneSinkFrequencyChecks(sink)
@@ -2726,36 +2726,36 @@ macro EmitOneSinkFrequencyChecks(sink)
       local active = "(" + sink["variant_condition"] + ") && (" + sink["condition"] + ")"
     else
       local active = sink["condition"]
-    endif
+    end
     local limit = GetLimitDeclaration(model["limits"]["limits"], sink["limits"]["ref"])
     if limit["min"] == "yes"
       local minval = GetLimitMacro(limit, "min")
     else
       local minval = ""
-    endif
+    end
     if limit["max"] == "yes"
       local maxval = GetLimitMacro(limit, "max")
     else
       local maxval = ""
-    endif
+    end
 
     if minval != ""
       ppcode.EmitPPAssert(
         expression="!(" + active + ") || (" + freqmacro + " >= " + minval + ")",
         message="\"" + freqmacro + " below minimum frequency for " + sink["name"] + "\"")
-    endif
+    end
 
     if minval != "" && maxval != ""
       emit "\e"
-    endif
+    end
 
     if maxval != ""
       ppcode.EmitPPAssert(
         expression="!(" + active + ") || (" + freqmacro + " <= " + maxval + ")",
         message="\"" + freqmacro + " above maximum frequency for " + sink["name"] + "\"")
-    endif
-  endif
-endmacro
+    end
+  end
+end
 
 /* Emits frequency range checks for sinks.*/
 macro EmitSinkFrequencyChecks()
@@ -2770,22 +2770,22 @@ macro EmitSinkFrequencyChecks()
       if HasSinkFrequencyChecks(sink)
         if emitted
           emit "\e"
-        endif
+        end
         EmitOneSinkFrequencyChecks(sink=sink)
         local emitted = true
-      endif
-    endlist
-  endif
-endmacro
+      end
+    end
+  end
+end
 
 /* Returns true if source dependency checks are emitted for one clock point.*/
 function HasSourceDependencyChecks(point)
   if point["enable"] == "manual" && GetDemandConditions(point)?size > 0
     return true
-  endif
+  end
 
   return false
-endfunction
+end
 
 /* Emits checks requiring manually-enabled sources when selected downstream.*/
 macro EmitSourceDependencyChecks(point)
@@ -2800,10 +2800,10 @@ macro EmitSourceDependencyChecks(point)
         requires=condition["requires"])
       if !condition?is_last
         emit "\e"
-      endif
-    endlist
-  endif
-endmacro
+      end
+    end
+  end
+end
 
 /* Emits derived register bits for one clock point.*/
 macro EmitClockBits(point)
@@ -2819,7 +2819,7 @@ macro EmitClockBits(point)
       local allbits = []
       list point["frequencies"] as frequency
         local allbits = allbits + frequency["bits"]
-      endlist
+      end
       local targets = GetBitTargets(point["bits"], allbits)
       list targets as target
         if !HasValueBitsTarget(allbits, target)
@@ -2837,23 +2837,23 @@ macro EmitClockBits(point)
               emit """
 #else
 """
-            endif
+            end
             local bits = GetValueBitsExpression(frequency["bits"], target)
             EmitTargetBitsDefinitionAt(point=point, bits=bits, target=target, indent=1)
-          endlist
+          end
           emit """
 #endif
 """
-        endif
+        end
         sep
           emit "\e"
-        endsep
-      endlist
+        end
+      end
     elseif point["bits"]?size > 0
       EmitBitsDefinitions(point=point, valuebits=[])
     else
       EmitBitsDefinitions(point=point, valuebits=[{"target":"", "value":"0U"}])
-    endif
+    end
   elseif point["type"] == "mux"
     local selmacro = GetMuxSettingMacro(point)
     local enmacro = GetEnableMacro(point)
@@ -2870,7 +2870,7 @@ macro EmitClockBits(point)
       else
         local condition = "(" + branch["condition"] + ") && (" + selmacro + " == " + branch["value"] + ")"
         local conditiondoxygen = condition
-      endif
+      end
       if branch?is_first
         if disabledbits != "" && point["enable"] != "always"
           ppcode.EmitPPIfAt(expression="(" + enmacro + " == FALSE)", level=0)
@@ -2878,12 +2878,12 @@ macro EmitClockBits(point)
           ppcode.EmitPPElifAt(expression=conditiondoxygen, level=0)
         else
           ppcode.EmitPPIfAt(expression=conditiondoxygen, level=0)
-        endif
+        end
       else
         ppcode.EmitPPElifAt(expression=condition, level=0)
-      endif
+      end
       EmitTargetBitsDefinitionAt(point=point, bits=branch["bits"], target="", indent=1)
-    endlist
+    end
     ppcode.EmitPPElseAt(level=0)
     ppcode.EmitPPErrorAt(message="\"invalid " + selmacro + " value specified\"", level=1)
     ppcode.EmitPPEndifAt(level=0)
@@ -2900,18 +2900,18 @@ macro EmitClockBits(point)
           ppcode.EmitPPIfAt(expression="(" + valmacro + " == " + choice["value"] + ") || defined(__DOXYGEN__)", level=0)
         else
           ppcode.EmitPPElifAt(expression="(" + valmacro + " == " + choice["value"] + ")", level=0)
-        endif
+        end
         EmitTargetBitsDefinitionAt(point=point, bits=choice["bits"], target="", indent=1)
-      endlist
+      end
       ppcode.EmitPPElseAt(level=0)
       ppcode.EmitPPErrorAt(message="\"invalid " + valmacro + " value specified\"", level=1)
       ppcode.EmitPPEndifAt(level=0)
     else
       local bits = point["data"]["bits"]?replace("%N%", valmacro)
       EmitBitsDefinition(point=point, bits=bits)
-    endif
-  endif
-endmacro
+    end
+  end
+end
 
 /* Emits the calculated frequency for one clock point.*/
 macro EmitClockFrequency(point)
@@ -2932,7 +2932,7 @@ macro EmitClockFrequency(point)
         ppcode.EmitPPDefineAt(name=freqmacro, value="0U", level=1)
         if !IsPublicDynamicPoint(point)
           ppcode.EmitPPDefineAt(name=clockmacro, value="0U", level=1)
-        endif
+        end
         list point["frequencies"] as frequency
           if frequency?is_first
             EmitStateCondition(keyword="#elif", expression=frequency["when"], doxygen=true)
@@ -2942,17 +2942,17 @@ macro EmitClockFrequency(point)
             emit """
 #else
 """
-          endif
+          end
           ppcode.EmitPPDefineAt(name=freqmacro, value=frequency["value"], level=1)
           if !IsPublicDynamicPoint(point)
             ppcode.EmitPPDefineAt(name=clockmacro, value=frequency["value"], level=1)
-          endif
-        endlist
+          end
+        end
         ppcode.EmitPPEndifAt(level=0)
         if IsPublicDynamicPoint(point)
           EmitDynamicCurrentClockDefinition(point=point)
-        endif
-      endif
+        end
+      end
     else
       if point["sourceonly"]
         local frequency = GetClockNominalFrequencyMacro(point["name"])
@@ -2965,10 +2965,10 @@ macro EmitClockFrequency(point)
           local frequency = frequency?replace("%I%", inputfreq)
           local inputclock = GetClockCurrentMacro(point["input"])
           local current = current?replace("%I%", inputclock)
-        endif
-      endif
+        end
+      end
       EmitFrequencyDefinition(point=point, frequency=frequency, current=current)
-    endif
+    end
   elseif point["type"] == "mux"
     local selmacro = GetMuxSettingMacro(point)
     local freqmacro = premacro + point["name"] + postclocks
@@ -2980,22 +2980,22 @@ macro EmitClockFrequency(point)
         EmitStateCondition(keyword="#if", expression=condition, doxygen=true)
       else
         EmitStateCondition(keyword="#elif", expression=condition, doxygen=false)
-      endif
+      end
       local inputfreq = GetDefaultFrequencyExpression(input["point"])
       ppcode.EmitPPDefineAt(name=freqmacro, value=inputfreq, level=1)
       if !IsPublicDynamicPoint(point)
         ppcode.EmitPPDefineAt(name=clockmacro, value=GetClockCurrentMacro(input["point"]), level=1)
-      endif
-    endlist
+      end
+    end
     ppcode.EmitPPElseAt(level=0)
     ppcode.EmitPPDefineAt(name=freqmacro, value="0U", level=1)
     if !IsPublicDynamicPoint(point)
       ppcode.EmitPPDefineAt(name=clockmacro, value="0U", level=1)
-    endif
+    end
     ppcode.EmitPPEndifAt(level=0)
     if IsPublicDynamicPoint(point)
       EmitDynamicCurrentClockDefinition(point=point)
-    endif
+    end
   elseif point["type"] == "divider"
     local valmacro = GetScalerSettingMacro(point)
     local inputfreq = GetDefaultFrequencyExpression(point["input"])
@@ -3010,8 +3010,8 @@ macro EmitClockFrequency(point)
     local inputclock = GetClockCurrentMacro(point["input"])
     local current = "(" + inputclock + " * " + valmacro + ")"
     EmitFrequencyDefinition(point=point, frequency=frequency, current=current)
-  endif
-endmacro
+  end
+end
 
 /* Returns all value bits that can be emitted by a source-style frequency table.*/
 function GetSourceFrequencyValueBits(point)
@@ -3020,89 +3020,89 @@ function GetSourceFrequencyValueBits(point)
   if point["type"] == "source" && point["subtype"] == "frequencies"
     list point["frequencies"] as frequency
       local bits = bits + frequency["bits"]
-    endlist
-  endif
+    end
+  end
 
   return bits
-endfunction
+end
 
 /* Emits inert definitions for a clock point outside the selected variant.*/
 macro EmitInactiveVariantClockPoint(point)
   if point["type"] == "source" && (point["sourceonly"]!false)
     ppcode.EmitPPDefine(name=GetClockNominalFrequencyMacro(point["name"]), value="0U")
-  endif
+  end
 
   local targets = GetBitTargets(point["bits"], GetSourceFrequencyValueBits(point))
   list targets as target
     ppcode.EmitPPDefine(name=GetBitsMacro(point, target), value="0U")
-  endlist
+  end
 
   ppcode.EmitPPDefine(name=GetClockFrequencyMacro(point["name"]), value="0U")
   ppcode.EmitPPDefine(name=GetClockCurrentMacro(point["name"]), value="0U")
-endmacro
+end
 
 /* Emits a visual separator for one clock point.*/
 macro EmitClockPointSeparator(point)
   local line = "/* --- Macros and checks for the " + point["name"] + " clock point. "
   emit line?right_pad(76, "-") + "*/\n"
-endmacro
+end
 
 /* Emits checks, register bits and calculated frequencies in XML order.*/
 macro EmitDerivedConstants()
   EmitGenericConfigChecks()
   if HasGenericConfigChecks() && model["derived_configs"]?size > 0
     emit "\e"
-  endif
+  end
   EmitDerivedConfigurationMacros()
   if (HasGenericConfigChecks() || model["derived_configs"]?size > 0) && model["limits"]["limits"]?size > 0
     emit "\e"
-  endif
+  end
   EmitLimitDefinitions()
   if model["configs"]?size > 0 || model["derived_configs"]?size > 0 || model["limits"]["limits"]?size > 0
     emit "\e"
-  endif
+  end
   EmitSinkDemandDefinitions()
   if model["sinks"]?size > 0
     emit "\e"
-  endif
+  end
   EmitEnableDefinitions()
   emit "\e"
   list model["clocks"] as point
     if !point?is_first
       emit "\e"
-    endif
+    end
     EmitClockPointSeparator(point=point)
     emit "\e"
     if IsVariantSpecific(point)
       EmitVariantGuardStart(item=point)
-    endif
+    end
     EmitClockChecks(point=point)
     if HasClockChecks(point)
       emit "\e"
-    endif
+    end
     EmitSourceDependencyChecks(point=point)
     if HasSourceDependencyChecks(point)
       emit "\e"
-    endif
+    end
     EmitNominalFrequency(point=point)
     if point["type"] == "source" && (point["sourceonly"]!false)
       emit "\e"
-    endif
+    end
     EmitClockBits(point=point)
     emit "\e"
     EmitClockFrequency(point=point)
     if HasClockFrequencyChecks(point)
       emit "\e"
       EmitClockFrequencyChecks(point=point)
-    endif
+    end
     if IsVariantSpecific(point)
       ppcode.EmitPPElse()
       EmitInactiveVariantClockPoint(point=point)
       ppcode.EmitPPEndif()
-    endif
-  endlist
+    end
+  end
   if HasAnySinkFrequencyChecks()
     emit "\e"
     EmitSinkFrequencyChecks()
-  endif
-endmacro
+  end
+end

--- a/tools/ftl/libs/libcode.ftlc
+++ b/tools/ftl/libs/libcode.ftlc
@@ -36,8 +36,8 @@ macro EmitDoxygenBrief(object=[])
       utils.WithDot(object.brief[0]?cap_first),
       boundary
     )
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a detailed description in DoxyGen format.
@@ -50,8 +50,8 @@ macro EmitDoxygenDetails(object=[])
       utils.WithDot(object.details[0]?cap_first),
       boundary
     )
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a notes list in DoxyGen format.
@@ -65,9 +65,9 @@ macro EmitDoxygenNotes(object=[])
         utils.WithDot(note[0]?cap_first),
         boundary
       )
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a pre-requisites list in DoxyGen format.
@@ -81,9 +81,9 @@ macro EmitDoxygenPrerequisites(object=[])
         utils.WithDot(pre[0]?cap_first),
         boundary
       )
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a post-requisites list in DoxyGen format.
@@ -97,9 +97,9 @@ macro EmitDoxygenPostrequisites(object=[])
         utils.WithDot(post[0]?cap_first),
         boundary
       )
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a complete Doxygen documentation comment.
@@ -112,7 +112,7 @@ macro EmitDoxygenDocumentationComment(object=[])
   code.EmitDoxygenPostrequisites(object)
   code.EmitDoxygenNotes(object)
   emit " */\n"
-endmacro
+end
 
 /*
   -- This macro generates the parameters description in DoxyGen format.
@@ -150,9 +150,9 @@ macro EmitDoxygenParams(params=[])
         utils.IntelligentDot(name + " " + brief?uncap_first),
         boundary
       )
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates a return description followed by a retval list
@@ -168,7 +168,7 @@ macro EmitDoxygenReturn(return=[])
         utils.WithDot(brief?cap_first),
         boundary
       )
-    endif
+    end
     list return[0].value as value
       local label = (value.@name[0]!"no-val")?trim
       local brief = (value.@brief[0]!"")?trim
@@ -178,9 +178,9 @@ macro EmitDoxygenReturn(return=[])
         utils.WithDot(label + " " + brief?uncap_first),
         boundary
       )
-    endlist
-  endif
-endmacro
+    end
+  end
+end
 
 /*
   -- This macro generates the inner function code (if present).
@@ -188,8 +188,8 @@ endmacro
 macro EmitCode(code=[])
   if function.code[0]?? && (function.code[0]?trim != "")
     emit "${indentation}${function.code[0]?trim}\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- Returns true if the module exports some functions.
@@ -199,10 +199,10 @@ function HasPublicFunctions(module=[])
   list module.function as function
     if (function.@visibility[0]!"private") == "public"
       local flag = true
-    endif
-  endlist
+    end
+  end
   return flag
-endfunction
+end
 
 /*
   -- Returns true if the module has static functions.
@@ -212,10 +212,10 @@ function HasPrivateFunctions(module=[])
   list module.function as function
     if (function.@visibility[0]!"private") == "private"
       local flag = true
-    endif
-  endlist
+    end
+  end
   return flag
-endfunction
+end
 
 /*
   -- This macro generates a function prototype from an XML "function"
@@ -227,7 +227,7 @@ macro GeneratePrototype(function={})
     local rettype = (function.return[0].@type[0]!"void")?trim
   else
     local rettype = "void"
-  endif
+  end
   local name = (function.@name[0]!"no-name")?trim
   local visibility = (function.@visibility[0]!"private")?trim
   if function.param?? && function.param[0]??
@@ -235,7 +235,7 @@ macro GeneratePrototype(function={})
     local l1 = rettype + " " + name + "("
     if visibility == "private"
       local l1 = "static " + l1
-    endif
+    end
     local ln = ""?right_pad(l1?length)
     list function.param as param
       local type = (param.@type[0]!"no-type")?trim
@@ -243,11 +243,11 @@ macro GeneratePrototype(function={})
         local pstring = type?replace("$", (param.@name[0]!"no-name")?trim)
       else
         local pstring = type + " " + (param.@name[0]!"no-name")?trim
-      endif
+      end
       local dir = (param.@dir[0]!"boh")?trim?lower_case
       if dir == "in"
         local pstring = "const " + pstring
-      endif
+      end
       if param_index == 0
         local line = l1 + pstring
       else
@@ -256,14 +256,14 @@ macro GeneratePrototype(function={})
           local line = ln + pstring
         else
           local line = line + ", " + pstring
-        endif
-      endif
-    endlist
+        end
+      end
+    end
     emit line + ")"
   else
     emit rettype + " " + name + "(void)"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a function (and its Doxygen documentation)
@@ -293,9 +293,9 @@ macro GenerateFunction(function={})
   else
     emit "\n"
     emit "${indentation}/* ${function.@name[0]!\"no-name\"} Implementation here! */\n"
-  endif
+  end
   emit "}\n"
-endmacro
+end
 
 /*
   -- Generates the implementations for the private functions in the specified
@@ -306,9 +306,9 @@ macro GeneratePrivateFunctionsImplementations(module)
     if (function.@visibility[0]!"private") == "private"
       code.GenerateFunction(function)
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- Generates the prototypes of the public functions in the specified
@@ -320,9 +320,9 @@ macro GeneratePublicFunctionsPrototypes(indentation, module)
       emit indentation
       code.GeneratePrototype(function)
       emit ";\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- Generates the implementations for the public functions in the specified
@@ -333,6 +333,6 @@ macro GeneratePublicFunctionsImplementations(module)
     if (function.@visibility[0]!"private") == "public"
       code.GenerateFunction(function)
       emit "\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end

--- a/tools/ftl/libs/libdoxygen.ftlc
+++ b/tools/ftl/libs/libdoxygen.ftlc
@@ -35,14 +35,14 @@ macro EmitRichTextFromNode(p1="", pn="", textnode=[], limit=doxygen_boundary)
     else
       local l1 = pn
       local ln = pn
-    endif
+    end
     if node?node_type == "text"
       local text = node?trim?cap_first
       if text?matches("^.*[a-zA-Z0-9]$")
         utils.FormatStringAsText(l1, ln, utils.WithDot(text), limit)
       else
         utils.FormatStringAsText(l1, ln, text, doxygen_boundary)
-      endif
+      end
     elseif node?node_type == "element"
       if node?node_name == "verbatim"
         local lines = node?string?split("^", "rm")
@@ -53,14 +53,14 @@ macro EmitRichTextFromNode(p1="", pn="", textnode=[], limit=doxygen_boundary)
               emit "${l1}${s}\n"
             else
               emit "${ln}${s}\n"
-            endif
-          endif
-        endlist
+            end
+          end
+        end
       elseif node?node_name == "br"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end
 
 /*
   -- This macro generates a generic tag with unformatted text.
@@ -68,7 +68,7 @@ endmacro
 macro EmitTagVerbatim(indent="", tag="no-tag", text="", align=near_align)
   local s = (indent + " * @" + tag + " ")?right_pad(align) + text
   emit "${s}\n"
-endmacro
+end
 
 /*
   -- This macro generates a generic tag with formatted text.
@@ -80,7 +80,7 @@ macro EmitTagFormatted(indent="", tag="no-tag", text="", align=near_align)
     utils.WithDot(text?cap_first),
     doxygen_boundary
   )
-endmacro
+end
 
 /*
   -- This macro generates a generic tag with formatted text.
@@ -92,42 +92,42 @@ macro EmitTagFormattedNoCap(indent="", tag="no-tag", text="", align=near_align)
     utils.WithDot(text),
     doxygen_boundary
   )
-endmacro
+end
 
 /*
   -- This macro generates a brief tag description.
   */
 macro EmitBrief(indent="", text="")
   EmitTagFormatted(indent=indent, tag="brief", text=text)
-endmacro
+end
 
 /*
   -- This macro generates a details tag description.
   */
 macro EmitDetails(indent="", text="")
   EmitTagFormatted(indent=indent, tag="details", text=text)
-endmacro
+end
 
 /*
   -- This macro generates a pre tag description.
   */
 macro EmitPre(indent="", text="")
   EmitTagFormatted(indent=indent, tag="pre", text=text)
-endmacro
+end
 
 /*
   -- This macro generates a post tag description.
   */
 macro EmitPost(indent="", text="")
   EmitTagFormatted(indent=indent, tag="post", text=text)
-endmacro
+end
 
 /*
   -- This macro generates a note tag description.
   */
 macro EmitNote(indent="", text="")
   EmitTagFormatted(indent=indent, tag="note", text=text)
-endmacro
+end
 
 /*
   -- This macro generates a param tag description.
@@ -135,7 +135,7 @@ endmacro
 macro EmitParam(indent="", name="no-name", dir="boh", text="no-text")
   if text?trim?length == 0
     local text="missing description"
-  endif
+  end
   if dir == "in"
     utils.FormatStringAsText(
       indent + (" * @param[in]     " + name + " ")?right_pad(middle_align),
@@ -164,8 +164,8 @@ macro EmitParam(indent="", name="no-name", dir="boh", text="no-text")
       utils.WithDot(text?cap_first),
       doxygen_boundary
     )
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a return tag description.
@@ -177,7 +177,7 @@ macro EmitReturn(indent="", text="")
     utils.WithDot(text?cap_first),
     doxygen_boundary
   )
-endmacro
+end
 
 /*
   -- This macro generates a brief description from an XML node.
@@ -185,8 +185,8 @@ endmacro
 macro EmitBriefFromNode(indent="", node=[])
   if node.brief[0]??
     doxygen.EmitBrief(indent=indent, text=node.brief[0]!"no description")
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a detailed description from an XML node.
@@ -198,8 +198,8 @@ macro EmitDetailsFromNode(indent="", node=[])
       pn=indent + " *"?right_pad(near_align),
       textnode=node.details
     )
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a pre tags list from an XML nodet.
@@ -211,8 +211,8 @@ macro EmitPreFromNode(indent="", node=[])
       pn=indent + " *"?right_pad(near_align),
       textnode=pre
     )
-  endlist
-endmacro
+  end
+end
 
 /*
   -- This macro generates a post tags list from an XML node.
@@ -224,8 +224,8 @@ macro EmitPostFromNode(indent="", node=[])
       pn=indent + " *"?right_pad(near_align),
       textnode=post
     )
-  endlist
-endmacro
+  end
+end
 
 /*
   -- This macro generates a notes list from an XML node.
@@ -237,8 +237,8 @@ macro EmitNoteFromNode(indent="", node=[])
       pn=indent + " *"?right_pad(near_align),
       textnode=note
     )
-  endlist
-endmacro
+  end
+end
 
 /*
   -- This macro generates a params list from an XML node.
@@ -255,11 +255,11 @@ macro EmitParamFromNode(indent="", node=[])
       local p1 = indent + (" * @param[in,out] " + name + " ")?right_pad(middle_align)
     else
       local p1 = indent + (" * @param         " + name + " ")?right_pad(middle_align)
-    endif
+    end
     local pn = indent + " *"?right_pad(middle_align)
     EmitRichTextFromNode(p1=p1, pn=pn, textnode=param)
-  endlist
-endmacro
+  end
+end
 
 /*
   -- This macro generates a return tag from an XML node.
@@ -269,8 +269,8 @@ macro EmitReturnFromNode(indent="", node=[])
     local p1 = (indent + " * @return ")?right_pad(middle_align)
     local pn = (indent + " *         ")?right_pad(middle_align)
     EmitRichTextFromNode(p1=p1, pn=pn, textnode=node.return)
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates retval tags from an XML node.
@@ -281,8 +281,8 @@ macro EmitRetvalFromNode(indent="", node=[])
     local p1 = (indent + " * @retval " + value + " ")?right_pad(middle_align)
     local pn = (indent + " *         ")?right_pad(middle_align)
     EmitRichTextFromNode(p1=p1, pn=pn, textnode=retval)
-  endlist
-endmacro
+  end
+end
 
 /*
   -- This macro generates a function class tag from an XML node.
@@ -312,8 +312,8 @@ macro EmitFunctionClassFromNode(indent="", node=[])
   elseif node.xclass[0]??
     emit indent + " *\n"
     emit indent + " * @xclass\n"
-  endif
-endmacro
+  end
+end
 
 /*
   -- This macro generates a complete Doxygen documentation comment.
@@ -327,7 +327,7 @@ macro EmitFullCommentFromNode(indent="", node=[],
       EmitTagVerbatim(indent=indent, tag="memberof", text=memberof)
       emit "${indent} * @public\n"
       emit "${indent} *\n"
-    endif
+    end
     EmitBriefFromNode(indent=indent, node=node)
     EmitDetailsFromNode(indent=indent, node=node)
     EmitPreFromNode(indent=indent, node=node)
@@ -337,12 +337,12 @@ macro EmitFullCommentFromNode(indent="", node=[],
       emit "${indent} *\n"
       if extraname?length > 0
         EmitParam(indent=indent, name=extraname, dir=extradir, text=extratext)
-      endif
+      end
       EmitParamFromNode(indent=indent, node=node)
       EmitReturnFromNode(indent=indent, node=node)
       EmitRetvalFromNode(indent=indent, node=node)
-    endif
+    end
     EmitFunctionClassFromNode(indent=indent, node=node)
     emit "${indent} */\n"
-  endif
-endmacro
+  end
+end

--- a/tools/ftl/libs/liblicense.ftlc
+++ b/tools/ftl/libs/liblicense.ftlc
@@ -36,4 +36,4 @@ macro EmitLicenseAsText()
     See the License for the specific language governing permissions and
     limitations under the License.
 """
-endmacro
+end

--- a/tools/ftl/libs/libpp.ftlc
+++ b/tools/ftl/libs/libpp.ftlc
@@ -16,18 +16,18 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-ppIndentFactor = 2
-ppValueColumn = 44
-ppBackslashColumn = 76
-ppSplitColumn = 80
-ppDepth = 0
-ppCheckedRequirements = []
+assign ppIndentFactor = 2
+assign ppValueColumn = 44
+assign ppBackslashColumn = 76
+assign ppSplitColumn = 80
+assign ppDepth = 0
+assign ppCheckedRequirements = []
 
 /* Resets the preprocessor nesting state.*/
 macro ResetPP()
   assign ppDepth = 0
   assign ppCheckedRequirements = []
-endmacro
+end
 
 /* Configures preprocessor formatting parameters.*/
 macro ConfigurePP(
@@ -40,40 +40,40 @@ macro ConfigurePP(
   assign ppValueColumn = valueColumn
   assign ppBackslashColumn = backslashColumn
   assign ppSplitColumn = splitColumn
-endmacro
+end
 
 /* Returns indentation for a preprocessor nesting level.*/
 function GetPPIndentAt(level)
   if ppIndentFactor <= 0 || level <= 0
     return ""
-  endif
+  end
 
   return ""?left_pad(level * ppIndentFactor)
-endfunction
+end
 
 /* Returns the current preprocessor indentation.*/
 function GetPPIndent()
   return GetPPIndentAt(ppDepth)
-endfunction
+end
 
 /* Returns a safe level for #elif, #else and #endif directives.*/
 function GetPPParentLevel()
   if ppDepth <= 0
     return 0
-  endif
+  end
 
   return ppDepth - 1
-endfunction
+end
 
 /* Returns true if a colon belongs to a ternary operator.*/
 function IsPPTernaryColon(text, index)
   if index <= 0 || index >= text?length
     return false
-  endif
+  end
 
   if text[index] != ":"
     return false
-  endif
+  end
 
   local depth = 0
   list 0..(index - 1) as i
@@ -82,46 +82,46 @@ function IsPPTernaryColon(text, index)
       local depth = depth + 1
     elseif ch == ":" && depth > 0
       local depth = depth - 1
-    endif
-  endlist
+    end
+  end
 
   return depth > 0
-endfunction
+end
 
 /* Returns the preferred ternary colon split point around a threshold.*/
 function FindPPTernaryColonIndex(text, threshold)
   local fallback = -1
   if text?length == 0
     return -1
-  endif
+  end
 
   list 0..(text?length - 1) as i
     if IsPPTernaryColon(text, i)
       if i > threshold
         if fallback >= 0
           return fallback
-        endif
+        end
         return i
-      endif
+      end
       local fallback = i
-    endif
-  endlist
+    end
+  end
 
   return fallback
-endfunction
+end
 
 /* Returns true if an operator can be used as a line split point.*/
 function IsPPSplitOperator(text, index)
   if index < 0 || index >= text?length
     return false
-  endif
+  end
 
   if index + 1 < text?length
     local two = text?substring(index, index + 2)
     if two == "&&" || two == "||"
       return true
-    endif
-  endif
+    end
+  end
 
   local ch = text[index]
   if ch == "+" || ch == "-" || ch == "*" || ch == "/" || ch == "|" || ch == "&" || ch == "^"
@@ -129,25 +129,25 @@ function IsPPSplitOperator(text, index)
       local prev = text[index - 1]
     else
       local prev = ""
-    endif
+    end
     if index + 1 < text?length
       local next = text[index + 1]
     else
       local next = ""
-    endif
+    end
 
     if (ch == "|" && next == "|") || (ch == "|" && prev == "|")
       return false
-    endif
+    end
     if (ch == "&" && next == "&") || (ch == "&" && prev == "&")
       return false
-    endif
+    end
 
     return true
-  endif
+  end
 
   return false
-endfunction
+end
 
 /* Returns the operator text at a split point.*/
 function GetPPSplitOperator(text, index)
@@ -155,73 +155,73 @@ function GetPPSplitOperator(text, index)
     local two = text?substring(index, index + 2)
     if two == "&&" || two == "||"
       return two
-    endif
-  endif
+    end
+  end
 
   return text[index]
-endfunction
+end
 
 /* Returns the safe split point closest to the threshold without crossing it.*/
 function FindPPSplitIndex(text, threshold)
   local fallback = -1
   if text?length == 0
     return -1
-  endif
+  end
 
   local ternarycolon = FindPPTernaryColonIndex(text, threshold)
   if ternarycolon >= 0
     return ternarycolon
-  endif
+  end
 
   list 0..(text?length - 1) as i
     if IsPPSplitOperator(text, i)
       if i > threshold
         if fallback >= 0
           return fallback
-        endif
+        end
         return i
-      endif
+      end
       local fallback = i
-    endif
-  endlist
+    end
+  end
 
   return fallback
-endfunction
+end
 
 /* Splits one preprocessor expression or value into continued line fragments.*/
 function SplitPPValue(value, baseColumn)
   local text = value?trim
   if text?length == 0
     return [""]
-  endif
+  end
 
   if baseColumn + text?length <= ppSplitColumn
     return [text]
-  endif
+  end
 
   local threshold = ppSplitColumn - baseColumn
   if threshold < 0
     local threshold = 0
-  endif
+  end
 
   local index = FindPPSplitIndex(text, threshold)
   if index < 0
     return [text]
-  endif
+  end
 
   local operator = GetPPSplitOperator(text, index)
   local left = text?substring(0, index)?trim + " " + operator
   local right = text?substring(index + operator?length)?trim
 
   return [left] + SplitPPValue(right, baseColumn)
-endfunction
+end
 
 /* Returns the parenthesis balance of one emitted fragment.*/
 function GetPPParenthesisBalance(text)
   local balance = 0
   if text?length == 0
     return 0
-  endif
+  end
 
   list 0..(text?length - 1) as i
     local ch = text[i]
@@ -229,23 +229,23 @@ function GetPPParenthesisBalance(text)
       local balance = balance + 1
     elseif ch == ")"
       local balance = balance - 1
-    endif
-  endlist
+    end
+  end
 
   return balance
-endfunction
+end
 
 /* Keeps continuation micro-indentation within readable limits.*/
 function ClampPPMicroIndent(value)
   if value < 0
     return 0
-  endif
+  end
   if value > 8
     return 8
-  endif
+  end
 
   return value
-endfunction
+end
 
 /* Emits one logical preprocessor line, optionally with a continuation slash.*/
 macro EmitPPLogicalLine(text, continued=false)
@@ -254,11 +254,11 @@ macro EmitPPLogicalLine(text, continued=false)
       emit text?right_pad(ppBackslashColumn) + "\\" + "\n"
     else
       emit text + " \\" + "\n"
-    endif
+    end
   else
     emit text + "\n"
-  endif
-endmacro
+  end
+end
 
 /* Emits a wrapped preprocessor value after a prepared line prefix.*/
 macro EmitPPWrapped(prefix, value)
@@ -270,67 +270,67 @@ macro EmitPPWrapped(prefix, value)
       local line = prefix + fragment
     else
       local line = ""?left_pad(prefix?length + ClampPPMicroIndent(microindent)) + fragment
-    endif
+    end
 
     EmitPPLogicalLine(text=line, continued=!fragment?is_last)
     local microindent = ClampPPMicroIndent(microindent + GetPPParenthesisBalance(fragment))
-  endlist
-endmacro
+  end
+end
 
 /* Emits one preprocessor directive with a wrapped expression.*/
 macro EmitPPDirective(keyword, expression, level)
   local prefix = GetPPIndentAt(level) + keyword + " "
   EmitPPWrapped(prefix=prefix, value=expression)
-endmacro
+end
 
 /* Emits one preprocessor directive at an explicit nesting level.*/
 macro EmitPPDirectiveAt(keyword, expression, level)
   EmitPPDirective(keyword=keyword, expression=expression, level=level)
-endmacro
+end
 
 /* Emits a #if directive and updates the nesting level.*/
 macro EmitPPIf(expression)
   EmitPPDirective(keyword="#if", expression=expression, level=ppDepth)
   assign ppDepth = ppDepth + 1
-endmacro
+end
 
 /* Emits a #if directive at an explicit nesting level without changing state.*/
 macro EmitPPIfAt(expression, level)
   EmitPPDirectiveAt(keyword="#if", expression=expression, level=level)
-endmacro
+end
 
 /* Emits a #elif directive at the current nesting level.*/
 macro EmitPPElif(expression)
   EmitPPDirective(keyword="#elif", expression=expression, level=GetPPParentLevel())
-endmacro
+end
 
 /* Emits a #elif directive at an explicit nesting level without changing state.*/
 macro EmitPPElifAt(expression, level)
   EmitPPDirectiveAt(keyword="#elif", expression=expression, level=level)
-endmacro
+end
 
 /* Emits a #else directive at the current nesting level.*/
 macro EmitPPElse()
   emit GetPPIndentAt(GetPPParentLevel()) + "#else\n"
-endmacro
+end
 
 /* Emits a #else directive at an explicit nesting level without changing state.*/
 macro EmitPPElseAt(level)
   emit GetPPIndentAt(level) + "#else\n"
-endmacro
+end
 
 /* Emits a #endif directive and updates the nesting level.*/
 macro EmitPPEndif()
   if ppDepth > 0
     assign ppDepth = ppDepth - 1
-  endif
+  end
   emit GetPPIndentAt(ppDepth) + "#endif\n"
-endmacro
+end
 
 /* Emits a #endif directive at an explicit nesting level without changing state.*/
 macro EmitPPEndifAt(level)
   emit GetPPIndentAt(level) + "#endif\n"
-endmacro
+end
 
 /* Builds a #define prefix, preserving a separator for long macro names.*/
 function GetPPDefinePrefix(name, level)
@@ -338,32 +338,32 @@ function GetPPDefinePrefix(name, level)
 
   if prefix?length >= ppValueColumn
     return prefix + " "
-  endif
+  end
 
   return prefix?right_pad(ppValueColumn)
-endfunction
+end
 
 /* Emits a #define directive using the configured value column.*/
 macro EmitPPDefine(name, value)
   local prefix = GetPPDefinePrefix(name, ppDepth)
   EmitPPWrapped(prefix=prefix, value=value)
-endmacro
+end
 
 /* Emits a #define directive at an explicit nesting level without changing state.*/
 macro EmitPPDefineAt(name, value, level)
   local prefix = GetPPDefinePrefix(name, level)
   EmitPPWrapped(prefix=prefix, value=value)
-endmacro
+end
 
 /* Emits a #error directive.*/
 macro EmitPPError(message)
   emit GetPPIndent() + "#error " + message + "\n"
-endmacro
+end
 
 /* Emits a #error directive at an explicit nesting level without changing state.*/
 macro EmitPPErrorAt(message, level)
   emit GetPPIndentAt(level) + "#error " + message + "\n"
-endmacro
+end
 
 /* Emits a preprocessor assertion with explicit required macro checks.*/
 macro EmitPPAssert(expression, message, requires=[], doxygen=true)
@@ -373,25 +373,25 @@ macro EmitPPAssert(expression, message, requires=[], doxygen=true)
         EmitPPIf(expression="!defined(" + required + ") && !defined(__DOXYGEN__)")
       else
         EmitPPIf(expression="!defined(" + required + ")")
-      endif
+      end
       EmitPPError(message="\"" + required + " not defined\"")
       EmitPPEndif()
       assign ppCheckedRequirements = ppCheckedRequirements + [required]
-    endif
-  endlist
+    end
+  end
 
   if doxygen
     EmitPPIf(expression="!(" + expression + ") && !defined(__DOXYGEN__)")
   else
     EmitPPIf(expression="!(" + expression + ")")
-  endif
+  end
   EmitPPError(message=message)
   EmitPPEndif()
-endmacro
+end
 
 /* Emits a guarded default setting.*/
 macro EmitPPSetting(name, value)
   EmitPPIf(expression="!defined(" + name + ") || defined(__DOXYGEN__)")
   EmitPPDefine(name=name, value=value)
   EmitPPEndif()
-endmacro
+end

--- a/tools/ftl/libs/libsnippets.ftlc
+++ b/tools/ftl/libs/libsnippets.ftlc
@@ -26,7 +26,7 @@ function GetThreadCode(name)
     if ((snippet.type[0] == "thread_body") &&
         ((snippet.name[0]!"")?trim?lower_case == name?trim?lower_case))
       return snippet.text[0]!""
-    endif
-  endlist
+    end
+  end
   return "/* Thread style not found: " + name + " */"
-endfunction
+end

--- a/tools/ftl/libs/libutils.ftlc
+++ b/tools/ftl/libs/libutils.ftlc
@@ -27,12 +27,12 @@ function WithDot(s)
   local s = s?trim
   if s == ""
     return s
-  endif
+  end
   if s?ends_with(".")
     return s
-  endif
+  end
   return s + "."
-endfunction
+end
 
 /*
   -- Returns the trimmed text "s" making sure it is not terminated by a dot.
@@ -41,9 +41,9 @@ function WithoutDot(s)
   local s = s?trim
   if s?ends_with(".")
     return s?substring(0, s?length - 1)
-  endif
+  end
   return s
-endfunction
+end
 
 /*
   -- Returns the trimmed text "s" making sure it is terminated by a dot if the
@@ -57,9 +57,9 @@ function IntelligentDot(s)
   local s = s?trim
   if s?contains(". ")
     return WithDot(s)
-  endif
+  end
   return WithoutDot(s)
-endfunction
+end
 
 /*
   -- Formats a text string in a sequence of strings no longer than "len" (first
@@ -76,19 +76,19 @@ function StringToText(len1, lenn, s)
       local len = len1
     else
       local len = lenn
-    endif
+    end
     if (line?length + word?length + 1 > len)
       local lines = lines + [line?trim]
       local line = word + " "
     else
       local line = line + word + " "
-    endif
-  endlist
+    end
+  end
   if line != ""
     local lines = lines + [line?trim]
-  endif
+  end
   return lines
-endfunction
+end
 
 /*
   -- Emits a string "s" as a formatted text, the first line is prefixed by the
@@ -103,9 +103,9 @@ macro FormatStringAsText(p1, pn, s, len)
       emit "${p1}${line}\n"
     else
       emit "${pn}${line}\n"
-    endif
-  endlist
-endmacro
+    end
+  end
+end
 
 /*
   -- Emits a C function body code reformatting the indentation using the
@@ -120,10 +120,10 @@ macro EmitIndentedCCode(start, tab, ccode)
           emit "${line?chop_linebreak}\n"
         else
           emit "${start + line?chop_linebreak}\n"
-        endif
+        end
       else
         emit "\n"
-      endif
-    endif
-  endlist
-endmacro
+      end
+    end
+  end
+end


### PR DESCRIPTION
*Drafted by Claude (an AI coding assistant) working with me. The syntax decisions behind it — replacing the ten per-block closers with a single generic `end`, and requiring a scope keyword on assignments — were discussed with me and are mine; the migration and this write-up are its work.*

---

The code-first mode of [FreeMarker Codegen](https://github.com/gdisirio/freemarker-codegen) changed two things that these libraries use throughout, so they no longer parse with the current version without this update.

### What changed

**Block closers.** The ten per-block keywords — `endif`, `endlist`, `endmacro`, `endfunction`, `endswitch`, `endsep`, `enditems`, `endattempt`, `endautoesc`, `endnoautoesc` — are replaced by a single generic `end`, which closes whatever block is open. **1097 closers** here.

The `/if`-style closers are unchanged and remain the explicit form: they also state, and therefore check, *what* is being closed, so they catch a block closed by mistake. `end` can't — a mismatch only surfaces later, at the outer level. This pairing is the one Ada uses (`end;` versus `end Foo;`); bare `end` on its own is the Pascal-family convention, and what Ruby, Lua, Julia and Elixir settled on too.

**Assignments now state their scope.** A bare `x = 1` could only mean "namespace at the top level, local inside a macro or function", which makes moving a fragment of a template into a macro silently change where the value is written. **20 assignments** here, all at module level and therefore all `assign`; the **923** already written as `local` are unaffected.

### Why it's safe

The change is mechanical and behaviour-preserving: **1117 lines changed, 1117 lines changed back**, with no line added or removed.

Verified by:

- **Parsing all 159 templates** in the tree — all parse.
- **Loading each library** and checking it still defines the same macros and functions as before: 6, 21, 41, 24, 1, 1, 38 and 58 respectively, identical to before the change. (`libclocks.ftlc` can't be loaded standalone either way, as it needs FMPP's `/@lib/` link alias and the `doc1` data model.)

Content that only looks like the old syntax is untouched — C preprocessor `#endif` inside emitted strings, example code in `/* */` documentation comments, and the contents of `"""` text blocks. Named arguments of multi-line calls and macro parameter lists with defaults are likewise left alone, as they aren't assignments.

### Before you merge

These libraries now **require the FreeMarker Codegen jar**, and won't parse with an older one. See its [README](https://github.com/gdisirio/freemarker-codegen#fmpp-integration) for replacing `freemarker.jar` in an FMPP installation. Anyone regenerating sources will need to update that jar at the same time as taking this commit.

The same change is proposed for `stable-21.11.x` separately; it was redone against that branch rather than cherry-picked, as three of the libraries differ between the two.
